### PR TITLE
Add variants CLI subcommand, document MCP tools, fix headless docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .swiftpm/
 xcuserdata/
 DerivedData/
+.claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ previewsmcp run MyView.swift
 # Run a specific preview (0-based index)
 previewsmcp run MyView.swift --preview 1
 
-# Run on iOS simulator (headless by default)
+# Run on iOS simulator (Simulator.app window visible by default)
 previewsmcp run MyView.swift --platform ios
 
-# Run with a visible Simulator.app window
-previewsmcp run MyView.swift --platform ios --no-headless
+# Run iOS preview headless (hide Simulator.app GUI)
+previewsmcp run MyView.swift --platform ios --headless
 
 # Specify project root for Xcode/Bazel projects
 previewsmcp run MyView.swift --project ./MyApp
@@ -55,10 +55,19 @@ previewsmcp run MyView.swift --color-scheme dark --dynamic-type-size accessibili
 previewsmcp snapshot MyView.swift -o preview.png
 
 # Snapshot a specific preview with traits
-previewsmcp snapshot MyView.swift --preview 1 --color-scheme light -o dark.jpg
+previewsmcp snapshot MyView.swift --preview 1 --color-scheme dark -o dark.jpg
 
 # Snapshot on iOS simulator
 previewsmcp snapshot MyView.swift --platform ios -o ios_preview.png
+
+# Capture multiple trait variants in one run (creates one image per variant)
+previewsmcp variants MyView.swift --variant light --variant dark -o snapshots/
+
+# Custom variants with JSON object strings (label sets the output filename)
+previewsmcp variants MyView.swift \
+  --variant '{"colorScheme":"dark","dynamicTypeSize":"large","label":"dark-large"}' \
+  --variant '{"colorScheme":"light","dynamicTypeSize":"xSmall","label":"light-xSmall"}' \
+  --platform ios -o snapshots/
 ```
 
 Supports both `#Preview` macros and the legacy `PreviewProvider` protocol — `list` shows all previews from both, and `run`/`snapshot` can render any by index.

