### PR TITLE
Migrate run to daemon client + add --detach

### DIFF
--- a/Sources/PreviewsCLI/DaemonClient.swift
+++ b/Sources/PreviewsCLI/DaemonClient.swift
@@ -1,0 +1,81 @@
+import Foundation
+import MCP
+import Network
+
+/// Client-side handle to the previewsmcp daemon.
+///
+/// Connects to `~/.previewsmcp/serve.sock`. If no daemon is listening, spawns
+/// one (`previewsmcp serve --daemon`) and polls until the socket is ready. The
+/// spawned daemon outlives this client.
+///
+/// ADB-style UX: users don't think about daemon management during normal
+/// command flow — first CLI invocation transparently starts it.
+enum DaemonClient {
+
+    /// Connect to the daemon, auto-starting it if necessary, and return a
+    /// ready-to-use MCP client.
+    ///
+    /// - Parameters:
+    ///   - clientName: MCP client identity reported in the initialize
+    ///     handshake (useful in daemon logs).
+    ///   - startTimeout: How long to wait for a newly-spawned daemon to become
+    ///     reachable on the socket.
+    static func connect(
+        clientName: String,
+        startTimeout: TimeInterval = 10
+    ) async throws -> Client {
+        if !DaemonProbe.canConnect() {
+            try spawnDaemon()
+            try await waitForSocket(timeout: startTimeout)
+        }
+
+        let connection = NWConnection(
+            to: NWEndpoint.unix(path: DaemonPaths.socket.path),
+            using: .tcp
+        )
+        let transport = NetworkTransport(connection: connection)
+        let client = Client(name: clientName, version: PreviewsMCPCommand.version)
+        _ = try await client.connect(transport: transport)
+        return client
+    }
+
+    /// Spawn the daemon as an independent child process. We don't wait for it —
+    /// the daemon keeps running after this function returns and after the
+    /// parent CLI exits.
+    private static func spawnDaemon() throws {
+        let selfPath = ProcessInfo.processInfo.arguments[0]
+        let binaryURL = URL(fileURLWithPath: selfPath).standardizedFileURL
+
+        let proc = Process()
+        proc.executableURL = binaryURL
+        proc.arguments = ["serve", "--daemon"]
+        // Detach stdio from the client so terminal closure / pipe signals
+        // don't affect the daemon. Daemon logs go nowhere for now (future:
+        // redirect to ~/.previewsmcp/serve.log).
+        proc.standardInput = FileHandle.nullDevice
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+        try proc.run()
+    }
+
+    /// Poll the socket until it accepts connections or we give up.
+    private static func waitForSocket(timeout: TimeInterval) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if DaemonProbe.canConnect() { return }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+        throw DaemonClientError.startupTimedOut
+    }
+}
+
+enum DaemonClientError: Error, CustomStringConvertible {
+    case startupTimedOut
+
+    var description: String {
+        switch self {
+        case .startupTimedOut:
+            return "daemon did not become ready on \(DaemonPaths.socket.path)"
+        }
+    }
+}

