### PR TITLE
Add previewsmcp agent skill with static drift eval

### DIFF
--- a/Tests/PreviewsCoreTests/SkillDriftTests.swift
+++ b/Tests/PreviewsCoreTests/SkillDriftTests.swift
@@ -1,0 +1,177 @@
+import Foundation
+import Testing
+
+/// Static eval: parse `docs/skills/previewsmcp.md` and assert every tool and trait
+/// preset it mentions exists in the live source. Catches mechanical drift
+/// (renames, removals, additions) in CI without running the MCP server.
+///
+/// This is a text-level eval — it reads source files as strings rather than
+/// importing PreviewsCLI, so it works as a plain PreviewsCoreTests test with no
+/// extra build dependencies.
+@Suite("SkillDrift")
+struct SkillDriftTests {
+
+    // MARK: - Package layout
+
+    /// Walk up from this test file to the package root (contains Package.swift).
+    private static let packageRoot: URL = {
+        var url = URL(fileURLWithPath: #filePath)
+        while url.pathComponents.count > 1 {
+            url.deleteLastPathComponent()
+            if FileManager.default.fileExists(
+                atPath: url.appendingPathComponent("Package.swift").path)
+            {
+                return url
+            }
+        }
+        fatalError("could not locate package root from \(#filePath)")
+    }()
+
+    private static func read(_ relativePath: String) throws -> String {
+        try String(contentsOf: packageRoot.appendingPathComponent(relativePath), encoding: .utf8)
+    }
+
+    // MARK: - Sources of truth
+
+    /// Tool names declared in `private enum ToolName: String { ... }` in MCPServer.swift.
+    private static func registeredToolNames() throws -> Set<String> {
+        let source = try read("Sources/PreviewsCLI/MCPServer.swift")
+        guard let header = source.range(of: "enum ToolName: String {") else {
+            Issue.record("could not find ToolName enum in MCPServer.swift")
+            return []
+        }
+        let tail = source[header.upperBound...]
+        guard let closing = tail.range(of: "}") else { return [] }
+        let body = tail[..<closing.lowerBound]
+
+        var names = Set<String>()
+        for line in body.split(separator: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard trimmed.hasPrefix("case "),
+                let eq = trimmed.range(of: "= \"")
+            else { continue }
+            let afterOpen = trimmed[eq.upperBound...]
+            guard let closeQuote = afterOpen.firstIndex(of: "\"") else { continue }
+            names.insert(String(afterOpen[..<closeQuote]))
+        }
+        return names
+    }
+
+    /// Valid trait preset names: `validColorSchemes ∪ validDynamicTypeSizes` from PreviewTraits.swift.
+    private static func validPresets() throws -> Set<String> {
+        let source = try read("Sources/PreviewsCore/PreviewTraits.swift")
+        return try extractQuotedElements(
+            ofSetLiteral: "validColorSchemes", in: source)
+            .union(
+                extractQuotedElements(ofSetLiteral: "validDynamicTypeSizes", in: source))
+    }
+
+    /// Parse `<name>: Set<String> = [ "a", "b", ... ]` and return the quoted elements.
+    private static func extractQuotedElements(
+        ofSetLiteral name: String, in source: String
+    ) throws -> Set<String> {
+        guard let anchor = source.range(of: "\(name): Set<String> = [") else {
+            Issue.record("could not find set literal `\(name)`")
+            return []
+        }
+        let afterOpen = source[anchor.upperBound...]
+        guard let closeBracket = afterOpen.firstIndex(of: "]") else { return [] }
+        let body = afterOpen[..<closeBracket]
+
+        var values = Set<String>()
+        var cursor = body.startIndex
+        while let openQuote = body[cursor...].firstIndex(of: "\"") {
+            let afterOpenQuote = body.index(after: openQuote)
+            guard let closeQuote = body[afterOpenQuote...].firstIndex(of: "\"") else { break }
+            values.insert(String(body[afterOpenQuote..<closeQuote]))
+            cursor = body.index(after: closeQuote)
+        }
+        return values
+    }
+
+    // MARK: - Skill parsing
+
+    private static func skillContents() throws -> String {
+        try read("docs/skills/previewsmcp.md")
+    }
+
+    /// Read the single comma-separated line immediately following `<!-- eval:<name> -->`.
+    private static func evalBlock(_ name: String, in skill: String) -> Set<String> {
+        let marker = "<!-- eval:\(name) -->"
+        guard let range = skill.range(of: marker) else { return [] }
+        let after = skill[range.upperBound...]
+        for line in after.split(separator: "\n", omittingEmptySubsequences: false) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty { continue }
+            return Set(
+                trimmed.split(separator: ",")
+                    .map { $0.trimmingCharacters(in: .whitespaces) }
+                    .filter { !$0.isEmpty })
+        }
+        return []
+    }
+
+    /// Scrape every `preview_*` or `simulator_*` identifier from the skill prose.
+    /// Catches drift where the skill references a nonexistent tool in text even if
+    /// the eval:tools block is correct.
+    private static func toolMentionsInProse(_ skill: String) -> Set<String> {
+        let pattern = #"(?:preview|simulator)_[a-z_]+"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let range = NSRange(skill.startIndex..., in: skill)
+        var mentions = Set<String>()
+        regex.enumerateMatches(in: skill, range: range) { match, _, _ in
+            if let m = match, let r = Range(m.range, in: skill) {
+                mentions.insert(String(skill[r]))
+            }
+        }
+        return mentions
+    }
+
+    // MARK: - Tests
+
+    @Test("eval:tools block matches the live MCP tool registry")
+    func toolsBlockMatchesRegistry() throws {
+        let registered = try Self.registeredToolNames()
+        let advertised = Self.evalBlock("tools", in: try Self.skillContents())
+
+        #expect(!registered.isEmpty, "failed to extract tool names from MCPServer.swift")
+        #expect(!advertised.isEmpty, "skill has no <!-- eval:tools --> block")
+
+        let missingFromSkill = registered.subtracting(advertised)
+        let extraInSkill = advertised.subtracting(registered)
+        #expect(
+            missingFromSkill.isEmpty,
+            "tools exist in code but are not listed in the skill: \(missingFromSkill.sorted())")
+        #expect(
+            extraInSkill.isEmpty,
+            "skill lists tools that do not exist in code: \(extraInSkill.sorted())")
+    }
+
+    @Test("eval:presets block matches PreviewTraits valid sets")
+    func presetsBlockMatchesValidTraits() throws {
+        let valid = try Self.validPresets()
+        let advertised = Self.evalBlock("presets", in: try Self.skillContents())
+
+        #expect(!valid.isEmpty, "failed to extract trait presets from PreviewTraits.swift")
+        #expect(!advertised.isEmpty, "skill has no <!-- eval:presets --> block")
+
+        let missingFromSkill = valid.subtracting(advertised)
+        let extraInSkill = advertised.subtracting(valid)
+        #expect(
+            missingFromSkill.isEmpty,
+            "presets exist in code but are not listed in the skill: \(missingFromSkill.sorted())")
+        #expect(
+            extraInSkill.isEmpty,
+            "skill lists presets that do not exist in code: \(extraInSkill.sorted())")
+    }
+
+    @Test("every preview_/simulator_ identifier in skill prose exists in the registry")
+    func proseToolMentionsExistInRegistry() throws {
+        let registered = try Self.registeredToolNames()
+        let mentioned = Self.toolMentionsInProse(try Self.skillContents())
+        let unknown = mentioned.subtracting(registered)
+        #expect(
+            unknown.isEmpty,
+            "skill prose references tools that do not exist: \(unknown.sorted())")
+    }
+}

