### PR TITLE
Revise README, fix setup state loss (#86), auto-detect platform (#83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,21 @@ A live macOS preview window opens. Edit the source file and the window hot-reloa
 
 ## Why PreviewsMCP?
 
-Xcode previews run in a sandboxed process with no app lifecycle — no `UIApplicationDelegate`, no `didBecomeActive`, no real `UIApplication`. This means Firebase, analytics, auth, and custom fonts crash or silently break. The ecosystem answer is "mock everything," and at scale teams maintain **micro apps** — standalone app targets that render a single feature with controlled dependencies. Airbnb's dev apps drive over 50% of local iOS builds. Point-Free's isowords has 9 preview apps. Every team pays the maintenance tax: separate targets, schemes, and mock setups that drift.
+PreviewsMCP compiles your `#Preview` closure into a dylib and loads it into a real app process (macOS `NSApplication` or iOS simulator `UIApplication`) with hot-reload — driven entirely from the command line or over MCP. No Xcode process required.
 
-PreviewsMCP eliminates this tradeoff. It compiles your `#Preview` closure into a dylib and loads it into a real app process (macOS `NSApplication` or iOS simulator `UIApplication`) with hot-reload. Firebase, auth, fonts, and DI containers just work — because there's a real app lifecycle.
+That makes it a standalone, extensible preview workflow:
 
-The [setup plugin](Sources/PreviewsSetupKit/PreviewSetup.swift) completes the picture: a `PreviewSetup` protocol where `setUp()` runs once per session (SDK init, auth, DI registration) and `wrap()` surrounds every preview (themes, environment values). It's the micro app's dependency layer extracted into a reusable framework — without maintaining a separate app target.
+- **CLI and MCP-native** — preview, snapshot, and iterate from the terminal or let an AI agent drive the loop
+- **Hot-reload** — edit a file, see changes immediately, with `@State` preserved across literal edits
+- **Trait and variant sweeps** — render one preview across color schemes, dynamic type sizes, locales, and layout directions in a single call
+- **iOS interaction** — walk the accessibility tree and inject taps/swipes through an in-simulator touch bridge
+- **Build system flexible** — works with **SPM**, **Xcode projects** (`.xcodeproj` / `.xcworkspace`), and **Bazel**
 
-Works with **SPM**, **Xcode projects** (`.xcodeproj` / `.xcworkspace`), and **Bazel**.
+### Solving the Xcode preview sandbox problem
+
+Xcode previews run your code inside Apple's preview agent — a real app process, but an opaque one. You can't hook into its lifecycle, run your own initialization, or extend it. `FirebaseApp.configure()`, custom font registration, auth setup, and DI containers have nowhere to run. The ecosystem answer is "mock everything," and at scale teams maintain **micro apps** — standalone app targets that render a single feature with controlled dependencies. Airbnb's dev apps drive over 50% of local iOS builds. Point-Free's isowords has 9 preview apps. Every team pays the maintenance tax: separate targets, schemes, and mock setups that drift.
+
+Because PreviewsMCP hosts your preview in its own app process, you can extend that process. The [setup plugin](Sources/PreviewsSetupKit/PreviewSetup.swift) provides the hook: a `PreviewSetup` protocol where `setUp()` runs once per session (SDK init, auth, font registration, DI container) and `wrap()` surrounds every preview render (themes, environment values). It's the micro app's dependency layer extracted into a reusable framework — without maintaining a separate app target.
 
 ## Installation
 

--- a/Sources/PreviewsCLI/BuildHelpers.swift
+++ b/Sources/PreviewsCLI/BuildHelpers.swift
@@ -99,6 +99,7 @@ func launchMacOSPreview(
 
     await progress?.report(.compilingBridge, message: "Compiling \(fileURL.lastPathComponent)...")
     let compileResult = try await session.compile()
+    let setupDylibPath = setupResult?.dylibPath
 
     await MainActor.run {
         do {
@@ -106,7 +107,8 @@ func launchMacOSPreview(
                 sessionID: session.id,
                 dylibPath: compileResult.dylibPath,
                 title: title,
-                size: NSSize(width: width, height: height)
+                size: NSSize(width: width, height: height),
+                setupDylibPath: setupDylibPath
             )
             App.host.watchFile(
                 sessionID: session.id,
@@ -154,6 +156,7 @@ func launchIOSPreview(
         setupModule: setupResult?.moduleName,
         setupType: setupResult?.typeName,
         setupCompilerFlags: setupResult?.compilerFlags ?? [],
+        setupDylibPath: setupResult?.dylibPath,
         progress: progress
     )
 

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -532,7 +532,18 @@ private func handlePreviewStart(params: CallTool.Parameters, macCompiler: Compil
 
     let configResult = await configCache.load(for: fileURL)
     let config = configResult?.config
-    let platformStr = extractOptionalString("platform", from: params) ?? config?.platform ?? "macos"
+    let platformStr: String
+    if let explicit = extractOptionalString("platform", from: params) {
+        platformStr = explicit
+    } else if let configPlatform = config?.platform {
+        platformStr = configPlatform
+    } else if let spmPlatforms = SPMBuildSystem.detectPlatforms(for: fileURL),
+        spmPlatforms.contains("ios"), !spmPlatforms.contains("macos")
+    {
+        platformStr = "ios"
+    } else {
+        platformStr = "macos"
+    }
 
     let (explicitTraits, traitsError) = parseTraits(from: params)
     if let traitsError { return traitsError }
@@ -645,6 +656,7 @@ private func handleIOSPreviewStart(
         setupModule: setupResult?.moduleName,
         setupType: setupResult?.typeName,
         setupCompilerFlags: setupResult?.compilerFlags ?? [],
+        setupDylibPath: setupResult?.dylibPath,
         progress: progress
     )
 
@@ -731,6 +743,7 @@ private func startMacOSPreview(
 
     let compileResult = try await session.compile()
     let sessionID = session.id
+    let setupDylibPath = setupResult?.dylibPath
 
     await MainActor.run {
         do {
@@ -739,7 +752,8 @@ private func startMacOSPreview(
                 dylibPath: compileResult.dylibPath,
                 title: title,
                 size: NSSize(width: width, height: height),
-                headless: headless
+                headless: headless,
+                setupDylibPath: setupDylibPath
             )
             App.host.watchFile(
                 sessionID: sessionID,

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -537,7 +537,7 @@ private func handlePreviewStart(params: CallTool.Parameters, macCompiler: Compil
         platformStr = explicit
     } else if let configPlatform = config?.platform {
         platformStr = configPlatform
-    } else if let spmPlatforms = SPMBuildSystem.detectPlatforms(for: fileURL),
+    } else if let spmPlatforms = await SPMBuildSystem.detectPlatformsAsync(for: fileURL),
         spmPlatforms.contains("ios"), !spmPlatforms.contains("macos")
     {
         platformStr = "ios"

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -537,9 +537,7 @@ private func handlePreviewStart(params: CallTool.Parameters, macCompiler: Compil
         platformStr = explicit
     } else if let configPlatform = config?.platform {
         platformStr = configPlatform
-    } else if let spmPlatforms = await SPMBuildSystem.detectPlatformsAsync(for: fileURL),
-        spmPlatforms.contains("ios"), !spmPlatforms.contains("macos")
-    {
+    } else if await SPMBuildSystem.inferredPlatformAsync(for: fileURL) == .iOS {
         platformStr = "ios"
     } else {
         platformStr = "macos"

--- a/Sources/PreviewsCLI/RunCommand.swift
+++ b/Sources/PreviewsCLI/RunCommand.swift
@@ -21,8 +21,8 @@ struct RunCommand: ParsableCommand {
     @Option(name: .long, help: "Window height")
     var height: Int = 600
 
-    @Option(name: .long, help: "Target platform: 'macos' (default) or 'ios'")
-    var platform: CLIPlatform = .macos
+    @Option(name: .long, help: "Target platform: 'macos' or 'ios' (auto-detected if omitted)")
+    var platform: CLIPlatform?
 
     @Option(name: .long, help: "Project root path (auto-detected if omitted)")
     var project: String?
@@ -77,12 +77,12 @@ struct RunCommand: ParsableCommand {
         }
 
         let resolvedPlatform: CLIPlatform = {
-            if platform != .macos { return platform }
+            if let explicit = platform { return explicit }
             if let cp = projectConfig?.platform, cp == "ios" { return .ios }
             if SPMBuildSystem.inferredPlatform(for: fileURL) == .iOS {
                 return .ios
             }
-            return platform
+            return .macos
         }()
 
         switch resolvedPlatform {

--- a/Sources/PreviewsCLI/RunCommand.swift
+++ b/Sources/PreviewsCLI/RunCommand.swift
@@ -79,6 +79,11 @@ struct RunCommand: ParsableCommand {
         let resolvedPlatform: CLIPlatform = {
             if platform != .macos { return platform }
             if let cp = projectConfig?.platform, cp == "ios" { return .ios }
+            if let spmPlatforms = SPMBuildSystem.detectPlatforms(for: fileURL),
+                spmPlatforms.contains("ios"), !spmPlatforms.contains("macos")
+            {
+                return .ios
+            }
             return platform
         }()
 

--- a/Sources/PreviewsCLI/RunCommand.swift
+++ b/Sources/PreviewsCLI/RunCommand.swift
@@ -79,9 +79,7 @@ struct RunCommand: ParsableCommand {
         let resolvedPlatform: CLIPlatform = {
             if platform != .macos { return platform }
             if let cp = projectConfig?.platform, cp == "ios" { return .ios }
-            if let spmPlatforms = SPMBuildSystem.detectPlatforms(for: fileURL),
-                spmPlatforms.contains("ios"), !spmPlatforms.contains("macos")
-            {
+            if SPMBuildSystem.inferredPlatform(for: fileURL) == .iOS {
                 return .ios
             }
             return platform

--- a/Sources/PreviewsCLI/RunCommand.swift
+++ b/Sources/PreviewsCLI/RunCommand.swift
@@ -78,7 +78,7 @@ struct RunCommand: ParsableCommand {
 
         let resolvedPlatform: CLIPlatform = {
             if let explicit = platform { return explicit }
-            if let cp = projectConfig?.platform, cp == "ios" { return .ios }
+            if let cp = projectConfig?.platform { return cp == "ios" ? .ios : .macos }
             if SPMBuildSystem.inferredPlatform(for: fileURL) == .iOS {
                 return .ios
             }

--- a/Sources/PreviewsCLI/SnapshotCommand.swift
+++ b/Sources/PreviewsCLI/SnapshotCommand.swift
@@ -81,6 +81,11 @@ struct SnapshotCommand: ParsableCommand {
         let resolvedPlatform: CLIPlatform = {
             if platform != .macos { return platform }
             if let cp = projectConfig?.platform, cp == "ios" { return .ios }
+            if let spmPlatforms = SPMBuildSystem.detectPlatforms(for: fileURL),
+                spmPlatforms.contains("ios"), !spmPlatforms.contains("macos")
+            {
+                return .ios
+            }
             return platform
         }()
 
@@ -139,13 +144,15 @@ struct SnapshotCommand: ParsableCommand {
                 let compileResult = try await session.compile()
                 let sessionID = session.id
 
+                let setupDylibPath = setupResult?.dylibPath
                 await MainActor.run {
                     do {
                         try App.host.loadPreview(
                             sessionID: sessionID,
                             dylibPath: compileResult.dylibPath,
                             title: "Snapshot",
-                            size: NSSize(width: windowWidth, height: windowHeight)
+                            size: NSSize(width: windowWidth, height: windowHeight),
+                            setupDylibPath: setupDylibPath
                         )
                     } catch {
                         fputs("Failed to load preview: \(error)\n", stderr)
@@ -230,6 +237,7 @@ struct SnapshotCommand: ParsableCommand {
                     setupModule: setupResult?.moduleName,
                     setupType: setupResult?.typeName,
                     setupCompilerFlags: setupResult?.compilerFlags ?? [],
+                    setupDylibPath: setupResult?.dylibPath,
                     progress: progress
                 )
 

--- a/Sources/PreviewsCLI/SnapshotCommand.swift
+++ b/Sources/PreviewsCLI/SnapshotCommand.swift
@@ -81,9 +81,7 @@ struct SnapshotCommand: ParsableCommand {
         let resolvedPlatform: CLIPlatform = {
             if platform != .macos { return platform }
             if let cp = projectConfig?.platform, cp == "ios" { return .ios }
-            if let spmPlatforms = SPMBuildSystem.detectPlatforms(for: fileURL),
-                spmPlatforms.contains("ios"), !spmPlatforms.contains("macos")
-            {
+            if SPMBuildSystem.inferredPlatform(for: fileURL) == .iOS {
                 return .ios
             }
             return platform

--- a/Sources/PreviewsCLI/SnapshotCommand.swift
+++ b/Sources/PreviewsCLI/SnapshotCommand.swift
@@ -26,8 +26,8 @@ struct SnapshotCommand: ParsableCommand {
     @Option(name: .long, help: "Window height")
     var height: Int = 600
 
-    @Option(name: .long, help: "Target platform: 'macos' (default) or 'ios'")
-    var platform: CLIPlatform = .macos
+    @Option(name: .long, help: "Target platform: 'macos' or 'ios' (auto-detected if omitted)")
+    var platform: CLIPlatform?
 
     @Option(name: .long, help: "Project root path (auto-detected if omitted)")
     var project: String?
@@ -79,12 +79,12 @@ struct SnapshotCommand: ParsableCommand {
         }
 
         let resolvedPlatform: CLIPlatform = {
-            if platform != .macos { return platform }
+            if let explicit = platform { return explicit }
             if let cp = projectConfig?.platform, cp == "ios" { return .ios }
             if SPMBuildSystem.inferredPlatform(for: fileURL) == .iOS {
                 return .ios
             }
-            return platform
+            return .macos
         }()
 
         switch resolvedPlatform {

--- a/Sources/PreviewsCLI/SnapshotCommand.swift
+++ b/Sources/PreviewsCLI/SnapshotCommand.swift
@@ -80,7 +80,7 @@ struct SnapshotCommand: ParsableCommand {
 
         let resolvedPlatform: CLIPlatform = {
             if let explicit = platform { return explicit }
-            if let cp = projectConfig?.platform, cp == "ios" { return .ios }
+            if let cp = projectConfig?.platform { return cp == "ios" ? .ios : .macos }
             if SPMBuildSystem.inferredPlatform(for: fileURL) == .iOS {
                 return .ios
             }

--- a/Sources/PreviewsCLI/VariantsCommand.swift
+++ b/Sources/PreviewsCLI/VariantsCommand.swift
@@ -105,6 +105,11 @@ struct VariantsCommand: ParsableCommand {
         let resolvedPlatform: CLIPlatform = {
             if platform != .macos { return platform }
             if let cp = configResult?.config.platform, cp == "ios" { return .ios }
+            if let spmPlatforms = SPMBuildSystem.detectPlatforms(for: fileURL),
+                spmPlatforms.contains("ios"), !spmPlatforms.contains("macos")
+            {
+                return .ios
+            }
             return platform
         }()
 
@@ -166,6 +171,7 @@ struct VariantsCommand: ParsableCommand {
             // Setup phase — any failure here is a hard exit (no variants can be captured).
             let session: PreviewSession
             let sessionID: String
+            let setupDylibPath: URL?
             do {
                 let compiler = try await Compiler()
                 let projectRootURL = projectPath.map { URL(fileURLWithPath: $0) }
@@ -174,6 +180,7 @@ struct VariantsCommand: ParsableCommand {
                     progress: progress)
 
                 let setupResult = try await buildSetupFromConfig(configResult, platform: .macOS)
+                setupDylibPath = setupResult?.dylibPath
 
                 session = PreviewSession(
                     sourceFile: fileURL,
@@ -207,7 +214,8 @@ struct VariantsCommand: ParsableCommand {
                             sessionID: sessionID,
                             dylibPath: compileResult.dylibPath,
                             title: "Variant: \(variant.label)",
-                            size: NSSize(width: windowWidth, height: windowHeight)
+                            size: NSSize(width: windowWidth, height: windowHeight),
+                            setupDylibPath: setupDylibPath
                         )
                     }
 
@@ -289,6 +297,7 @@ struct VariantsCommand: ParsableCommand {
                     setupModule: setupResult?.moduleName,
                     setupType: setupResult?.typeName,
                     setupCompilerFlags: setupResult?.compilerFlags ?? [],
+                    setupDylibPath: setupResult?.dylibPath,
                     progress: progress
                 )
 

--- a/Sources/PreviewsCLI/VariantsCommand.swift
+++ b/Sources/PreviewsCLI/VariantsCommand.swift
@@ -105,9 +105,7 @@ struct VariantsCommand: ParsableCommand {
         let resolvedPlatform: CLIPlatform = {
             if platform != .macos { return platform }
             if let cp = configResult?.config.platform, cp == "ios" { return .ios }
-            if let spmPlatforms = SPMBuildSystem.detectPlatforms(for: fileURL),
-                spmPlatforms.contains("ios"), !spmPlatforms.contains("macos")
-            {
+            if SPMBuildSystem.inferredPlatform(for: fileURL) == .iOS {
                 return .ios
             }
             return platform

--- a/Sources/PreviewsCLI/VariantsCommand.swift
+++ b/Sources/PreviewsCLI/VariantsCommand.swift
@@ -50,8 +50,8 @@ struct VariantsCommand: ParsableCommand {
     @Option(name: .long, help: "Window height")
     var height: Int = 600
 
-    @Option(name: .long, help: "Target platform: 'macos' (default) or 'ios'")
-    var platform: CLIPlatform = .macos
+    @Option(name: .long, help: "Target platform: 'macos' or 'ios' (auto-detected if omitted)")
+    var platform: CLIPlatform?
 
     @Option(name: .long, help: "Project root path (auto-detected if omitted)")
     var project: String?
@@ -103,12 +103,12 @@ struct VariantsCommand: ParsableCommand {
             at: outputDirURL, withIntermediateDirectories: true)
 
         let resolvedPlatform: CLIPlatform = {
-            if platform != .macos { return platform }
+            if let explicit = platform { return explicit }
             if let cp = configResult?.config.platform, cp == "ios" { return .ios }
             if SPMBuildSystem.inferredPlatform(for: fileURL) == .iOS {
                 return .ios
             }
-            return platform
+            return .macos
         }()
 
         switch resolvedPlatform {

--- a/Sources/PreviewsCLI/VariantsCommand.swift
+++ b/Sources/PreviewsCLI/VariantsCommand.swift
@@ -104,7 +104,7 @@ struct VariantsCommand: ParsableCommand {
 
         let resolvedPlatform: CLIPlatform = {
             if let explicit = platform { return explicit }
-            if let cp = configResult?.config.platform, cp == "ios" { return .ios }
+            if let cp = configResult?.config.platform { return cp == "ios" ? .ios : .macos }
             if SPMBuildSystem.inferredPlatform(for: fileURL) == .iOS {
                 return .ios
             }

--- a/Sources/PreviewsCore/SPMBuildSystem.swift
+++ b/Sources/PreviewsCore/SPMBuildSystem.swift
@@ -70,6 +70,21 @@ public actor SPMBuildSystem: BuildSystem {
         return nil
     }
 
+    /// Returns .iOS if the SPM package declares iOS but not macOS; nil otherwise.
+    /// Convenience for the common "should we default to iOS?" check at CLI/MCP call sites.
+    public static func inferredPlatform(for sourceFile: URL) -> PreviewPlatform? {
+        guard let platforms = detectPlatforms(for: sourceFile) else { return nil }
+        if platforms.contains("ios"), !platforms.contains("macos") { return .iOS }
+        return nil
+    }
+
+    /// Async variant of `inferredPlatform` for MCP server contexts.
+    public static func inferredPlatformAsync(for sourceFile: URL) async -> PreviewPlatform? {
+        guard let platforms = await detectPlatformsAsync(for: sourceFile) else { return nil }
+        if platforms.contains("ios"), !platforms.contains("macos") { return .iOS }
+        return nil
+    }
+
     private static func decodePlatforms(from data: Data) -> [String]? {
         struct PlatformInfo: Decodable {
             let platforms: [PlatformEntry]?

--- a/Sources/PreviewsCore/SPMBuildSystem.swift
+++ b/Sources/PreviewsCore/SPMBuildSystem.swift
@@ -29,6 +29,13 @@ public actor SPMBuildSystem: BuildSystem {
             try process.run()
         } catch { return nil }
 
+        // Kill the process if it doesn't finish in 10 seconds (e.g., network
+        // stall during dependency resolution on CI).
+        let proc = process
+        DispatchQueue.global().asyncAfter(deadline: .now() + 10) {
+            if proc.isRunning { proc.terminate() }
+        }
+
         // Read pipe data BEFORE waitUntilExit to avoid deadlock.
         // If the subprocess writes more than the pipe buffer (~64KB),
         // it blocks until the parent drains the pipe. Calling

--- a/Sources/PreviewsCore/SPMBuildSystem.swift
+++ b/Sources/PreviewsCore/SPMBuildSystem.swift
@@ -10,6 +10,49 @@ public actor SPMBuildSystem: BuildSystem {
         self.sourceFile = sourceFile
     }
 
+    // MARK: - Platform Detection
+
+    /// Detect platforms declared in the SPM package containing this source file.
+    /// Returns nil if no SPM package found or platforms can't be determined.
+    /// Runs synchronously (short-lived subprocess) for use in CLI resolution.
+    public static func detectPlatforms(for sourceFile: URL) -> [String]? {
+        var dir = sourceFile.deletingLastPathComponent().standardizedFileURL
+        let root = URL(fileURLWithPath: "/")
+        var packageDir: URL?
+        while dir.path != root.path {
+            let packageSwift = dir.appendingPathComponent("Package.swift")
+            if FileManager.default.fileExists(atPath: packageSwift.path) {
+                packageDir = dir
+                break
+            }
+            dir = dir.deletingLastPathComponent()
+        }
+        guard let packageDir else { return nil }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["swift", "package", "describe", "--type", "json"]
+        process.currentDirectoryURL = packageDir
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
+        } catch { return nil }
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        struct PlatformInfo: Decodable {
+            let platforms: [PlatformEntry]?
+            struct PlatformEntry: Decodable { let name: String }
+        }
+        guard let info = try? JSONDecoder().decode(PlatformInfo.self, from: data),
+            let platforms = info.platforms, !platforms.isEmpty
+        else { return nil }
+        return platforms.map(\.name)
+    }
+
     // MARK: - Detection
 
     public static func detect(for sourceFile: URL) async throws -> SPMBuildSystem? {

--- a/Sources/PreviewsCore/SPMBuildSystem.swift
+++ b/Sources/PreviewsCore/SPMBuildSystem.swift
@@ -16,18 +16,7 @@ public actor SPMBuildSystem: BuildSystem {
     /// Returns nil if no SPM package found or platforms can't be determined.
     /// Runs synchronously (short-lived subprocess) for use in CLI resolution.
     public static func detectPlatforms(for sourceFile: URL) -> [String]? {
-        var dir = sourceFile.deletingLastPathComponent().standardizedFileURL
-        let root = URL(fileURLWithPath: "/")
-        var packageDir: URL?
-        while dir.path != root.path {
-            let packageSwift = dir.appendingPathComponent("Package.swift")
-            if FileManager.default.fileExists(atPath: packageSwift.path) {
-                packageDir = dir
-                break
-            }
-            dir = dir.deletingLastPathComponent()
-        }
-        guard let packageDir else { return nil }
+        guard let packageDir = findPackageDirectory(from: sourceFile) else { return nil }
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
@@ -43,6 +32,42 @@ public actor SPMBuildSystem: BuildSystem {
         } catch { return nil }
 
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return decodePlatforms(from: data)
+    }
+
+    /// Async variant of `detectPlatforms` that avoids blocking the cooperative thread pool.
+    /// Preferred in async contexts like the MCP server.
+    public static func detectPlatformsAsync(for sourceFile: URL) async -> [String]? {
+        guard let packageDir = findPackageDirectory(from: sourceFile) else { return nil }
+
+        guard
+            let output = try? await runAsync(
+                "/usr/bin/env",
+                arguments: ["swift", "package", "describe", "--type", "json"],
+                workingDirectory: packageDir,
+                discardStderr: true
+            ),
+            output.exitCode == 0,
+            let data = output.stdout.data(using: .utf8)
+        else { return nil }
+        return decodePlatforms(from: data)
+    }
+
+    /// Walk up from a source file to find the nearest directory containing Package.swift.
+    public static func findPackageDirectory(from sourceFile: URL) -> URL? {
+        var dir = sourceFile.deletingLastPathComponent().standardizedFileURL
+        let root = URL(fileURLWithPath: "/")
+        while dir.path != root.path {
+            let packageSwift = dir.appendingPathComponent("Package.swift")
+            if FileManager.default.fileExists(atPath: packageSwift.path) {
+                return dir
+            }
+            dir = dir.deletingLastPathComponent()
+        }
+        return nil
+    }
+
+    private static func decodePlatforms(from data: Data) -> [String]? {
         struct PlatformInfo: Decodable {
             let platforms: [PlatformEntry]?
             struct PlatformEntry: Decodable { let name: String }

--- a/Sources/PreviewsCore/SPMBuildSystem.swift
+++ b/Sources/PreviewsCore/SPMBuildSystem.swift
@@ -27,11 +27,15 @@ public actor SPMBuildSystem: BuildSystem {
         process.standardError = FileHandle.nullDevice
         do {
             try process.run()
-            process.waitUntilExit()
-            guard process.terminationStatus == 0 else { return nil }
         } catch { return nil }
 
+        // Read pipe data BEFORE waitUntilExit to avoid deadlock.
+        // If the subprocess writes more than the pipe buffer (~64KB),
+        // it blocks until the parent drains the pipe. Calling
+        // waitUntilExit first would deadlock both sides.
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return nil }
         return decodePlatforms(from: data)
     }
 

--- a/Sources/PreviewsCore/SPMBuildSystem.swift
+++ b/Sources/PreviewsCore/SPMBuildSystem.swift
@@ -59,7 +59,10 @@ public actor SPMBuildSystem: BuildSystem {
         let root = URL(fileURLWithPath: "/")
         while dir.path != root.path {
             let packageSwift = dir.appendingPathComponent("Package.swift")
-            if FileManager.default.fileExists(atPath: packageSwift.path) {
+            var isDir: ObjCBool = false
+            if FileManager.default.fileExists(atPath: packageSwift.path, isDirectory: &isDir),
+                !isDir.boolValue
+            {
                 return dir
             }
             dir = dir.deletingLastPathComponent()

--- a/Sources/PreviewsCore/SetupBuilder.swift
+++ b/Sources/PreviewsCore/SetupBuilder.swift
@@ -94,10 +94,12 @@ public enum SetupBuilder {
         var flags: [String] = [
             "-I", modulesDir.path,
             // Link against the setup dylib so the linker resolves setup symbols at link time.
-            // At runtime the host pre-loads the dylib with RTLD_GLOBAL, so dyld reuses it.
-            // This is preferred over -undefined dynamic_lookup which suppresses ALL undefined
-            // symbol errors, masking genuine missing-dependency problems.
+            // At runtime the host pre-loads the dylib with RTLD_GLOBAL, so dyld reuses it
+            // (matched by install_name). This is preferred over -undefined dynamic_lookup
+            // which suppresses ALL undefined symbol errors, masking genuine problems.
             "-L", binPath.path, "-lPreviewSetup",
+            // rpath so dyld can find libPreviewSetup.dylib when loading the preview dylib.
+            "-Xlinker", "-rpath", "-Xlinker", binPath.path,
         ]
 
         let frameworkNames = collectFrameworks(binPath: binPath)
@@ -166,6 +168,9 @@ public enum SetupBuilder {
 
         let swiftcPath = try await resolveSwiftc()
         var args = ["-emit-library", "-o", dylibPath.path]
+        // Set the install name to the absolute path so dyld recognizes the
+        // already-RTLD_GLOBAL-loaded image when preview dylibs reference it.
+        args += ["-Xlinker", "-install_name", "-Xlinker", dylibPath.path]
         args += ["-target", platform.targetTriple]
 
         // Always pass -sdk — swiftc needs it for both macOS and iOS to locate

--- a/Sources/PreviewsCore/SetupBuilder.swift
+++ b/Sources/PreviewsCore/SetupBuilder.swift
@@ -93,9 +93,11 @@ public enum SetupBuilder {
 
         var flags: [String] = [
             "-I", modulesDir.path,
-            // Let the linker resolve setup symbols at runtime from the RTLD_GLOBAL-loaded
-            // setup dylib rather than statically linking setup code into each preview dylib.
-            "-Xlinker", "-undefined", "-Xlinker", "dynamic_lookup",
+            // Link against the setup dylib so the linker resolves setup symbols at link time.
+            // At runtime the host pre-loads the dylib with RTLD_GLOBAL, so dyld reuses it.
+            // This is preferred over -undefined dynamic_lookup which suppresses ALL undefined
+            // symbol errors, masking genuine missing-dependency problems.
+            "-L", binPath.path, "-lPreviewSetup",
         ]
 
         let frameworkNames = collectFrameworks(binPath: binPath)
@@ -156,16 +158,26 @@ public enum SetupBuilder {
             )
         }
 
+        // Remove stale static archives from previous builds so they don't confuse the linker.
+        cleanStaleArchives(binPath: binPath)
+
         let dylibPath = binPath.appendingPathComponent("libPreviewSetup.dylib")
         try? fm.removeItem(at: dylibPath)
 
         let swiftcPath = try await resolveSwiftc()
         var args = ["-emit-library", "-o", dylibPath.path]
         args += ["-target", platform.targetTriple]
-        if platform == .iOS {
-            let sdkPath = try await resolveIOSSDK()
-            args += ["-sdk", sdkPath]
+
+        // Always pass -sdk — swiftc needs it for both macOS and iOS to locate
+        // the Swift runtime and system frameworks.
+        let sdkPath: String
+        switch platform {
+        case .iOS:
+            sdkPath = try await resolveIOSSDK()
+        case .macOS:
+            sdkPath = try await resolveMacOSSDK()
         }
+        args += ["-sdk", sdkPath]
 
         let frameworks = collectFrameworks(binPath: binPath)
         if !frameworks.isEmpty {
@@ -194,6 +206,18 @@ public enum SetupBuilder {
         }
 
         return dylibPath
+    }
+
+    /// Remove stale .a files from previous builds that used static linking.
+    private static func cleanStaleArchives(binPath: URL) {
+        guard
+            let entries = try? FileManager.default.contentsOfDirectory(
+                at: binPath, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]
+            )
+        else { return }
+        for entry in entries where entry.pathExtension == "a" {
+            try? FileManager.default.removeItem(at: entry)
+        }
     }
 
     private static func collectObjectFiles(in directory: URL) -> [URL] {
@@ -240,6 +264,18 @@ public enum SetupBuilder {
         guard result.exitCode == 0 else {
             throw SetupBuilderError.buildFailed(
                 package: "iOS SDK", stderr: result.stderr
+            )
+        }
+        return result.stdout
+    }
+
+    private static func resolveMacOSSDK() async throws -> String {
+        let result = try await runAsync(
+            "/usr/bin/xcrun", arguments: ["--show-sdk-path", "--sdk", "macosx"]
+        )
+        guard result.exitCode == 0 else {
+            throw SetupBuilderError.buildFailed(
+                package: "macOS SDK", stderr: result.stderr
             )
         }
         return result.stdout

--- a/Sources/PreviewsCore/SetupBuilder.swift
+++ b/Sources/PreviewsCore/SetupBuilder.swift
@@ -7,6 +7,9 @@ public enum SetupBuilder {
         public let moduleName: String
         public let typeName: String
         public let compilerFlags: [String]
+        /// Path to the setup dynamic library. Must be loaded with RTLD_GLOBAL
+        /// before any preview dylib so all preview dylibs share the same statics.
+        public let dylibPath: URL
     }
 
     /// Build the setup package and return flags needed to compile bridge code that imports it.
@@ -83,18 +86,17 @@ public enum SetupBuilder {
             )
         }
 
-        // Archive .o files into .a libraries (SPM doesn't create archives for library targets)
-        let archivedLibs = try await archiveTargets(binPath: binPath)
+        // Link .o files into a dynamic library so all preview dylibs share the same statics.
+        // Static linking (.a) gives each preview dylib its own copy of statics, which breaks
+        // setUp() state persistence across hot-reload cycles (see issue #86).
+        let dylibPath = try await linkDynamicLibrary(binPath: binPath, platform: platform)
 
         var flags: [String] = [
             "-I", modulesDir.path,
+            // Let the linker resolve setup symbols at runtime from the RTLD_GLOBAL-loaded
+            // setup dylib rather than statically linking setup code into each preview dylib.
+            "-Xlinker", "-undefined", "-Xlinker", "dynamic_lookup",
         ]
-        if !archivedLibs.isEmpty {
-            flags += ["-L", binPath.path]
-            for lib in archivedLibs {
-                flags += ["-l\(lib)"]
-            }
-        }
 
         let frameworkNames = collectFrameworks(binPath: binPath)
         if !frameworkNames.isEmpty {
@@ -108,7 +110,8 @@ public enum SetupBuilder {
         let result = Result(
             moduleName: config.moduleName,
             typeName: config.typeName,
-            compilerFlags: flags
+            compilerFlags: flags,
+            dylibPath: dylibPath
         )
 
         SetupCache.store(
@@ -122,48 +125,75 @@ public enum SetupBuilder {
         return result
     }
 
-    /// Archive .o files from each target's build directory into .a static libraries.
-    /// SPM leaves loose .o files under `<binPath>/<Target>.build/` without creating archives.
-    private static func archiveTargets(binPath: URL) async throws -> [String] {
+    /// Link .o files from all target build directories into a single dynamic library.
+    /// This ensures all preview dylibs share the same statics from the setup module.
+    private static func linkDynamicLibrary(
+        binPath: URL,
+        platform: PreviewPlatform
+    ) async throws -> URL {
         let fm = FileManager.default
-        guard
-            let entries = try? fm.contentsOfDirectory(
-                at: binPath, includingPropertiesForKeys: [.isDirectoryKey],
-                options: [.skipsHiddenFiles]
-            )
-        else { return [] }
+        var allObjectFiles: [URL] = []
 
-        let arPath = try await resolveAr()
-        var libs: [String] = []
-
-        for entry in entries {
-            let name = entry.lastPathComponent
-            guard name.hasSuffix(".build") else { continue }
-            var isDir: ObjCBool = false
-            guard fm.fileExists(atPath: entry.path, isDirectory: &isDir), isDir.boolValue else {
-                continue
+        if let entries = try? fm.contentsOfDirectory(
+            at: binPath, includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) {
+            for entry in entries {
+                let name = entry.lastPathComponent
+                guard name.hasSuffix(".build") else { continue }
+                var isDir: ObjCBool = false
+                guard fm.fileExists(atPath: entry.path, isDirectory: &isDir), isDir.boolValue
+                else { continue }
+                let targetName = String(name.dropLast(".build".count))
+                if targetName.hasPrefix("_") { continue }
+                allObjectFiles.append(contentsOf: collectObjectFiles(in: entry))
             }
-
-            let targetName = String(name.dropLast(".build".count))
-            if targetName.hasPrefix("_") { continue }
-
-            let objectFiles = collectObjectFiles(in: entry)
-            guard !objectFiles.isEmpty else { continue }
-
-            let archivePath = binPath.appendingPathComponent("lib\(targetName).a")
-            try? fm.removeItem(at: archivePath)
-
-            var arArgs = ["rcs", archivePath.path]
-            arArgs.append(contentsOf: objectFiles.map(\.path))
-            let result = try await runAsync(arPath, arguments: arArgs)
-            guard result.exitCode == 0 else {
-                throw SetupBuilderError.buildFailed(
-                    package: targetName, stderr: "ar failed: \(result.stderr)"
-                )
-            }
-            libs.append(targetName)
         }
-        return libs
+
+        guard !allObjectFiles.isEmpty else {
+            throw SetupBuilderError.buildFailed(
+                package: "setup", stderr: "No object files found to link"
+            )
+        }
+
+        let dylibPath = binPath.appendingPathComponent("libPreviewSetup.dylib")
+        try? fm.removeItem(at: dylibPath)
+
+        let swiftcPath = try await resolveSwiftc()
+        var args = ["-emit-library", "-o", dylibPath.path]
+        args += ["-target", platform.targetTriple]
+        if platform == .iOS {
+            let sdkPath = try await resolveIOSSDK()
+            args += ["-sdk", sdkPath]
+        }
+
+        let frameworks = collectFrameworks(binPath: binPath)
+        if !frameworks.isEmpty {
+            args += ["-F", binPath.path]
+            for fw in frameworks {
+                args += ["-framework", fw]
+            }
+        }
+
+        args += allObjectFiles.map(\.path)
+
+        let linkResult = try await runAsync(swiftcPath, arguments: args)
+        guard linkResult.exitCode == 0 else {
+            throw SetupBuilderError.buildFailed(
+                package: "setup dylib", stderr: linkResult.stderr
+            )
+        }
+
+        // Ad-hoc codesign (required on Apple Silicon)
+        let codesignPath = try await resolveCodesign()
+        let signResult = try await runAsync(codesignPath, arguments: ["-s", "-", dylibPath.path])
+        guard signResult.exitCode == 0 else {
+            throw SetupBuilderError.buildFailed(
+                package: "setup dylib codesign", stderr: signResult.stderr
+            )
+        }
+
+        return dylibPath
     }
 
     private static func collectObjectFiles(in directory: URL) -> [URL] {
@@ -179,12 +209,26 @@ public enum SetupBuilder {
         return files
     }
 
-    private static func resolveAr() async throws -> String {
+    private static func resolveSwiftc() async throws -> String {
         let result = try await runAsync(
-            "/usr/bin/xcrun", arguments: ["--find", "ar"], discardStderr: true
+            "/usr/bin/xcrun", arguments: ["--find", "swiftc"], discardStderr: true
         )
         guard result.exitCode == 0 else {
-            throw SetupBuilderError.buildFailed(package: "ar", stderr: "Could not locate ar via xcrun")
+            throw SetupBuilderError.buildFailed(
+                package: "swiftc", stderr: "Could not locate swiftc via xcrun"
+            )
+        }
+        return result.stdout
+    }
+
+    private static func resolveCodesign() async throws -> String {
+        let result = try await runAsync(
+            "/usr/bin/xcrun", arguments: ["--find", "codesign"], discardStderr: true
+        )
+        guard result.exitCode == 0 else {
+            throw SetupBuilderError.buildFailed(
+                package: "codesign", stderr: "Could not locate codesign via xcrun"
+            )
         }
         return result.stdout
     }

--- a/Sources/PreviewsCore/SetupCache.swift
+++ b/Sources/PreviewsCore/SetupCache.swift
@@ -107,6 +107,7 @@ public enum SetupCache {
         let moduleName: String
         let typeName: String
         let compilerFlags: [String]
+        let dylibPath: String
         let sourceHash: String
         let swiftVersion: String
         let platform: String
@@ -149,10 +150,14 @@ public enum SetupCache {
             return nil
         }
 
+        let dylibURL = URL(fileURLWithPath: entry.dylibPath)
+        guard FileManager.default.fileExists(atPath: dylibURL.path) else { return nil }
+
         return SetupBuilder.Result(
             moduleName: entry.moduleName,
             typeName: entry.typeName,
-            compilerFlags: entry.compilerFlags
+            compilerFlags: entry.compilerFlags,
+            dylibPath: dylibURL
         )
     }
 
@@ -176,6 +181,7 @@ public enum SetupCache {
                 moduleName: result.moduleName,
                 typeName: result.typeName,
                 compilerFlags: result.compilerFlags,
+                dylibPath: result.dylibPath.path,
                 sourceHash: sourceHash,
                 swiftVersion: swiftVersion,
                 platform: platform.rawValue
@@ -241,10 +247,13 @@ public enum SetupCache {
             guard fm.fileExists(atPath: dir) else { return false }
         }
 
-        // Validate -l libraries resolve to lib<name>.a under -L dirs
+        // Validate -l libraries resolve to lib<name>.dylib or lib<name>.a under -L dirs
         for lib in libs {
             let found = lDirs.contains { dir in
-                fm.fileExists(atPath: (dir as NSString).appendingPathComponent("lib\(lib).a"))
+                fm.fileExists(
+                    atPath: (dir as NSString).appendingPathComponent("lib\(lib).dylib"))
+                    || fm.fileExists(
+                        atPath: (dir as NSString).appendingPathComponent("lib\(lib).a"))
             }
             guard found else { return false }
         }

--- a/Sources/PreviewsIOS/IOSHostAppSource.swift
+++ b/Sources/PreviewsIOS/IOSHostAppSource.swift
@@ -38,6 +38,18 @@ enum IOSHostAppSource {
                 }
 
                 let dylibPath = args[dylibIndex + 1]
+
+                // Load setup dylib with RTLD_GLOBAL before any preview dylib so all
+                // preview dylibs share the same statics (issue #86).
+                if let setupIndex = args.firstIndex(of: "--setup-dylib"),
+                   setupIndex + 1 < args.count {
+                    let setupPath = args[setupIndex + 1]
+                    if dlopen(setupPath, RTLD_NOW | RTLD_GLOBAL) == nil {
+                        let err = String(cString: dlerror())
+                        NSLog("PreviewHost: Failed to load setup dylib: \\(err)")
+                    }
+                }
+
                 loadPreview(dylibPath: dylibPath)
 
                 initTouchInjection()

--- a/Sources/PreviewsIOS/IOSPreviewSession.swift
+++ b/Sources/PreviewsIOS/IOSPreviewSession.swift
@@ -24,6 +24,7 @@ public actor IOSPreviewSession {
     private let setupModule: String?
     private let setupType: String?
     private let setupCompilerFlags: [String]
+    private let setupDylibPath: URL?
     public var currentTraits: PreviewTraits { traits }
 
     // TCP socket state
@@ -49,6 +50,7 @@ public actor IOSPreviewSession {
         setupModule: String? = nil,
         setupType: String? = nil,
         setupCompilerFlags: [String] = [],
+        setupDylibPath: URL? = nil,
         progress: (any ProgressReporter)? = nil
     ) {
         self.id = UUID().uuidString
@@ -64,6 +66,7 @@ public actor IOSPreviewSession {
         self.setupModule = setupModule
         self.setupType = setupType
         self.setupCompilerFlags = setupCompilerFlags
+        self.setupDylibPath = setupDylibPath
         self.progress = progress
     }
 
@@ -166,13 +169,17 @@ public actor IOSPreviewSession {
 
         // 5. Launch host app with dylib path and port
         await progress?.report(.launchingApp, message: "Launching host app...")
+        var launchArgs = [
+            "--dylib", compileResult.dylibPath.path,
+            "--port", String(port),
+        ]
+        if let setupPath = setupDylibPath {
+            launchArgs += ["--setup-dylib", setupPath.path]
+        }
         let pid = try await simulatorManager.launchApp(
             udid: deviceUDID,
             bundleID: Self.hostBundleID,
-            arguments: [
-                "--dylib", compileResult.dylibPath.path,
-                "--port", String(port),
-            ]
+            arguments: launchArgs
         )
 
         // 6. Accept connection from host app (up to 10 seconds)

--- a/Sources/PreviewsMacOS/HostApp.swift
+++ b/Sources/PreviewsMacOS/HostApp.swift
@@ -25,6 +25,8 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     private var retainedLoaders: [DylibLoader] = []
     private var retainedViews: [NSView] = []
     private var hasCalledSetUp = false
+    /// Retains the setup dylib loaded with RTLD_GLOBAL so all preview dylibs share its statics.
+    private var setupDylibLoader: DylibLoader?
 
     /// Callback invoked after NSApplication finishes launching.
     public var onLaunch: (@MainActor () -> Void)?
@@ -64,15 +66,24 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     /// Load a dylib and display its preview view in a window.
     /// If a window already exists for this session, reuses it (swaps content view).
     /// - Parameter headless: If provided, overrides the instance-level default for this window.
+    /// - Parameter setupDylibPath: Path to the setup dynamic library. Loaded once with RTLD_GLOBAL
+    ///   so all preview dylibs share the same statics (see issue #86).
     public func loadPreview(
         sessionID: String,
         dylibPath: URL,
         entryPoint: String = "createPreviewView",
         title: String = "Preview",
         size: NSSize = NSSize(width: 400, height: 600),
-        headless: Bool? = nil
+        headless: Bool? = nil,
+        setupDylibPath: URL? = nil
     ) throws {
         let headless = headless ?? self.headless
+
+        // Load the setup dylib once before any preview dylib. RTLD_GLOBAL ensures
+        // all preview dylibs resolve setup symbols from this shared image.
+        if let setupPath = setupDylibPath, setupDylibLoader == nil {
+            setupDylibLoader = try DylibLoader(path: setupPath.path)
+        }
 
         let loader = try DylibLoader(path: dylibPath.path)
 

--- a/Sources/PreviewsMacOS/HostApp.swift
+++ b/Sources/PreviewsMacOS/HostApp.swift
@@ -27,6 +27,8 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     private var hasCalledSetUp = false
     /// Retains the setup dylib loaded with RTLD_GLOBAL so all preview dylibs share its statics.
     private var setupDylibLoader: DylibLoader?
+    /// Remembered so the watchFile reload path can pass it to loadPreview.
+    private var setupDylibPath: URL?
 
     /// Callback invoked after NSApplication finishes launching.
     public var onLaunch: (@MainActor () -> Void)?
@@ -81,8 +83,11 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
 
         // Load the setup dylib once before any preview dylib. RTLD_GLOBAL ensures
         // all preview dylibs resolve setup symbols from this shared image.
-        if let setupPath = setupDylibPath, setupDylibLoader == nil {
-            setupDylibLoader = try DylibLoader(path: setupPath.path)
+        if let path = setupDylibPath {
+            self.setupDylibPath = path
+        }
+        if let path = self.setupDylibPath, setupDylibLoader == nil {
+            setupDylibLoader = try DylibLoader(path: path.path)
         }
 
         let loader = try DylibLoader(path: dylibPath.path)
@@ -203,7 +208,8 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
                                 sessionID: sessionID,
                                 dylibPath: compileResult.dylibPath,
                                 title: "Preview: \(fileURL.lastPathComponent)",
-                                size: existingFrame?.size ?? NSSize(width: 400, height: 600)
+                                size: existingFrame?.size ?? NSSize(width: 400, height: 600),
+                                setupDylibPath: self.setupDylibPath
                             )
                             if let frame = existingFrame {
                                 self.windows[sessionID]?.setFrameOrigin(frame.origin)

--- a/Tests/PreviewsCoreTests/BuildSystemTests.swift
+++ b/Tests/PreviewsCoreTests/BuildSystemTests.swift
@@ -839,18 +839,18 @@ struct BuildSystemTests {
     // MARK: - SPMBuildSystem.findPackageDirectory
 
     @Test("findPackageDirectory walks up to Package.swift")
-    func findPackageDirectory() {
+    func findPackageDirectory() throws {
         let tmpDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("previewsmcp-test-\(UUID().uuidString)")
         let sourcesDir = tmpDir.appendingPathComponent("Sources/MyTarget")
-        try! FileManager.default.createDirectory(at: sourcesDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: sourcesDir, withIntermediateDirectories: true)
 
         let packageSwift = tmpDir.appendingPathComponent("Package.swift")
-        try! "// swift-tools-version: 6.0".write(
+        try "// swift-tools-version: 6.0".write(
             to: packageSwift, atomically: true, encoding: .utf8)
 
         let sourceFile = sourcesDir.appendingPathComponent("MyView.swift")
-        try! "import SwiftUI".write(to: sourceFile, atomically: true, encoding: .utf8)
+        try "import SwiftUI".write(to: sourceFile, atomically: true, encoding: .utf8)
 
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
@@ -859,18 +859,18 @@ struct BuildSystemTests {
     }
 
     @Test("findPackageDirectory ignores directory named Package.swift")
-    func findPackageDirectoryIgnoresDirectory() {
+    func findPackageDirectoryIgnoresDirectory() throws {
         let tmpDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("previewsmcp-test-\(UUID().uuidString)")
         let sourcesDir = tmpDir.appendingPathComponent("Sources/MyTarget")
-        try! FileManager.default.createDirectory(at: sourcesDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: sourcesDir, withIntermediateDirectories: true)
 
         // Create a directory named Package.swift instead of a file
         let packageDir = tmpDir.appendingPathComponent("Package.swift")
-        try! FileManager.default.createDirectory(at: packageDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: packageDir, withIntermediateDirectories: true)
 
         let sourceFile = sourcesDir.appendingPathComponent("MyView.swift")
-        try! "import SwiftUI".write(to: sourceFile, atomically: true, encoding: .utf8)
+        try "import SwiftUI".write(to: sourceFile, atomically: true, encoding: .utf8)
 
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
@@ -879,13 +879,13 @@ struct BuildSystemTests {
     }
 
     @Test("findPackageDirectory returns nil for standalone file")
-    func findPackageDirectoryNilForStandalone() {
+    func findPackageDirectoryNilForStandalone() throws {
         let tmpDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("previewsmcp-test-\(UUID().uuidString)")
-        try! FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
 
         let sourceFile = tmpDir.appendingPathComponent("Standalone.swift")
-        try! "import SwiftUI".write(to: sourceFile, atomically: true, encoding: .utf8)
+        try "import SwiftUI".write(to: sourceFile, atomically: true, encoding: .utf8)
 
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
@@ -913,13 +913,13 @@ struct BuildSystemTests {
     }
 
     @Test("detectPlatforms returns nil for standalone file with no package")
-    func detectPlatformsNilForStandalone() {
+    func detectPlatformsNilForStandalone() throws {
         let tmpDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("previewsmcp-test-\(UUID().uuidString)")
-        try! FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
 
         let sourceFile = tmpDir.appendingPathComponent("Standalone.swift")
-        try! "import SwiftUI".write(to: sourceFile, atomically: true, encoding: .utf8)
+        try "import SwiftUI".write(to: sourceFile, atomically: true, encoding: .utf8)
 
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 

--- a/Tests/PreviewsCoreTests/BuildSystemTests.swift
+++ b/Tests/PreviewsCoreTests/BuildSystemTests.swift
@@ -858,6 +858,26 @@ struct BuildSystemTests {
         #expect(found?.standardizedFileURL.path == tmpDir.standardizedFileURL.path)
     }
 
+    @Test("findPackageDirectory ignores directory named Package.swift")
+    func findPackageDirectoryIgnoresDirectory() {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-test-\(UUID().uuidString)")
+        let sourcesDir = tmpDir.appendingPathComponent("Sources/MyTarget")
+        try! FileManager.default.createDirectory(at: sourcesDir, withIntermediateDirectories: true)
+
+        // Create a directory named Package.swift instead of a file
+        let packageDir = tmpDir.appendingPathComponent("Package.swift")
+        try! FileManager.default.createDirectory(at: packageDir, withIntermediateDirectories: true)
+
+        let sourceFile = sourcesDir.appendingPathComponent("MyView.swift")
+        try! "import SwiftUI".write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let found = SPMBuildSystem.findPackageDirectory(from: sourceFile)
+        #expect(found == nil)
+    }
+
     @Test("findPackageDirectory returns nil for standalone file")
     func findPackageDirectoryNilForStandalone() {
         let tmpDir = FileManager.default.temporaryDirectory

--- a/Tests/PreviewsCoreTests/BuildSystemTests.swift
+++ b/Tests/PreviewsCoreTests/BuildSystemTests.swift
@@ -835,4 +835,90 @@ struct BuildSystemTests {
         #expect(result != nil)
         #expect(result?.lastPathComponent == "ToDo.xcworkspace")
     }
+
+    // MARK: - SPMBuildSystem.findPackageDirectory
+
+    @Test("findPackageDirectory walks up to Package.swift")
+    func findPackageDirectory() {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-test-\(UUID().uuidString)")
+        let sourcesDir = tmpDir.appendingPathComponent("Sources/MyTarget")
+        try! FileManager.default.createDirectory(at: sourcesDir, withIntermediateDirectories: true)
+
+        let packageSwift = tmpDir.appendingPathComponent("Package.swift")
+        try! "// swift-tools-version: 6.0".write(
+            to: packageSwift, atomically: true, encoding: .utf8)
+
+        let sourceFile = sourcesDir.appendingPathComponent("MyView.swift")
+        try! "import SwiftUI".write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let found = SPMBuildSystem.findPackageDirectory(from: sourceFile)
+        #expect(found?.standardizedFileURL.path == tmpDir.standardizedFileURL.path)
+    }
+
+    @Test("findPackageDirectory returns nil for standalone file")
+    func findPackageDirectoryNilForStandalone() {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-test-\(UUID().uuidString)")
+        try! FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+
+        let sourceFile = tmpDir.appendingPathComponent("Standalone.swift")
+        try! "import SwiftUI".write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let found = SPMBuildSystem.findPackageDirectory(from: sourceFile)
+        #expect(found == nil)
+    }
+
+    // MARK: - SPMBuildSystem.detectPlatforms
+
+    @Test("detectPlatforms returns platforms from real SPM package")
+    func detectPlatformsFromRealPackage() {
+        // Use the examples/spm package which declares both macOS and iOS
+        let sourceFile = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // Tests/PreviewsCoreTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+            .appendingPathComponent("examples/spm/Sources/ToDo/ToDoView.swift")
+
+        guard FileManager.default.fileExists(atPath: sourceFile.path) else { return }
+
+        let platforms = SPMBuildSystem.detectPlatforms(for: sourceFile)
+        #expect(platforms != nil)
+        #expect(platforms?.contains("ios") == true)
+        #expect(platforms?.contains("macos") == true)
+    }
+
+    @Test("detectPlatforms returns nil for standalone file with no package")
+    func detectPlatformsNilForStandalone() {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-test-\(UUID().uuidString)")
+        try! FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+
+        let sourceFile = tmpDir.appendingPathComponent("Standalone.swift")
+        try! "import SwiftUI".write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let platforms = SPMBuildSystem.detectPlatforms(for: sourceFile)
+        #expect(platforms == nil)
+    }
+
+    @Test("detectPlatformsAsync returns same result as sync variant")
+    func detectPlatformsAsync() async {
+        let sourceFile = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("examples/spm/Sources/ToDo/ToDoView.swift")
+
+        guard FileManager.default.fileExists(atPath: sourceFile.path) else { return }
+
+        let asyncPlatforms = await SPMBuildSystem.detectPlatformsAsync(for: sourceFile)
+        let syncPlatforms = SPMBuildSystem.detectPlatforms(for: sourceFile)
+        #expect(asyncPlatforms == syncPlatforms)
+    }
 }

--- a/Tests/PreviewsCoreTests/SetupBuilderTests.swift
+++ b/Tests/PreviewsCoreTests/SetupBuilderTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+
+@testable import PreviewsCore
+
+@Suite("SetupBuilder")
+struct SetupBuilderTests {
+
+    // MARK: - Result struct
+
+    @Test("SetupBuilder.Result includes dylibPath field")
+    func resultIncludesDylibPath() {
+        let result = SetupBuilder.Result(
+            moduleName: "TestSetup",
+            typeName: "AppSetup",
+            compilerFlags: ["-I", "/some/path"],
+            dylibPath: URL(fileURLWithPath: "/tmp/libPreviewSetup.dylib")
+        )
+
+        #expect(result.moduleName == "TestSetup")
+        #expect(result.typeName == "AppSetup")
+        #expect(result.dylibPath.lastPathComponent == "libPreviewSetup.dylib")
+        #expect(result.compilerFlags.contains("-I"))
+    }
+
+    // MARK: - Build with real example setup package
+
+    @Test("SetupBuilder builds example setup package for macOS and produces dylib")
+    func buildExampleSetupMacOS() async throws {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // Tests/PreviewsCoreTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+
+        let configURL = repoRoot.appendingPathComponent("examples/.previewsmcp.json")
+        guard FileManager.default.fileExists(atPath: configURL.path) else { return }
+        let data = try Data(contentsOf: configURL)
+        let config = try JSONDecoder().decode(ProjectConfig.self, from: data)
+        guard let setup = config.setup else { return }
+
+        let configDirectory = configURL.deletingLastPathComponent()
+        let result = try await SetupBuilder.build(
+            config: setup,
+            configDirectory: configDirectory,
+            platform: .macOS
+        )
+
+        // Verify the dylib was produced
+        #expect(FileManager.default.fileExists(atPath: result.dylibPath.path))
+        #expect(result.dylibPath.pathExtension == "dylib")
+        #expect(result.dylibPath.lastPathComponent == "libPreviewSetup.dylib")
+
+        // Verify compiler flags include module search path and dylib linking
+        #expect(result.compilerFlags.contains("-I"))
+        #expect(result.compilerFlags.contains("-L"))
+        #expect(result.compilerFlags.contains("-lPreviewSetup"))
+
+        // Verify no -undefined dynamic_lookup
+        #expect(!result.compilerFlags.contains("dynamic_lookup"))
+    }
+
+    // MARK: - Error cases
+
+    @Test("SetupBuilder throws packageNotFound for missing directory")
+    func missingPackageThrows() async throws {
+        let json = """
+            {"moduleName": "DoesNotExist", "typeName": "Setup", "packagePath": "nonexistent"}
+            """
+        let config = try JSONDecoder().decode(
+            ProjectConfig.SetupConfig.self, from: json.data(using: .utf8)!
+        )
+
+        do {
+            _ = try await SetupBuilder.build(
+                config: config,
+                configDirectory: FileManager.default.temporaryDirectory,
+                platform: .macOS
+            )
+            Issue.record("Expected SetupBuilderError.packageNotFound")
+        } catch let error as SetupBuilderError {
+            if case .packageNotFound = error {
+                // expected
+            } else {
+                Issue.record("Expected packageNotFound, got: \(error)")
+            }
+        }
+    }
+}

--- a/Tests/PreviewsCoreTests/SetupCacheTests.swift
+++ b/Tests/PreviewsCoreTests/SetupCacheTests.swift
@@ -134,7 +134,9 @@ struct SetupCacheTests {
     // MARK: - Store / Load
 
     /// Create a fake build artifacts directory that matches expected compiler flags.
-    private func makeArtifacts(packageDir: URL, moduleName: String) throws -> [String] {
+    private func makeArtifacts(packageDir: URL, moduleName: String) throws
+        -> (flags: [String], dylibPath: URL)
+    {
         let buildDir = packageDir.appendingPathComponent(".build/debug")
         let modulesDir = buildDir.appendingPathComponent("Modules")
         try FileManager.default.createDirectory(
@@ -147,11 +149,14 @@ struct SetupCacheTests {
         try Data("fake".utf8).write(
             to: swiftmoduleDir.appendingPathComponent("arm64-apple-macos.swiftmodule"))
 
-        // Create static library
-        try Data("fake".utf8).write(
-            to: buildDir.appendingPathComponent("lib\(moduleName).a"))
+        // Create setup dylib
+        let dylibPath = buildDir.appendingPathComponent("libPreviewSetup.dylib")
+        try Data("fake".utf8).write(to: dylibPath)
 
-        return ["-I", modulesDir.path, "-L", buildDir.path, "-l\(moduleName)"]
+        return (
+            flags: ["-I", modulesDir.path, "-L", buildDir.path, "-lPreviewSetup"],
+            dylibPath: dylibPath
+        )
     }
 
     @Test("load returns nil when no cache file exists")
@@ -191,7 +196,8 @@ struct SetupCacheTests {
         // Store a valid entry with flags pointing to non-existent paths
         let fakeResult = SetupBuilder.Result(
             moduleName: "TestSetup", typeName: "Setup",
-            compilerFlags: ["-I", "/nonexistent/Modules", "-L", "/nonexistent"])
+            compilerFlags: ["-I", "/nonexistent/Modules", "-L", "/nonexistent"],
+            dylibPath: URL(fileURLWithPath: "/nonexistent/libPreviewSetup.dylib"))
         SetupCache.store(
             fakeResult, packageDir: dir, platform: .macOS,
             sourceHash: "abc123", swiftVersion: "Swift 6.0")
@@ -216,12 +222,19 @@ struct SetupCacheTests {
         try Data("fake".utf8).write(
             to: swiftmoduleDir.appendingPathComponent("arm64.swiftmodule"))
 
+        let dylibPath = buildDir.appendingPathComponent("libPreviewSetup.dylib")
+        try Data("fake".utf8).write(to: dylibPath)
+
         let fakeResult = SetupBuilder.Result(
             moduleName: "TestSetup", typeName: "Setup",
-            compilerFlags: ["-I", modulesDir.path, "-L", buildDir.path, "-lTestSetup"])
+            compilerFlags: ["-I", modulesDir.path, "-L", buildDir.path, "-lPreviewSetup"],
+            dylibPath: dylibPath)
         SetupCache.store(
             fakeResult, packageDir: dir, platform: .macOS,
             sourceHash: "abc123", swiftVersion: "Swift 6.0")
+
+        // Delete the dylib to simulate missing artifact
+        try FileManager.default.removeItem(at: dylibPath)
 
         let loaded = SetupCache.load(
             packageDir: dir, platform: .macOS, sourceHash: "abc123",
@@ -234,9 +247,10 @@ struct SetupCacheTests {
         let dir = try makePackageDir()
         defer { try? FileManager.default.removeItem(at: dir) }
 
-        let flags = try makeArtifacts(packageDir: dir, moduleName: "TestSetup")
+        let (flags, dylibPath) = try makeArtifacts(packageDir: dir, moduleName: "TestSetup")
         let original = SetupBuilder.Result(
-            moduleName: "TestSetup", typeName: "AppSetup", compilerFlags: flags)
+            moduleName: "TestSetup", typeName: "AppSetup", compilerFlags: flags,
+            dylibPath: dylibPath)
 
         SetupCache.store(
             original, packageDir: dir, platform: .macOS,
@@ -270,7 +284,8 @@ struct SetupCacheTests {
         }
 
         let result = SetupBuilder.Result(
-            moduleName: "Test", typeName: "Setup", compilerFlags: [])
+            moduleName: "Test", typeName: "Setup", compilerFlags: [],
+            dylibPath: URL(fileURLWithPath: "/tmp/libPreviewSetup.dylib"))
         // Should not throw — errors are swallowed
         SetupCache.store(
             result, packageDir: dir, platform: .macOS,
@@ -284,9 +299,10 @@ struct SetupCacheTests {
         let dir = try makePackageDir()
         defer { try? FileManager.default.removeItem(at: dir) }
 
-        let macFlags = try makeArtifacts(packageDir: dir, moduleName: "TestSetup")
+        let (macFlags, macDylibPath) = try makeArtifacts(packageDir: dir, moduleName: "TestSetup")
         let macResult = SetupBuilder.Result(
-            moduleName: "TestSetup", typeName: "Setup", compilerFlags: macFlags)
+            moduleName: "TestSetup", typeName: "Setup", compilerFlags: macFlags,
+            dylibPath: macDylibPath)
 
         // Create separate iOS artifacts
         let iosBuildDir = dir.appendingPathComponent(".build/ios-debug")
@@ -296,11 +312,12 @@ struct SetupCacheTests {
             at: iosSwiftmodule, withIntermediateDirectories: true)
         try Data("fake".utf8).write(
             to: iosSwiftmodule.appendingPathComponent("arm64.swiftmodule"))
-        try Data("fake".utf8).write(
-            to: iosBuildDir.appendingPathComponent("libTestSetup.a"))
-        let iosFlags = ["-I", iosModulesDir.path, "-L", iosBuildDir.path, "-lTestSetup"]
+        let iosDylibPath = iosBuildDir.appendingPathComponent("libPreviewSetup.dylib")
+        try Data("fake".utf8).write(to: iosDylibPath)
+        let iosFlags = ["-I", iosModulesDir.path, "-L", iosBuildDir.path, "-lPreviewSetup"]
         let iosResult = SetupBuilder.Result(
-            moduleName: "TestSetup", typeName: "Setup", compilerFlags: iosFlags)
+            moduleName: "TestSetup", typeName: "Setup", compilerFlags: iosFlags,
+            dylibPath: iosDylibPath)
 
         // Store both
         SetupCache.store(


### PR DESCRIPTION
## Summary

- **README rewrite**: Revised "Why PreviewsMCP?" section to lead with standalone workflow value (CLI, hot-reload, variants, interaction) and fix inaccuracy about Xcode previews. Xcode previews run in a real app process — but it's Apple's opaque shell, not extensible by the developer. Setup plugin is now positioned as additive, not the core pitch.

- **Fix #86 — Setup plugin state lost after hot-reload**: Build the setup module as a dynamic library (`libPreviewSetup.dylib`) instead of static archives (`.a`). The dylib is loaded once with `RTLD_GLOBAL` before any preview dylib, so all preview dylibs share the same statics (e.g., `PreviewEnvironment.shared`). Previously, static linking gave each dylib its own copy of statics, causing `setUp()` state to vanish on hot-reload.

- **Fix #83 — Auto-detect platform from SPM metadata**: When no explicit platform is specified (CLI flag, MCP parameter, or `.previewsmcp.json`), detect the platform from `swift package describe --type json`. If the package declares only iOS (no macOS), the platform defaults to `ios` instead of `macos`. Applies to all CLI commands (`run`, `snapshot`, `variants`) and the MCP server.

## Test plan

- [x] Build succeeds (`swift build`)
- [x] Existing test suite passes (`swift test`)
- [x] Verify setup plugin state persists across hot-reload with the example ToDo app:
  ```bash
  previewsmcp run --preview 1 examples/spm/Sources/ToDo/ToDoView.swift --platform ios \
    --config examples/PreviewSetup/.previewsmcp.json
  ```
  Edit `ToDoView.swift` → purple badge should persist after reload
- [x] Verify platform auto-detection: run `previewsmcp` on an iOS-only SPM package without `--platform` → should default to iOS
- [x] Verify explicit `--platform macos` still overrides auto-detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)