### PR TITLE
CLI/MCP parity (feature branch)

### DIFF
--- a/Sources/PreviewsCLI/DaemonLifecycle.swift
+++ b/Sources/PreviewsCLI/DaemonLifecycle.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Writes the daemon PID on startup and removes it on graceful shutdown.
+/// Installs SIGTERM/SIGINT handlers that trigger cleanup before exiting.
+enum DaemonLifecycle {
+
+    /// Register this process as the running daemon. Writes `serve.pid` and
+    /// installs signal handlers. Call once during daemon startup, after the
+    /// socket is listening.
+    static func register() throws {
+        try DaemonPaths.ensureDirectory()
+
+        let pid = ProcessInfo.processInfo.processIdentifier
+        try "\(pid)\n".write(to: DaemonPaths.pidFile, atomically: true, encoding: .utf8)
+
+        installSignalHandlers()
+    }
+
+    /// Remove PID file and socket. Safe to call multiple times.
+    static func unregister() {
+        try? FileManager.default.removeItem(at: DaemonPaths.pidFile)
+        try? FileManager.default.removeItem(at: DaemonPaths.socket)
+    }
+
+    /// Read the PID from the PID file, if present. Returns nil if missing,
+    /// unreadable, or unparseable.
+    static func readPID() -> Int32? {
+        guard
+            let contents = try? String(contentsOf: DaemonPaths.pidFile, encoding: .utf8),
+            let pid = Int32(contents.trimmingCharacters(in: .whitespacesAndNewlines))
+        else { return nil }
+        return pid
+    }
+
+    /// Check whether a process with the given PID is alive.
+    /// Uses `kill(pid, 0)` which returns success if the process exists and we
+    /// have permission to signal it.
+    static func isProcessAlive(_ pid: Int32) -> Bool {
+        kill(pid, 0) == 0
+    }
+
+    private static func installSignalHandlers() {
+        // Ignore default Swift signal behavior; handle explicitly.
+        signal(SIGTERM, SIG_IGN)
+        signal(SIGINT, SIG_IGN)
+
+        let termSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
+        termSource.setEventHandler {
+            fputs("daemon: received SIGTERM, shutting down\n", stderr)
+            unregister()
+            Darwin.exit(0)
+        }
+        termSource.resume()
+
+        let intSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
+        intSource.setEventHandler {
+            fputs("daemon: received SIGINT, shutting down\n", stderr)
+            unregister()
+            Darwin.exit(0)
+        }
+        intSource.resume()
+
+        // Hold strong refs so the sources aren't deallocated.
+        retainedSources = [termSource, intSource]
+    }
+
+    private nonisolated(unsafe) static var retainedSources: [DispatchSourceSignal] = []
+}

--- a/Sources/PreviewsCLI/DaemonLifecycle.swift
+++ b/Sources/PreviewsCLI/DaemonLifecycle.swift
@@ -39,6 +39,16 @@ enum DaemonLifecycle {
         kill(pid, 0) == 0
     }
 
+    /// Returns the PID of the running daemon, or nil if no daemon is running
+    /// *according to the PID file*. Note: the PID file is a management hint,
+    /// not a liveness check — a live daemon with a deleted PID file looks
+    /// "not running" to this function. Use `DaemonProbe.canConnect()` for
+    /// authoritative liveness.
+    static func daemonRunningPID() -> Int32? {
+        guard let pid = readPID(), isProcessAlive(pid) else { return nil }
+        return pid
+    }
+
     private static func installSignalHandlers() {
         // Ignore default Swift signal behavior; handle explicitly.
         signal(SIGTERM, SIG_IGN)

--- a/Sources/PreviewsCLI/DaemonListener.swift
+++ b/Sources/PreviewsCLI/DaemonListener.swift
@@ -1,0 +1,83 @@
+import Foundation
+import MCP
+import Network
+
+/// Runs the MCP server daemon on a Unix domain socket.
+///
+/// Accepts multiple concurrent client connections. Each connection gets its own
+/// `MCP.Server` instance, but all connections share the module-level actors in
+/// `MCPServer.swift` (`IOSState`, `ConfigCache`) — so preview sessions persist
+/// across CLI invocations and simultaneous clients see consistent state.
+enum DaemonListener {
+
+    /// Start the daemon listener. Returns when the listener is ready.
+    /// Call `runForever` to block the caller until the process is terminated.
+    @MainActor
+    static func start() async throws -> NWListener {
+        try DaemonPaths.ensureDirectory()
+
+        // Clean up any stale socket file from a previous crashed daemon.
+        // bind() would fail with EADDRINUSE otherwise.
+        try? FileManager.default.removeItem(at: DaemonPaths.socket)
+
+        let params = NWParameters.tcp
+        params.requiredLocalEndpoint = NWEndpoint.unix(path: DaemonPaths.socket.path)
+        // Allow multiple clients; each is handled in its own Task.
+        params.allowLocalEndpointReuse = true
+
+        let listener = try NWListener(using: params)
+
+        listener.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                fputs("previewsmcp daemon listening on \(DaemonPaths.socket.path)\n", stderr)
+            case .failed(let error):
+                fputs("previewsmcp daemon listener failed: \(error)\n", stderr)
+                Darwin.exit(1)
+            default:
+                break
+            }
+        }
+
+        listener.newConnectionHandler = { connection in
+            Task {
+                await handleConnection(connection)
+            }
+        }
+
+        // Wait for listener to become ready before returning.
+        let ready = AsyncStream<Void> { continuation in
+            let original = listener.stateUpdateHandler
+            listener.stateUpdateHandler = { state in
+                original?(state)
+                if case .ready = state { continuation.yield(); continuation.finish() }
+                if case .failed = state { continuation.finish() }
+            }
+        }
+
+        listener.start(queue: .global(qos: .userInitiated))
+        for await _ in ready { break }
+
+        return listener
+    }
+
+    /// Block the calling thread indefinitely. Used after the daemon is set up
+    /// to keep the NSApplication run loop alive for accepting connections.
+    static func runForever() {
+        dispatchMain()
+    }
+
+    /// Handle one client connection. Creates a per-connection MCP Server
+    /// sharing module-level state with other connections.
+    private static func handleConnection(_ connection: NWConnection) async {
+        do {
+            let transport = NetworkTransport(connection: connection)
+            let (server, _) = try await configureMCPServer()
+            try await server.start(transport: transport)
+            // `start` returns when the transport closes (client disconnected).
+        } catch {
+            fputs("daemon connection error: \(error)\n", stderr)
+            connection.cancel()
+        }
+    }
+}