--- a/README.md
+++ b/README.md
@@ -77,3 +77,43 @@ Add to your `.mcp.json` (or Claude Code MCP config):
   }
 }
 ```
+
+### Tools
+
+| Tool | Description |
+|---|---|
+| `preview_list` | List `#Preview` blocks and `PreviewProvider` previews in a Swift file |
+| `preview_start` | Compile and launch a live preview (macOS or iOS simulator). Returns a session ID |
+| `preview_snapshot` | Capture a screenshot of the active session (JPEG by default; `quality: 1.0` for PNG) |
+| `preview_configure` | Update traits (`colorScheme`, `dynamicTypeSize`) on a running session |
+| `preview_switch` | Swap to a different `#Preview` index without tearing down the session |
+| `preview_variants` | Capture screenshots under multiple trait configurations in one call |
+| `preview_elements` | Inspect the accessibility tree of an iOS preview |
+| `preview_touch` | Send a tap or swipe to an iOS preview |
+| `preview_stop` | Close a session |
+| `simulator_list` | List available iOS simulator devices |
+
+### Capturing variants
+
+`preview_variants` captures multiple snapshots in a single call — useful for comparing light/dark mode, dynamic type sizes, or custom trait combinations. Each variant triggers a recompile, and the session's original traits are restored afterward.
+
+Pass an array of preset names or JSON object strings as the `variants` argument:
+
+```jsonc
+// Preset names — light/dark and xSmall through accessibility5
+{
+  "sessionID": "...",
+  "variants": ["light", "dark", "accessibility3"]
+}
+
+// Custom combinations via JSON object strings
+{
+  "sessionID": "...",
+  "variants": [
+    "{\"colorScheme\":\"dark\",\"dynamicTypeSize\":\"large\",\"label\":\"dark+large\"}",
+    "{\"colorScheme\":\"light\",\"dynamicTypeSize\":\"xSmall\",\"label\":\"light+xSmall\"}"
+  ]
+}
+```
+
+The response contains one labeled image per variant.

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -814,18 +814,11 @@ private func handlePreviewConfigure(params: CallTool.Parameters) async throws ->
 // MARK: - preview_variants
 
 private enum VariantError: Error, LocalizedError {
-    case unknownPreset(String)
-    case emptyVariantObject
     case invalidVariantType
     case emptyVariantsArray
 
     var errorDescription: String? {
         switch self {
-        case .unknownPreset(let name):
-            return
-                "Unknown variant preset '\(name)'. Valid presets: \(PreviewTraits.allPresetNames.sorted().joined(separator: ", "))"
-        case .emptyVariantObject:
-            return "Variant object must specify at least one trait (colorScheme or dynamicTypeSize)"
         case .invalidVariantType:
             return
                 "Each variant must be a preset name string or a JSON object string with colorScheme/dynamicTypeSize"
@@ -835,32 +828,12 @@ private enum VariantError: Error, LocalizedError {
     }
 }
 
-/// Resolve a variant value (preset name string or JSON object string) to traits and a label.
-private func resolveVariant(_ value: Value) throws -> (traits: PreviewTraits, label: String) {
+/// Unwrap an MCP Value to a String, then resolve via PreviewTraits.parseVariantString.
+private func resolveVariant(_ value: Value) throws -> PreviewTraits.Variant {
     guard case .string(let str) = value else {
         throw VariantError.invalidVariantType
     }
-
-    // Try as a preset name first
-    if let traits = PreviewTraits.fromPreset(str) {
-        return (traits, str)
-    }
-
-    // Try parsing as JSON object string
-    guard let data = str.data(using: .utf8),
-        let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-    else {
-        throw VariantError.unknownPreset(str)
-    }
-
-    let colorScheme = json["colorScheme"] as? String
-    let dynamicTypeSize = json["dynamicTypeSize"] as? String
-    let traits = try PreviewTraits.validated(colorScheme: colorScheme, dynamicTypeSize: dynamicTypeSize)
-    if traits.isEmpty {
-        throw VariantError.emptyVariantObject
-    }
-    let label = (json["label"] as? String) ?? traitsSummary(traits)
-    return (traits, label)
+    return try PreviewTraits.parseVariantString(str)
 }
 
 private func handlePreviewVariants(params: CallTool.Parameters) async throws -> CallTool.Result {
@@ -879,7 +852,7 @@ private func handlePreviewVariants(params: CallTool.Parameters) async throws -> 
     }
 
     // Resolve all variants upfront — fail fast on validation errors before any recompilation
-    let resolved: [(traits: PreviewTraits, label: String)]
+    let resolved: [PreviewTraits.Variant]
     do {
         resolved = try variantValues.map { try resolveVariant($0) }
     } catch {

--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -26,7 +26,8 @@ struct PreviewsMCPApp {
 
         // Commands that don't need NSApplication (list, help, etc.)
         if command is ListCommand
-            || !(command is RunCommand || command is ServeCommand || command is SnapshotCommand)
+            || !(command is RunCommand || command is ServeCommand || command is SnapshotCommand
+                || command is VariantsCommand)
         {
             do {
                 var mutable = command
@@ -43,7 +44,7 @@ struct PreviewsMCPApp {
         let mode: PreviewHost.Mode
         if command is ServeCommand {
             mode = .serve
-        } else if command is SnapshotCommand {
+        } else if command is SnapshotCommand || command is VariantsCommand {
             mode = .snapshot
         } else {
             mode = .interactive
@@ -77,7 +78,8 @@ struct PreviewsMCPCommand: ParsableCommand {
         commandName: "previewsmcp",
         abstract: "Run SwiftUI previews outside of Xcode",
         subcommands: [
-            RunCommand.self, ListCommand.self, SnapshotCommand.self, ServeCommand.self,
+            RunCommand.self, ListCommand.self, SnapshotCommand.self, VariantsCommand.self,
+            ServeCommand.self,
         ],
         defaultSubcommand: RunCommand.self
     )

--- a/Sources/PreviewsCLI/VariantsCommand.swift
+++ b/Sources/PreviewsCLI/VariantsCommand.swift
@@ -1,0 +1,294 @@
+import AppKit
+import ArgumentParser
+import Foundation
+import PreviewsCore
+import PreviewsIOS
+import PreviewsMacOS
+
+struct VariantsCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "variants",
+        abstract:
+            "Capture multiple snapshots of a SwiftUI preview under different trait configurations"
+    )
+
+    @Argument(help: "Path to Swift source file containing #Preview")
+    var file: String
+
+    @Option(
+        name: .long,
+        parsing: .singleValue,
+        help: ArgumentHelp(
+            "A trait variant to capture. Repeat for multiple variants.",
+            discussion: """
+                Either a preset name (light, dark, xSmall…accessibility5) or a JSON object \
+                string like '{"colorScheme":"dark","dynamicTypeSize":"large","label":"dark+large"}'.
+                """
+        )
+    )
+    var variant: [String] = []
+
+    @Option(name: [.short, .long], help: "Output directory for snapshots")
+    var outputDir: String = "."
+
+    @Option(name: .long, help: "Image format")
+    var format: ImageFormat = .jpeg
+
+    @Option(name: .long, help: "JPEG quality 0.0–1.0 (ignored for PNG)")
+    var quality: Double = 0.85
+
+    @Option(name: .long, help: "Which preview to capture (0-based index)")
+    var preview: Int = 0
+
+    @Option(name: .long, help: "Window width")
+    var width: Int = 400
+
+    @Option(name: .long, help: "Window height")
+    var height: Int = 600
+
+    @Option(name: .long, help: "Target platform: 'macos' (default) or 'ios'")
+    var platform: CLIPlatform = .macos
+
+    @Option(name: .long, help: "Project root path (auto-detected if omitted)")
+    var project: String?
+
+    @Option(name: .long, help: "Simulator device UDID (for ios; auto-selects if omitted)")
+    var device: String?
+
+    enum ImageFormat: String, ExpressibleByArgument, CaseIterable {
+        case jpeg, png
+    }
+
+    mutating func run() throws {
+        let fileURL = URL(fileURLWithPath: file).standardizedFileURL
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            throw ValidationError("File not found: \(file)")
+        }
+
+        guard !variant.isEmpty else {
+            throw ValidationError("At least one --variant is required")
+        }
+
+        // Resolve all variants up front to fail fast on invalid input.
+        let resolved: [(traits: PreviewTraits, label: String)]
+        do {
+            resolved = try variant.map(Self.resolveVariant)
+        } catch {
+            throw ValidationError(error.localizedDescription)
+        }
+
+        // Reject duplicate labels — they would overwrite each other on disk.
+        var seen: Set<String> = []
+        for (_, label) in resolved {
+            if !seen.insert(label).inserted {
+                throw ValidationError(
+                    "Duplicate variant label '\(label)'. Provide a unique 'label' field in JSON variants.")
+            }
+        }
+
+        let outputDirURL = URL(fileURLWithPath: outputDir)
+        try FileManager.default.createDirectory(
+            at: outputDirURL, withIntermediateDirectories: true)
+
+        switch platform {
+        case .ios:
+            runIOSVariants(fileURL: fileURL, resolved: resolved, outputDirURL: outputDirURL)
+        case .macos:
+            runMacOSVariants(fileURL: fileURL, resolved: resolved, outputDirURL: outputDirURL)
+        }
+    }
+
+    /// Resolve a variant string (preset name or JSON object) to traits and a label.
+    static func resolveVariant(_ str: String) throws -> (traits: PreviewTraits, label: String) {
+        if let traits = PreviewTraits.fromPreset(str) {
+            return (traits, str)
+        }
+        guard let data = str.data(using: .utf8),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            throw VariantsCommandError.unknownPreset(str)
+        }
+        let colorScheme = json["colorScheme"] as? String
+        let dynamicTypeSize = json["dynamicTypeSize"] as? String
+        let traits = try PreviewTraits.validated(
+            colorScheme: colorScheme, dynamicTypeSize: dynamicTypeSize)
+        if traits.isEmpty {
+            throw VariantsCommandError.emptyVariantObject
+        }
+        let label = (json["label"] as? String) ?? Self.defaultLabel(traits)
+        return (traits, label)
+    }
+
+    /// Filename-friendly label derived from non-nil trait values, joined with `+`.
+    static func defaultLabel(_ traits: PreviewTraits) -> String {
+        var parts: [String] = []
+        if let cs = traits.colorScheme { parts.append(cs) }
+        if let dts = traits.dynamicTypeSize { parts.append(dts) }
+        return parts.joined(separator: "+")
+    }
+
+    private func outputURL(in dir: URL, label: String) -> URL {
+        let ext = format == .png ? "png" : "jpg"
+        return dir.appendingPathComponent("\(label).\(ext)")
+    }
+
+    private func runMacOSVariants(
+        fileURL: URL,
+        resolved: [(traits: PreviewTraits, label: String)],
+        outputDirURL: URL
+    ) {
+        let previewIndex = preview
+        let windowWidth = width
+        let windowHeight = height
+        let projectPath = project
+        let snapshotFormat: Snapshot.ImageFormat =
+            format == .png ? .png : .jpeg(quality: quality)
+
+        Task {
+            do {
+                let compiler = try await Compiler()
+
+                let projectRootURL = projectPath.map { URL(fileURLWithPath: $0) }
+                let buildContext = try await detectAndBuild(
+                    for: fileURL, projectRoot: projectRootURL, platform: .macOS)
+
+                // Single session, recompiled per variant via setTraits.
+                let session = PreviewSession(
+                    sourceFile: fileURL,
+                    previewIndex: previewIndex,
+                    compiler: compiler,
+                    buildContext: buildContext,
+                    traits: resolved[0].traits
+                )
+                let sessionID = session.id
+
+                fputs(
+                    "Capturing \(resolved.count) variant(s) of \(fileURL.lastPathComponent)...\n",
+                    stderr)
+
+                // Compile + display the first variant via the normal compile() path,
+                // then loop using setTraits() (which also recompiles).
+                var first = true
+                for (traits, label) in resolved {
+                    let compileResult: CompileResult
+                    if first {
+                        compileResult = try await session.compile()
+                        first = false
+                    } else {
+                        compileResult = try await session.setTraits(traits)
+                    }
+
+                    try await MainActor.run {
+                        try App.host.loadPreview(
+                            sessionID: sessionID,
+                            dylibPath: compileResult.dylibPath,
+                            title: "Variant: \(label)",
+                            size: NSSize(width: windowWidth, height: windowHeight)
+                        )
+                    }
+
+                    // Wait for SwiftUI layout
+                    try await Task.sleep(for: .milliseconds(500))
+
+                    let outURL = outputURL(in: outputDirURL, label: label)
+                    try await MainActor.run {
+                        guard let window = App.host.window(for: sessionID) else {
+                            throw VariantsCommandError.captureFailed(label: label)
+                        }
+                        try Snapshot.capture(
+                            window: window, format: snapshotFormat, to: outURL)
+                    }
+                    print(outURL.path)
+                }
+
+                await MainActor.run { NSApp.terminate(nil) }
+            } catch {
+                fputs("Error: \(error.localizedDescription)\n", stderr)
+                Darwin.exit(1)
+            }
+        }
+    }
+
+    private func runIOSVariants(
+        fileURL: URL,
+        resolved: [(traits: PreviewTraits, label: String)],
+        outputDirURL: URL
+    ) {
+        let previewIndex = preview
+        let deviceUDID = device
+        let projectPath = project
+        let jpegQuality: Double = format == .png ? 1.0 : quality
+
+        Task {
+            do {
+                let compiler = try await Compiler(platform: .iOS)
+                let hostBuilder = try await IOSHostBuilder()
+                let simulatorManager = SimulatorManager()
+
+                let udid = try await resolveDeviceUDID(
+                    provided: deviceUDID, using: simulatorManager)
+
+                let projectRootURL = projectPath.map { URL(fileURLWithPath: $0) }
+                let buildContext = try await detectAndBuild(
+                    for: fileURL, projectRoot: projectRootURL, platform: .iOS)
+
+                let session = IOSPreviewSession(
+                    sourceFile: fileURL,
+                    previewIndex: previewIndex,
+                    deviceUDID: udid,
+                    compiler: compiler,
+                    hostBuilder: hostBuilder,
+                    simulatorManager: simulatorManager,
+                    headless: true,
+                    buildContext: buildContext,
+                    traits: resolved[0].traits
+                )
+
+                fputs(
+                    "Capturing \(resolved.count) variant(s) on simulator \(udid)...\n", stderr)
+                _ = try await session.start()
+                try await Task.sleep(for: .seconds(2))
+
+                var first = true
+                for (traits, label) in resolved {
+                    if !first {
+                        try await session.setTraits(traits)
+                        try await Task.sleep(for: .seconds(1))
+                    }
+                    first = false
+
+                    let imageData = try await session.screenshot(jpegQuality: jpegQuality)
+                    let outURL = outputURL(in: outputDirURL, label: label)
+                    try imageData.write(to: outURL)
+                    print(outURL.path)
+                }
+
+                await session.stop()
+                await MainActor.run { NSApp.terminate(nil) }
+            } catch {
+                fputs("Error: \(error.localizedDescription)\n", stderr)
+                Darwin.exit(1)
+            }
+        }
+    }
+}
+
+enum VariantsCommandError: Error, LocalizedError {
+    case unknownPreset(String)
+    case emptyVariantObject
+    case captureFailed(label: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unknownPreset(let name):
+            let presets = PreviewTraits.allPresetNames.sorted().joined(separator: ", ")
+            return
+                "Unknown variant '\(name)'. Expected a preset name (\(presets)) or a JSON object string."
+        case .emptyVariantObject:
+            return
+                "Variant object must specify at least one trait (colorScheme or dynamicTypeSize)."
+        case .captureFailed(let label):
+            return "Failed to capture variant '\(label)': no preview window found."
+        }
+    }
+}

--- a/Sources/PreviewsCLI/VariantsCommand.swift
+++ b/Sources/PreviewsCLI/VariantsCommand.swift
@@ -5,6 +5,10 @@ import PreviewsCore
 import PreviewsIOS
 import PreviewsMacOS
 
+/// Exit codes:
+///   0 — all variants captured
+///   1 — partial failure (some variants captured, others failed) or setup/validation error
+///   2 — total failure (every variant failed)
 struct VariantsCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "variants",
@@ -17,7 +21,6 @@ struct VariantsCommand: ParsableCommand {
 
     @Option(
         name: .long,
-        parsing: .singleValue,
         help: ArgumentHelp(
             "A trait variant to capture. Repeat for multiple variants.",
             discussion: """
@@ -69,21 +72,23 @@ struct VariantsCommand: ParsableCommand {
             throw ValidationError("At least one --variant is required")
         }
 
-        // Resolve all variants up front to fail fast on invalid input.
-        let resolved: [(traits: PreviewTraits, label: String)]
+        // Resolve all variants up front — validation errors are setup-time failures (exit 1).
+        let resolved: [PreviewTraits.Variant]
         do {
-            resolved = try variant.map(Self.resolveVariant)
+            resolved = try variant.map(PreviewTraits.parseVariantString)
         } catch {
             throw ValidationError(error.localizedDescription)
         }
 
-        // Reject duplicate labels — they would overwrite each other on disk.
-        var seen: Set<String> = []
-        for (_, label) in resolved {
-            if !seen.insert(label).inserted {
+        // Reject duplicate labels — they would silently overwrite each other on disk.
+        var seen: [String: Int] = [:]
+        for (index, variant) in resolved.enumerated() {
+            if let prior = seen[variant.label] {
                 throw ValidationError(
-                    "Duplicate variant label '\(label)'. Provide a unique 'label' field in JSON variants.")
+                    "Duplicate variant label '\(variant.label)' at indices \(prior) and \(index). "
+                        + "Provide a unique 'label' field in JSON variants.")
             }
+            seen[variant.label] = index
         }
 
         let outputDirURL = URL(fileURLWithPath: outputDir)
@@ -98,43 +103,32 @@ struct VariantsCommand: ParsableCommand {
         }
     }
 
-    /// Resolve a variant string (preset name or JSON object) to traits and a label.
-    static func resolveVariant(_ str: String) throws -> (traits: PreviewTraits, label: String) {
-        if let traits = PreviewTraits.fromPreset(str) {
-            return (traits, str)
-        }
-        guard let data = str.data(using: .utf8),
-            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else {
-            throw VariantsCommandError.unknownPreset(str)
-        }
-        let colorScheme = json["colorScheme"] as? String
-        let dynamicTypeSize = json["dynamicTypeSize"] as? String
-        let traits = try PreviewTraits.validated(
-            colorScheme: colorScheme, dynamicTypeSize: dynamicTypeSize)
-        if traits.isEmpty {
-            throw VariantsCommandError.emptyVariantObject
-        }
-        let label = (json["label"] as? String) ?? Self.defaultLabel(traits)
-        return (traits, label)
-    }
-
-    /// Filename-friendly label derived from non-nil trait values, joined with `+`.
-    static func defaultLabel(_ traits: PreviewTraits) -> String {
-        var parts: [String] = []
-        if let cs = traits.colorScheme { parts.append(cs) }
-        if let dts = traits.dynamicTypeSize { parts.append(dts) }
-        return parts.joined(separator: "+")
-    }
-
     private func outputURL(in dir: URL, label: String) -> URL {
         let ext = format == .png ? "png" : "jpg"
         return dir.appendingPathComponent("\(label).\(ext)")
     }
 
+    /// Print a per-variant failure to stderr in the same format as the MCP `preview_variants` tool.
+    private func reportVariantFailure(index: Int, label: String, error: Error) {
+        fputs("[\(index)] \(label): ERROR — \(error.localizedDescription)\n", stderr)
+    }
+
+    /// Print a final summary line and return the appropriate exit code.
+    private func summarize(successCount: Int, failCount: Int) -> Int32 {
+        let total = successCount + failCount
+        if failCount == 0 {
+            fputs("Captured \(successCount)/\(total) variants.\n", stderr)
+            return 0
+        }
+        fputs(
+            "Captured \(successCount)/\(total) variants (\(failCount) failed). "
+                + "See stderr for details.\n", stderr)
+        return failCount == total ? 2 : 1
+    }
+
     private func runMacOSVariants(
         fileURL: URL,
-        resolved: [(traits: PreviewTraits, label: String)],
+        resolved: [PreviewTraits.Variant],
         outputDirURL: URL
     ) {
         let previewIndex = preview
@@ -145,44 +139,45 @@ struct VariantsCommand: ParsableCommand {
             format == .png ? .png : .jpeg(quality: quality)
 
         Task {
+            // Setup phase — any failure here is a hard exit (no variants can be captured).
+            let session: PreviewSession
+            let sessionID: String
             do {
                 let compiler = try await Compiler()
-
                 let projectRootURL = projectPath.map { URL(fileURLWithPath: $0) }
                 let buildContext = try await detectAndBuild(
                     for: fileURL, projectRoot: projectRootURL, platform: .macOS)
 
-                // Single session, recompiled per variant via setTraits.
-                let session = PreviewSession(
+                session = PreviewSession(
                     sourceFile: fileURL,
                     previewIndex: previewIndex,
                     compiler: compiler,
                     buildContext: buildContext,
                     traits: resolved[0].traits
                 )
-                let sessionID = session.id
+                sessionID = session.id
+            } catch {
+                fputs("Error: \(error.localizedDescription)\n", stderr)
+                Darwin.exit(2)
+            }
 
-                fputs(
-                    "Capturing \(resolved.count) variant(s) of \(fileURL.lastPathComponent)...\n",
-                    stderr)
+            fputs(
+                "Capturing \(resolved.count) variant(s) of \(fileURL.lastPathComponent)...\n",
+                stderr)
 
-                // Compile + display the first variant via the normal compile() path,
-                // then loop using setTraits() (which also recompiles).
-                var first = true
-                for (traits, label) in resolved {
-                    let compileResult: CompileResult
-                    if first {
-                        compileResult = try await session.compile()
-                        first = false
-                    } else {
-                        compileResult = try await session.setTraits(traits)
-                    }
+            // Per-variant phase — collect failures, continue past them, stream successes.
+            var successCount = 0
+            var failCount = 0
+
+            for (index, variant) in resolved.enumerated() {
+                do {
+                    let compileResult = try await session.setTraits(variant.traits)
 
                     try await MainActor.run {
                         try App.host.loadPreview(
                             sessionID: sessionID,
                             dylibPath: compileResult.dylibPath,
-                            title: "Variant: \(label)",
+                            title: "Variant: \(variant.label)",
                             size: NSSize(width: windowWidth, height: windowHeight)
                         )
                     }
@@ -190,28 +185,33 @@ struct VariantsCommand: ParsableCommand {
                     // Wait for SwiftUI layout
                     try await Task.sleep(for: .milliseconds(500))
 
-                    let outURL = outputURL(in: outputDirURL, label: label)
+                    let outURL = outputURL(in: outputDirURL, label: variant.label)
                     try await MainActor.run {
                         guard let window = App.host.window(for: sessionID) else {
-                            throw VariantsCommandError.captureFailed(label: label)
+                            throw VariantsCommandError.captureFailed(label: variant.label)
                         }
                         try Snapshot.capture(
                             window: window, format: snapshotFormat, to: outURL)
                     }
                     print(outURL.path)
+                    successCount += 1
+                } catch {
+                    failCount += 1
+                    reportVariantFailure(
+                        index: index, label: variant.label, error: error)
                 }
-
-                await MainActor.run { NSApp.terminate(nil) }
-            } catch {
-                fputs("Error: \(error.localizedDescription)\n", stderr)
-                Darwin.exit(1)
             }
+
+            let exitCode = summarize(successCount: successCount, failCount: failCount)
+            await MainActor.run { NSApp.terminate(nil) }
+            // NSApp.terminate sends an event; explicit exit ensures the right code propagates.
+            Darwin.exit(exitCode)
         }
     }
 
     private func runIOSVariants(
         fileURL: URL,
-        resolved: [(traits: PreviewTraits, label: String)],
+        resolved: [PreviewTraits.Variant],
         outputDirURL: URL
     ) {
         let previewIndex = preview
@@ -220,6 +220,8 @@ struct VariantsCommand: ParsableCommand {
         let jpegQuality: Double = format == .png ? 1.0 : quality
 
         Task {
+            // Setup phase — any failure here is a hard exit (no variants can be captured).
+            let session: IOSPreviewSession
             do {
                 let compiler = try await Compiler(platform: .iOS)
                 let hostBuilder = try await IOSHostBuilder()
@@ -232,7 +234,7 @@ struct VariantsCommand: ParsableCommand {
                 let buildContext = try await detectAndBuild(
                     for: fileURL, projectRoot: projectRootURL, platform: .iOS)
 
-                let session = IOSPreviewSession(
+                session = IOSPreviewSession(
                     sourceFile: fileURL,
                     previewIndex: previewIndex,
                     deviceUDID: udid,
@@ -248,45 +250,52 @@ struct VariantsCommand: ParsableCommand {
                     "Capturing \(resolved.count) variant(s) on simulator \(udid)...\n", stderr)
                 _ = try await session.start()
                 try await Task.sleep(for: .seconds(2))
+            } catch {
+                fputs("Error: \(error.localizedDescription)\n", stderr)
+                Darwin.exit(2)
+            }
 
-                var first = true
-                for (traits, label) in resolved {
+            // Per-variant phase. Whatever happens, stop the session before exiting so we
+            // don't leak the simulator's preview app.
+            var successCount = 0
+            var failCount = 0
+            var first = true
+
+            for (index, variant) in resolved.enumerated() {
+                do {
                     if !first {
-                        try await session.setTraits(traits)
+                        try await session.setTraits(variant.traits)
                         try await Task.sleep(for: .seconds(1))
                     }
                     first = false
 
                     let imageData = try await session.screenshot(jpegQuality: jpegQuality)
-                    let outURL = outputURL(in: outputDirURL, label: label)
+                    let outURL = outputURL(in: outputDirURL, label: variant.label)
                     try imageData.write(to: outURL)
                     print(outURL.path)
+                    successCount += 1
+                } catch {
+                    failCount += 1
+                    reportVariantFailure(
+                        index: index, label: variant.label, error: error)
+                    // Reset `first` so the next iteration tries to apply its traits.
+                    first = false
                 }
-
-                await session.stop()
-                await MainActor.run { NSApp.terminate(nil) }
-            } catch {
-                fputs("Error: \(error.localizedDescription)\n", stderr)
-                Darwin.exit(1)
             }
+
+            await session.stop()
+            let exitCode = summarize(successCount: successCount, failCount: failCount)
+            await MainActor.run { NSApp.terminate(nil) }
+            Darwin.exit(exitCode)
         }
     }
 }
 
 enum VariantsCommandError: Error, LocalizedError {
-    case unknownPreset(String)
-    case emptyVariantObject
     case captureFailed(label: String)
 
     var errorDescription: String? {
         switch self {
-        case .unknownPreset(let name):
-            let presets = PreviewTraits.allPresetNames.sorted().joined(separator: ", ")
-            return
-                "Unknown variant '\(name)'. Expected a preset name (\(presets)) or a JSON object string."
-        case .emptyVariantObject:
-            return
-                "Variant object must specify at least one trait (colorScheme or dynamicTypeSize)."
         case .captureFailed(let label):
             return "Failed to capture variant '\(label)': no preview window found."
         }

--- a/Sources/PreviewsCore/PreviewTraits.swift
+++ b/Sources/PreviewsCore/PreviewTraits.swift
@@ -60,6 +60,73 @@ public struct PreviewTraits: Sendable, Equatable {
         validColorSchemes.union(validDynamicTypeSizes)
     }
 
+    /// A trait variant resolved from a user-supplied string (preset name or JSON object).
+    /// Used by both the MCP `preview_variants` tool and the CLI `variants` subcommand.
+    public struct Variant: Sendable, Equatable {
+        public let traits: PreviewTraits
+        public let label: String
+    }
+
+    /// Resolve a variant string to a `Variant` (traits + label).
+    ///
+    /// Accepts:
+    /// - A preset name from `allPresetNames` (light, dark, xSmall…accessibility5).
+    ///   The label defaults to the preset name.
+    /// - A JSON object string with `colorScheme` and/or `dynamicTypeSize` and an
+    ///   optional `label` field. The default label joins non-nil trait values with `+`.
+    ///
+    /// Validates that:
+    /// - At least one trait is set in JSON variants.
+    /// - Trait values are valid (via `PreviewTraits.validated`).
+    /// - The label is a valid filename component (no `/`, `\`, or leading `.`)
+    ///   so callers can safely use it for output paths.
+    public static func parseVariantString(_ str: String) throws -> Variant {
+        let traits: PreviewTraits
+        let label: String
+
+        if let presetTraits = fromPreset(str) {
+            traits = presetTraits
+            label = str
+        } else {
+            guard let data = str.data(using: .utf8),
+                let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else {
+                throw VariantError.unknownPreset(str)
+            }
+            let cs = json["colorScheme"] as? String
+            let dts = json["dynamicTypeSize"] as? String
+            traits = try validated(colorScheme: cs, dynamicTypeSize: dts)
+            if traits.isEmpty {
+                throw VariantError.emptyVariantObject
+            }
+            label = (json["label"] as? String) ?? Self.defaultLabel(traits)
+        }
+
+        try Self.validateLabel(label)
+        return Variant(traits: traits, label: label)
+    }
+
+    /// Filename-friendly default label derived from non-nil trait values, joined with `+`.
+    public static func defaultLabel(_ traits: PreviewTraits) -> String {
+        var parts: [String] = []
+        if let cs = traits.colorScheme { parts.append(cs) }
+        if let dts = traits.dynamicTypeSize { parts.append(dts) }
+        return parts.joined(separator: "+")
+    }
+
+    /// Reject labels that aren't safe to use as a filename component.
+    private static func validateLabel(_ label: String) throws {
+        if label.isEmpty {
+            throw VariantError.invalidLabel(label, reason: "label is empty")
+        }
+        if label.contains("/") || label.contains("\\") {
+            throw VariantError.invalidLabel(label, reason: "label cannot contain '/' or '\\\\'")
+        }
+        if label.hasPrefix(".") {
+            throw VariantError.invalidLabel(label, reason: "label cannot start with '.'")
+        }
+    }
+
     public enum ValidationError: Error, LocalizedError {
         case invalidColorScheme(String)
         case invalidDynamicTypeSize(String)
@@ -71,6 +138,26 @@ public struct PreviewTraits: Sendable, Equatable {
             case .invalidDynamicTypeSize(let dts):
                 return
                     "Invalid dynamic type size '\(dts)'. Valid values: \(PreviewTraits.validDynamicTypeSizes.sorted().joined(separator: ", "))"
+            }
+        }
+    }
+
+    public enum VariantError: Error, LocalizedError {
+        case unknownPreset(String)
+        case emptyVariantObject
+        case invalidLabel(String, reason: String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .unknownPreset(let name):
+                let presets = PreviewTraits.allPresetNames.sorted().joined(separator: ", ")
+                return
+                    "Unknown variant '\(name)'. Expected a preset name (\(presets)) or a JSON object string."
+            case .emptyVariantObject:
+                return
+                    "Variant object must specify at least one trait (colorScheme or dynamicTypeSize)."
+            case .invalidLabel(let label, let reason):
+                return "Invalid variant label '\(label)': \(reason)."
             }
         }
     }

--- a/Tests/CLIIntegrationTests/VariantsCommandTests.swift
+++ b/Tests/CLIIntegrationTests/VariantsCommandTests.swift
@@ -1,0 +1,210 @@
+import Foundation
+import Testing
+
+@Suite("CLI variants command", .serialized)
+struct VariantsCommandTests {
+
+    // MARK: - Happy paths
+
+    @Test("Captures multiple presets to distinct files", .timeLimit(.minutes(2)))
+    func capturesMultiplePresets() async throws {
+        let tempDir = try CLIRunner.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let file = CLIRunner.spmExampleRoot
+            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+
+        let result = try await CLIRunner.run(
+            "variants",
+            arguments: [
+                file,
+                "--variant", "light",
+                "--variant", "dark",
+                "-o", tempDir.path,
+                "--project", CLIRunner.spmExampleRoot.path,
+            ])
+
+        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+        #expect(
+            result.stderr.contains("Captured 2/2 variants"),
+            "Expected success summary in stderr: \(result.stderr)")
+
+        let lightPath = tempDir.appendingPathComponent("light.jpg").path
+        let darkPath = tempDir.appendingPathComponent("dark.jpg").path
+        try CLIRunner.assertValidJPEG(at: lightPath)
+        try CLIRunner.assertValidJPEG(at: darkPath)
+
+        // light and dark should produce visually different images
+        let lightData = try Data(contentsOf: URL(fileURLWithPath: lightPath))
+        let darkData = try Data(contentsOf: URL(fileURLWithPath: darkPath))
+        #expect(lightData != darkData, "light and dark variants should differ")
+    }
+
+    @Test("JSON variant uses custom label as filename", .timeLimit(.minutes(2)))
+    func jsonVariantUsesCustomLabel() async throws {
+        let tempDir = try CLIRunner.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let file = CLIRunner.spmExampleRoot
+            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+
+        let result = try await CLIRunner.run(
+            "variants",
+            arguments: [
+                file,
+                "--variant",
+                #"{"colorScheme":"dark","dynamicTypeSize":"large","label":"my-custom-label"}"#,
+                "-o", tempDir.path,
+                "--project", CLIRunner.spmExampleRoot.path,
+            ])
+
+        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+        let outPath = tempDir.appendingPathComponent("my-custom-label.jpg").path
+        try CLIRunner.assertValidJPEG(at: outPath)
+    }
+
+    @Test("PNG format produces valid PNG files", .timeLimit(.minutes(2)))
+    func pngFormat() async throws {
+        let tempDir = try CLIRunner.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let file = CLIRunner.spmExampleRoot
+            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+
+        let result = try await CLIRunner.run(
+            "variants",
+            arguments: [
+                file,
+                "--variant", "light",
+                "--format", "png",
+                "-o", tempDir.path,
+                "--project", CLIRunner.spmExampleRoot.path,
+            ])
+
+        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+        try CLIRunner.assertValidPNG(at: tempDir.appendingPathComponent("light.png").path)
+    }
+
+    // MARK: - Validation errors (exit 1)
+
+    @Test("Missing --variant returns non-zero exit")
+    func missingVariant() async throws {
+        let file = CLIRunner.spmExampleRoot
+            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+
+        let result = try await CLIRunner.run("variants", arguments: [file])
+
+        #expect(result.exitCode != 0, "Should fail without --variant")
+        #expect(
+            result.stderr.contains("At least one --variant is required"),
+            "stderr: \(result.stderr)")
+    }
+
+    @Test("Invalid preset name returns non-zero exit and lists valid presets")
+    func invalidPreset() async throws {
+        let file = CLIRunner.spmExampleRoot
+            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+
+        let result = try await CLIRunner.run(
+            "variants", arguments: [file, "--variant", "neon"])
+
+        #expect(result.exitCode != 0, "Should fail with invalid preset")
+        #expect(
+            result.stderr.contains("Unknown variant 'neon'"),
+            "stderr should name the bad variant: \(result.stderr)")
+        #expect(
+            result.stderr.contains("light"),
+            "stderr should list valid presets: \(result.stderr)")
+    }
+
+    @Test("Path traversal in label is rejected")
+    func pathTraversalLabelRejected() async throws {
+        let tempDir = try CLIRunner.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let file = CLIRunner.spmExampleRoot
+            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+
+        let result = try await CLIRunner.run(
+            "variants",
+            arguments: [
+                file,
+                "--variant", #"{"colorScheme":"dark","label":"../escape"}"#,
+                "-o", tempDir.path,
+            ])
+
+        #expect(result.exitCode != 0, "Should fail with path-traversal label")
+        #expect(
+            result.stderr.contains("Invalid variant label"),
+            "stderr should explain rejection: \(result.stderr)")
+    }
+
+    @Test("Leading-dot label is rejected")
+    func leadingDotLabelRejected() async throws {
+        let file = CLIRunner.spmExampleRoot
+            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+
+        let result = try await CLIRunner.run(
+            "variants",
+            arguments: [
+                file,
+                "--variant", #"{"colorScheme":"dark","label":".hidden"}"#,
+            ])
+
+        #expect(result.exitCode != 0, "Should reject hidden-file label")
+        #expect(
+            result.stderr.contains("cannot start with '.'"),
+            "stderr: \(result.stderr)")
+    }
+
+    @Test("Duplicate label is rejected with both indices")
+    func duplicateLabelRejected() async throws {
+        let tempDir = try CLIRunner.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let file = CLIRunner.spmExampleRoot
+            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+
+        let result = try await CLIRunner.run(
+            "variants",
+            arguments: [
+                file,
+                "--variant", "dark",
+                "--variant", #"{"colorScheme":"light","label":"dark"}"#,
+                "-o", tempDir.path,
+            ])
+
+        #expect(result.exitCode != 0, "Should reject duplicate label")
+        #expect(
+            result.stderr.contains("Duplicate variant label 'dark'"),
+            "stderr: \(result.stderr)")
+        #expect(
+            result.stderr.contains("indices 0 and 1"),
+            "stderr should name conflicting indices: \(result.stderr)")
+    }
+
+    @Test("Empty JSON variant object is rejected")
+    func emptyJsonVariantRejected() async throws {
+        let file = CLIRunner.spmExampleRoot
+            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+
+        let result = try await CLIRunner.run(
+            "variants",
+            arguments: [file, "--variant", "{}"])
+
+        #expect(result.exitCode != 0, "Should reject empty JSON variant")
+        #expect(
+            result.stderr.contains("at least one trait"),
+            "stderr: \(result.stderr)")
+    }
+
+    @Test("Nonexistent file returns non-zero exit")
+    func nonexistentFile() async throws {
+        let result = try await CLIRunner.run(
+            "variants",
+            arguments: ["/nonexistent/file.swift", "--variant", "light"])
+
+        #expect(result.exitCode != 0, "Should fail with nonexistent file")
+        #expect(result.stderr.contains("File not found"), "stderr: \(result.stderr)")
+    }
+}


### PR DESCRIPTION
## Summary

- **New feature:** `previewsmcp variants` CLI subcommand — captures multiple snapshots in one invocation under different trait configurations. Mirrors the MCP `preview_variants` tool. Accepts preset names (`light`, `dark`, `xSmall`…`accessibility5`) and JSON object strings with an optional `label` for the output filename. Supports both macOS and iOS.
- **Docs:** Add a Tools table to README listing all MCP tools (the new `preview_variants` and the rest were undocumented in the README before this).
- **Docs:** Add a "Capturing variants" subsection with preset and JSON examples for both the CLI and MCP tool.
- **Docs fix:** README's `--headless` documentation was wrong — it's a single `--headless` flag (not `--no-headless`), and the default is the visible Simulator.app window, not headless as previously claimed. Verified at \`Sources/PreviewsCLI/RunCommand.swift:40\` (\`var headless: Bool = false\`).
- **Tooling:** Add \`.claude/worktrees/\` to \`.gitignore\` — local worktree state shouldn't be tracked or shown as untracked.

## Test plan

- [x] \`swift build\` clean
- [x] \`swift test --filter PreviewsCoreTests\` — all 127 unit tests pass
- [x] \`swift-format lint --strict\` — clean
- [x] \`previewsmcp --help\` shows the new \`variants\` subcommand
- [x] \`previewsmcp variants <file> --variant light --variant dark\` writes \`light.jpg\` and \`dark.jpg\` with different content (verified by SHA)
- [x] JSON variant with custom label produces filename matching \`label\`
- [x] Error paths fail fast: missing variants, invalid preset, duplicate labels, empty JSON object
- [x] iOS path works end-to-end (boots simulator, captures both variants)
- [x] \`git status\` no longer shows \`.claude/worktrees/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)