### PR TITLE
Merge format+lint CI jobs and add caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,24 +7,25 @@ on:
     branches: [main]
 
 jobs:
-  format:
-    runs-on: macos-15
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install swift-format
-        run: brew install swift-format
-
-      - name: Check formatting
-        run: swift-format lint --strict --recursive Sources/ Tests/ examples/
-
   lint:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install SwiftLint
-        run: brew install swiftlint
+      - name: Cache Homebrew
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/Homebrew/downloads
+            ~/Library/Caches/Homebrew/Cask
+          key: brew-${{ runner.os }}-${{ hashFiles('Brewfile') }}
+          restore-keys: brew-${{ runner.os }}-
+
+      - name: Install tools
+        run: brew bundle
+
+      - name: Check formatting
+        run: swift-format lint --strict --recursive Sources/ Tests/ examples/
 
       - name: SwiftLint
         run: swiftlint lint --quiet Sources/ Tests/
@@ -72,7 +73,9 @@ jobs:
       - name: Cache SPM build
         uses: actions/cache@v4
         with:
-          path: .build
+          path: |
+            .build
+            examples/spm/.build
           key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
           restore-keys: spm-${{ runner.os }}-
 
@@ -110,7 +113,9 @@ jobs:
       - name: Cache SPM build
         uses: actions/cache@v4
         with:
-          path: .build
+          path: |
+            .build
+            examples/spm/.build
           key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
           restore-keys: spm-${{ runner.os }}-
 


### PR DESCRIPTION
## Summary

- Combine the separate `format` and `lint` CI jobs into a single `lint` job — saves a runner startup (~60s) since both are read-only checks sharing the same Homebrew tools.
- Cache Homebrew downloads keyed on `Brewfile` hash so swift-format and swiftlint bottle downloads are skipped on cache hit.
- Add `examples/spm/.build` to the SPM cache path in `build-and-test` and `ios-tests` — this directory is separate from the root `.build` and was rebuilt from scratch on every run.

## Test plan

- [x] CI `lint` job passes (formatting + SwiftLint in one job)
- [x] `build-and-test` and `ios-tests` cache hits on second run include `examples/spm/.build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)