--- a/Sources/PreviewsCLI/DaemonListener.swift
+++ b/Sources/PreviewsCLI/DaemonListener.swift
@@ -1,78 +1,79 @@
 import Foundation
 import MCP
 import Network
+import PreviewsCore
 
 /// Runs the MCP server daemon on a Unix domain socket.
 ///
 /// Accepts multiple concurrent client connections. Each connection gets its own
 /// `MCP.Server` instance, but all connections share the module-level actors in
-/// `MCPServer.swift` (`IOSState`, `ConfigCache`) — so preview sessions persist
-/// across CLI invocations and simultaneous clients see consistent state.
+/// `MCPServer.swift` (`IOSState`, `ConfigCache`) and a single `Compiler` built
+/// at daemon startup — so preview sessions persist across CLI invocations and
+/// simultaneous clients see consistent state.
 enum DaemonListener {
 
-    /// Start the daemon listener. Returns when the listener is ready.
-    /// Call `runForever` to block the caller until the process is terminated.
-    @MainActor
+    /// Start the daemon listener. Returns once the listener is ready to accept
+    /// connections. Callers hold the process alive via the existing
+    /// `NSApplication` run loop (see `PreviewsMCPApp.main`).
     static func start() async throws -> NWListener {
         try DaemonPaths.ensureDirectory()
 
         // Clean up any stale socket file from a previous crashed daemon.
-        // bind() would fail with EADDRINUSE otherwise.
+        // bind() would fail with EADDRINUSE otherwise. Callers must have
+        // already verified via DaemonProbe that no live daemon is listening.
         try? FileManager.default.removeItem(at: DaemonPaths.socket)
+
+        // Build the shared compiler once. Each accepted connection creates its
+        // own MCP.Server but reuses this compiler (and the module-level
+        // IOSState / ConfigCache), avoiding the ~seconds of per-connection
+        // xcrun / SDK resolution cost.
+        let sharedCompiler = try await Compiler()
 
         let params = NWParameters.tcp
         params.requiredLocalEndpoint = NWEndpoint.unix(path: DaemonPaths.socket.path)
-        // Allow multiple clients; each is handled in its own Task.
         params.allowLocalEndpointReuse = true
 
         let listener = try NWListener(using: params)
 
-        listener.stateUpdateHandler = { state in
-            switch state {
-            case .ready:
-                fputs("previewsmcp daemon listening on \(DaemonPaths.socket.path)\n", stderr)
-            case .failed(let error):
-                fputs("previewsmcp daemon listener failed: \(error)\n", stderr)
-                Darwin.exit(1)
-            default:
-                break
-            }
-        }
-
         listener.newConnectionHandler = { connection in
             Task {
-                await handleConnection(connection)
+                await handleConnection(connection, compiler: sharedCompiler)
             }
         }
 
-        // Wait for listener to become ready before returning.
-        let ready = AsyncStream<Void> { continuation in
-            let original = listener.stateUpdateHandler
+        // Block until the listener reports ready (or fails).
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
             listener.stateUpdateHandler = { state in
-                original?(state)
-                if case .ready = state { continuation.yield(); continuation.finish() }
-                if case .failed = state { continuation.finish() }
+                switch state {
+                case .ready:
+                    fputs(
+                        "previewsmcp daemon listening on \(DaemonPaths.socket.path)\n",
+                        stderr
+                    )
+                    cont.resume()
+                    // Clear after resuming so the closure isn't retained.
+                    listener.stateUpdateHandler = nil
+                case .failed(let error):
+                    cont.resume(throwing: error)
+                    listener.stateUpdateHandler = nil
+                default:
+                    break
+                }
             }
+            listener.start(queue: .global(qos: .userInitiated))
         }
-
-        listener.start(queue: .global(qos: .userInitiated))
-        for await _ in ready { break }
 
         return listener
     }
 
-    /// Block the calling thread indefinitely. Used after the daemon is set up
-    /// to keep the NSApplication run loop alive for accepting connections.
-    static func runForever() {
-        dispatchMain()
-    }
-
     /// Handle one client connection. Creates a per-connection MCP Server
-    /// sharing module-level state with other connections.
-    private static func handleConnection(_ connection: NWConnection) async {
+    /// sharing the given compiler and module-level state with other connections.
+    private static func handleConnection(
+        _ connection: NWConnection, compiler: Compiler
+    ) async {
         do {
             let transport = NetworkTransport(connection: connection)
-            let (server, _) = try await configureMCPServer()
+            let (server, _) = try await configureMCPServer(sharedCompiler: compiler)
             try await server.start(transport: transport)
             // `start` returns when the transport closes (client disconnected).
         } catch {

--- a/Sources/PreviewsCLI/DaemonPaths.swift
+++ b/Sources/PreviewsCLI/DaemonPaths.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Filesystem paths for the daemon.
+///
+/// All daemon state lives under `~/.previewsmcp/`. Sessions themselves are held
+/// in the daemon's memory (not on disk) — this directory only holds IPC
+/// primitives and lifecycle metadata.
+enum DaemonPaths {
+
+    /// The `~/.previewsmcp/` directory. Created on first use.
+    static var directory: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".previewsmcp", isDirectory: true)
+    }
+
+    /// Unix domain socket the daemon listens on.
+    /// Clients connect here to issue MCP JSON-RPC calls.
+    static var socket: URL {
+        directory.appendingPathComponent("serve.sock")
+    }
+
+    /// PID file for the running daemon.
+    /// Written on startup, removed on graceful shutdown.
+    /// Used by `kill-daemon` and `status` for process targeting and display.
+    /// Not used for liveness — that's determined by trying to connect the socket.
+    static var pidFile: URL {
+        directory.appendingPathComponent("serve.pid")
+    }
+
+    /// Log file for daemon stdout/stderr when running detached.
+    static var logFile: URL {
+        directory.appendingPathComponent("serve.log")
+    }
+
+    /// Ensure the directory exists. Call before reading or writing any daemon file.
+    static func ensureDirectory() throws {
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true
+        )
+    }
+}

--- a/Sources/PreviewsCLI/DaemonProbe.swift
+++ b/Sources/PreviewsCLI/DaemonProbe.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Network
+
+/// Liveness check for the daemon: can we connect to its socket?
+///
+/// This is the canonical "is the daemon running?" test. The kernel atomically
+/// tracks socket-to-fd associations, so if `connect()` succeeds, something is
+/// listening. A lingering `serve.sock` file from a crashed daemon returns
+/// ECONNREFUSED, so socket file presence alone is not enough.
+///
+/// Used by:
+/// - `ServeCommand --daemon` before unlinking a stale socket, to avoid
+///   clobbering a running daemon whose PID file was deleted.
+/// - `StatusCommand` for its liveness report.
+/// - `DaemonClient` (PR 2) as the auto-start trigger.
+enum DaemonProbe {
+
+    /// Try to connect to the daemon socket with a short timeout.
+    /// Returns true on success, false on ENOENT / ECONNREFUSED / timeout.
+    static func canConnect(timeout: TimeInterval = 1.0) -> Bool {
+        // Fast path: if the socket file doesn't exist, no daemon is listening.
+        guard FileManager.default.fileExists(atPath: DaemonPaths.socket.path) else {
+            return false
+        }
+
+        let connection = NWConnection(
+            to: NWEndpoint.unix(path: DaemonPaths.socket.path),
+            using: .tcp
+        )
+        let semaphore = DispatchSemaphore(value: 0)
+        let result = ConnectResult()
+
+        connection.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                result.set(true)
+                semaphore.signal()
+            case .failed, .cancelled:
+                semaphore.signal()
+            default:
+                break
+            }
+        }
+        connection.start(queue: .global())
+        _ = semaphore.wait(timeout: .now() + timeout)
+        connection.cancel()
+        return result.value
+    }
+}
+
+/// Thread-safe boolean set from the NWConnection state handler (runs on a
+/// background queue) and read from the main thread.
+private final class ConnectResult: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value = false
+    var value: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _value
+    }
+    func set(_ v: Bool) {
+        lock.lock(); _value = v; lock.unlock()
+    }
+}

