### PR TITLE
Wrap #Preview body in @ViewBuilder func to accept if #available et al

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 xcuserdata/
 DerivedData/
 .claude/worktrees/
+
+# The example's Package.resolved is deliberately left unpinned so the SPM
+# integration tests always exercise fresh dependency resolution (and catch
+# upstream breakage in deps like lottie-spm early). The ROOT /Package.resolved
+# stays tracked — this exclusion is scoped to the example package only.
+examples/spm/Package.resolved

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,3 @@
 xcuserdata/
 DerivedData/
 .claude/worktrees/
-
-# The example's Package.resolved is deliberately left unpinned so the SPM
-# integration tests always exercise fresh dependency resolution (and catch
-# upstream breakage in deps like lottie-spm early). The ROOT /Package.resolved
-# stays tracked — this exclusion is scoped to the example package only.
-examples/spm/Package.resolved

--- a/Sources/PreviewsCore/BridgeGenerator.swift
+++ b/Sources/PreviewsCore/BridgeGenerator.swift
@@ -42,9 +42,10 @@ public enum BridgeGenerator {
 
                 @_cdecl("\(entryPoint)")
                 public func \(entryPoint)() -> UnsafeMutableRawPointer {
-                    let view = SwiftUI.AnyView(
-                        \(transformedClosureBody)\(modifiers)
-                    )
+                    @ViewBuilder func __previewBody() -> some SwiftUI.View {
+                        \(transformedClosureBody)
+                    }
+                    let view = SwiftUI.AnyView(__previewBody()\(modifiers))
                     let hostingView = NSHostingView(rootView: view)
                     return Unmanaged.passRetained(hostingView).toOpaque()
                 }
@@ -55,9 +56,10 @@ public enum BridgeGenerator {
 
                 @_cdecl("\(entryPoint)")
                 public func \(entryPoint)() -> UnsafeMutableRawPointer {
-                    let view = SwiftUI.AnyView(
-                        \(transformedClosureBody)\(modifiers)
-                    )
+                    @ViewBuilder func __previewBody() -> some SwiftUI.View {
+                        \(transformedClosureBody)
+                    }
+                    let view = SwiftUI.AnyView(__previewBody()\(modifiers))
                     let hostingController = UIHostingController(rootView: view)
                     return Unmanaged.passRetained(hostingController).toOpaque()
                 }
@@ -116,9 +118,10 @@ public enum BridgeGenerator {
 
             @_cdecl("\(entryPoint)")
             public func \(entryPoint)() -> UnsafeMutableRawPointer {
-                let view = SwiftUI.AnyView(
-                    \(closureBody)\(modifiers)
-                )
+                @ViewBuilder func __previewBody() -> some SwiftUI.View {
+                    \(closureBody)
+                }
+                let view = SwiftUI.AnyView(__previewBody()\(modifiers))
                 \(hostCode)
             }
             """
@@ -150,6 +153,37 @@ public enum BridgeGenerator {
             traits: traits
         )
     }
+
+    // MARK: - @ViewBuilder context
+    //
+    // The generated bridge wraps the closure body in a nested
+    // `@ViewBuilder func __previewBody() -> some SwiftUI.View { <body> }`
+    // and calls it from `AnyView(__previewBody())`.
+    //
+    // Why: `AnyView.init` takes a bare `View` expression. That rejects several
+    // constructs that Xcode's `#Preview` (which forwards its trailing closure
+    // to `DeveloperToolsSupport.Preview.init` — a `@ViewBuilder` closure)
+    // accepts without ceremony:
+    //   - `if #available` / `if #unavailable` (statement-only in Swift)
+    //   - Multi-statement bodies with leading `let`/`var` declarations
+    //   - `if` / `switch` branches producing different concrete `View` types
+    //
+    // Regular `if` / `switch` are valid expressions in Swift 5.9+ *only* when
+    // every branch has the same type; `@ViewBuilder` lifts that restriction via
+    // `_ConditionalContent`. Giving the body a `@ViewBuilder` context
+    // unconditionally (rather than pattern-matching specific syntactic forms)
+    // catches every case the compiler would otherwise reject, including ones
+    // we haven't enumerated.
+    //
+    // Why a nested function and not `Group { ... }`: `Group` has a special
+    // canvas-level behavior in the legacy `PreviewProvider` API — Xcode's
+    // preview inspector walks into a top-level `Group` and renders each child
+    // as a separate preview card. That's a canvas-inspection quirk, not a
+    // runtime behavior (and not relevant to the new `#Preview` macro at all),
+    // but seeing `Group` in generated bridge code is a code smell that invites
+    // confusion. A nested `@ViewBuilder` function gives the exact same runtime
+    // semantics with zero added view types in the render tree and unambiguous
+    // intent at the source level.
 
     /// Build SwiftUI modifier chain for the given traits.
     private static func traitModifiers(_ traits: PreviewTraits) -> String {

--- a/Tests/PreviewsCoreTests/BridgeGeneratorTraitsTests.swift
+++ b/Tests/PreviewsCoreTests/BridgeGeneratorTraitsTests.swift
@@ -503,6 +503,255 @@ struct BridgeGeneratorTraitsTests {
         #expect(hash == 0xa430_d846_80aa_bd0b)
     }
 
+    // MARK: - @ViewBuilder nested function
+
+    /// Isolate the bridge `@_cdecl` function from the rest of the combined source
+    /// so substring assertions don't accidentally match the original user source.
+    private func bridgeSlice(_ source: String) -> String {
+        let range = source.range(of: "@_cdecl(\"createPreviewView\")")!
+        return String(source[range.lowerBound...])
+    }
+
+    static let availablePreviewSource = """
+        import SwiftUI
+
+        struct NewView: View {
+            var body: some View { Text("new") }
+        }
+
+        struct FallbackView: View {
+            var body: some View { Text("fallback") }
+        }
+
+        #Preview {
+            if #available(iOS 16.0, *) {
+                NewView()
+            } else {
+                FallbackView()
+            }
+        }
+        """
+
+    @Test("generateCombinedSource wraps if #available body in a @ViewBuilder function")
+    func combinedSourceWrapsAvailable() {
+        let (source, _) = BridgeGenerator.generateCombinedSource(
+            originalSource: Self.availablePreviewSource,
+            closureBody: """
+                if #available(iOS 16.0, *) {
+                    NewView()
+                } else {
+                    FallbackView()
+                }
+                """
+        )
+        let bridge = bridgeSlice(source)
+        let vbRange = bridge.range(of: "@ViewBuilder func __previewBody()")
+        let ifRange = bridge.range(of: "if #available")
+        #expect(vbRange != nil, "Bridge must declare @ViewBuilder __previewBody()")
+        #expect(ifRange != nil)
+        #expect(
+            vbRange!.lowerBound < ifRange!.lowerBound,
+            "@ViewBuilder function must be declared before the if #available body it contains"
+        )
+        #expect(
+            bridge.contains("AnyView(__previewBody()"),
+            "Bridge must call __previewBody() from AnyView(...)"
+        )
+        #expect(
+            !bridge.contains("Group {"),
+            "Bridge must not use Group (to avoid confusion with Xcode's canvas Group-enumeration)"
+        )
+    }
+
+    @Test("generateBridgeOnlySource wraps if #available body in a @ViewBuilder function")
+    func bridgeOnlySourceWrapsAvailable() {
+        let source = BridgeGenerator.generateBridgeOnlySource(
+            moduleName: "MyTarget",
+            closureBody: """
+                if #available(iOS 16.0, *) {
+                    NewView()
+                } else {
+                    FallbackView()
+                }
+                """
+        )
+        #expect(source.contains("@ViewBuilder func __previewBody()"))
+        #expect(source.contains("if #available"))
+        #expect(source.contains("AnyView(__previewBody()"))
+    }
+
+    @Test("generateBridgeOnlySource wraps if #unavailable body in a @ViewBuilder function")
+    func bridgeOnlySourceWrapsUnavailable() {
+        let source = BridgeGenerator.generateBridgeOnlySource(
+            moduleName: "MyTarget",
+            closureBody: """
+                if #unavailable(iOS 26.0) {
+                    FallbackView()
+                } else {
+                    NewView()
+                }
+                """
+        )
+        #expect(source.contains("@ViewBuilder func __previewBody()"))
+        #expect(source.contains("if #unavailable"))
+    }
+
+    @Test("generateCombinedSource wraps simple bodies in @ViewBuilder too (matches Xcode semantics)")
+    func combinedSourceWrapsSimpleBody() {
+        let (source, _) = BridgeGenerator.generateCombinedSource(
+            originalSource: Self.testSource,
+            closureBody: "TestView()"
+        )
+        let bridge = bridgeSlice(source)
+        // Simple bodies go through the @ViewBuilder function too — the wrapping
+        // is unconditional so every @ViewBuilder-accepted pattern works.
+        #expect(bridge.contains("@ViewBuilder func __previewBody()"))
+        #expect(bridge.contains("TestView()"))
+        #expect(bridge.contains("AnyView(__previewBody()"))
+    }
+
+    @Test("generateCombinedSource wraps multi-statement body (leading let) in @ViewBuilder")
+    func combinedSourceWrapsMultiStatement() {
+        let multiStmtSource = """
+            import SwiftUI
+
+            struct TestView: View {
+                let label: String
+                var body: some View { Text(label) }
+            }
+
+            #Preview {
+                let label = "hello"
+                TestView(label: label)
+            }
+            """
+        let previews = PreviewParser.parse(source: multiStmtSource)
+        #expect(previews.count == 1)
+
+        let (source, _) = BridgeGenerator.generateCombinedSource(
+            originalSource: multiStmtSource,
+            closureBody: previews[0].closureBody
+        )
+        let bridge = bridgeSlice(source)
+        let vbRange = bridge.range(of: "@ViewBuilder func __previewBody()")
+        let letRange = bridge.range(of: "let label")
+        #expect(vbRange != nil && letRange != nil)
+        #expect(
+            vbRange!.lowerBound < letRange!.lowerBound,
+            "@ViewBuilder function must wrap the multi-statement body so `let` is not a bare expression"
+        )
+    }
+
+    @Test("if #available body with traits applies modifiers on the __previewBody() call")
+    func availableBodyWithTraits() {
+        let traits = PreviewTraits(colorScheme: "dark")
+        let source = BridgeGenerator.generateBridgeOnlySource(
+            moduleName: "MyTarget",
+            closureBody: """
+                if #available(iOS 16.0, *) {
+                    NewView()
+                } else {
+                    FallbackView()
+                }
+                """,
+            traits: traits
+        )
+        #expect(source.contains("@ViewBuilder func __previewBody()"))
+        #expect(source.contains(".preferredColorScheme(.dark)"))
+        // The modifier must be chained onto __previewBody(), inside the AnyView(...) call.
+        #expect(
+            source.contains("AnyView(__previewBody()"),
+            "Bridge must call AnyView on the __previewBody() result"
+        )
+        // And the modifier must come after __previewBody(), not inside its body.
+        let callRange = source.range(of: "__previewBody()")!
+        let modifierRange = source.range(of: ".preferredColorScheme(.dark)")!
+        #expect(
+            callRange.upperBound <= modifierRange.lowerBound,
+            "Modifier must be applied to the __previewBody() result, not inside its body"
+        )
+    }
+
+    @Test("Full pipeline with if #available body compiles successfully")
+    func fullPipelineWithIfAvailable() async throws {
+        let availableSource = """
+            import SwiftUI
+
+            struct NewView: View {
+                var body: some View { Text("new") }
+            }
+
+            struct FallbackView: View {
+                var body: some View { Text("fallback") }
+            }
+
+            #Preview {
+                if #available(macOS 14.0, iOS 17.0, *) {
+                    NewView()
+                } else {
+                    FallbackView()
+                }
+            }
+            """
+
+        let previews = PreviewParser.parse(source: availableSource)
+        #expect(previews.count == 1)
+
+        let (combined, _) = BridgeGenerator.generateCombinedSource(
+            originalSource: availableSource,
+            closureBody: previews[0].closureBody
+        )
+
+        let compiler = try await Compiler()
+        let result = try await compiler.compileCombined(
+            source: combined,
+            moduleName: "AvailTest_\(Int.random(in: 0...999999))"
+        )
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: result.dylibPath.path)
+        let size = attrs[.size] as? Int ?? 0
+        #expect(size > 0, "Dylib should be non-empty")
+
+        let loader = try DylibLoader(path: result.dylibPath.path)
+        typealias CreateFunc = @convention(c) () -> UnsafeMutableRawPointer
+        let _: CreateFunc = try loader.symbol(name: "createPreviewView")
+    }
+
+    @Test("Full pipeline with multi-statement body compiles successfully")
+    func fullPipelineWithMultiStatement() async throws {
+        let multiSource = """
+            import SwiftUI
+
+            struct TestView: View {
+                let label: String
+                var body: some View { Text(label) }
+            }
+
+            #Preview {
+                let label = "hello"
+                TestView(label: label)
+            }
+            """
+
+        let previews = PreviewParser.parse(source: multiSource)
+        #expect(previews.count == 1)
+
+        let (combined, _) = BridgeGenerator.generateCombinedSource(
+            originalSource: multiSource,
+            closureBody: previews[0].closureBody
+        )
+
+        let compiler = try await Compiler()
+        let result = try await compiler.compileCombined(
+            source: combined,
+            moduleName: "MultiStmtTest_\(Int.random(in: 0...999999))"
+        )
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: result.dylibPath.path)
+        let size = attrs[.size] as? Int ?? 0
+        #expect(size > 0, "Dylib should be non-empty")
+    }
+
     // MARK: - Equatable
 
     @Test("PreviewTraits Equatable works correctly")

--- a/examples/spm/.gitignore
+++ b/examples/spm/.gitignore
@@ -1,0 +1,5 @@
+# Deliberately unpinned so SPM integration tests exercise fresh dependency
+# resolution every run, catching upstream breakage in deps like lottie-spm
+# early. The root /Package.resolved stays tracked — this exclusion is
+# scoped to the example package only.
+Package.resolved


### PR DESCRIPTION
## Summary

- Fixes a bug where `BridgeGenerator` emitted invalid Swift when a `#Preview` body started with `if #available` / `if #unavailable`, used a leading `let`/`var`, or had `if`/`switch` branches with different concrete `View` types. Reported against Prism iOS (`CatalogChatThread.swift:360`).
- The root cause: we were pasting the closure body as a bare expression argument to `AnyView(...)`, stripping the `@ViewBuilder` context that Xcode's `#Preview` macro provides via `DeveloperToolsSupport.Preview.init`.
- The fix: declare a nested `@ViewBuilder func __previewBody() -> some SwiftUI.View` inside the generated bridge and call it from `AnyView(__previewBody())`. Same runtime semantics as Xcode's `#Preview`, zero added view types in the render tree.

## Why not `Group { }`?

`Group` would have worked functionally, but it has a canvas-level quirk in the legacy `PreviewProvider` API where Xcode's preview inspector walks into a top-level `Group` and renders each child as a separate preview card. That quirk doesn't apply to our runtime render path (we go through `NSHostingView` / `UIHostingController`, not Xcode's canvas) or to the new `#Preview` macro, but seeing `Group` in generated bridge code is a code smell that invites confusion. A nested `@ViewBuilder` function gives unambiguous intent and the same compiler machinery Xcode's macro uses.

The rationale is documented inline in `BridgeGenerator.swift`.

## Cases this now handles

| Pattern | Previously | Now |
|---|---|---|
| `MyView()` | ✅ worked | ✅ works |
| `if #available(iOS X, *) { A() } else { B() }` | ❌ invalid Swift | ✅ tested end-to-end |
| `let model = Model(); MyView(model: model)` | ❌ silent bug | ✅ tested end-to-end |
| `switch state { case .a: A(); case .b: B() }` with different branch types | ❌ type error | ✅ (via `_ConditionalContent`) |
| `if cond { A() } else { B() }` with different branch types | ❌ type error | ✅ (via `_ConditionalContent`) |

## Test plan

- [x] `swift test --filter "BridgeGeneratorTraits"` — 40/40 pass, including:
  - `fullPipelineWithIfAvailable` — real `Compiler` proves `if #available` body compiles
  - `fullPipelineWithMultiStatement` — real `Compiler` proves `let x = ...; MyView()` body compiles
  - Source-level assertions that `@ViewBuilder func __previewBody()` precedes the body it wraps
  - Ordering assertion that trait modifiers land on `__previewBody()`, not inside its body
- [x] `swift test --filter "PreviewsCoreTests"` — 141/141 pass (no regressions in other test suites)
- [x] `swift build` — clean
- [x] `swift-format lint --strict` — clean
- [ ] Smoke test against the original repro (Prism iOS `CatalogChatThread.swift:360`) — reporter to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)