### PR TITLE
Fix SPM dependency linking and Xcode multi-scheme selection

### DIFF
--- a/Sources/PreviewsCLI/BuildHelpers.swift
+++ b/Sources/PreviewsCLI/BuildHelpers.swift
@@ -10,11 +10,12 @@ func detectAndBuild(
     for fileURL: URL,
     projectRoot projectRootURL: URL?,
     platform: PreviewPlatform,
+    scheme: String? = nil,
     logPrefix: String = ""
 ) async throws -> BuildContext? {
     guard
         let buildSystem = try await BuildSystemDetector.detect(
-            for: fileURL, projectRoot: projectRootURL
+            for: fileURL, projectRoot: projectRootURL, scheme: scheme
         )
     else {
         return nil

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -136,6 +136,12 @@ func configureMCPServer() async throws -> (Server, Compiler) {
                                 "Project root path (auto-detected if omitted). Enables importing project types from SPM packages, Bazel swift_library targets, or Xcode projects (.xcodeproj / .xcworkspace)."
                             ),
                         ]),
+                        "scheme": .object([
+                            "type": .string("string"),
+                            "description": .string(
+                                "Xcode scheme name (only used for .xcodeproj / .xcworkspace projects). Required when the project contains more than one scheme and none of them match the source file's directory."
+                            ),
+                        ]),
                         "colorScheme": .object([
                             "type": .string("string"),
                             "enum": .array([.string("light"), .string("dark")]),
@@ -723,7 +729,14 @@ private func detectBuildContext(
     platform: PreviewPlatform
 ) async throws -> BuildContext? {
     let projectRootURL = extractOptionalString("projectPath", from: params).map { URL(fileURLWithPath: $0) }
-    return try await detectAndBuild(for: fileURL, projectRoot: projectRootURL, platform: platform, logPrefix: "MCP:")
+    let scheme = extractOptionalString("scheme", from: params)
+    return try await detectAndBuild(
+        for: fileURL,
+        projectRoot: projectRootURL,
+        platform: platform,
+        scheme: scheme,
+        logPrefix: "MCP:"
+    )
 }
 
 private func handleSimulatorList() async throws -> CallTool.Result {

--- a/Sources/PreviewsCLI/RunCommand.swift
+++ b/Sources/PreviewsCLI/RunCommand.swift
@@ -27,6 +27,12 @@ struct RunCommand: ParsableCommand {
     @Option(name: .long, help: "Project root path (auto-detected if omitted)")
     var project: String?
 
+    @Option(
+        name: .long,
+        help: "Xcode scheme name (only for .xcodeproj / .xcworkspace projects with multiple schemes)"
+    )
+    var scheme: String?
+
     @Option(name: .long, help: "Simulator device UDID (for ios; auto-selects if omitted)")
     var device: String?
 
@@ -64,13 +70,17 @@ struct RunCommand: ParsableCommand {
         let windowWidth = width
         let windowHeight = height
         let projectPath = project
+        let schemeName = scheme
         let traits = PreviewTraits(colorScheme: colorScheme, dynamicTypeSize: dynamicTypeSize)
 
         Task {
             do {
                 let projectRootURL = projectPath.map { URL(fileURLWithPath: $0) }
                 let buildContext = try await detectAndBuild(
-                    for: fileURL, projectRoot: projectRootURL, platform: .macOS)
+                    for: fileURL,
+                    projectRoot: projectRootURL,
+                    platform: .macOS,
+                    scheme: schemeName)
 
                 try await launchMacOSPreview(
                     fileURL: fileURL,
@@ -92,6 +102,7 @@ struct RunCommand: ParsableCommand {
         let previewIndex = preview
         let deviceUDID = device
         let projectPath = project
+        let schemeName = scheme
         let traits = PreviewTraits(colorScheme: colorScheme, dynamicTypeSize: dynamicTypeSize)
         let isHeadless = headless
 
@@ -99,7 +110,10 @@ struct RunCommand: ParsableCommand {
             do {
                 let projectRootURL = projectPath.map { URL(fileURLWithPath: $0) }
                 let buildContext = try await detectAndBuild(
-                    for: fileURL, projectRoot: projectRootURL, platform: .iOS)
+                    for: fileURL,
+                    projectRoot: projectRootURL,
+                    platform: .iOS,
+                    scheme: schemeName)
 
                 try await launchIOSPreview(
                     fileURL: fileURL,

--- a/Sources/PreviewsCLI/SnapshotCommand.swift
+++ b/Sources/PreviewsCLI/SnapshotCommand.swift
@@ -32,6 +32,12 @@ struct SnapshotCommand: ParsableCommand {
     @Option(name: .long, help: "Project root path (auto-detected if omitted)")
     var project: String?
 
+    @Option(
+        name: .long,
+        help: "Xcode scheme name (only for .xcodeproj / .xcworkspace projects with multiple schemes)"
+    )
+    var scheme: String?
+
     @Option(name: .long, help: "Simulator device UDID (for ios; auto-selects if omitted)")
     var device: String?
 
@@ -67,6 +73,7 @@ struct SnapshotCommand: ParsableCommand {
         let windowHeight = height
         let outputURL = URL(fileURLWithPath: output)
         let projectPath = project
+        let schemeName = scheme
         let traits = PreviewTraits(colorScheme: colorScheme, dynamicTypeSize: dynamicTypeSize)
 
         Task {
@@ -75,7 +82,11 @@ struct SnapshotCommand: ParsableCommand {
 
                 // Detect build system
                 let projectRootURL = projectPath.map { URL(fileURLWithPath: $0) }
-                let buildContext = try await detectAndBuild(for: fileURL, projectRoot: projectRootURL, platform: .macOS)
+                let buildContext = try await detectAndBuild(
+                    for: fileURL,
+                    projectRoot: projectRootURL,
+                    platform: .macOS,
+                    scheme: schemeName)
 
                 let session = PreviewSession(
                     sourceFile: fileURL,
@@ -134,6 +145,7 @@ struct SnapshotCommand: ParsableCommand {
         let outputURL = URL(fileURLWithPath: output)
         let deviceUDID = device
         let projectPath = project
+        let schemeName = scheme
         let traits = PreviewTraits(colorScheme: colorScheme, dynamicTypeSize: dynamicTypeSize)
 
         Task {
@@ -148,7 +160,10 @@ struct SnapshotCommand: ParsableCommand {
                 // Detect build system
                 let projectRootURL = projectPath.map { URL(fileURLWithPath: $0) }
                 let buildContext = try await detectAndBuild(
-                    for: fileURL, projectRoot: projectRootURL, platform: .iOS)
+                    for: fileURL,
+                    projectRoot: projectRootURL,
+                    platform: .iOS,
+                    scheme: schemeName)
 
                 let session = IOSPreviewSession(
                     sourceFile: fileURL,

--- a/Sources/PreviewsCore/BuildSystem.swift
+++ b/Sources/PreviewsCore/BuildSystem.swift
@@ -20,7 +20,13 @@ public enum BuildSystemDetector {
     /// - Parameters:
     ///   - sourceFile: The Swift source file to detect the build system for.
     ///   - projectRoot: If provided, use this as the project root instead of auto-detecting.
-    public static func detect(for sourceFile: URL, projectRoot: URL? = nil) async throws -> (any BuildSystem)? {
+    ///   - scheme: Optional Xcode scheme name. Only used when the detected build
+    ///     system is `XcodeBuildSystem`; ignored for SPM and Bazel.
+    public static func detect(
+        for sourceFile: URL,
+        projectRoot: URL? = nil,
+        scheme: String? = nil
+    ) async throws -> (any BuildSystem)? {
         // If an explicit project root is provided, detect which build system applies there
         if let projectRoot = projectRoot {
             let fm = FileManager.default
@@ -43,7 +49,10 @@ public enum BuildSystemDetector {
             // Xcode: enumerate directory for *.xcworkspace / *.xcodeproj (name varies)
             if let projectFile = XcodeBuildSystem.findXcodeProject(in: projectRoot) {
                 return XcodeBuildSystem(
-                    projectRoot: projectRoot, sourceFile: sourceFile, projectFile: projectFile)
+                    projectRoot: projectRoot,
+                    sourceFile: sourceFile,
+                    projectFile: projectFile,
+                    requestedScheme: scheme)
             }
             return nil
         }
@@ -56,7 +65,7 @@ public enum BuildSystemDetector {
             return bazel
         }
         // Xcode (.xcworkspace / .xcodeproj)
-        if let xcode = try await XcodeBuildSystem.detect(for: sourceFile) {
+        if let xcode = try await XcodeBuildSystem.detect(for: sourceFile, scheme: scheme) {
             return xcode
         }
         return nil
@@ -69,6 +78,7 @@ public enum BuildSystemError: Error, LocalizedError {
     case targetNotFound(sourceFile: String, project: String)
     case missingArtifacts(String)
     case ambiguousTarget(sourceFile: String, candidates: [String])
+    case unknownScheme(requested: String, candidates: [String])
 
     public var errorDescription: String? {
         switch self {
@@ -80,7 +90,10 @@ public enum BuildSystemError: Error, LocalizedError {
             return "Build artifacts not found: \(msg)"
         case .ambiguousTarget(let file, let candidates):
             return
-                "Multiple schemes found for \(file). Use projectRoot to disambiguate. Available schemes: \(candidates.joined(separator: ", "))"
+                "Multiple schemes found for \(file) and none matched the source file's directory. Pass the `scheme` parameter to pick one. Available schemes: \(candidates.joined(separator: ", "))"
+        case .unknownScheme(let requested, let candidates):
+            return
+                "Scheme '\(requested)' not found in project. Available schemes: \(candidates.joined(separator: ", "))"
         }
     }
 }

--- a/Sources/PreviewsCore/SPMBuildSystem.swift
+++ b/Sources/PreviewsCore/SPMBuildSystem.swift
@@ -61,10 +61,30 @@ public actor SPMBuildSystem: BuildSystem {
             )
         }
 
-        // 6. Build compiler flags
+        // 6. Archive dependency targets into libDep.a files.
+        //    SPM leaves library targets as loose .o files under <Dep>.build/ instead
+        //    of creating .a archives, and .swiftmodule files don't carry autolink
+        //    hints (no -module-link-name), so we have to make the archives ourselves
+        //    and pass -l<Dep> explicitly below.
+        let dependencyLibs = try await archiveDependencyTargets(
+            binPath: binPath,
+            consumerTargetName: targetName
+        )
+
+        // 7. Build compiler flags
+        //    -I <Modules>   resolves dependency .swiftmodule files at compile time
+        //    -L <binPath>   library search path for the archives created above
+        //    -l<Dep>        per-dependency archive (lazy archive linking means only
+        //                   object files actually referenced get pulled in)
         var flags: [String] = [
             "-I", modulesDir.path,
         ]
+        if !dependencyLibs.isEmpty {
+            flags += ["-L", binPath.path]
+            for dep in dependencyLibs {
+                flags += ["-l\(dep)"]
+            }
+        }
 
         // Add C module include paths for targets with C shims
         let targetBuildDir = binPath.appendingPathComponent("\(targetName).build")
@@ -73,7 +93,7 @@ public actor SPMBuildSystem: BuildSystem {
             flags += ["-I", includeDir.path]
         }
 
-        // 7. Collect Tier 2 data: other source files in the target
+        // 8. Collect Tier 2 data: other source files in the target
         let otherSourceFiles = try collectSourceFiles(
             targetName: targetName,
             in: description
@@ -155,6 +175,104 @@ public actor SPMBuildSystem: BuildSystem {
             "/usr/bin/env", args: args, workingDirectory: projectRoot
         )
         return URL(fileURLWithPath: output)
+    }
+
+    // MARK: - Private: Dependency Archives
+
+    /// Archive every non-consumer target's `.o` files into `<binPath>/lib<Target>.a`
+    /// and return the list of target names (for use with `-l<Target>`).
+    ///
+    /// SPM's `swift build` produces loose object files under `<binPath>/<Target>.build/`
+    /// for each library target without creating a static archive, and doesn't emit
+    /// autolink hints for them either. So the bridge compile can't discover or link
+    /// dependency symbols on its own — we have to stage the archives ourselves.
+    ///
+    /// Consumer target `.build/` is skipped because Tier 2 already recompiles its
+    /// sources directly. All other sibling targets (and transitively-built external
+    /// packages, which land in the same bin path) are archived.
+    private func archiveDependencyTargets(
+        binPath: URL,
+        consumerTargetName: String
+    ) async throws -> [String] {
+        let fm = FileManager.default
+        guard
+            let entries = try? fm.contentsOfDirectory(
+                at: binPath,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+        else {
+            return []
+        }
+
+        let arPath = try await Self.resolvedArPath()
+        var libs: [String] = []
+
+        for entry in entries {
+            // We want `<binPath>/<Target>.build/` directories.
+            let name = entry.lastPathComponent
+            guard name.hasSuffix(".build") else { continue }
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: entry.path, isDirectory: &isDir), isDir.boolValue else {
+                continue
+            }
+
+            let targetName = String(name.dropLast(".build".count))
+            // Skip the consumer target — Tier 2 compiles its sources directly, and
+            // archiving them here would cause duplicate-symbol errors at link time.
+            if targetName == consumerTargetName { continue }
+            // Skip SPM's own plugin/support bundles if any.
+            if targetName.hasPrefix("_") { continue }
+
+            // Collect .o files produced for this target.
+            let objectFiles = collectObjectFiles(in: entry)
+            guard !objectFiles.isEmpty else { continue }
+
+            let archivePath = binPath.appendingPathComponent("lib\(targetName).a")
+            // `ar rcs` replaces any existing archive, so rebuilds stay consistent.
+            try? fm.removeItem(at: archivePath)
+
+            var arArgs = ["rcs", archivePath.path]
+            arArgs.append(contentsOf: objectFiles.map(\.path))
+            let result = try await runAsync(arPath, arguments: arArgs)
+            guard result.exitCode == 0 else {
+                throw BuildSystemError.buildFailed(
+                    stderr: "ar failed for \(targetName): \(result.stderr)",
+                    exitCode: result.exitCode
+                )
+            }
+            libs.append(targetName)
+        }
+
+        return libs
+    }
+
+    /// Recursively collect `.o` files under a target's build directory, including
+    /// files named `Foo.swift.o` that swift build emits for Swift sources.
+    private func collectObjectFiles(in directory: URL) -> [URL] {
+        guard
+            let enumerator = FileManager.default.enumerator(
+                at: directory,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )
+        else {
+            return []
+        }
+        var files: [URL] = []
+        for case let url as URL in enumerator where url.pathExtension == "o" {
+            files.append(url)
+        }
+        return files
+    }
+
+    private static func resolvedArPath() async throws -> String {
+        let output = try await runAsync(
+            "/usr/bin/xcrun", arguments: ["--find", "ar"], discardStderr: true)
+        guard output.exitCode == 0 else {
+            throw BuildSystemError.missingArtifacts("Could not locate `ar` via xcrun")
+        }
+        return output.stdout
     }
 
     // MARK: - Private: Source Files (Tier 2)

--- a/Sources/PreviewsCore/XcodeBuildSystem.swift
+++ b/Sources/PreviewsCore/XcodeBuildSystem.swift
@@ -5,21 +5,35 @@ public actor XcodeBuildSystem: BuildSystem {
     public nonisolated let projectRoot: URL
     private let sourceFile: URL
     private let projectFile: URL
+    private let requestedScheme: String?
 
     /// The xcodebuild flag for referencing the project or workspace.
     private var xcodebuildFlag: String {
         projectFile.pathExtension == "xcworkspace" ? "-workspace" : "-project"
     }
 
-    public init(projectRoot: URL, sourceFile: URL, projectFile: URL) {
+    public init(
+        projectRoot: URL,
+        sourceFile: URL,
+        projectFile: URL,
+        requestedScheme: String? = nil
+    ) {
         self.projectRoot = projectRoot
         self.sourceFile = sourceFile.standardizedFileURL
         self.projectFile = projectFile
+        self.requestedScheme = requestedScheme
     }
 
     // MARK: - Detection
 
     public static func detect(for sourceFile: URL) async throws -> XcodeBuildSystem? {
+        try await detect(for: sourceFile, scheme: nil)
+    }
+
+    public static func detect(
+        for sourceFile: URL,
+        scheme: String?
+    ) async throws -> XcodeBuildSystem? {
         var dir = sourceFile.deletingLastPathComponent().standardizedFileURL
         let root = URL(fileURLWithPath: "/")
 
@@ -27,8 +41,10 @@ public actor XcodeBuildSystem: BuildSystem {
             if let projectFile = findXcodeProject(in: dir) {
                 guard await isXcodebuildAvailable() else { return nil }
                 return XcodeBuildSystem(
-                    projectRoot: dir, sourceFile: sourceFile.standardizedFileURL,
-                    projectFile: projectFile)
+                    projectRoot: dir,
+                    sourceFile: sourceFile.standardizedFileURL,
+                    projectFile: projectFile,
+                    requestedScheme: scheme)
             }
             dir = dir.deletingLastPathComponent()
         }
@@ -134,14 +150,29 @@ public actor XcodeBuildSystem: BuildSystem {
                 sourceFile: sourceFile.lastPathComponent,
                 project: projectFile.lastPathComponent)
         }
+
+        // 1. Explicit scheme from caller wins, if it's actually in the list.
+        if let requested = requestedScheme {
+            if schemes.contains(requested) {
+                return requested
+            }
+            throw BuildSystemError.unknownScheme(
+                requested: requested,
+                candidates: schemes)
+        }
+
+        // 2. Exactly one scheme: unambiguous.
         if schemes.count == 1 { return schemes[0] }
 
-        // Try to match a scheme name to a directory component in the source file path
+        // 3. Multiple schemes: try to match the target directory containing the
+        //    source file. This is a heuristic and only fires when a scheme name
+        //    appears as a directory component on the source file path.
         let pathComponents = Set(sourceFile.pathComponents)
         if let match = schemes.first(where: { pathComponents.contains($0) }) {
             return match
         }
 
+        // 4. Give up and ask the caller to disambiguate.
         throw BuildSystemError.ambiguousTarget(
             sourceFile: sourceFile.lastPathComponent,
             candidates: schemes)

--- a/Tests/PreviewsCoreTests/BuildSystemTests.swift
+++ b/Tests/PreviewsCoreTests/BuildSystemTests.swift
@@ -531,6 +531,104 @@ struct BuildSystemTests {
         }
     }
 
+    @Test("XcodeBuildSystem ambiguousTarget error lists candidates and mentions scheme param")
+    func ambiguousTargetErrorMessage() async throws {
+        let xcode = XcodeBuildSystem(
+            projectRoot: URL(fileURLWithPath: "/tmp"),
+            sourceFile: URL(fileURLWithPath: "/tmp/Sources/Unknown/View.swift"),
+            projectFile: URL(fileURLWithPath: "/tmp/App.xcodeproj"))
+
+        let info = XcodeBuildSystem.ProjectInfo(schemes: ["Alpha", "Beta", "Gamma"])
+        do {
+            _ = try await xcode.pickScheme(from: info)
+            Issue.record("expected pickScheme to throw")
+        } catch let error as BuildSystemError {
+            let message = error.errorDescription ?? ""
+            #expect(message.contains("scheme"), "error should mention the scheme parameter")
+            #expect(message.contains("Alpha"))
+            #expect(message.contains("Beta"))
+            #expect(message.contains("Gamma"))
+        }
+    }
+
+    @Test("XcodeBuildSystem uses requestedScheme when it exists in the list")
+    func pickSchemeHonorsRequested() async throws {
+        let xcode = XcodeBuildSystem(
+            projectRoot: URL(fileURLWithPath: "/tmp"),
+            sourceFile: URL(fileURLWithPath: "/tmp/Sources/Alpha/View.swift"),
+            projectFile: URL(fileURLWithPath: "/tmp/App.xcodeproj"),
+            requestedScheme: "Beta")
+
+        // Path-component heuristic would pick Alpha, but explicit request wins.
+        let info = XcodeBuildSystem.ProjectInfo(schemes: ["Alpha", "Beta", "Gamma"])
+        let scheme = try await xcode.pickScheme(from: info)
+        #expect(scheme == "Beta")
+    }
+
+    @Test("XcodeBuildSystem throws unknownScheme when requestedScheme is not in the list")
+    func pickSchemeRejectsUnknownRequested() async throws {
+        let xcode = XcodeBuildSystem(
+            projectRoot: URL(fileURLWithPath: "/tmp"),
+            sourceFile: URL(fileURLWithPath: "/tmp/Sources/Alpha/View.swift"),
+            projectFile: URL(fileURLWithPath: "/tmp/App.xcodeproj"),
+            requestedScheme: "DoesNotExist")
+
+        let info = XcodeBuildSystem.ProjectInfo(schemes: ["Alpha", "Beta"])
+        do {
+            _ = try await xcode.pickScheme(from: info)
+            Issue.record("expected pickScheme to throw")
+        } catch let error as BuildSystemError {
+            let message = error.errorDescription ?? ""
+            #expect(message.contains("DoesNotExist"), "error should name the requested scheme")
+            #expect(message.contains("Alpha"))
+            #expect(message.contains("Beta"))
+        }
+    }
+
+    @Test("XcodeBuildSystem requestedScheme wins over single-scheme fast path")
+    func pickSchemeRequestedWinsOverSingle() async throws {
+        // Even when there's only one scheme, an explicit (mismatched) request
+        // should surface a clear error rather than silently using the only one.
+        let xcode = XcodeBuildSystem(
+            projectRoot: URL(fileURLWithPath: "/tmp"),
+            sourceFile: URL(fileURLWithPath: "/tmp/Sources/Alpha/View.swift"),
+            projectFile: URL(fileURLWithPath: "/tmp/App.xcodeproj"),
+            requestedScheme: "WrongName")
+
+        let info = XcodeBuildSystem.ProjectInfo(schemes: ["OnlyScheme"])
+        await #expect(throws: BuildSystemError.self) {
+            try await xcode.pickScheme(from: info)
+        }
+    }
+
+    @Test("BuildSystemDetector threads scheme into XcodeBuildSystem for explicit projectRoot")
+    func detectorPassesSchemeToXcode() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+
+        let xcodeproj = tmpDir.appendingPathComponent("MyApp.xcodeproj")
+        try FileManager.default.createDirectory(at: xcodeproj, withIntermediateDirectories: true)
+
+        let sourceFile = tmpDir.appendingPathComponent("main.swift")
+        try "import SwiftUI".write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        // Without a scheme, the detector should still return an XcodeBuildSystem.
+        let unbranded = try await BuildSystemDetector.detect(
+            for: sourceFile, projectRoot: tmpDir)
+        #expect(unbranded is XcodeBuildSystem)
+
+        // With a scheme, pickScheme should honor it instead of the heuristic.
+        let branded = try await BuildSystemDetector.detect(
+            for: sourceFile, projectRoot: tmpDir, scheme: "Beta")
+        let xcode = try #require(branded as? XcodeBuildSystem)
+        let info = XcodeBuildSystem.ProjectInfo(schemes: ["Alpha", "Beta"])
+        let picked = try await xcode.pickScheme(from: info)
+        #expect(picked == "Beta")
+    }
+
     // MARK: - XcodeBuildSystem build settings parsing
 
     @Test("XcodeBuildSystem parses build settings output")

--- a/Tests/PreviewsCoreTests/PreviewSessionBuildContextTests.swift
+++ b/Tests/PreviewsCoreTests/PreviewSessionBuildContextTests.swift
@@ -48,6 +48,33 @@ struct PreviewSessionBuildContextTests {
 
     // MARK: - Tests
 
+    @Test("SPM build context surfaces dependency libs for sibling and cross-package targets (#69)")
+    func spmLinksDependencyTargets() async throws {
+        let ctx = try await Self.buildSPMExample()
+
+        let flags = ctx.compilerFlags
+        #expect(
+            flags.contains("-L"),
+            "SPMBuildSystem should add -L <binPath> after swift build"
+        )
+        // Sibling target inside the same Package.swift
+        #expect(
+            flags.contains("-lToDoExtras"),
+            "SPMBuildSystem should archive and link sibling target deps; flags were: \(flags)"
+        )
+        // Cross-package dependency resolved via .package(path: "LocalDep")
+        #expect(
+            flags.contains("-lLocalDep"),
+            "SPMBuildSystem should archive and link cross-package path deps; flags were: \(flags)"
+        )
+        // The consumer target itself must not be linked as -lToDo; Tier 2 compiles
+        // those sources directly and a second copy would cause duplicate-symbol errors.
+        #expect(
+            !flags.contains("-lToDo"),
+            "Consumer target should not be linked as a library"
+        )
+    }
+
     @Test("Tier 2 compile: dylib + populated literals + DesignTimeStore symbols")
     func tier2Compile() async throws {
         let ctx = try await Self.buildSPMExample()

--- a/examples/spm/LocalDep/Package.swift
+++ b/examples/spm/LocalDep/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "LocalDep",
+    platforms: [.macOS(.v14), .iOS(.v17)],
+    products: [
+        .library(name: "LocalDep", targets: ["LocalDep"])
+    ],
+    targets: [
+        .target(name: "LocalDep", path: "Sources/LocalDep")
+    ]
+)

--- a/examples/spm/LocalDep/Sources/LocalDep/Badge.swift
+++ b/examples/spm/LocalDep/Sources/LocalDep/Badge.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// A small SwiftUI component in a separate local package.
+/// Used to verify that SPMBuildSystem correctly links cross-package
+/// dependencies resolved via `.package(path:)`.
+public struct Badge: View {
+    let text: String
+    let color: Color
+
+    public init(_ text: String, color: Color = .blue) {
+        self.text = text
+        self.color = color
+    }
+
+    public var body: some View {
+        Text(text)
+            .font(.caption2)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.15))
+            .foregroundStyle(color)
+            .clipShape(Capsule())
+    }
+}

--- a/examples/spm/Package.swift
+++ b/examples/spm/Package.swift
@@ -4,10 +4,22 @@ import PackageDescription
 let package = Package(
     name: "ToDo",
     platforms: [.macOS(.v14), .iOS(.v17)],
+    products: [
+        .library(name: "ToDo", targets: ["ToDo"]),
+        .library(name: "ToDoExtras", targets: ["ToDoExtras"]),
+    ],
+    dependencies: [
+        .package(path: "LocalDep")
+    ],
     targets: [
         .target(
+            name: "ToDoExtras",
+            path: "Sources/ToDoExtras"
+        ),
+        .target(
             name: "ToDo",
+            dependencies: ["ToDoExtras", .product(name: "LocalDep", package: "LocalDep")],
             path: "Sources/ToDo"
-        )
+        ),
     ]
 )

--- a/examples/spm/Sources/ToDo/BadgePreview.swift
+++ b/examples/spm/Sources/ToDo/BadgePreview.swift
@@ -1,0 +1,14 @@
+import LocalDep
+import SwiftUI
+
+/// Preview that references the cross-package `Badge` component from `LocalDep`.
+/// This exercises the `.package(path:)` dependency resolution path in
+/// SPMBuildSystem — the same code path external third-party packages use.
+#Preview("Badges from LocalDep") {
+    VStack(spacing: 12) {
+        Badge("In Progress", color: .orange)
+        Badge("Done", color: .green)
+        Badge("Blocked", color: .red)
+    }
+    .padding()
+}

--- a/examples/spm/Sources/ToDo/Summary.swift
+++ b/examples/spm/Sources/ToDo/Summary.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+import ToDoExtras
+
+/// A view that imports a sibling target (`ToDoExtras`). Its presence in the
+/// ToDo target means compiling any Tier 2 dylib for this package requires
+/// linking `libToDoExtras.a`, which in turn requires SPMBuildSystem to add
+/// `-L <binPath>` to the compiler flags.
+struct Summary: View {
+    let items: [Item]
+
+    var body: some View {
+        let completed = items.filter(\.isComplete).count
+        Text(ProgressFormatter.summary(completed: completed, total: items.count))
+            .font(.headline)
+    }
+}
+
+#Preview("Summary") {
+    Summary(items: Item.samples)
+}

--- a/examples/spm/Sources/ToDoExtras/Formatter.swift
+++ b/examples/spm/Sources/ToDoExtras/Formatter.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// A small helper living in a sibling target. The fact that `ToDo` imports this
+/// module exercises SPMBuildSystem's dependency linking — without the `-L <binPath>`
+/// flag, compiling any file that `import`s `ToDoExtras` will fail at link time.
+public enum ProgressFormatter {
+    public static func summary(completed: Int, total: Int) -> String {
+        guard total > 0 else { return "No items" }
+        let percent = Int(Double(completed) / Double(total) * 100)
+        return "\(completed)/\(total) (\(percent)%)"
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #69 and #70.

- **SPM dependency linking (#69):** After `swift build`, SPMBuildSystem now archives each dependency target's `.o` files into `lib<Dep>.a` and passes `-L <binPath> -l<Dep>` to the bridge compilation. SPM doesn't create static archives or emit autolink hints for library targets, so the build system stages them explicitly. Covers both sibling targets within the same `Package.swift` and cross-package dependencies resolved via `.package(path:)` or `.package(url:)`.

- **Xcode multi-scheme selection (#70):** Adds an optional `scheme` parameter to `preview_start` (MCP), `--scheme` (CLI run/snapshot), and `BuildSystemDetector.detect()`. When set, `pickScheme()` validates it against the project's scheme list and returns it (overriding heuristics). When unset, existing behavior is preserved (single-scheme auto-pick, path-component matching). The ambiguous-target error now names the `scheme` parameter and lists candidates. Also adds `BuildSystemError.unknownScheme` for when an explicit scheme isn't found.

## Test plan

- [x] `PreviewSessionBuildContextTests.spmLinksDependencyTargets` — verifies `-L`, `-lToDoExtras` (sibling target), and `-lLocalDep` (cross-package) are in compiler flags, and `-lToDo` (consumer) is excluded
- [x] `PreviewSessionBuildContextTests.tier2Compile` — end-to-end Tier 2 dylib compilation succeeds with `import ToDoExtras` and `import LocalDep` in the source tree
- [x] `BuildSystemTests.pickSchemeHonorsRequested` — explicit scheme overrides path-component heuristic
- [x] `BuildSystemTests.pickSchemeRejectsUnknownRequested` — unknown scheme surfaces clear error with candidates
- [x] `BuildSystemTests.pickSchemeRequestedWinsOverSingle` — explicit mismatch throws even with one scheme
- [x] `BuildSystemTests.ambiguousTargetErrorMessage` — error text mentions `scheme` parameter
- [x] `BuildSystemTests.detectorPassesSchemeToXcode` — scheme threads through BuildSystemDetector to XcodeBuildSystem
- [x] All 50 targeted tests pass locally (BuildSystem + PreviewSessionBuildContextTests suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)