### PR TITLE
Fix race condition in dependency archive creation

### DIFF
--- a/Sources/PreviewsCore/SPMBuildSystem.swift
+++ b/Sources/PreviewsCore/SPMBuildSystem.swift
@@ -228,11 +228,12 @@ public actor SPMBuildSystem: BuildSystem {
             let objectFiles = collectObjectFiles(in: entry)
             guard !objectFiles.isEmpty else { continue }
 
-            // Write to a temp file and atomically rename to avoid a race where a
-            // concurrent compile reads the archive between delete and recreate.
+            // Write to a unique temp file and atomically swap into place so a
+            // concurrent linker never sees the archive as missing. UUID avoids
+            // collisions between parallel archiveDependencyTargets callers.
             let archivePath = binPath.appendingPathComponent("lib\(targetName).a")
-            let tmpArchivePath = binPath.appendingPathComponent("lib\(targetName).a.tmp")
-            try? fm.removeItem(at: tmpArchivePath)
+            let tmpArchivePath = binPath.appendingPathComponent(
+                "lib\(targetName).a.\(UUID().uuidString).tmp")
 
             var arArgs = ["rcs", tmpArchivePath.path]
             arArgs.append(contentsOf: objectFiles.map(\.path))
@@ -244,9 +245,13 @@ public actor SPMBuildSystem: BuildSystem {
                     exitCode: result.exitCode
                 )
             }
-            // Atomic rename: the archive is never absent from the perspective of
-            // a concurrent linker that reads it between two archiveDependencyTargets calls.
-            _ = try? fm.replaceItemAt(archivePath, withItemAt: tmpArchivePath)
+            // replaceItemAt swaps atomically on APFS. Falls back to moveItem
+            // when the archive doesn't exist yet (first build).
+            do {
+                _ = try fm.replaceItemAt(archivePath, withItemAt: tmpArchivePath)
+            } catch {
+                try fm.moveItem(at: tmpArchivePath, to: archivePath)
+            }
             libs.append(targetName)
         }
 

--- a/Sources/PreviewsCore/SPMBuildSystem.swift
+++ b/Sources/PreviewsCore/SPMBuildSystem.swift
@@ -228,19 +228,25 @@ public actor SPMBuildSystem: BuildSystem {
             let objectFiles = collectObjectFiles(in: entry)
             guard !objectFiles.isEmpty else { continue }
 
+            // Write to a temp file and atomically rename to avoid a race where a
+            // concurrent compile reads the archive between delete and recreate.
             let archivePath = binPath.appendingPathComponent("lib\(targetName).a")
-            // `ar rcs` replaces any existing archive, so rebuilds stay consistent.
-            try? fm.removeItem(at: archivePath)
+            let tmpArchivePath = binPath.appendingPathComponent("lib\(targetName).a.tmp")
+            try? fm.removeItem(at: tmpArchivePath)
 
-            var arArgs = ["rcs", archivePath.path]
+            var arArgs = ["rcs", tmpArchivePath.path]
             arArgs.append(contentsOf: objectFiles.map(\.path))
             let result = try await runAsync(arPath, arguments: arArgs)
             guard result.exitCode == 0 else {
+                try? fm.removeItem(at: tmpArchivePath)
                 throw BuildSystemError.buildFailed(
                     stderr: "ar failed for \(targetName): \(result.stderr)",
                     exitCode: result.exitCode
                 )
             }
+            // Atomic rename: the archive is never absent from the perspective of
+            // a concurrent linker that reads it between two archiveDependencyTargets calls.
+            _ = try? fm.replaceItemAt(archivePath, withItemAt: tmpArchivePath)
             libs.append(targetName)
         }
 

--- a/Sources/PreviewsCore/SPMBuildSystem.swift
+++ b/Sources/PreviewsCore/SPMBuildSystem.swift
@@ -229,11 +229,10 @@ public actor SPMBuildSystem: BuildSystem {
             guard !objectFiles.isEmpty else { continue }
 
             // Write to a unique temp file and atomically swap into place so a
-            // concurrent linker never sees the archive as missing. UUID avoids
-            // collisions between parallel archiveDependencyTargets callers.
+            // concurrent linker never sees the archive as missing.
             let archivePath = binPath.appendingPathComponent("lib\(targetName).a")
             let tmpArchivePath = binPath.appendingPathComponent(
-                "lib\(targetName).a.\(UUID().uuidString).tmp")
+                "lib\(targetName).a.\(ProcessInfo.processInfo.globallyUniqueString).tmp")
 
             var arArgs = ["rcs", tmpArchivePath.path]
             arArgs.append(contentsOf: objectFiles.map(\.path))


### PR DESCRIPTION
## Summary
Fixes intermittent CI failure: `ld: library 'LocalDep' not found` during CLI integration tests.

## Root Cause
`archiveDependencyTargets` deleted `libDep.a` before recreating it with `ar rcs`. The `CLI snapshot command` and `CLI variants command` test suites run in parallel — when a snapshot test called `detectAndBuild` (which re-archives dependencies) while the variants test was between its first and second `compileCombined` calls, the linker saw the archive as missing during the delete-to-recreate window.

The race was exposed by #74's progress reporting, which adds small `await` pauses between operations, widening the timing window.

## Fix
Write to a temp file (`libDep.a.tmp`) and atomically rename via `FileManager.replaceItemAt`, so the archive is never absent from the linker's perspective.

## Test plan
- [x] `swift build` succeeds
- [x] `previewsmcp variants --variant light --variant dark` produces both images
- [x] CI should pass (race condition eliminated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)