--- a/Sources/PreviewsCLI/KillDaemonCommand.swift
+++ b/Sources/PreviewsCLI/KillDaemonCommand.swift
@@ -1,0 +1,45 @@
+import ArgumentParser
+import Foundation
+
+struct KillDaemonCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "kill-daemon",
+        abstract: "Stop the running previewsmcp daemon"
+    )
+
+    @Option(name: .long, help: "Seconds to wait for graceful shutdown before giving up")
+    var timeout: Double = 5.0
+
+    func run() throws {
+        guard let pid = DaemonLifecycle.readPID() else {
+            print("daemon not running (no PID file)")
+            return
+        }
+
+        guard DaemonLifecycle.isProcessAlive(pid) else {
+            print("daemon not running (stale PID \(pid))")
+            DaemonLifecycle.unregister()
+            return
+        }
+
+        // Send SIGTERM for graceful shutdown.
+        guard kill(pid, SIGTERM) == 0 else {
+            let reason = String(cString: strerror(errno))
+            print("failed to signal daemon (pid \(pid)): \(reason)")
+            throw ExitCode(1)
+        }
+
+        // Poll until the process is gone or timeout elapses.
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if !DaemonLifecycle.isProcessAlive(pid) {
+                print("daemon stopped (pid \(pid))")
+                return
+            }
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+
+        print("daemon did not exit within \(timeout)s; leaving it running")
+        throw ExitCode(1)
+    }
+}

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -128,11 +128,22 @@ private func mcpReporter(
 }
 
 /// Configures and returns an MCP server with preview tools.