--- a/Sources/PreviewsCLI/DaemonClient.swift
+++ b/Sources/PreviewsCLI/DaemonClient.swift
@@ -20,9 +20,16 @@ enum DaemonClient {
     ///     handshake (useful in daemon logs).
     ///   - startTimeout: How long to wait for a newly-spawned daemon to become
     ///     reachable on the socket.
+    ///   - configure: Optional setup closure that runs *before* the MCP
+    ///     initialize handshake, so notification handlers registered here
+    ///     will receive all server-emitted notifications including any that
+    ///     arrive during or immediately after the handshake. Register any
+    ///     `onNotification` handlers here rather than on the returned client
+    ///     to avoid dropping early notifications.
     static func connect(
         clientName: String,
-        startTimeout: TimeInterval = 10
+        startTimeout: TimeInterval = 10,
+        configure: ((Client) async -> Void)? = nil
     ) async throws -> Client {
         if !DaemonProbe.canConnect() {
             try spawnDaemon()
@@ -35,6 +42,7 @@ enum DaemonClient {
         )
         let transport = NetworkTransport(connection: connection)
         let client = Client(name: clientName, version: PreviewsMCPCommand.version)
+        await configure?(client)
         _ = try await client.connect(transport: transport)
         return client
     }
@@ -45,6 +53,13 @@ enum DaemonClient {
     private static func spawnDaemon() throws {
         let selfPath = ProcessInfo.processInfo.arguments[0]
         let binaryURL = URL(fileURLWithPath: selfPath).standardizedFileURL
+
+        // Guard against argv[0] pointing at a missing or non-executable path
+        // (happens if the binary was moved or invoked with a spoofed argv[0]).
+        // Process.run() would surface a generic Posix error otherwise.
+        guard FileManager.default.isExecutableFile(atPath: binaryURL.path) else {
+            throw DaemonClientError.binaryNotFound(path: binaryURL.path)
+        }
 
         let proc = Process()
         proc.executableURL = binaryURL
@@ -71,11 +86,14 @@ enum DaemonClient {
 
 enum DaemonClientError: Error, CustomStringConvertible {
     case startupTimedOut
+    case binaryNotFound(path: String)
 
     var description: String {
         switch self {
         case .startupTimedOut:
             return "daemon did not become ready on \(DaemonPaths.socket.path)"
+        case .binaryNotFound(let path):
+            return "previewsmcp binary not found or not executable at \(path)"
         }
     }
 }

--- a/Sources/PreviewsCLI/DaemonClient.swift
+++ b/Sources/PreviewsCLI/DaemonClient.swift
@@ -54,9 +54,11 @@ enum DaemonClient {
         let selfPath = ProcessInfo.processInfo.arguments[0]
         let binaryURL = URL(fileURLWithPath: selfPath).standardizedFileURL
 
-        // Guard against argv[0] pointing at a missing or non-executable path
-        // (happens if the binary was moved or invoked with a spoofed argv[0]).
-        // Process.run() would surface a generic Posix error otherwise.
+        // Best-effort sanity check so a missing binary surfaces as a clear
+        // error instead of Process.run()'s generic POSIX failure. This is
+        // not a security boundary — a spoofed argv[0] pointing at some
+        // other real executable would still pass this check. See #100 for
+        // authoritative self-path resolution via _NSGetExecutablePath.
         guard FileManager.default.isExecutableFile(atPath: binaryURL.path) else {
             throw DaemonClientError.binaryNotFound(path: binaryURL.path)
         }

--- a/Sources/PreviewsCLI/DaemonLifecycle.swift
+++ b/Sources/PreviewsCLI/DaemonLifecycle.swift
@@ -4,20 +4,27 @@ import Foundation
 /// Installs SIGTERM/SIGINT handlers that trigger cleanup before exiting.
 enum DaemonLifecycle {
 
-    /// Register this process as the running daemon. Writes `serve.pid`,
-    /// installs signal handlers, and detaches from the parent's process
-    /// group so the daemon survives the client's terminal closing (SIGHUP)
-    /// or the client exiting. Call once during daemon startup, after the
-    /// socket is listening.
+    /// Detach from the parent's controlling terminal and process group.
+    ///
+    /// Call this as the *first* step of daemon startup — before the socket
+    /// listener binds and starts accepting connections. If setsid() runs
+    /// after the socket is live, a client that observes the socket ready
+    /// and exits during that window can cascade SIGHUP through the shared
+    /// process group and kill the daemon. Doing setsid first eliminates
+    /// that race.
+    ///
+    /// Returns -1 if the process is already a session leader (e.g., when
+    /// launched by launchd), which is fine — we're already detached.
+    static func detachFromTerminal() {
+        _ = Darwin.setsid()
+    }
+
+    /// Register this process as the running daemon. Writes `serve.pid` and
+    /// installs signal handlers. Call after the socket is listening.
+    /// Terminal detachment should have already happened via
+    /// `detachFromTerminal()` earlier in startup.
     static func register() throws {
         try DaemonPaths.ensureDirectory()
-
-        // Detach from the controlling terminal and the parent's process
-        // group so terminal close (SIGHUP) doesn't cascade to the daemon.
-        // setsid returns -1 if this process is already a session leader
-        // (uncommon — typically only true for launchd-started processes),
-        // which is fine; in that case we're already detached.
-        _ = Darwin.setsid()
 
         let pid = ProcessInfo.processInfo.processIdentifier
         try "\(pid)\n".write(to: DaemonPaths.pidFile, atomically: true, encoding: .utf8)

--- a/Sources/PreviewsCLI/DaemonLifecycle.swift
+++ b/Sources/PreviewsCLI/DaemonLifecycle.swift
@@ -4,11 +4,20 @@ import Foundation
 /// Installs SIGTERM/SIGINT handlers that trigger cleanup before exiting.
 enum DaemonLifecycle {
 
-    /// Register this process as the running daemon. Writes `serve.pid` and
-    /// installs signal handlers. Call once during daemon startup, after the
+    /// Register this process as the running daemon. Writes `serve.pid`,
+    /// installs signal handlers, and detaches from the parent's process
+    /// group so the daemon survives the client's terminal closing (SIGHUP)
+    /// or the client exiting. Call once during daemon startup, after the
     /// socket is listening.
     static func register() throws {
         try DaemonPaths.ensureDirectory()
+
+        // Detach from the controlling terminal and the parent's process
+        // group so terminal close (SIGHUP) doesn't cascade to the daemon.
+        // setsid returns -1 if this process is already a session leader
+        // (uncommon — typically only true for launchd-started processes),
+        // which is fine; in that case we're already detached.
+        _ = Darwin.setsid()
 
         let pid = ProcessInfo.processInfo.processIdentifier
         try "\(pid)\n".write(to: DaemonPaths.pidFile, atomically: true, encoding: .utf8)

--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -34,18 +34,17 @@ struct PreviewsMCPApp {
             // NWConnection callbacks on DispatchQueue.main, so we can't just
             // block main with a semaphore — the callbacks would never fire.
             // Use dispatchMain() to yield to libdispatch and let the async Task
-            // drive to completion, then exit() explicitly from the Task.
+            // drive to completion, then delegate to ParsableCommand.exit()
+            // from the Task so error formatting matches the sync branch
+            // (ArgumentParser formats ValidationError / ExitCode correctly).
             if let asyncCommand = command as? any AsyncParsableCommand {
                 Task {
                     do {
                         var mutable = asyncCommand
                         try await mutable.run()
                         Darwin.exit(0)
-                    } catch let error as ExitCode {
-                        Darwin.exit(error.rawValue)
                     } catch {
-                        fputs("\(error)\n", stderr)
-                        Darwin.exit(1)
+                        PreviewsMCPCommand.exit(withError: error)
                     }
                 }
                 dispatchMain()  // never returns; Task exits the process

--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -24,11 +24,33 @@ struct PreviewsMCPApp {
             PreviewsMCPCommand.exit(withError: error)
         }
 
-        // Commands that don't need NSApplication (list, help, status, kill-daemon)
+        // Commands that don't need NSApplication (list, help, status, kill-daemon,
+        // and `run` which is now a lightweight daemon client).
         if command is ListCommand
-            || !(command is RunCommand || command is ServeCommand || command is SnapshotCommand
+            || !(command is ServeCommand || command is SnapshotCommand
                 || command is VariantsCommand)
         {
+            // Handle async commands: the MCP SDK's NetworkTransport schedules
+            // NWConnection callbacks on DispatchQueue.main, so we can't just
+            // block main with a semaphore — the callbacks would never fire.
+            // Use dispatchMain() to yield to libdispatch and let the async Task
+            // drive to completion, then exit() explicitly from the Task.
+            if let asyncCommand = command as? any AsyncParsableCommand {
+                Task {
+                    do {
+                        var mutable = asyncCommand
+                        try await mutable.run()
+                        Darwin.exit(0)
+                    } catch let error as ExitCode {
+                        Darwin.exit(error.rawValue)
+                    } catch {
+                        fputs("\(error)\n", stderr)
+                        Darwin.exit(1)
+                    }
+                }
+                dispatchMain()  // never returns; Task exits the process
+            }
+
             do {
                 var mutable = command
                 try mutable.run()

--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -24,11 +24,11 @@ struct PreviewsMCPApp {
             PreviewsMCPCommand.exit(withError: error)
         }
 
-        // Commands that don't need NSApplication (list, help, status, kill-daemon,
-        // and `run` which is now a lightweight daemon client).
-        if command is ListCommand
-            || !(command is ServeCommand || command is SnapshotCommand
-                || command is VariantsCommand)
+        // Commands that don't need NSApplication (list, help, status,
+        // kill-daemon, and `run` which is now a lightweight daemon client).
+        // Only serve/snapshot/variants still drive AppKit in-process.
+        if !(command is ServeCommand || command is SnapshotCommand
+            || command is VariantsCommand)
         {
             // Handle async commands: the MCP SDK's NetworkTransport schedules
             // NWConnection callbacks on DispatchQueue.main, so we can't just

--- a/Sources/PreviewsCLI/RunCommand.swift
+++ b/Sources/PreviewsCLI/RunCommand.swift
@@ -126,7 +126,7 @@ struct RunCommand: AsyncParsableCommand {
         if detach {
             // Scriptable: print session ID to stdout, human line to stderr.
             print(sessionID)
-            fputs("session started in daemon; run `previewsmcp stop --session \(sessionID)` to end\n", stderr)
+            fputs("session \(sessionID) started in daemon\n", stderr)
             await client.disconnect()
             return
         }

--- a/Sources/PreviewsCLI/RunCommand.swift
+++ b/Sources/PreviewsCLI/RunCommand.swift
@@ -1,12 +1,21 @@
-import AppKit
 import ArgumentParser
 import Foundation
+import MCP
 import PreviewsCore
 
-struct RunCommand: ParsableCommand {
+struct RunCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "run",
-        abstract: "Compile and display a live SwiftUI preview"
+        abstract: "Compile and display a live SwiftUI preview",
+        discussion: """
+            Starts a preview session in the previewsmcp daemon. The daemon owns
+            the preview window and file watcher; this command is a lightweight
+            client. Starts the daemon automatically if not running.
+
+            By default, blocks until Ctrl+C, which stops the session. Pass
+            `--detach` to start the session and exit (session UUID is printed
+            to stdout for use with other commands).
+            """
     )
 
     @Argument(help: "Path to Swift source file containing #Preview")
@@ -57,15 +66,19 @@ struct RunCommand: ParsableCommand {
     @Option(name: .long, help: "Path to .previewsmcp.json config file (auto-discovered if omitted)")
     var config: String?
 
-    mutating func run() throws {
+    @Flag(
+        name: .long,
+        help: "Start the session and exit; session keeps running in the daemon"
+    )
+    var detach: Bool = false
+
+    mutating func run() async throws {
         let fileURL = URL(fileURLWithPath: file).standardizedFileURL
         guard FileManager.default.fileExists(atPath: fileURL.path) else {
             throw ValidationError("File not found: \(file)")
         }
 
-        let configResult = loadProjectConfig(explicit: config, fileURL: fileURL)
-        let projectConfig = configResult?.config
-
+        // Local trait validation — fail fast before reaching the daemon.
         do {
             _ = try PreviewTraits.validated(
                 colorScheme: colorScheme, dynamicTypeSize: dynamicTypeSize,
@@ -76,109 +89,147 @@ struct RunCommand: ParsableCommand {
             throw ValidationError(error.localizedDescription)
         }
 
-        let resolvedPlatform: CLIPlatform = {
-            if let explicit = platform { return explicit }
-            if let cp = projectConfig?.platform { return cp == "ios" ? .ios : .macos }
-            if SPMBuildSystem.inferredPlatform(for: fileURL) == .iOS {
-                return .ios
-            }
-            return .macos
-        }()
+        let client = try await DaemonClient.connect(clientName: "previewsmcp-run")
 
-        switch resolvedPlatform {
-        case .ios:
-            runIOS(fileURL: fileURL, configResult: configResult)
-        case .macos:
-            runMacOS(fileURL: fileURL, configResult: configResult)
+        // Relay daemon log messages to stderr so users see build progress.
+        await client.onNotification(LogMessageNotification.self) { message in
+            if case .string(let text) = message.params.data {
+                fputs("\(text)\n", stderr)
+            }
         }
+
+        let arguments = buildPreviewStartArguments(fileURL: fileURL)
+
+        let response: (content: [Tool.Content], isError: Bool?)
+        do {
+            response = try await client.callTool(name: "preview_start", arguments: arguments)
+        } catch {
+            fputs("Failed to start preview: \(error)\n", stderr)
+            await client.disconnect()
+            throw ExitCode(1)
+        }
+
+        if response.isError == true {
+            let text = textFromContent(response.content)
+            fputs("Preview start failed: \(text)\n", stderr)
+            await client.disconnect()
+            throw ExitCode(1)
+        }
+
+        let text = textFromContent(response.content)
+        guard let sessionID = extractSessionID(from: text) else {
+            fputs("Unexpected daemon response (no session ID): \(text)\n", stderr)
+            await client.disconnect()
+            throw ExitCode(1)
+        }
+
+        if detach {
+            // Scriptable: print session ID to stdout, human line to stderr.
+            print(sessionID)
+            fputs("session started in daemon; run `previewsmcp stop --session \(sessionID)` to end\n", stderr)
+            await client.disconnect()
+            return
+        }
+
+        // Attached: print the daemon's response once for user feedback, then
+        // block until Ctrl+C. On signal, stop the session and exit cleanly.
+        fputs("\(text)\n", stderr)
+        fputs("Press Ctrl+C to stop the preview.\n", stderr)
+
+        await blockUntilSignal()
+
+        do {
+            _ = try await client.callTool(
+                name: "preview_stop",
+                arguments: ["sessionID": .string(sessionID)]
+            )
+        } catch {
+            // Best-effort. If stop fails, the daemon will still have the session;
+            // user can call `kill-daemon` to clean up.
+            fputs("warning: failed to stop session \(sessionID): \(error)\n", stderr)
+        }
+        await client.disconnect()
     }
 
-    private func runMacOS(fileURL: URL, configResult: ProjectConfigLoader.Result?) {
-        let previewIndex = preview
-        let windowWidth = width
-        let windowHeight = height
-        let projectPath = project
-        let schemeName = scheme
-        let configTraits = configResult?.config.traits?.toPreviewTraits() ?? PreviewTraits()
-        let explicitTraits = PreviewTraits(
-            colorScheme: colorScheme, dynamicTypeSize: dynamicTypeSize,
-            locale: locale, layoutDirection: layoutDirection,
-            legibilityWeight: legibilityWeight
-        )
-        let traits = configTraits.merged(with: explicitTraits)
-        let progress: any ProgressReporter = StderrProgressReporter(totalSteps: 3)
+    // MARK: - Helpers
 
-        Task {
-            do {
-                let projectRootURL = projectPath.map { URL(fileURLWithPath: $0) }
-                let buildContext = try await detectAndBuild(
-                    for: fileURL,
-                    projectRoot: projectRootURL,
-                    platform: .macOS,
-                    scheme: schemeName,
-                    progress: progress)
-
-                let setupResult = try await buildSetupFromConfig(configResult, platform: .macOS)
-
-                try await launchMacOSPreview(
-                    fileURL: fileURL,
-                    previewIndex: previewIndex,
-                    title: "Preview: \(fileURL.lastPathComponent)",
-                    width: windowWidth,
-                    height: windowHeight,
-                    buildContext: buildContext,
-                    traits: traits,
-                    setupResult: setupResult,
-                    progress: progress
-                )
-            } catch {
-                fputs("Error: \(error)\n", stderr)
-                Darwin.exit(1)
-            }
-        }
+    private func buildPreviewStartArguments(fileURL: URL) -> [String: Value] {
+        var args: [String: Value] = [
+            "filePath": .string(fileURL.path),
+            "preview": .int(preview),
+            "width": .int(width),
+            "height": .int(height),
+        ]
+        if let platform { args["platform"] = .string(platform.rawValue) }
+        if let project { args["project"] = .string(project) }
+        if let scheme { args["scheme"] = .string(scheme) }
+        if let device { args["device"] = .string(device) }
+        if let colorScheme { args["colorScheme"] = .string(colorScheme) }
+        if let dynamicTypeSize { args["dynamicTypeSize"] = .string(dynamicTypeSize) }
+        if let locale { args["locale"] = .string(locale) }
+        if let layoutDirection { args["layoutDirection"] = .string(layoutDirection) }
+        if let legibilityWeight { args["legibilityWeight"] = .string(legibilityWeight) }
+        if headless { args["headless"] = .bool(true) }
+        if let config { args["config"] = .string(config) }
+        return args
     }
 
-    private func runIOS(fileURL: URL, configResult: ProjectConfigLoader.Result?) {
-        let previewIndex = preview
-        let deviceUDID = device ?? configResult?.config.device
-        let projectPath = project
-        let schemeName = scheme
-        let configTraits = configResult?.config.traits?.toPreviewTraits() ?? PreviewTraits()
-        let explicitTraits = PreviewTraits(
-            colorScheme: colorScheme, dynamicTypeSize: dynamicTypeSize,
-            locale: locale, layoutDirection: layoutDirection,
-            legibilityWeight: legibilityWeight
-        )
-        let traits = configTraits.merged(with: explicitTraits)
-        let isHeadless = headless
-        let progress: any ProgressReporter = StderrProgressReporter(totalSteps: 8)
+    private func textFromContent(_ content: [Tool.Content]) -> String {
+        content.compactMap { item in
+            if case .text(let t) = item { return t }
+            return nil
+        }.joined(separator: "\n")
+    }
 
-        Task {
-            do {
-                let projectRootURL = projectPath.map { URL(fileURLWithPath: $0) }
-                let buildContext = try await detectAndBuild(
-                    for: fileURL,
-                    projectRoot: projectRootURL,
-                    platform: .iOS,
-                    scheme: schemeName,
-                    progress: progress)
+    private func extractSessionID(from text: String) -> String? {
+        let pattern = /Session ID: ([0-9a-fA-F-]{36})/
+        guard let match = text.firstMatch(of: pattern) else { return nil }
+        return String(match.1)
+    }
+}
 
-                let setupResult = try await buildSetupFromConfig(configResult, platform: .iOS)
+/// Block the calling task until the process receives SIGINT or SIGTERM.
+/// Returns immediately after the first signal is delivered.
+private func blockUntilSignal() async {
+    // Suppress default terminate-on-signal behavior; DispatchSource handles it.
+    signal(SIGINT, SIG_IGN)
+    signal(SIGTERM, SIG_IGN)
 
-                try await launchIOSPreview(
-                    fileURL: fileURL,
-                    previewIndex: previewIndex,
-                    deviceUDID: deviceUDID,
-                    headless: isHeadless,
-                    buildContext: buildContext,
-                    traits: traits,
-                    setupResult: setupResult,
-                    progress: progress
-                )
-            } catch {
-                fputs("Error: \(error)\n", stderr)
-                Darwin.exit(1)
-            }
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        let box = ContinuationBox(continuation)
+        let sources = [
+            DispatchSource.makeSignalSource(signal: SIGINT, queue: .main),
+            DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main),
+        ]
+        for source in sources {
+            source.setEventHandler { box.resumeOnce() }
+            source.resume()
         }
+        box.retainSources(sources)
+    }
+}
+
+/// Ensures a continuation is resumed exactly once, regardless of how many
+/// signals arrive or which source fires first.
+private final class ContinuationBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var retainedSources: [DispatchSourceSignal] = []
+
+    init(_ continuation: CheckedContinuation<Void, Never>) {
+        self.continuation = continuation
+    }
+
+    func retainSources(_ sources: [DispatchSourceSignal]) {
+        lock.lock(); defer { lock.unlock() }
+        retainedSources = sources
+    }
+
+    func resumeOnce() {
+        lock.lock()
+        let c = continuation
+        continuation = nil
+        lock.unlock()
+        c?.resume()
     }
 }

--- a/Sources/PreviewsCLI/RunCommand.swift
+++ b/Sources/PreviewsCLI/RunCommand.swift
@@ -89,12 +89,13 @@ struct RunCommand: AsyncParsableCommand {
             throw ValidationError(error.localizedDescription)
         }
 
-        let client = try await DaemonClient.connect(clientName: "previewsmcp-run")
-
-        // Relay daemon log messages to stderr so users see build progress.
-        await client.onNotification(LogMessageNotification.self) { message in
-            if case .string(let text) = message.params.data {
-                fputs("\(text)\n", stderr)
+        // Register the log handler *before* the MCP initialize handshake so
+        // we don't miss notifications emitted during early server startup.
+        let client = try await DaemonClient.connect(clientName: "previewsmcp-run") { client in
+            await client.onNotification(LogMessageNotification.self) { message in
+                if case .string(let text) = message.params.data {
+                    fputs("\(text)\n", stderr)
+                }
             }
         }
 
@@ -144,9 +145,16 @@ struct RunCommand: AsyncParsableCommand {
                 arguments: ["sessionID": .string(sessionID)]
             )
         } catch {
-            // Best-effort. If stop fails, the daemon will still have the session;
-            // user can call `kill-daemon` to clean up.
-            fputs("warning: failed to stop session \(sessionID): \(error)\n", stderr)
+            // Best-effort — the session may still be alive in the daemon.
+            // Surface the session ID so the user can target it with `stop`
+            // (once that command ships) or fall back to `kill-daemon` to
+            // wipe everything.
+            fputs(
+                "warning: failed to stop session \(sessionID): \(error)\n"
+                    + "  session may still be running in the daemon; "
+                    + "run `previewsmcp kill-daemon` to clean up.\n",
+                stderr
+            )
         }
         await client.disconnect()
     }

--- a/Sources/PreviewsCLI/ServeCommand.swift
+++ b/Sources/PreviewsCLI/ServeCommand.swift
@@ -80,6 +80,12 @@ struct ServeCommand: ParsableCommand {
                     Darwin.exit(1)
                 }
 
+                // Detach before any client can observe us as "ready" via the
+                // socket. Otherwise a SIGHUP during the tiny window between
+                // socket bind and setsid could cascade through the shared
+                // process group and kill the daemon.
+                DaemonLifecycle.detachFromTerminal()
+
                 _ = try await DaemonListener.start()
                 try DaemonLifecycle.register()
                 fputs(

--- a/Sources/PreviewsCore/SetupBuilder.swift
+++ b/Sources/PreviewsCore/SetupBuilder.swift
@@ -33,6 +33,13 @@ public enum SetupBuilder {
             throw SetupBuilderError.packageNotFound(packageDir.path)
         }
 
+        // Concurrent builders of the same package coexist safely because
+        // `linkDynamicLibrary` uses atomic rename — the on-disk
+        // libPreviewSetup.dylib is never missing, so concurrent preview
+        // compiles linking against it always find a valid file. Whichever
+        // builder writes last wins; cache entries are idempotent per
+        // source hash.
+
         // Resolve inputs for the cache key before checking the cache.
         let iosSDKPath: String? = platform == .iOS ? try await resolveIOSSDK() : nil
         let swiftVersion = try await SetupCache.resolveSwiftVersion()
@@ -163,13 +170,24 @@ public enum SetupBuilder {
         // Remove stale static archives from previous builds so they don't confuse the linker.
         cleanStaleArchives(binPath: binPath)
 
+        // Build to a temp path in the same directory, then atomically replace
+        // the final dylib. Concurrent preview compiles that link against the
+        // final path always see a valid file: either the old one (before
+        // rename) or the new one (after rename), never a missing file.
+        //
+        // Keeping the install_name as the final path is critical — dyld
+        // matches on install_name, not the on-disk path it was loaded from.
         let dylibPath = binPath.appendingPathComponent("libPreviewSetup.dylib")
-        try? fm.removeItem(at: dylibPath)
+        let tempDylib = binPath.appendingPathComponent(
+            "libPreviewSetup.\(UUID().uuidString).dylib.tmp"
+        )
+        try? fm.removeItem(at: tempDylib)
 
         let swiftcPath = try await resolveSwiftc()
-        var args = ["-emit-library", "-o", dylibPath.path]
-        // Set the install name to the absolute path so dyld recognizes the
-        // already-RTLD_GLOBAL-loaded image when preview dylibs reference it.
+        var args = ["-emit-library", "-o", tempDylib.path]
+        // Set the install name to the FINAL path (not the temp path). After
+        // atomic rename, preview dylibs linked with this install_name will
+        // find the file where dyld expects it.
         args += ["-Xlinker", "-install_name", "-Xlinker", dylibPath.path]
         args += ["-target", platform.targetTriple]
 
@@ -196,17 +214,32 @@ public enum SetupBuilder {
 
         let linkResult = try await runAsync(swiftcPath, arguments: args)
         guard linkResult.exitCode == 0 else {
+            try? fm.removeItem(at: tempDylib)
             throw SetupBuilderError.buildFailed(
                 package: "setup dylib", stderr: linkResult.stderr
             )
         }
 
-        // Ad-hoc codesign (required on Apple Silicon)
+        // Ad-hoc codesign the temp file before it's visible at the final path
+        // (required on Apple Silicon; dyld refuses unsigned dylibs).
         let codesignPath = try await resolveCodesign()
-        let signResult = try await runAsync(codesignPath, arguments: ["-s", "-", dylibPath.path])
+        let signResult = try await runAsync(codesignPath, arguments: ["-s", "-", tempDylib.path])
         guard signResult.exitCode == 0 else {
+            try? fm.removeItem(at: tempDylib)
             throw SetupBuilderError.buildFailed(
                 package: "setup dylib codesign", stderr: signResult.stderr
+            )
+        }
+
+        // Atomic rename. On Darwin, rename(2) atomically replaces the target
+        // if it exists — concurrent readers see either the old inode or the
+        // new one. Never a window where the file is missing.
+        guard rename(tempDylib.path, dylibPath.path) == 0 else {
+            let reason = String(cString: strerror(errno))
+            try? fm.removeItem(at: tempDylib)
+            throw SetupBuilderError.buildFailed(
+                package: "setup dylib rename",
+                stderr: "rename(\(tempDylib.path) → \(dylibPath.path)) failed: \(reason)"
             )
         }
 
@@ -305,6 +338,7 @@ public enum SetupBuilder {
             return String(name.dropLast(".framework".count))
         }
     }
+
 }
 
 public enum SetupBuilderError: Error, LocalizedError {

--- a/Sources/PreviewsCore/SetupBuilder.swift
+++ b/Sources/PreviewsCore/SetupBuilder.swift
@@ -246,15 +246,25 @@ public enum SetupBuilder {
         return dylibPath
     }
 
-    /// Remove stale .a files from previous builds that used static linking.
+    /// Remove stale artifacts from previous builds:
+    /// - `.a` files from pre-dylib static-linking days
+    /// - `libPreviewSetup.<UUID>.dylib.tmp` files leaked when a previous
+    ///   builder crashed between `swiftc -emit-library` and the atomic
+    ///   rename in `linkDynamicLibrary`.
     private static func cleanStaleArchives(binPath: URL) {
         guard
             let entries = try? FileManager.default.contentsOfDirectory(
                 at: binPath, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]
             )
         else { return }
-        for entry in entries where entry.pathExtension == "a" {
-            try? FileManager.default.removeItem(at: entry)
+        for entry in entries {
+            let name = entry.lastPathComponent
+            let isLegacyArchive = entry.pathExtension == "a"
+            let isLeakedTempDylib =
+                name.hasPrefix("libPreviewSetup.") && name.hasSuffix(".dylib.tmp")
+            if isLegacyArchive || isLeakedTempDylib {
+                try? FileManager.default.removeItem(at: entry)
+            }
         }
     }
 

--- a/Tests/CLIIntegrationTests/DaemonTestLock.swift
+++ b/Tests/CLIIntegrationTests/DaemonTestLock.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Filesystem lock to serialize daemon-touching tests across suites and test
+/// targets. Swift Testing's `.serialized` trait only orders tests within its
+/// own suite; two suites (even in the same process) can run in parallel and
+/// stomp on each other's daemon.
+///
+/// The lock is advisory (`flock`) on a well-known path. Tests acquire the
+/// lock before any daemon interaction and release it when the test body
+/// returns. A crashed test releases the lock when its file descriptor
+/// closes on process exit.
+///
+/// Duplicated in both CLIIntegrationTests and MCPIntegrationTests because
+/// Swift test targets can't share source files.
+enum DaemonTestLock {
+
+    static let lockPath: String =
+        FileManager.default.temporaryDirectory
+        .appendingPathComponent("previewsmcp-daemon-test.lock").path
+
+    /// Acquire the lock, run the given async body, release the lock.
+    /// Blocks (via polling) until the lock is available.
+    static func run<T>(body: () async throws -> T) async throws -> T {
+        let fd = open(lockPath, O_CREAT | O_RDWR, 0o644)
+        guard fd >= 0 else {
+            throw NSError(
+                domain: NSPOSIXErrorDomain, code: Int(errno),
+                userInfo: [NSLocalizedDescriptionKey: "open(\(lockPath)) failed: \(String(cString: strerror(errno)))"]
+            )
+        }
+        defer { close(fd) }
+
+        // Poll flock with LOCK_NB so we don't block a pthread — yield to the
+        // async runtime between attempts.
+        while flock(fd, LOCK_EX | LOCK_NB) != 0 {
+            if errno != EWOULDBLOCK {
+                throw NSError(
+                    domain: NSPOSIXErrorDomain, code: Int(errno),
+                    userInfo: [NSLocalizedDescriptionKey: "flock failed: \(String(cString: strerror(errno)))"]
+                )
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        defer { _ = flock(fd, LOCK_UN) }
+
+        return try await body()
+    }
+}

--- a/Tests/CLIIntegrationTests/RunCommandTests.swift
+++ b/Tests/CLIIntegrationTests/RunCommandTests.swift
@@ -27,7 +27,8 @@ private final class StderrBuffer: @unchecked Sendable {
 /// DaemonLifecycleTests in another test target. Swift Testing may run
 /// different suites in parallel even when each is .serialized, which causes
 /// one suite's cleanup to stomp on the other's daemon. Guard with a
-/// filesystem lock so only one daemon-owning test runs at a time.
+/// filesystem lock (DaemonTestLock) so only one daemon-owning test runs at
+/// a time.
 @Suite(.serialized)
 struct RunCommandTests {
 
@@ -54,10 +55,44 @@ struct RunCommandTests {
     func detachStartsSessionAndExits() async throws {
         try await DaemonTestLock.run {
             try await Self.cleanSlate()
-            try await Self.runDetachStartsSessionAndExits()
+
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
+
+            let result = try await CLIRunner.run(
+                "run",
+                arguments: [
+                    file, "--platform", "macos", "--config", configPath, "--detach",
+                ]
+            )
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+
+            let uuid = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            let uuidPattern = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+            #expect(
+                uuid.wholeMatch(of: uuidPattern) != nil,
+                "stdout should be a bare UUID, got: '\(uuid)'"
+            )
+
+            let status = try await CLIRunner.run("status")
+            #expect(status.exitCode == 0, "daemon should be running after detach")
+            #expect(status.stdout.contains("daemon running"))
         }
     }
 
+    /// `run` without --detach should:
+    ///   1. auto-start the daemon,
+    ///   2. create a live session (verified via a "Session ID:" line from
+    ///      the daemon's log relay in the client's stderr),
+    ///   3. block until signalled,
+    ///   4. exit cleanly on SIGINT while the daemon keeps running.
+    ///
+    /// Reading stderr for "Session ID:" is deliberate — the socket file
+    /// appears before preview_start completes, so waiting on the socket
+    /// alone doesn't prove a session was actually rendered. A faulty run
+    /// that never called preview_start would pass that weaker check.
     @Test(
         "run (attached) creates a live session then exits on SIGINT",
         .timeLimit(.minutes(2))
@@ -65,7 +100,93 @@ struct RunCommandTests {
     func attachedBlocksUntilSignal() async throws {
         try await DaemonTestLock.run {
             try await Self.cleanSlate()
-            try await Self.runAttachedBlocksUntilSignal()
+
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
+
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: CLIRunner.binaryPath)
+            proc.arguments = ["run", file, "--platform", "macos", "--config", configPath]
+            proc.standardOutput = FileHandle.nullDevice
+            let stderrPipe = Pipe()
+            proc.standardError = stderrPipe
+            try proc.run()
+
+            let sessionIDPattern = /Session ID: [0-9a-fA-F-]{36}/
+            let sawSession = try await Self.waitForStderrMatch(
+                pipe: stderrPipe,
+                pattern: sessionIDPattern,
+                timeout: 60
+            )
+            #expect(sawSession, "daemon should report Session ID within 60s")
+            #expect(proc.isRunning, "run should block after session is established")
+
+            kill(proc.processIdentifier, SIGINT)
+            let exitDeadline = Date().addingTimeInterval(10)
+            while proc.isRunning && Date() < exitDeadline {
+                try await Task.sleep(nanoseconds: 50_000_000)
+            }
+            if proc.isRunning { proc.terminate() }
+            #expect(!proc.isRunning, "run should exit within 10s of SIGINT")
+
+            let status = try await CLIRunner.run("status")
+            #expect(status.exitCode == 0, "daemon should stay alive after client exits")
+        }
+    }
+
+    /// Guards the setsid detachment. Without `setsid()` running before the
+    /// socket listener starts, SIGHUP to the `run` client cascades to the
+    /// daemon (shared process group) and kills it. With the fix, the daemon
+    /// is in its own session and survives.
+    ///
+    /// `run` doesn't handle SIGHUP itself — the default action terminates
+    /// the client. That's expected; the *daemon* surviving is what we test.
+    @Test(
+        "daemon survives SIGHUP to the run client",
+        .timeLimit(.minutes(2))
+    )
+    func daemonSurvivesClientSIGHUP() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
+
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: CLIRunner.binaryPath)
+            proc.arguments = ["run", file, "--platform", "macos", "--config", configPath]
+            proc.standardOutput = FileHandle.nullDevice
+            let stderrPipe = Pipe()
+            proc.standardError = stderrPipe
+            try proc.run()
+
+            // Wait for the session to be live (same signal as the SIGINT test).
+            let sessionIDPattern = /Session ID: [0-9a-fA-F-]{36}/
+            let sawSession = try await Self.waitForStderrMatch(
+                pipe: stderrPipe,
+                pattern: sessionIDPattern,
+                timeout: 60
+            )
+            #expect(sawSession, "daemon should report Session ID within 60s")
+            #expect(proc.isRunning)
+
+            kill(proc.processIdentifier, SIGHUP)
+            let exitDeadline = Date().addingTimeInterval(10)
+            while proc.isRunning && Date() < exitDeadline {
+                try await Task.sleep(nanoseconds: 50_000_000)
+            }
+            if proc.isRunning { proc.terminate() }
+            #expect(!proc.isRunning, "run should exit after SIGHUP")
+
+            // Daemon must still be alive — setsid was supposed to detach it
+            // from the client's process group.
+            let status = try await CLIRunner.run("status")
+            #expect(status.exitCode == 0, "daemon should survive SIGHUP to client")
+            #expect(status.stdout.contains("daemon running"))
         }
     }
 
@@ -76,116 +197,49 @@ struct RunCommandTests {
     func detachReusesDaemon() async throws {
         try await DaemonTestLock.run {
             try await Self.cleanSlate()
-            try await Self.runDetachReusesDaemon()
+
+            let daemonStarter = Process()
+            daemonStarter.executableURL = URL(fileURLWithPath: CLIRunner.binaryPath)
+            daemonStarter.arguments = ["serve", "--daemon"]
+            daemonStarter.standardOutput = FileHandle.nullDevice
+            daemonStarter.standardError = FileHandle.nullDevice
+            try daemonStarter.run()
+            defer { if daemonStarter.isRunning { daemonStarter.terminate() } }
+
+            let readyDeadline = Date().addingTimeInterval(5)
+            while Date() < readyDeadline,
+                !FileManager.default.fileExists(atPath: Self.socketPath)
+            {
+                try await Task.sleep(nanoseconds: 50_000_000)
+            }
+            try await Task.sleep(nanoseconds: 100_000_000)
+
+            let home = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".previewsmcp")
+            let pidBefore =
+                (try? String(contentsOf: home.appendingPathComponent("serve.pid"), encoding: .utf8))?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
+            let result = try await CLIRunner.run(
+                "run",
+                arguments: [
+                    file, "--platform", "macos", "--config", configPath, "--detach",
+                ]
+            )
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+
+            let pidAfter =
+                (try? String(contentsOf: home.appendingPathComponent("serve.pid"), encoding: .utf8))?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            #expect(
+                pidAfter == pidBefore,
+                "daemon should not have been restarted (before=\(pidBefore ?? "nil"), after=\(pidAfter ?? "nil"))"
+            )
         }
-    }
-
-    // MARK: - Test bodies (extracted so @Test wrappers only handle the lock)
-
-    private static func runDetachStartsSessionAndExits() async throws {
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
-        let configPath = CLIRunner.repoRoot
-            .appendingPathComponent("examples/.previewsmcp.json").path
-
-        let result = try await CLIRunner.run(
-            "run",
-            arguments: [
-                file, "--platform", "macos", "--config", configPath, "--detach",
-            ]
-        )
-        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
-
-        let uuid = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-        let uuidPattern = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
-        #expect(
-            uuid.wholeMatch(of: uuidPattern) != nil,
-            "stdout should be a bare UUID, got: '\(uuid)'"
-        )
-
-        let status = try await CLIRunner.run("status")
-        #expect(status.exitCode == 0, "daemon should be running after detach")
-        #expect(status.stdout.contains("daemon running"))
-    }
-
-    private static func runAttachedBlocksUntilSignal() async throws {
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
-        let configPath = CLIRunner.repoRoot
-            .appendingPathComponent("examples/.previewsmcp.json").path
-
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: CLIRunner.binaryPath)
-        proc.arguments = ["run", file, "--platform", "macos", "--config", configPath]
-        proc.standardOutput = FileHandle.nullDevice
-        let stderrPipe = Pipe()
-        proc.standardError = stderrPipe
-        try proc.run()
-
-        let sessionIDPattern = /Session ID: [0-9a-fA-F-]{36}/
-        let sawSession = try await waitForStderrMatch(
-            pipe: stderrPipe,
-            pattern: sessionIDPattern,
-            timeout: 60
-        )
-        #expect(sawSession, "daemon should report Session ID within 60s")
-
-        #expect(proc.isRunning, "run should block after session is established")
-
-        kill(proc.processIdentifier, SIGINT)
-        let exitDeadline = Date().addingTimeInterval(10)
-        while proc.isRunning && Date() < exitDeadline {
-            try await Task.sleep(nanoseconds: 50_000_000)
-        }
-        if proc.isRunning { proc.terminate() }
-        #expect(!proc.isRunning, "run should exit within 10s of SIGINT")
-
-        let status = try await CLIRunner.run("status")
-        #expect(status.exitCode == 0, "daemon should stay alive after client exits")
-    }
-
-    private static func runDetachReusesDaemon() async throws {
-        let daemonStarter = Process()
-        daemonStarter.executableURL = URL(fileURLWithPath: CLIRunner.binaryPath)
-        daemonStarter.arguments = ["serve", "--daemon"]
-        daemonStarter.standardOutput = FileHandle.nullDevice
-        daemonStarter.standardError = FileHandle.nullDevice
-        try daemonStarter.run()
-        defer { if daemonStarter.isRunning { daemonStarter.terminate() } }
-
-        let readyDeadline = Date().addingTimeInterval(5)
-        while Date() < readyDeadline,
-            !FileManager.default.fileExists(atPath: Self.socketPath)
-        {
-            try await Task.sleep(nanoseconds: 50_000_000)
-        }
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        let home = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".previewsmcp")
-        let pidBefore =
-            (try? String(contentsOf: home.appendingPathComponent("serve.pid"), encoding: .utf8))?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
-        let configPath = CLIRunner.repoRoot
-            .appendingPathComponent("examples/.previewsmcp.json").path
-        let result = try await CLIRunner.run(
-            "run",
-            arguments: [
-                file, "--platform", "macos", "--config", configPath, "--detach",
-            ]
-        )
-        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
-
-        let pidAfter =
-            (try? String(contentsOf: home.appendingPathComponent("serve.pid"), encoding: .utf8))?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        #expect(
-            pidAfter == pidBefore,
-            "daemon should not have been restarted (before=\(pidBefore ?? "nil"), after=\(pidAfter ?? "nil"))"
-        )
     }
 
     // MARK: - Helpers

--- a/Tests/CLIIntegrationTests/RunCommandTests.swift
+++ b/Tests/CLIIntegrationTests/RunCommandTests.swift
@@ -1,0 +1,177 @@
+import Foundation
+import Testing
+
+/// Integration tests for the `run` subcommand after its migration to
+/// DaemonClient. Exercises the attached / detached flows end-to-end against
+/// a real daemon and real preview compilation.
+@Suite(.serialized)
+struct RunCommandTests {
+
+    // MARK: - Paths (reuse CLIRunner's)
+
+    static var socketPath: String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".previewsmcp/serve.sock").path
+    }
+
+    /// Kill any running daemon between tests so we start from a known state.
+    private static func cleanSlate() async throws {
+        _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        let home = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".previewsmcp")
+        try? FileManager.default.removeItem(at: home.appendingPathComponent("serve.sock"))
+        try? FileManager.default.removeItem(at: home.appendingPathComponent("serve.pid"))
+    }
+
+    // MARK: - Tests
+
+    /// `run --detach` should auto-start the daemon if needed, start a session,
+    /// print the session UUID to stdout, and exit without blocking.
+    @Test(
+        "run --detach starts daemon, prints session UUID, exits",
+        .timeLimit(.minutes(2))
+    )
+    func detachStartsSessionAndExits() async throws {
+        try await Self.cleanSlate()
+        defer { Task { try? await Self.cleanSlate() } }
+
+        let file = CLIRunner.spmExampleRoot
+            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+        let configPath = CLIRunner.repoRoot
+            .appendingPathComponent("examples/.previewsmcp.json").path
+
+        let result = try await CLIRunner.run(
+            "run",
+            arguments: [
+                file, "--platform", "macos", "--config", configPath, "--detach",
+            ]
+        )
+        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+
+        // stdout should be a bare UUID (scriptable).
+        let uuid = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        let uuidPattern = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+        #expect(
+            uuid.wholeMatch(of: uuidPattern) != nil,
+            "stdout should be a bare UUID, got: '\(uuid)'"
+        )
+
+        // Daemon should still be running (detach does not tear it down).
+        let status = try await CLIRunner.run("status")
+        #expect(status.exitCode == 0, "daemon should be running after detach")
+        #expect(status.stdout.contains("daemon running"))
+    }
+
+    /// `run` without --detach should block until signalled. Verified by
+    /// spawning the process, waiting briefly for the session to come up,
+    /// sending SIGINT, and checking the client exits within a reasonable
+    /// bound. The daemon must survive; only the client exits.
+    @Test(
+        "run (attached) blocks until SIGINT, then exits cleanly",
+        .timeLimit(.minutes(2))
+    )
+    func attachedBlocksUntilSignal() async throws {
+        try await Self.cleanSlate()
+        defer { Task { try? await Self.cleanSlate() } }
+
+        let file = CLIRunner.spmExampleRoot
+            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+        let configPath = CLIRunner.repoRoot
+            .appendingPathComponent("examples/.previewsmcp.json").path
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: CLIRunner.binaryPath)
+        proc.arguments = ["run", file, "--platform", "macos", "--config", configPath]
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+        try proc.run()
+
+        // Wait for the daemon socket to appear and a session to be live.
+        // The daemon is auto-started by the run client, so we check for the
+        // socket file as the readiness signal.
+        let deadline = Date().addingTimeInterval(30)
+        while Date() < deadline,
+            !FileManager.default.fileExists(atPath: Self.socketPath)
+        {
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+        #expect(
+            FileManager.default.fileExists(atPath: Self.socketPath),
+            "daemon socket should appear within 30s"
+        )
+
+        // The run client should still be blocking.
+        #expect(proc.isRunning, "run should block until signal")
+
+        // Send SIGINT; expect a clean exit within a couple of seconds.
+        kill(proc.processIdentifier, SIGINT)
+        let exitDeadline = Date().addingTimeInterval(10)
+        while proc.isRunning && Date() < exitDeadline {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        if proc.isRunning { proc.terminate() }
+        #expect(!proc.isRunning, "run should exit within 10s of SIGINT")
+
+        // Daemon should still be running — it outlives the client.
+        let status = try await CLIRunner.run("status")
+        #expect(status.exitCode == 0, "daemon should stay alive after client exits")
+    }
+
+    /// When a daemon is already running, `run --detach` should connect to it
+    /// (not spawn a second) and still create a session.
+    @Test(
+        "run --detach reuses an already-running daemon",
+        .timeLimit(.minutes(2))
+    )
+    func detachReusesDaemon() async throws {
+        try await Self.cleanSlate()
+        defer { Task { try? await Self.cleanSlate() } }
+
+        // Pre-start the daemon manually.
+        let daemonStarter = Process()
+        daemonStarter.executableURL = URL(fileURLWithPath: CLIRunner.binaryPath)
+        daemonStarter.arguments = ["serve", "--daemon"]
+        daemonStarter.standardOutput = FileHandle.nullDevice
+        daemonStarter.standardError = FileHandle.nullDevice
+        try daemonStarter.run()
+        defer { if daemonStarter.isRunning { daemonStarter.terminate() } }
+
+        // Wait for socket to be ready.
+        let readyDeadline = Date().addingTimeInterval(5)
+        while Date() < readyDeadline,
+            !FileManager.default.fileExists(atPath: Self.socketPath)
+        {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // Record daemon PID.
+        let home = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".previewsmcp")
+        let pidBefore =
+            (try? String(contentsOf: home.appendingPathComponent("serve.pid"), encoding: .utf8))?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Detach should reuse the existing daemon.
+        let file = CLIRunner.spmExampleRoot
+            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+        let configPath = CLIRunner.repoRoot
+            .appendingPathComponent("examples/.previewsmcp.json").path
+        let result = try await CLIRunner.run(
+            "run",
+            arguments: [
+                file, "--platform", "macos", "--config", configPath, "--detach",
+            ]
+        )
+        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+
+        // Daemon PID must be unchanged.
+        let pidAfter =
+            (try? String(contentsOf: home.appendingPathComponent("serve.pid"), encoding: .utf8))?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(
+            pidAfter == pidBefore,
+            "daemon should not have been restarted (before=\(pidBefore ?? "nil"), after=\(pidAfter ?? "nil"))"
+        )
+    }
+}

--- a/Tests/CLIIntegrationTests/RunCommandTests.swift
+++ b/Tests/CLIIntegrationTests/RunCommandTests.swift
@@ -1,13 +1,35 @@
 import Foundation
 import Testing
 
+/// Thread-safe accumulator for a pipe's stderr output. The readabilityHandler
+/// closure runs on a background queue; this class synchronizes writes so the
+/// poll loop can safely read contents().
+private final class StderrBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var text = ""
+
+    func append(_ s: String) {
+        lock.lock(); defer { lock.unlock() }
+        text.append(s)
+    }
+
+    func contents() -> String {
+        lock.lock(); defer { lock.unlock() }
+        return text
+    }
+}
+
 /// Integration tests for the `run` subcommand after its migration to
 /// DaemonClient. Exercises the attached / detached flows end-to-end against
 /// a real daemon and real preview compilation.
+///
+/// These tests share global daemon state (~/.previewsmcp/serve.sock) with
+/// DaemonLifecycleTests in another test target. Swift Testing may run
+/// different suites in parallel even when each is .serialized, which causes
+/// one suite's cleanup to stomp on the other's daemon. Guard with a
+/// filesystem lock so only one daemon-owning test runs at a time.
 @Suite(.serialized)
 struct RunCommandTests {
-
-    // MARK: - Paths (reuse CLIRunner's)
 
     static var socketPath: String {
         FileManager.default.homeDirectoryForCurrentUser
@@ -25,16 +47,42 @@ struct RunCommandTests {
 
     // MARK: - Tests
 
-    /// `run --detach` should auto-start the daemon if needed, start a session,
-    /// print the session UUID to stdout, and exit without blocking.
     @Test(
         "run --detach starts daemon, prints session UUID, exits",
         .timeLimit(.minutes(2))
     )
     func detachStartsSessionAndExits() async throws {
-        try await Self.cleanSlate()
-        defer { Task { try? await Self.cleanSlate() } }
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            try await Self.runDetachStartsSessionAndExits()
+        }
+    }
 
+    @Test(
+        "run (attached) creates a live session then exits on SIGINT",
+        .timeLimit(.minutes(2))
+    )
+    func attachedBlocksUntilSignal() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            try await Self.runAttachedBlocksUntilSignal()
+        }
+    }
+
+    @Test(
+        "run --detach reuses an already-running daemon",
+        .timeLimit(.minutes(2))
+    )
+    func detachReusesDaemon() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            try await Self.runDetachReusesDaemon()
+        }
+    }
+
+    // MARK: - Test bodies (extracted so @Test wrappers only handle the lock)
+
+    private static func runDetachStartsSessionAndExits() async throws {
         let file = CLIRunner.spmExampleRoot
             .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
         let configPath = CLIRunner.repoRoot
@@ -48,7 +96,6 @@ struct RunCommandTests {
         )
         #expect(result.exitCode == 0, "stderr: \(result.stderr)")
 
-        // stdout should be a bare UUID (scriptable).
         let uuid = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         let uuidPattern = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
         #expect(
@@ -56,24 +103,12 @@ struct RunCommandTests {
             "stdout should be a bare UUID, got: '\(uuid)'"
         )
 
-        // Daemon should still be running (detach does not tear it down).
         let status = try await CLIRunner.run("status")
         #expect(status.exitCode == 0, "daemon should be running after detach")
         #expect(status.stdout.contains("daemon running"))
     }
 
-    /// `run` without --detach should block until signalled. Verified by
-    /// spawning the process, waiting briefly for the session to come up,
-    /// sending SIGINT, and checking the client exits within a reasonable
-    /// bound. The daemon must survive; only the client exits.
-    @Test(
-        "run (attached) blocks until SIGINT, then exits cleanly",
-        .timeLimit(.minutes(2))
-    )
-    func attachedBlocksUntilSignal() async throws {
-        try await Self.cleanSlate()
-        defer { Task { try? await Self.cleanSlate() } }
-
+    private static func runAttachedBlocksUntilSignal() async throws {
         let file = CLIRunner.spmExampleRoot
             .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
         let configPath = CLIRunner.repoRoot
@@ -83,27 +118,20 @@ struct RunCommandTests {
         proc.executableURL = URL(fileURLWithPath: CLIRunner.binaryPath)
         proc.arguments = ["run", file, "--platform", "macos", "--config", configPath]
         proc.standardOutput = FileHandle.nullDevice
-        proc.standardError = FileHandle.nullDevice
+        let stderrPipe = Pipe()
+        proc.standardError = stderrPipe
         try proc.run()
 
-        // Wait for the daemon socket to appear and a session to be live.
-        // The daemon is auto-started by the run client, so we check for the
-        // socket file as the readiness signal.
-        let deadline = Date().addingTimeInterval(30)
-        while Date() < deadline,
-            !FileManager.default.fileExists(atPath: Self.socketPath)
-        {
-            try await Task.sleep(nanoseconds: 100_000_000)
-        }
-        #expect(
-            FileManager.default.fileExists(atPath: Self.socketPath),
-            "daemon socket should appear within 30s"
+        let sessionIDPattern = /Session ID: [0-9a-fA-F-]{36}/
+        let sawSession = try await waitForStderrMatch(
+            pipe: stderrPipe,
+            pattern: sessionIDPattern,
+            timeout: 60
         )
+        #expect(sawSession, "daemon should report Session ID within 60s")
 
-        // The run client should still be blocking.
-        #expect(proc.isRunning, "run should block until signal")
+        #expect(proc.isRunning, "run should block after session is established")
 
-        // Send SIGINT; expect a clean exit within a couple of seconds.
         kill(proc.processIdentifier, SIGINT)
         let exitDeadline = Date().addingTimeInterval(10)
         while proc.isRunning && Date() < exitDeadline {
@@ -112,22 +140,11 @@ struct RunCommandTests {
         if proc.isRunning { proc.terminate() }
         #expect(!proc.isRunning, "run should exit within 10s of SIGINT")
 
-        // Daemon should still be running — it outlives the client.
         let status = try await CLIRunner.run("status")
         #expect(status.exitCode == 0, "daemon should stay alive after client exits")
     }
 
-    /// When a daemon is already running, `run --detach` should connect to it
-    /// (not spawn a second) and still create a session.
-    @Test(
-        "run --detach reuses an already-running daemon",
-        .timeLimit(.minutes(2))
-    )
-    func detachReusesDaemon() async throws {
-        try await Self.cleanSlate()
-        defer { Task { try? await Self.cleanSlate() } }
-
-        // Pre-start the daemon manually.
+    private static func runDetachReusesDaemon() async throws {
         let daemonStarter = Process()
         daemonStarter.executableURL = URL(fileURLWithPath: CLIRunner.binaryPath)
         daemonStarter.arguments = ["serve", "--daemon"]
@@ -136,7 +153,6 @@ struct RunCommandTests {
         try daemonStarter.run()
         defer { if daemonStarter.isRunning { daemonStarter.terminate() } }
 
-        // Wait for socket to be ready.
         let readyDeadline = Date().addingTimeInterval(5)
         while Date() < readyDeadline,
             !FileManager.default.fileExists(atPath: Self.socketPath)
@@ -145,14 +161,12 @@ struct RunCommandTests {
         }
         try await Task.sleep(nanoseconds: 100_000_000)
 
-        // Record daemon PID.
         let home = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".previewsmcp")
         let pidBefore =
             (try? String(contentsOf: home.appendingPathComponent("serve.pid"), encoding: .utf8))?
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
-        // Detach should reuse the existing daemon.
         let file = CLIRunner.spmExampleRoot
             .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
         let configPath = CLIRunner.repoRoot
@@ -165,7 +179,6 @@ struct RunCommandTests {
         )
         #expect(result.exitCode == 0, "stderr: \(result.stderr)")
 
-        // Daemon PID must be unchanged.
         let pidAfter =
             (try? String(contentsOf: home.appendingPathComponent("serve.pid"), encoding: .utf8))?
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -173,5 +186,30 @@ struct RunCommandTests {
             pidAfter == pidBefore,
             "daemon should not have been restarted (before=\(pidBefore ?? "nil"), after=\(pidAfter ?? "nil"))"
         )
+    }
+
+    // MARK: - Helpers
+
+    private static func waitForStderrMatch<Output>(
+        pipe: Pipe,
+        pattern: Regex<Output>,
+        timeout: TimeInterval
+    ) async throws -> Bool {
+        let buffer = StderrBuffer()
+        let handle = pipe.fileHandleForReading
+        handle.readabilityHandler = { fileHandle in
+            let data = fileHandle.availableData
+            if !data.isEmpty, let text = String(data: data, encoding: .utf8) {
+                buffer.append(text)
+            }
+        }
+        defer { handle.readabilityHandler = nil }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if buffer.contents().contains(pattern) { return true }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+        return false
     }
 }

--- a/Tests/MCPIntegrationTests/DaemonLifecycleTests.swift
+++ b/Tests/MCPIntegrationTests/DaemonLifecycleTests.swift
@@ -87,88 +87,98 @@ struct DaemonLifecycleTests {
 
     @Test("status reports 'not running' when no daemon is active")
     func statusNoDaemon() async throws {
-        try await Self.cleanSlate()
-        let (out, exit) = try await Self.runCLI(["status"])
-        #expect(out.contains("not running"))
-        #expect(exit == 1, "status should exit non-zero when daemon is down")
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let (out, exit) = try await Self.runCLI(["status"])
+            #expect(out.contains("not running"))
+            #expect(exit == 1, "status should exit non-zero when daemon is down")
+        }
     }
 
     @Test("daemon creates socket and pid file, status reports running")
     func daemonStartAndStatus() async throws {
-        try await Self.cleanSlate()
-        let proc = try await Self.startDaemon()
-        defer { proc.terminate() }
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let proc = try await Self.startDaemon()
+            defer { proc.terminate() }
 
-        let (out, exit) = try await Self.runCLI(["status"])
-        #expect(out.contains("daemon running"))
-        #expect(out.contains(Self.socketPath))
-        #expect(exit == 0)
+            let (out, exit) = try await Self.runCLI(["status"])
+            #expect(out.contains("daemon running"))
+            #expect(out.contains(Self.socketPath))
+            #expect(exit == 0)
+        }
     }
 
     @Test("MCP client can connect to daemon and list tools")
     func mcpClientListsTools() async throws {
-        try await Self.cleanSlate()
-        let proc = try await Self.startDaemon()
-        defer { proc.terminate() }
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let proc = try await Self.startDaemon()
+            defer { proc.terminate() }
 
-        let connection = NWConnection(
-            to: NWEndpoint.unix(path: Self.socketPath),
-            using: .tcp
-        )
-        let transport = NetworkTransport(connection: connection)
-        let client = Client(name: "daemon-lifecycle-test", version: "1.0")
-        _ = try await client.connect(transport: transport)
-        defer {
-            Task { await client.disconnect() }
+            let connection = NWConnection(
+                to: NWEndpoint.unix(path: Self.socketPath),
+                using: .tcp
+            )
+            let transport = NetworkTransport(connection: connection)
+            let client = Client(name: "daemon-lifecycle-test", version: "1.0")
+            _ = try await client.connect(transport: transport)
+            defer {
+                Task { await client.disconnect() }
+            }
+
+            let response = try await client.listTools()
+            #expect(!response.tools.isEmpty, "daemon should expose MCP tools")
+            let names = Set(response.tools.map { $0.name })
+            #expect(names.contains("preview_list"))
+            #expect(names.contains("preview_snapshot"))
         }
-
-        let response = try await client.listTools()
-        #expect(!response.tools.isEmpty, "daemon should expose MCP tools")
-        let names = Set(response.tools.map { $0.name })
-        #expect(names.contains("preview_list"))
-        #expect(names.contains("preview_snapshot"))
     }
 
     @Test("kill-daemon terminates the daemon and removes socket")
     func killDaemonCleansUp() async throws {
-        try await Self.cleanSlate()
-        let proc = try await Self.startDaemon()
-        defer {
-            // In case kill-daemon failed, force termination so the test doesn't leak.
-            if proc.isRunning { proc.terminate() }
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let proc = try await Self.startDaemon()
+            defer {
+                // In case kill-daemon failed, force termination so the test doesn't leak.
+                if proc.isRunning { proc.terminate() }
+            }
+
+            let (out, exit) = try await Self.runCLI(["kill-daemon", "--timeout", "5"])
+            #expect(exit == 0, "kill-daemon should exit 0: \(out)")
+            #expect(out.contains("stopped"))
+
+            // Verify files were cleaned up.
+            #expect(!FileManager.default.fileExists(atPath: Self.socketPath))
+
+            // Verify status reports not running.
+            let (statusOut, statusExit) = try await Self.runCLI(["status"])
+            #expect(statusOut.contains("not running"))
+            #expect(statusExit == 1)
         }
-
-        let (out, exit) = try await Self.runCLI(["kill-daemon", "--timeout", "5"])
-        #expect(exit == 0, "kill-daemon should exit 0: \(out)")
-        #expect(out.contains("stopped"))
-
-        // Verify files were cleaned up.
-        #expect(!FileManager.default.fileExists(atPath: Self.socketPath))
-
-        // Verify status reports not running.
-        let (statusOut, statusExit) = try await Self.runCLI(["status"])
-        #expect(statusOut.contains("not running"))
-        #expect(statusExit == 1)
     }
 
     @Test("starting a second daemon refuses and exits non-zero")
     func secondDaemonRefuses() async throws {
-        try await Self.cleanSlate()
-        let proc = try await Self.startDaemon()
-        defer { proc.terminate() }
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let proc = try await Self.startDaemon()
+            defer { proc.terminate() }
 
-        let secondProc = Process()
-        secondProc.executableURL = URL(fileURLWithPath: Self.binaryPath)
-        secondProc.arguments = ["serve", "--daemon"]
-        let errPipe = Pipe()
-        secondProc.standardError = errPipe
-        secondProc.standardOutput = FileHandle.nullDevice
-        try secondProc.run()
-        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
-        secondProc.waitUntilExit()
-        let stderr = String(data: errData, encoding: .utf8) ?? ""
-        #expect(secondProc.terminationStatus != 0, "second daemon should fail")
-        #expect(stderr.contains("already running"))
+            let secondProc = Process()
+            secondProc.executableURL = URL(fileURLWithPath: Self.binaryPath)
+            secondProc.arguments = ["serve", "--daemon"]
+            let errPipe = Pipe()
+            secondProc.standardError = errPipe
+            secondProc.standardOutput = FileHandle.nullDevice
+            try secondProc.run()
+            let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+            secondProc.waitUntilExit()
+            let stderr = String(data: errData, encoding: .utf8) ?? ""
+            #expect(secondProc.terminationStatus != 0, "second daemon should fail")
+            #expect(stderr.contains("already running"))
+        }
     }
 
     /// Catches a race: if the PID file is missing (daemon was started, PID
@@ -185,77 +195,79 @@ struct DaemonLifecycleTests {
     /// indefinitely), so we use a bounded wait and fail fast.
     @Test("second daemon refuses even when PID file is missing but socket is alive")
     func secondDaemonRefusesWithMissingPIDFile() async throws {
-        try await Self.cleanSlate()
-        let proc = try await Self.startDaemon()
-        defer { proc.terminate() }
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let proc = try await Self.startDaemon()
+            defer { proc.terminate() }
 
-        // Simulate the race: PID file gone, but daemon still running.
-        let pidPath = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".previewsmcp/serve.pid").path
-        try? FileManager.default.removeItem(atPath: pidPath)
+            // Simulate the race: PID file gone, but daemon still running.
+            let pidPath = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".previewsmcp/serve.pid").path
+            try? FileManager.default.removeItem(atPath: pidPath)
 
-        let secondProc = Process()
-        secondProc.executableURL = URL(fileURLWithPath: Self.binaryPath)
-        secondProc.arguments = ["serve", "--daemon"]
-        let errPipe = Pipe()
-        secondProc.standardError = errPipe
-        secondProc.standardOutput = FileHandle.nullDevice
-        try secondProc.run()
+            let secondProc = Process()
+            secondProc.executableURL = URL(fileURLWithPath: Self.binaryPath)
+            secondProc.arguments = ["serve", "--daemon"]
+            let errPipe = Pipe()
+            secondProc.standardError = errPipe
+            secondProc.standardOutput = FileHandle.nullDevice
+            try secondProc.run()
 
-        // Bounded wait: the second daemon should refuse and exit within ~2s.
-        // If it doesn't, the race bug has corrupted state — fail the test
-        // (rather than hanging) by terminating it.
-        let deadline = Date().addingTimeInterval(2)
-        while secondProc.isRunning && Date() < deadline {
-            try await Task.sleep(nanoseconds: 50_000_000)
+            // Bounded wait: the second daemon should refuse and exit within ~2s.
+            // If it doesn't, the race bug has corrupted state — fail the test
+            // (rather than hanging) by terminating it.
+            let deadline = Date().addingTimeInterval(2)
+            while secondProc.isRunning && Date() < deadline {
+                try await Task.sleep(nanoseconds: 50_000_000)
+            }
+            let refusedInTime = !secondProc.isRunning
+            if secondProc.isRunning {
+                secondProc.terminate()
+                secondProc.waitUntilExit()
+            }
+            let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+            let stderr = String(data: errData, encoding: .utf8) ?? ""
+
+            #expect(refusedInTime, "second daemon should exit quickly, not keep running")
+            #expect(secondProc.terminationStatus != 0, "second daemon should refuse")
+            #expect(
+                stderr.contains("already running"),
+                "should detect live daemon via socket probe: \(stderr)"
+            )
+
+            #expect(
+                FileManager.default.fileExists(atPath: Self.socketPath),
+                "daemon A's socket file should not have been removed by failed daemon B"
+            )
+
+            let connection = NWConnection(
+                to: NWEndpoint.unix(path: Self.socketPath),
+                using: .tcp
+            )
+            let transport = NetworkTransport(connection: connection)
+            let client = Client(name: "race-test", version: "1.0")
+            _ = try await client.connect(transport: transport)
+            await client.disconnect()
         }
-        let refusedInTime = !secondProc.isRunning
-        if secondProc.isRunning {
-            secondProc.terminate()
-            secondProc.waitUntilExit()
-        }
-        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
-        let stderr = String(data: errData, encoding: .utf8) ?? ""
-
-        #expect(refusedInTime, "second daemon should exit quickly, not keep running")
-        #expect(secondProc.terminationStatus != 0, "second daemon should refuse")
-        #expect(
-            stderr.contains("already running"),
-            "should detect live daemon via socket probe: \(stderr)"
-        )
-
-        // Daemon A must still be functional: its socket path must still exist
-        // on disk and MCP clients must still be able to connect.
-        #expect(
-            FileManager.default.fileExists(atPath: Self.socketPath),
-            "daemon A's socket file should not have been removed by failed daemon B"
-        )
-
-        let connection = NWConnection(
-            to: NWEndpoint.unix(path: Self.socketPath),
-            using: .tcp
-        )
-        let transport = NetworkTransport(connection: connection)
-        let client = Client(name: "race-test", version: "1.0")
-        _ = try await client.connect(transport: transport)
-        await client.disconnect()
     }
 
     @Test("kill-daemon on stale PID file cleans up without error")
     func killDaemonStalePID() async throws {
-        try await Self.cleanSlate()
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
 
-        // Write a PID file pointing to a definitely-dead process.
-        let home = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".previewsmcp")
-        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
-        try "99999\n".write(
-            to: home.appendingPathComponent("serve.pid"),
-            atomically: true, encoding: .utf8
-        )
+            // Write a PID file pointing to a definitely-dead process.
+            let home = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".previewsmcp")
+            try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+            try "99999\n".write(
+                to: home.appendingPathComponent("serve.pid"),
+                atomically: true, encoding: .utf8
+            )
 
-        let (out, exit) = try await Self.runCLI(["kill-daemon"])
-        #expect(exit == 0)
-        #expect(out.contains("stale"))
+            let (out, exit) = try await Self.runCLI(["kill-daemon"])
+            #expect(exit == 0)
+            #expect(out.contains("stale"))
+        }
     }
 }

--- a/Tests/MCPIntegrationTests/DaemonTestLock.swift
+++ b/Tests/MCPIntegrationTests/DaemonTestLock.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Filesystem lock to serialize daemon-touching tests across suites and test
+/// targets. Swift Testing's `.serialized` trait only orders tests within its
+/// own suite; two suites (even in the same process) can run in parallel and
+/// stomp on each other's daemon.
+///
+/// The lock is advisory (`flock`) on a well-known path. Tests acquire the
+/// lock before any daemon interaction and release it when the test body
+/// returns. A crashed test releases the lock when its file descriptor
+/// closes on process exit.
+///
+/// Duplicated in both CLIIntegrationTests and MCPIntegrationTests because
+/// Swift test targets can't share source files.
+enum DaemonTestLock {
+
+    static let lockPath: String =
+        FileManager.default.temporaryDirectory
+        .appendingPathComponent("previewsmcp-daemon-test.lock").path
+
+    /// Acquire the lock, run the given async body, release the lock.
+    /// Blocks (via polling) until the lock is available.
+    static func run<T>(body: () async throws -> T) async throws -> T {
+        let fd = open(lockPath, O_CREAT | O_RDWR, 0o644)
+        guard fd >= 0 else {
+            throw NSError(
+                domain: NSPOSIXErrorDomain, code: Int(errno),
+                userInfo: [NSLocalizedDescriptionKey: "open(\(lockPath)) failed: \(String(cString: strerror(errno)))"]
+            )
+        }
+        defer { close(fd) }
+
+        while flock(fd, LOCK_EX | LOCK_NB) != 0 {
+            if errno != EWOULDBLOCK {
+                throw NSError(
+                    domain: NSPOSIXErrorDomain, code: Int(errno),
+                    userInfo: [NSLocalizedDescriptionKey: "flock failed: \(String(cString: strerror(errno)))"]
+                )
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        defer { _ = flock(fd, LOCK_UN) }
+
+        return try await body()
+    }
+}


### PR DESCRIPTION
## Summary

Second PR in the [CLI/MCP parity stack](../blob/main/docs/cli-mcp-parity-spec.md). Migrates \`run\` from an in-process preview owner to a lightweight daemon client.

- **\`DaemonClient\`**: connects to \`~/.previewsmcp/serve.sock\`. Auto-starts the daemon (\`previewsmcp serve --daemon\`) if not running, polls for readiness, returns a connected \`MCP.Client\`. ADB-style UX — users don't think about daemon lifecycle.
- **\`RunCommand\` rewrite**: now an \`AsyncParsableCommand\`. Calls \`preview_start\` over UDS, streams log notifications to stderr, blocks on SIGINT (attached) or exits immediately (\`--detach\`). No longer imports \`PreviewsMacOS\` or drives AppKit.
- **\`--detach\` flag**: prints session UUID to stdout (scriptable), leaves session alive in daemon for subsequent commands.
- **\`PreviewsMCPApp\` async dispatch**: uses \`dispatchMain()\` + explicit \`exit()\` from the Task, because \`NetworkTransport\` schedules NWConnection callbacks on \`DispatchQueue.main\` — a semaphore wait on main would deadlock.

## What didn't change

- Stdio MCP (\`previewsmcp serve\`) untouched — Claude/Cursor integration unaffected.
- \`snapshot\`, \`variants\`, \`list\` still run in-process. They migrate in later PRs.

## Test plan

3 new integration tests in \`RunCommandTests\`:
- [x] \`run --detach\` prints a bare UUID to stdout and exits
- [x] \`run\` (attached) blocks until SIGINT, exits within 10s of signal, daemon survives
- [x] \`run --detach\` reuses an already-running daemon (PID unchanged)

Regression coverage:
- [x] All 7 daemon lifecycle tests still pass
- [x] All 229 existing PreviewsCoreTests + CLIIntegrationTests still pass (plus 3 new = 232)
- [x] All 9 non-iOS MCP integration tests still pass (stdio mode unaffected)

## Related

- Feature branch: #97
- Spec: [docs/cli-mcp-parity-spec.md](../blob/main/docs/cli-mcp-parity-spec.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)