### PR TITLE
Support binary XCFramework dependencies in SPM build system

### DIFF
--- a/Sources/PreviewsCore/SPMBuildSystem.swift
+++ b/Sources/PreviewsCore/SPMBuildSystem.swift
@@ -71,11 +71,20 @@ public actor SPMBuildSystem: BuildSystem {
             consumerTargetName: targetName
         )
 
+        // 6b. Discover binary XCFramework dependencies.
+        //     SPM copies pre-built .framework bundles (from binaryTarget / XCFramework
+        //     dependencies) directly into binPath. These aren't covered by the
+        //     .build/-directory scan above — they need -F (framework search path)
+        //     and -framework flags instead of -L/-l.
+        let frameworkNames = collectFrameworks(binPath: binPath)
+
         // 7. Build compiler flags
         //    -I <Modules>   resolves dependency .swiftmodule files at compile time
         //    -L <binPath>   library search path for the archives created above
         //    -l<Dep>        per-dependency archive (lazy archive linking means only
         //                   object files actually referenced get pulled in)
+        //    -F <binPath>   framework search path for binary XCFramework deps
+        //    -framework X   link against a binary framework
         var flags: [String] = [
             "-I", modulesDir.path,
         ]
@@ -84,6 +93,16 @@ public actor SPMBuildSystem: BuildSystem {
             for dep in dependencyLibs {
                 flags += ["-l\(dep)"]
             }
+        }
+        if !frameworkNames.isEmpty {
+            flags += ["-F", binPath.path]
+            for fw in frameworkNames {
+                flags += ["-framework", fw]
+            }
+            // Embed the framework search path as an rpath so dlopen can
+            // find the framework at runtime (the dylib references it via
+            // @rpath/Foo.framework/...).
+            flags += ["-Xlinker", "-rpath", "-Xlinker", binPath.path]
         }
 
         // Add C module include paths for targets with C shims
@@ -245,6 +264,34 @@ public actor SPMBuildSystem: BuildSystem {
         }
 
         return libs
+    }
+
+    /// Collect `.framework` bundles in binPath (binary XCFramework dependencies).
+    /// Returns the framework names (e.g. ["Lottie"]) for use with `-framework`.
+    private func collectFrameworks(binPath: URL) -> [String] {
+        let fm = FileManager.default
+        guard
+            let entries = try? fm.contentsOfDirectory(
+                at: binPath,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+        else {
+            return []
+        }
+
+        var frameworks: [String] = []
+        for entry in entries {
+            let name = entry.lastPathComponent
+            guard name.hasSuffix(".framework") else { continue }
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: entry.path, isDirectory: &isDir), isDir.boolValue else {
+                continue
+            }
+            let frameworkName = String(name.dropLast(".framework".count))
+            frameworks.append(frameworkName)
+        }
+        return frameworks
     }
 
     /// Recursively collect `.o` files under a target's build directory, including

--- a/Tests/PreviewsCoreTests/PreviewSessionBuildContextTests.swift
+++ b/Tests/PreviewsCoreTests/PreviewSessionBuildContextTests.swift
@@ -73,6 +73,20 @@ struct PreviewSessionBuildContextTests {
             !flags.contains("-lToDo"),
             "Consumer target should not be linked as a library"
         )
+        // Binary XCFramework dependency (lottie-spm) — SPM copies .framework bundles
+        // into binPath instead of producing .build/ directories with loose .o files.
+        #expect(
+            flags.contains("-F"),
+            "SPMBuildSystem should add -F <binPath> for binary framework deps; flags were: \(flags)"
+        )
+        #expect(
+            flags.contains("-framework"),
+            "SPMBuildSystem should add -framework flags for binary deps; flags were: \(flags)"
+        )
+        #expect(
+            flags.contains("-rpath"),
+            "SPMBuildSystem should add -rpath for framework dlopen; flags were: \(flags)"
+        )
     }
 
     @Test("Tier 2 compile: dylib + populated literals + DesignTimeStore symbols")