-func configureMCPServer() async throws -> (Server, Compiler) {
+///
+/// - Parameter sharedCompiler: Pass a pre-built `Compiler` to reuse across
+///   multiple server instances (e.g., daemon mode, where each accepted client
+///   connection gets its own `Server` but they all share one compiler). When
+///   nil, a fresh compiler is built — appropriate for single-connection modes
+///   like stdio.
+func configureMCPServer(sharedCompiler: Compiler? = nil) async throws -> (Server, Compiler) {
     // Clean up stale temp directories from previous sessions (older than 24 hours)
     cleanupStaleTempDirs()
 
-    let compiler = try await Compiler()
+    let compiler: Compiler
+    if let sharedCompiler {
+        compiler = sharedCompiler
+    } else {
+        compiler = try await Compiler()
+    }
 
     let server = Server(
         name: "previewsmcp",

--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -24,7 +24,7 @@ struct PreviewsMCPApp {
             PreviewsMCPCommand.exit(withError: error)
         }
 
-        // Commands that don't need NSApplication (list, help, etc.)
+        // Commands that don't need NSApplication (list, help, status, kill-daemon)
         if command is ListCommand
             || !(command is RunCommand || command is ServeCommand || command is SnapshotCommand
                 || command is VariantsCommand)
@@ -98,7 +98,7 @@ struct PreviewsMCPCommand: ParsableCommand {
         version: version,
         subcommands: [
             RunCommand.self, ListCommand.self, SnapshotCommand.self, VariantsCommand.self,
-            ServeCommand.self,
+            ServeCommand.self, StatusCommand.self, KillDaemonCommand.self,
         ],
         defaultSubcommand: RunCommand.self
     )

--- a/Sources/PreviewsCLI/ServeCommand.swift
+++ b/Sources/PreviewsCLI/ServeCommand.swift
@@ -62,12 +62,18 @@ struct ServeCommand: ParsableCommand {
     private func runDaemon() {
         Task { @MainActor in
             do {
-                // Refuse to start if another daemon is already running.
-                if let existing = DaemonLifecycle.readPID(),
-                    DaemonLifecycle.isProcessAlive(existing)
-                {
+                // Liveness check via `connect()` is authoritative — the PID file
+                // alone can be stale (deleted while daemon is still running) or
+                // missing during the brief window between bind and PID write.
+                // Without this check, a second daemon would unlink the first's
+                // socket file and attempt to rebind, corrupting the running
+                // system.
+                if DaemonProbe.canConnect() {
+                    let pidDesc =
+                        DaemonLifecycle.daemonRunningPID().map { "pid \($0)" }
+                        ?? "pid unknown"
                     fputs(
-                        "daemon already running (pid \(existing)); "
+                        "daemon already running (\(pidDesc)); "
                             + "use `previewsmcp kill-daemon` first\n",
                         stderr
                     )

--- a/Sources/PreviewsCLI/ServeCommand.swift
+++ b/Sources/PreviewsCLI/ServeCommand.swift
@@ -6,31 +6,46 @@ import MCP
 struct ServeCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "serve",
-        abstract: "Expose preview tools over MCP (stdio transport)",
+        abstract: "Expose preview tools over MCP",
         discussion: """
-            Runs an MCP server on stdin/stdout that exposes tools for listing,
-            launching, configuring, snapshotting, and interacting with SwiftUI
-            previews. Intended to be launched by an MCP-compatible client — for
-            example, by adding this to `.mcp.json`:
+            Two modes:
 
-              {
-                "mcpServers": {
-                  "previews": {
-                    "command": "/path/to/previewsmcp",
-                    "args": ["serve"]
+              • Stdio (default) — reads MCP JSON-RPC from stdin, writes to stdout.
+                Intended for MCP-compatible clients (Claude Code, Cursor) that
+                launch `previewsmcp serve` as a subprocess. Example `.mcp.json`:
+
+                  {
+                    "mcpServers": {
+                      "previews": {
+                        "command": "/path/to/previewsmcp",
+                        "args": ["serve"]
+                      }
+                    }
                   }
-                }
-              }
 
-            Once connected, the agent can discover the available tools
-            (preview_list, preview_start, preview_snapshot, preview_configure,
-            preview_switch, preview_variants, preview_elements, preview_touch,
-            preview_stop, simulator_list) and their schemas via the standard MCP
-            handshake.
+              • Daemon (`--daemon`) — listens on a Unix domain socket at
+                `~/.previewsmcp/serve.sock`. Multiplexes many concurrent preview
+                sessions. Used by the CLI (run, snapshot, etc.) and by any
+                external MCP client capable of speaking over UDS.
+
+            Both modes expose the same tools: preview_list, preview_start,
+            preview_snapshot, preview_configure, preview_switch, preview_variants,
+            preview_elements, preview_touch, preview_stop, simulator_list.
             """
     )
 
+    @Flag(name: .long, help: "Run as a daemon on a Unix domain socket instead of stdio")
+    var daemon: Bool = false
+
     mutating func run() throws {
+        if daemon {
+            runDaemon()
+        } else {
+            runStdio()
+        }
+    }
+
+    private func runStdio() {
         Task {
             do {
                 let (server, _) = try await configureMCPServer()
@@ -40,6 +55,35 @@ struct ServeCommand: ParsableCommand {
             } catch {
                 fputs("MCP server error: \(error)\n", stderr)
                 await MainActor.run { NSApp.terminate(nil) }
+            }
+        }
+    }
+
+    private func runDaemon() {
+        Task { @MainActor in
+            do {
+                // Refuse to start if another daemon is already running.
+                if let existing = DaemonLifecycle.readPID(),
+                    DaemonLifecycle.isProcessAlive(existing)
+                {
+                    fputs(
+                        "daemon already running (pid \(existing)); "
+                            + "use `previewsmcp kill-daemon` first\n",
+                        stderr
+                    )
+                    Darwin.exit(1)
+                }
+
+                _ = try await DaemonListener.start()
+                try DaemonLifecycle.register()
+                fputs(
+                    "daemon ready (pid \(ProcessInfo.processInfo.processIdentifier))\n",
+                    stderr
+                )
+            } catch {
+                fputs("daemon startup failed: \(error)\n", stderr)
+                DaemonLifecycle.unregister()
+                Darwin.exit(1)
             }
         }
     }

--- a/Sources/PreviewsCLI/StatusCommand.swift
+++ b/Sources/PreviewsCLI/StatusCommand.swift
@@ -1,21 +1,5 @@
 import ArgumentParser
 import Foundation
-import Network
-
-/// Thread-safe boolean for the connection result. Needed because the
-/// NWConnection state handler is a @Sendable closure that runs on a
-/// background queue.
-private final class ConnectResult: @unchecked Sendable {
-    private let lock = NSLock()
-    private var _value = false
-    var value: Bool {
-        lock.lock(); defer { lock.unlock() }
-        return _value
-    }
-    func set(_ v: Bool) {
-        lock.lock(); _value = v; lock.unlock()
-    }
-}
 
 struct StatusCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
@@ -24,54 +8,19 @@ struct StatusCommand: ParsableCommand {
     )
 
     func run() throws {
-        let pid = DaemonLifecycle.readPID()
-        let socketReachable = canConnectToDaemon()
+        let alive = DaemonProbe.canConnect()
+        let pid = DaemonLifecycle.daemonRunningPID()
 
-        switch (pid, socketReachable) {
-        case (let pid?, true) where DaemonLifecycle.isProcessAlive(pid):
-            print("daemon running (pid \(pid))")
+        if alive {
+            let pidDesc = pid.map { "pid \($0)" } ?? "pid unknown"
+            print("daemon running (\(pidDesc))")
             print("  socket: \(DaemonPaths.socket.path)")
-        case (.some, true), (.none, true):
-            // Socket reachable without a PID or with a dead PID — unusual, still report.
-            print("daemon running (pid unknown)")
-            print("  socket: \(DaemonPaths.socket.path)")
-        case (let pid?, false) where DaemonLifecycle.isProcessAlive(pid):
-            // Process alive but socket unreachable. Likely in the middle of startup or shutdown.
+        } else if let pid {
+            // Process alive but socket not accepting — likely mid-startup or shutdown.
             print("daemon starting or shutting down (pid \(pid))")
-        default:
+        } else {
             print("daemon not running")
-            Self.exit(withError: ExitCode(1))
+            throw ExitCode(1)
         }
-    }
-
-    /// Try to connect to the daemon socket with a short timeout.
-    /// Returns true if a connection is established, false otherwise.
-    private func canConnectToDaemon() -> Bool {
-        guard FileManager.default.fileExists(atPath: DaemonPaths.socket.path) else {
-            return false
-        }
-
-        let connection = NWConnection(
-            to: NWEndpoint.unix(path: DaemonPaths.socket.path),
-            using: .tcp
-        )
-        let semaphore = DispatchSemaphore(value: 0)
-        let result = ConnectResult()
-
-        connection.stateUpdateHandler = { state in
-            switch state {
-            case .ready:
-                result.set(true)
-                semaphore.signal()
-            case .failed, .cancelled:
-                semaphore.signal()
-            default:
-                break
-            }
-        }
-        connection.start(queue: .global())
-        _ = semaphore.wait(timeout: .now() + 1)
-        connection.cancel()
-        return result.value
     }
 }

--- a/Sources/PreviewsCLI/StatusCommand.swift
+++ b/Sources/PreviewsCLI/StatusCommand.swift
@@ -1,0 +1,77 @@
+import ArgumentParser
+import Foundation
+import Network
+
+/// Thread-safe boolean for the connection result. Needed because the
+/// NWConnection state handler is a @Sendable closure that runs on a
+/// background queue.
+private final class ConnectResult: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value = false
+    var value: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _value
+    }
+    func set(_ v: Bool) {
+        lock.lock(); _value = v; lock.unlock()
+    }
+}
+
+struct StatusCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "status",
+        abstract: "Report whether the previewsmcp daemon is running"
+    )
+
+    func run() throws {
+        let pid = DaemonLifecycle.readPID()
+        let socketReachable = canConnectToDaemon()
+
+        switch (pid, socketReachable) {
+        case (let pid?, true) where DaemonLifecycle.isProcessAlive(pid):
+            print("daemon running (pid \(pid))")
+            print("  socket: \(DaemonPaths.socket.path)")
+        case (.some, true), (.none, true):
+            // Socket reachable without a PID or with a dead PID — unusual, still report.
+            print("daemon running (pid unknown)")
+            print("  socket: \(DaemonPaths.socket.path)")
+        case (let pid?, false) where DaemonLifecycle.isProcessAlive(pid):
+            // Process alive but socket unreachable. Likely in the middle of startup or shutdown.
+            print("daemon starting or shutting down (pid \(pid))")
+        default:
+            print("daemon not running")
+            Self.exit(withError: ExitCode(1))
+        }
+    }
+
+    /// Try to connect to the daemon socket with a short timeout.
+    /// Returns true if a connection is established, false otherwise.
+    private func canConnectToDaemon() -> Bool {
+        guard FileManager.default.fileExists(atPath: DaemonPaths.socket.path) else {
+            return false
+        }
+
+        let connection = NWConnection(
+            to: NWEndpoint.unix(path: DaemonPaths.socket.path),
+            using: .tcp
+        )
+        let semaphore = DispatchSemaphore(value: 0)
+        let result = ConnectResult()
+
+        connection.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                result.set(true)
+                semaphore.signal()
+            case .failed, .cancelled:
+                semaphore.signal()
+            default:
+                break
+            }
+        }
+        connection.start(queue: .global())
+        _ = semaphore.wait(timeout: .now() + 1)
+        connection.cancel()
+        return result.value
+    }
+}

--- a/Tests/MCPIntegrationTests/DaemonLifecycleTests.swift
+++ b/Tests/MCPIntegrationTests/DaemonLifecycleTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import MCP
+import Network
+import Testing
+
+/// Integration tests for `previewsmcp serve --daemon` / `status` / `kill-daemon`.
+///
+/// These tests spawn the real `previewsmcp` binary and speak MCP over the Unix
+/// domain socket. They assume no other daemon is running — each test cleans up
+/// after itself, and the suite is serialized so they don't race.
+@Suite(.serialized)
+struct DaemonLifecycleTests {
+
+    // MARK: - Paths
+
+    static let repoRoot: URL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+
+    static let binaryPath: String =
+        repoRoot.appendingPathComponent(".build/debug/previewsmcp").path
+
+    static let socketPath: String =
+        FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".previewsmcp/serve.sock").path
+
+    // MARK: - Test helpers
+
+    /// Remove any daemon state from previous runs and kill any running daemon.
+    private static func cleanSlate() async throws {
+        // Best-effort kill. Ignore errors — daemon may not be running.
+        _ = try? await runCLI(["kill-daemon", "--timeout", "2"])
+        // Remove any leftover files.
+        let home = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".previewsmcp")
+        try? FileManager.default.removeItem(at: home.appendingPathComponent("serve.sock"))
+        try? FileManager.default.removeItem(at: home.appendingPathComponent("serve.pid"))
+    }
+
+    /// Start a daemon in the background. Returns the Process; caller must
+    /// terminate it (or kill-daemon) in cleanup.
+    private static func startDaemon() async throws -> Process {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: binaryPath)
+        proc.arguments = ["serve", "--daemon"]
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+        try proc.run()
+
+        // Wait for the socket to appear (daemon is ready when it binds).
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            if FileManager.default.fileExists(atPath: socketPath) { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        #expect(
+            FileManager.default.fileExists(atPath: socketPath),
+            "daemon did not create socket within 5s"
+        )
+        // Small additional grace period for the listener to actually be accepting.
+        try await Task.sleep(nanoseconds: 100_000_000)
+        return proc
+    }
+
+    /// Run a CLI subcommand and return stdout + exit code.
+    ///
+    /// Drains stdout *before* waitUntilExit to avoid pipe-buffer deadlock if
+    /// output exceeds ~64KB. These commands produce tiny output in practice,
+    /// but the safe ordering is cheap.
+    @discardableResult
+    private static func runCLI(_ args: [String]) async throws -> (stdout: String, exit: Int32) {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: binaryPath)
+        proc.arguments = args
+        let out = Pipe()
+        proc.standardOutput = out
+        proc.standardError = FileHandle.nullDevice
+        try proc.run()
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        proc.waitUntilExit()
+        let stdout = String(data: data, encoding: .utf8) ?? ""
+        return (stdout, proc.terminationStatus)
+    }
+
+    // MARK: - Tests
+
+    @Test("status reports 'not running' when no daemon is active")
+    func statusNoDaemon() async throws {
+        try await Self.cleanSlate()
+        let (out, exit) = try await Self.runCLI(["status"])
+        #expect(out.contains("not running"))
+        #expect(exit == 1, "status should exit non-zero when daemon is down")
+    }
+
+    @Test("daemon creates socket and pid file, status reports running")
+    func daemonStartAndStatus() async throws {
+        try await Self.cleanSlate()
+        let proc = try await Self.startDaemon()
+        defer { proc.terminate() }
+
+        let (out, exit) = try await Self.runCLI(["status"])
+        #expect(out.contains("daemon running"))
+        #expect(out.contains(Self.socketPath))
+        #expect(exit == 0)
+    }
+
+    @Test("MCP client can connect to daemon and list tools")
+    func mcpClientListsTools() async throws {
+        try await Self.cleanSlate()
+        let proc = try await Self.startDaemon()
+        defer { proc.terminate() }
+
+        let connection = NWConnection(
+            to: NWEndpoint.unix(path: Self.socketPath),
+            using: .tcp
+        )
+        let transport = NetworkTransport(connection: connection)
+        let client = Client(name: "daemon-lifecycle-test", version: "1.0")
+        _ = try await client.connect(transport: transport)
+        defer {
+            Task { await client.disconnect() }
+        }
+
+        let response = try await client.listTools()
+        #expect(!response.tools.isEmpty, "daemon should expose MCP tools")
+        let names = Set(response.tools.map { $0.name })
+        #expect(names.contains("preview_list"))
+        #expect(names.contains("preview_snapshot"))
+    }
+
+    @Test("kill-daemon terminates the daemon and removes socket")
+    func killDaemonCleansUp() async throws {
+        try await Self.cleanSlate()
+        let proc = try await Self.startDaemon()
+        defer {
+            // In case kill-daemon failed, force termination so the test doesn't leak.
+            if proc.isRunning { proc.terminate() }
+        }
+
+        let (out, exit) = try await Self.runCLI(["kill-daemon", "--timeout", "5"])
+        #expect(exit == 0, "kill-daemon should exit 0: \(out)")
+        #expect(out.contains("stopped"))
+
+        // Verify files were cleaned up.
+        #expect(!FileManager.default.fileExists(atPath: Self.socketPath))
+
+        // Verify status reports not running.
+        let (statusOut, statusExit) = try await Self.runCLI(["status"])
+        #expect(statusOut.contains("not running"))
+        #expect(statusExit == 1)
+    }
+
+    @Test("starting a second daemon refuses and exits non-zero")
+    func secondDaemonRefuses() async throws {
+        try await Self.cleanSlate()
+        let proc = try await Self.startDaemon()
+        defer { proc.terminate() }
+
+        let secondProc = Process()
+        secondProc.executableURL = URL(fileURLWithPath: Self.binaryPath)
+        secondProc.arguments = ["serve", "--daemon"]
+        let errPipe = Pipe()
+        secondProc.standardError = errPipe
+        secondProc.standardOutput = FileHandle.nullDevice
+        try secondProc.run()
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        secondProc.waitUntilExit()
+        let stderr = String(data: errData, encoding: .utf8) ?? ""
+        #expect(secondProc.terminationStatus != 0, "second daemon should fail")
+        #expect(stderr.contains("already running"))
+    }
+
+    @Test("kill-daemon on stale PID file cleans up without error")
+    func killDaemonStalePID() async throws {
+        try await Self.cleanSlate()
+
+        // Write a PID file pointing to a definitely-dead process.
+        let home = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".previewsmcp")
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        try "99999\n".write(
+            to: home.appendingPathComponent("serve.pid"),
+            atomically: true, encoding: .utf8
+        )
+
+        let (out, exit) = try await Self.runCLI(["kill-daemon"])
+        #expect(exit == 0)
+        #expect(out.contains("stale"))
+    }
+}