--- a/docs/skills/previewsmcp.md
+++ b/docs/skills/previewsmcp.md
@@ -1,0 +1,39 @@
+---
+name: previewsmcp
+description: Render SwiftUI previews outside Xcode with hot-reload, trait variants, and touch interaction. Use when an agent needs to see or interact with a `#Preview` without building the full app.
+---
+
+# previewsmcp
+
+Render SwiftUI `#Preview` blocks headlessly on macOS or iOS simulator. Hot-reload, trait overrides, accessibility tree, touch injection, variant snapshots.
+
+## Tools
+
+<!-- eval:tools -->
+preview_list, preview_start, preview_configure, preview_switch, preview_variants, preview_snapshot, preview_elements, preview_touch, preview_stop, simulator_list
+
+## When to use which tool
+
+**Just looking at a preview:** `preview_start` → `preview_snapshot` → `preview_stop`. Pass `platform: "ios"` only if the preview uses iOS-only APIs or you need touch interaction.
+
+**Iterating on design:** Keep one session alive. Edit the source file — hot-reload picks it up. Call `preview_snapshot` after each change. Don't tear down between edits.
+
+**Multiple `#Preview` blocks in one file:** `preview_list` first to see them all, then `preview_start` with `previewIndex`, then `preview_switch` to change which one renders without restarting the session. Traits persist across switches; `@State` resets.
+
+**Checking light/dark or Dynamic Type:** For a one-off, `preview_configure` on a live session. For a batch (light + dark + a11y sizes in one shot), `preview_variants` — it renders each, snapshots it, and restores the original traits. `preview_variants` is cheaper than repeated `preview_configure` calls because the session stays up.
+
+**Interacting with iOS previews:** `preview_elements` to get the accessibility tree (filter by `"interactable"` to narrow), then `preview_touch` with the element's frame center. Don't guess coordinates from a screenshot — ask the tree.
+
+## Trait presets
+
+<!-- eval:presets -->
+light, dark, xSmall, small, medium, large, xLarge, xxLarge, xxxLarge, accessibility1, accessibility2, accessibility3, accessibility4, accessibility5
+
+Pass these names directly to `preview_variants`. For custom combinations, pass a JSON object string: `{"colorScheme":"dark","dynamicTypeSize":"accessibility3","label":"dark+a11y3"}`.
+
+## Gotchas
+
+- `dynamicTypeSize` has no visible effect on macOS. Use `platform: "ios"` to test Dynamic Type.
+- Every `preview_configure`, `preview_switch`, and each variant in `preview_variants` triggers a recompile. `@State` is lost on each.
+- `preview_elements` and `preview_touch` are iOS-only.
+- Always call `preview_stop` when done — live sessions hold simulator resources.