--- a/Tests/PreviewsCoreTests/PreviewSessionBuildContextTests.swift
+++ b/Tests/PreviewsCoreTests/PreviewSessionBuildContextTests.swift
@@ -83,6 +83,13 @@ struct PreviewSessionBuildContextTests {
             flags.contains("-framework"),
             "SPMBuildSystem should add -framework flags for binary deps; flags were: \(flags)"
         )
+        // Verify the actual framework name is emitted, not just the flag.
+        if let idx = flags.firstIndex(of: "-framework") {
+            #expect(
+                idx + 1 < flags.count && flags[idx + 1] == "Lottie",
+                "Expected -framework Lottie; flags were: \(flags)"
+            )
+        }
         #expect(
             flags.contains("-rpath"),
             "SPMBuildSystem should add -rpath for framework dlopen; flags were: \(flags)"

--- a/examples/spm/Package.swift
+++ b/examples/spm/Package.swift
@@ -9,7 +9,8 @@ let package = Package(
         .library(name: "ToDoExtras", targets: ["ToDoExtras"]),
     ],
     dependencies: [
-        .package(path: "LocalDep")
+        .package(path: "LocalDep"),
+        .package(url: "https://github.com/airbnb/lottie-spm.git", from: "4.4.0"),
     ],
     targets: [
         .target(
@@ -18,7 +19,11 @@ let package = Package(
         ),
         .target(
             name: "ToDo",
-            dependencies: ["ToDoExtras", .product(name: "LocalDep", package: "LocalDep")],
+            dependencies: [
+                "ToDoExtras",
+                .product(name: "LocalDep", package: "LocalDep"),
+                .product(name: "Lottie", package: "lottie-spm"),
+            ],
             path: "Sources/ToDo"
         ),
     ]

--- a/examples/spm/Sources/ToDo/Item.swift
+++ b/examples/spm/Sources/ToDo/Item.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Lottie
 
 /// A simple model defined in a separate file from the views.
 /// Previews that reference this type require build system integration.

--- a/examples/spm/Sources/ToDo/Item.swift
+++ b/examples/spm/Sources/ToDo/Item.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Lottie
 
 /// A simple model defined in a separate file from the views.
 /// Previews that reference this type require build system integration.

--- a/examples/spm/Sources/ToDo/ToDoView.swift
+++ b/examples/spm/Sources/ToDo/ToDoView.swift
@@ -1,3 +1,4 @@
+import Lottie
 import SwiftUI
 
 /// A view that references `Item` from Item.swift.
@@ -60,6 +61,12 @@ struct ToDoView: View {
                 }
             }
             .navigationTitle("My Items")
+            .overlay {
+                if items.isEmpty {
+                    LottieView(animation: nil)
+                        .frame(width: 100, height: 100)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- SPM copies pre-built `.framework` bundles (from `binaryTarget` / XCFramework deps like `lottie-spm`) directly into `binPath` rather than producing `.build/` directories with loose `.o` files
- The Tier 2 bridge compilation was missing these entirely — no `-F` search path, no `-framework` flags, and no `-rpath` for `dlopen`
- Add `collectFrameworks()` to scan `binPath` for `.framework` bundles and emit the correct compiler/linker flags

Closes #69 (partial — the original fix handled source-compiled deps but missed binary targets)

## What changed
- **`SPMBuildSystem.swift`**: New `collectFrameworks(binPath:)` method scans for `.framework` bundles. Flags added: `-F <binPath>`, `-framework <Name>`, `-Xlinker -rpath -Xlinker <binPath>`
- **`examples/spm`**: Added `lottie-spm` (binary XCFramework) as a dependency with `import Lottie` and `LottieView` usage in the preview
- **`PreviewSessionBuildContextTests`**: Added assertions for `-F`, `-framework`, and `-rpath` flags

## Test plan
- [x] `swift test --filter PreviewSessionBuildContext` — all 5 tests pass (includes Tier 2 compile with Lottie XCFramework)
- [x] `swift run previewsmcp snapshot examples/spm/Sources/ToDo/ToDoView.swift` — renders correctly with Lottie binary dep
- [x] Existing sibling target and path dependency linking still works (`-lToDoExtras`, `-lLocalDep`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)