--- a/Tests/MCPIntegrationTests/DaemonLifecycleTests.swift
+++ b/Tests/MCPIntegrationTests/DaemonLifecycleTests.swift
@@ -171,6 +171,76 @@ struct DaemonLifecycleTests {
         #expect(stderr.contains("already running"))
     }
 
+    /// Catches a race: if the PID file is missing (daemon was started, PID
+    /// write hadn't happened yet, or someone deleted it), a startup check
+    /// based on PID alone lets a second daemon proceed. That second daemon
+    /// would then unlink the still-live daemon's socket file, corrupting the
+    /// running system.
+    ///
+    /// The correct check is a socket `connect()` probe: if anything is
+    /// listening on the socket, refuse to start — regardless of PID file
+    /// state.
+    ///
+    /// Without the fix this test would hang (second daemon rebinds and runs
+    /// indefinitely), so we use a bounded wait and fail fast.
+    @Test("second daemon refuses even when PID file is missing but socket is alive")
+    func secondDaemonRefusesWithMissingPIDFile() async throws {
+        try await Self.cleanSlate()
+        let proc = try await Self.startDaemon()
+        defer { proc.terminate() }
+
+        // Simulate the race: PID file gone, but daemon still running.
+        let pidPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".previewsmcp/serve.pid").path
+        try? FileManager.default.removeItem(atPath: pidPath)
+
+        let secondProc = Process()
+        secondProc.executableURL = URL(fileURLWithPath: Self.binaryPath)
+        secondProc.arguments = ["serve", "--daemon"]
+        let errPipe = Pipe()
+        secondProc.standardError = errPipe
+        secondProc.standardOutput = FileHandle.nullDevice
+        try secondProc.run()
+
+        // Bounded wait: the second daemon should refuse and exit within ~2s.
+        // If it doesn't, the race bug has corrupted state — fail the test
+        // (rather than hanging) by terminating it.
+        let deadline = Date().addingTimeInterval(2)
+        while secondProc.isRunning && Date() < deadline {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        let refusedInTime = !secondProc.isRunning
+        if secondProc.isRunning {
+            secondProc.terminate()
+            secondProc.waitUntilExit()
+        }
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderr = String(data: errData, encoding: .utf8) ?? ""
+
+        #expect(refusedInTime, "second daemon should exit quickly, not keep running")
+        #expect(secondProc.terminationStatus != 0, "second daemon should refuse")
+        #expect(
+            stderr.contains("already running"),
+            "should detect live daemon via socket probe: \(stderr)"
+        )
+
+        // Daemon A must still be functional: its socket path must still exist
+        // on disk and MCP clients must still be able to connect.
+        #expect(
+            FileManager.default.fileExists(atPath: Self.socketPath),
+            "daemon A's socket file should not have been removed by failed daemon B"
+        )
+
+        let connection = NWConnection(
+            to: NWEndpoint.unix(path: Self.socketPath),
+            using: .tcp
+        )
+        let transport = NetworkTransport(connection: connection)
+        let client = Client(name: "race-test", version: "1.0")
+        _ = try await client.connect(transport: transport)
+        await client.disconnect()
+    }
+
     @Test("kill-daemon on stale PID file cleans up without error")
     func killDaemonStalePID() async throws {
         try await Self.cleanSlate()


### PR DESCRIPTION
## Feature branch — do not merge until all child PRs land

This is the umbrella feature branch for the CLI/MCP parity work described in [docs/cli-mcp-parity-spec.md](https://github.com/obj-p/PreviewsMCP/blob/main/docs/cli-mcp-parity-spec.md).

**Workflow:**
- Each step from the spec's implementation plan ships as a child PR targeting `cli-mcp-parity` (not `main`).
- When all child PRs have landed and verification is complete, this branch merges to `main` as a single feature.

## Current contents (PR 1 of plan)

**Daemon foundation** — landed as the initial commit on this branch:

- `previewsmcp serve --daemon` — runs MCP server on `~/.previewsmcp/serve.sock`
- `previewsmcp status` — reports daemon liveness
- `previewsmcp kill-daemon` — graceful SIGTERM
- UDS transport via Apple Network framework (`NWEndpoint.unix`)
- One `MCP.Server` per connection, sharing module-level state + a single `Compiler`
- Startup race fix (authoritative socket-connect liveness probe)

Includes 7 daemon lifecycle integration tests. All MCP stdio paths (Claude/Cursor integration) unchanged and still passing.

## Pending child PRs

Per the spec's stacked plan:

- [ ] PR 2 — `DaemonClient` + `run` migration (+ `--detach`)
- [ ] PR 3 — `snapshot` magical reuse
- [ ] PR 4 — `configure`
- [ ] PR 5 — `switch`
- [ ] PR 6 — `elements` (iOS)
- [ ] PR 7 — `touch` (iOS)
- [ ] PR 8 — `simulators`
- [ ] PR 9 — `stop`
- [ ] PR 10 — `variants` migration

## Related

- Spec: [docs/cli-mcp-parity-spec.md](https://github.com/obj-p/PreviewsMCP/blob/main/docs/cli-mcp-parity-spec.md)
- Parent issues: #92, #94
- Deferred follow-up: #95 (interactive REPL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)