### PR DESCRIPTION
## Summary

- Ships a workflow-focused agent skill at `docs/skills/previewsmcp.md` so Claude Code (and other skill-aware clients) get guidance on **when** to reach for each MCP tool, not just parameter reference material.
- Adds a `SkillDrift` test suite that parses the skill and asserts every tool name and trait preset it mentions exists in the live source — catching mechanical drift in CI.

## Why

MCP tool descriptions only cover parameters, not workflows. A skill can encode things like "use `preview_variants` instead of looping `preview_configure`" or "always ask `preview_elements` before guessing touch coordinates." But skills rot silently as the CLI evolves. This PR pairs the skill with a cheap eval so drift fails the build.

## How it works

The eval is **text-level** — it reads `Sources/PreviewsCLI/MCPServer.swift` and `Sources/PreviewsCore/PreviewTraits.swift` as strings, extracts:

- Tool names from the `private enum ToolName: String { ... }` block
- Trait presets from the `validColorSchemes` and `validDynamicTypeSizes` set literals

…and compares them to what the skill advertises. No `@testable import PreviewsCLI`, no `Package.swift` changes — the test file drops into the existing `PreviewsCoreTests` target.

Skill marks its authoritative lists with HTML comments so the eval knows where to look:

```markdown
<!-- eval:tools -->
preview_list, preview_start, preview_configure, ...

<!-- eval:presets -->
light, dark, xSmall, small, ...
```

Three checks:

1. **`toolsBlockMatchesRegistry`** — eval:tools block must equal the `ToolName` enum raw values. Fails on renames, additions, removals.
2. **`presetsBlockMatchesValidTraits`** — eval:presets block must equal `validColorSchemes ∪ validDynamicTypeSizes`.
3. **`proseToolMentionsExistInRegistry`** — regex-scans the skill prose for every `preview_*` / `simulator_*` identifier; each must be a registered tool. Catches typos like `preview_screenshot`.

## Proven end-to-end

Injected three drift bugs (extra tool in eval block, missing preset, typo in prose). All three tests failed with clear messages:

```
✘ skill lists tools that do not exist in code: ["preview_launch"]
✘ presets exist in code but are not listed in the skill: ["accessibility5"]
✘ skill prose references tools that do not exist: ["preview_launch", "preview_screenshot"]
```

Reverting re-greens. Runs in ~3ms once built.

## Scope ceiling

This only catches **mechanical** drift. A workflow paragraph that becomes misleading but still uses valid tool names won't trip it — that's the LLM-in-the-loop layer for a future PR.

When #79 lands (new traits `locale` / `layoutDirection` / `legibilityWeight`, new presets `rtl` / `ltr` / `boldText`, `.previewsmcp.json`), `presetsBlockMatchesValidTraits` will fail loudly until the skill is updated. That's the intended signal — iterate on skill content in follow-up PRs.

## Test plan

- [x] \`swift test --filter SkillDrift\` — 3 tests pass on current main surface
- [x] Drift injection test — all 3 failure modes produce actionable error messages
- [ ] Update skill after #79 merges to cover extended traits, project config, and setup plugin workflows
- [ ] Consider a second test file for LLM-in-the-loop evals (scenario → tool sequence assertion), gated on \`docs/skills/**\` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)