### PR TITLE
Migrate snapshot to daemon client with magical reuse

### DIFF
--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -978,11 +978,9 @@ private func handleSessionList() async -> CallTool.Result {
     }
 
     // Stable ordering so clients parsing the output get consistent results.
+    // An empty lines array joins to "" — the expected "no active sessions"
+    // response for session_list.
     lines.sort()
-
-    if lines.isEmpty {
-        return CallTool.Result(content: [.text("")])
-    }
     return CallTool.Result(content: [.text(lines.joined(separator: "\n"))])
 }
 

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -17,6 +17,7 @@ private enum ToolName: String {
     case previewTouch = "preview_touch"
     case previewVariants = "preview_variants"
     case simulatorList = "simulator_list"
+    case sessionList = "session_list"
 }
 
 /// Tracks active iOS preview sessions and lazily creates shared iOS resources.
@@ -61,6 +62,12 @@ private actor IOSState {
 
     func allSessionIDs() -> [String] {
         Array(sessions.keys)
+    }
+
+    /// Pairs of (sessionID, sourceFile) for every active iOS session.
+    /// Used by the `session_list` MCP tool for session discovery.
+    func allSessionsInfo() -> [(id: String, sourceFile: URL)] {
+        sessions.map { ($0.key, $0.value.sourceFile) }
     }
 }
 
@@ -464,6 +471,15 @@ func configureMCPServer(sharedCompiler: Compiler? = nil) async throws -> (Server
                     "properties": .object([:]),
                 ])
             ),
+            Tool(
+                name: ToolName.sessionList.rawValue,
+                description:
+                    "List all active preview sessions in the daemon, with their source file paths and platforms. Used by CLI commands to resolve --file to --session, and for diagnostic tooling.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([:]),
+                ])
+            ),
         ])
     }
 
@@ -492,6 +508,8 @@ func configureMCPServer(sharedCompiler: Compiler? = nil) async throws -> (Server
             return try await handlePreviewVariants(params: params, server: server)
         case .simulatorList:
             return try await handleSimulatorList()
+        case .sessionList:
+            return await handleSessionList()
         }
     }
 
@@ -940,6 +958,31 @@ private func handleSimulatorList() async throws -> CallTool.Result {
         lines.append("\(device.name) — \(device.udid)\(state) (\(device.runtimeName ?? "unknown runtime"))")
     }
 
+    return CallTool.Result(content: [.text(lines.joined(separator: "\n"))])
+}
+
+/// List all active sessions (iOS + macOS). Output is one line per session in
+/// the format `<sessionID>\t<platform>\t<sourceFilePath>` — tab-delimited for
+/// simple client-side parsing. Empty result when no sessions are active.
+private func handleSessionList() async -> CallTool.Result {
+    var lines: [String] = []
+
+    let iosSessions = await iosState.allSessionsInfo()
+    for session in iosSessions {
+        lines.append("\(session.id)\tios\t\(session.sourceFile.path)")
+    }
+
+    let macSessions = await MainActor.run { App.host?.allSessions ?? [:] }
+    for (id, session) in macSessions {
+        lines.append("\(id)\tmacos\t\(session.sourceFile.path)")
+    }
+
+    // Stable ordering so clients parsing the output get consistent results.
+    lines.sort()
+
+    if lines.isEmpty {
+        return CallTool.Result(content: [.text("")])
+    }
     return CallTool.Result(content: [.text(lines.joined(separator: "\n"))])
 }
 

--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -25,11 +25,9 @@ struct PreviewsMCPApp {
         }
 
         // Commands that don't need NSApplication (list, help, status,
-        // kill-daemon, and `run` which is now a lightweight daemon client).
-        // Only serve/snapshot/variants still drive AppKit in-process.
-        if !(command is ServeCommand || command is SnapshotCommand
-            || command is VariantsCommand)
-        {
+        // kill-daemon, run, and snapshot — all now daemon clients).
+        // Only serve and variants still drive AppKit in-process.
+        if !(command is ServeCommand || command is VariantsCommand) {
             // Handle async commands: the MCP SDK's NetworkTransport schedules
             // NWConnection callbacks on DispatchQueue.main, so we can't just
             // block main with a semaphore — the callbacks would never fire.

--- a/Sources/PreviewsCLI/RunCommand.swift
+++ b/Sources/PreviewsCLI/RunCommand.swift
@@ -169,9 +169,9 @@ struct RunCommand: AsyncParsableCommand {
             "height": .int(height),
         ]
         if let platform { args["platform"] = .string(platform.rawValue) }
-        if let project { args["project"] = .string(project) }
+        if let project { args["projectPath"] = .string(project) }
         if let scheme { args["scheme"] = .string(scheme) }
-        if let device { args["device"] = .string(device) }
+        if let device { args["deviceUDID"] = .string(device) }
         if let colorScheme { args["colorScheme"] = .string(colorScheme) }
         if let dynamicTypeSize { args["dynamicTypeSize"] = .string(dynamicTypeSize) }
         if let locale { args["locale"] = .string(locale) }

--- a/Sources/PreviewsCLI/SessionResolver.swift
+++ b/Sources/PreviewsCLI/SessionResolver.swift
@@ -24,9 +24,25 @@ enum SessionResolver {
         if let session {
             return .found(sessionID: session)
         }
-
         let activeSessions = try await listSessions(client: client)
+        return try resolveAgainst(
+            sessions: activeSessions, file: file
+        )
+    }
 
+    /// Pure resolution policy, extracted so it can be tested without an MCP
+    /// client. Given a snapshot of active sessions and an optional file
+    /// filter, apply the same "smart default" rules as `resolve(session:file:client:)`:
+    /// - `file` matches exactly one session → that session
+    /// - `file` matches none → `.notFound`
+    /// - `file` matches multiple → `.multipleMatches` error
+    /// - no `file`, one session → that session
+    /// - no `file`, no sessions → `.notFound`
+    /// - no `file`, multiple sessions → `.ambiguous` error
+    static func resolveAgainst(
+        sessions activeSessions: [SessionInfo],
+        file: String?
+    ) throws -> Resolution {
         if let file {
             let targetPath = URL(fileURLWithPath: file).standardizedFileURL.path
             let matches = activeSessions.filter { $0.sourceFilePath == targetPath }
@@ -43,7 +59,6 @@ enum SessionResolver {
             }
         }
 
-        // No flag: use the sole session if exactly one is running.
         switch activeSessions.count {
         case 0:
             return .notFound

--- a/Sources/PreviewsCLI/SessionResolver.swift
+++ b/Sources/PreviewsCLI/SessionResolver.swift
@@ -1,0 +1,128 @@
+import Foundation
+import MCP
+
+/// Resolves CLI session-targeting flags (`--session <uuid>` / `--file <path>`
+/// / no flag) to an active session in the daemon.
+///
+/// Centralizes the "smart default" policy from the spec: when exactly one
+/// session is running, commands can omit the flags entirely and we use that
+/// sole session. When zero or multiple sessions are running and no flag
+/// disambiguates, return a clear error.
+enum SessionResolver {
+
+    /// Resolve a session targeting policy. Returns `.found(id)` on success
+    /// or `.notFound` when the caller should decide how to proceed
+    /// (e.g., snapshot creates an ephemeral session; configure errors out).
+    static func resolve(
+        session: String?,
+        file: String?,
+        client: Client
+    ) async throws -> Resolution {
+        // Explicit --session wins over everything else. We don't verify
+        // existence here — the subsequent MCP call will fail with a useful
+        // error if the session is gone.
+        if let session {
+            return .found(sessionID: session)
+        }
+
+        let activeSessions = try await listSessions(client: client)
+
+        if let file {
+            let targetPath = URL(fileURLWithPath: file).standardizedFileURL.path
+            let matches = activeSessions.filter { $0.sourceFilePath == targetPath }
+            switch matches.count {
+            case 0:
+                return .notFound
+            case 1:
+                return .found(sessionID: matches[0].sessionID)
+            default:
+                throw SessionResolverError.multipleMatches(
+                    file: targetPath,
+                    sessionIDs: matches.map(\.sessionID)
+                )
+            }
+        }
+
+        // No flag: use the sole session if exactly one is running.
+        switch activeSessions.count {
+        case 0:
+            return .notFound
+        case 1:
+            return .found(sessionID: activeSessions[0].sessionID)
+        default:
+            throw SessionResolverError.ambiguous(sessions: activeSessions)
+        }
+    }
+
+    /// Query the daemon for the list of active sessions.
+    private static func listSessions(client: Client) async throws -> [SessionInfo] {
+        let response = try await client.callTool(name: "session_list", arguments: [:])
+        if response.isError == true {
+            throw SessionResolverError.daemonError(
+                textFromContent(response.content)
+            )
+        }
+        let text = textFromContent(response.content)
+        return parseSessionList(text)
+    }
+
+    /// Parse the tab-delimited output of `session_list` into structured
+    /// session info. Each line: `<sessionID>\t<platform>\t<sourceFilePath>`.
+    static func parseSessionList(_ text: String) -> [SessionInfo] {
+        text.split(separator: "\n", omittingEmptySubsequences: true).compactMap { line in
+            let parts = line.split(separator: "\t", omittingEmptySubsequences: false)
+            guard parts.count == 3 else { return nil }
+            return SessionInfo(
+                sessionID: String(parts[0]),
+                platform: String(parts[1]),
+                sourceFilePath: String(parts[2])
+            )
+        }
+    }
+
+    private static func textFromContent(_ content: [Tool.Content]) -> String {
+        content.compactMap { item in
+            if case .text(let t) = item { return t }
+            return nil
+        }.joined(separator: "\n")
+    }
+}
+
+extension SessionResolver {
+
+    enum Resolution: Equatable {
+        case found(sessionID: String)
+        case notFound
+    }
+
+    struct SessionInfo: Equatable, Sendable {
+        let sessionID: String
+        let platform: String
+        let sourceFilePath: String
+    }
+}
+
+enum SessionResolverError: Error, CustomStringConvertible {
+    case multipleMatches(file: String, sessionIDs: [String])
+    case ambiguous(sessions: [SessionResolver.SessionInfo])
+    case daemonError(String)
+
+    var description: String {
+        switch self {
+        case .multipleMatches(let file, let ids):
+            return
+                "multiple sessions match \(file): \(ids.joined(separator: ", ")). "
+                + "Pass --session <id> to disambiguate."
+        case .ambiguous(let sessions):
+            let listing =
+                sessions
+                .map { "  \($0.sessionID) (\($0.platform)) \($0.sourceFilePath)" }
+                .joined(separator: "\n")
+            return
+                "multiple sessions are running; specify one with --session <id> or --file <path>:\n"
+                + listing
+        case .daemonError(let text):
+            return "daemon error: \(text)"
+        }
+    }
+}

--- a/Sources/PreviewsCLI/SnapshotCommand.swift
+++ b/Sources/PreviewsCLI/SnapshotCommand.swift
@@ -244,18 +244,31 @@ struct SnapshotCommand: AsyncParsableCommand {
             let snapResponse = try await client.callTool(
                 name: "preview_snapshot", arguments: snapshotArgs
             )
-            _ = try? await client.callTool(
-                name: "preview_stop",
-                arguments: ["sessionID": .string(sessionID)]
-            )
+            await stopEphemeralSession(sessionID: sessionID, client: client)
             try handleSnapshotResponse(snapResponse)
         } catch {
             // Best-effort cleanup if the snapshot call itself threw.
-            _ = try? await client.callTool(
+            await stopEphemeralSession(sessionID: sessionID, client: client)
+            throw error
+        }
+    }
+
+    /// Tear down an ephemeral session. Best-effort — logs a warning if the
+    /// stop RPC fails so the session leak is visible instead of silent.
+    /// The session would still be cleaned up when the daemon exits, but a
+    /// long-lived daemon with many leaked sessions could confuse future
+    /// snapshot reuse.
+    private func stopEphemeralSession(sessionID: String, client: Client) async {
+        do {
+            _ = try await client.callTool(
                 name: "preview_stop",
                 arguments: ["sessionID": .string(sessionID)]
             )
-            throw error
+        } catch {
+            fputs(
+                "warning: failed to stop ephemeral session \(sessionID): \(error)\n",
+                stderr
+            )
         }
     }
 

--- a/Sources/PreviewsCLI/SnapshotCommand.swift
+++ b/Sources/PreviewsCLI/SnapshotCommand.swift
@@ -1,29 +1,60 @@
-import AppKit
 import ArgumentParser
 import Foundation
+import MCP
 import PreviewsCore
-import PreviewsIOS
-import PreviewsMacOS
 
-struct SnapshotCommand: ParsableCommand {
+/// Capture a screenshot of a preview.
+///
+/// Magical resolution (per spec):
+///   * `--session <id>` — snapshot that specific session.
+///   * `--file <path>` or positional file — if an active session exists for
+///     that source file, snapshot it; otherwise create an ephemeral session,
+///     capture, and tear it down.
+///   * No flags — if exactly one session is running, snapshot it.
+///
+/// When snapshotting an *existing* session, trait flags (`--color-scheme`
+/// etc.) are ignored because they'd mutate the live session. We warn the
+/// user rather than silently dropping them. Ephemeral snapshots use the
+/// trait flags normally.
+struct SnapshotCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "snapshot",
-        abstract: "Compile a SwiftUI preview and save a screenshot"
+        abstract: "Compile a SwiftUI preview and save a screenshot",
+        discussion: """
+            Reuses an existing preview session if one is running for the
+            target file (or if you pass --session). Otherwise starts an
+            ephemeral session in the daemon, captures, and cleans up.
+
+            Uses the `previewsmcp` daemon — it will be auto-started if not
+            already running.
+            """
     )
 
     @Argument(help: "Path to Swift source file containing #Preview")
-    var file: String
+    var file: String?
 
     @Option(name: .shortAndLong, help: "Output image file path (.jpg or .png)")
     var output: String = "preview.jpg"
 
+    @Option(
+        name: .long,
+        help: "Target a specific running session by UUID instead of resolving by file"
+    )
+    var session: String?
+
+    @Option(
+        name: .long,
+        help: "JPEG quality 0.0–1.0 (default from config or 0.85). 1.0 produces PNG."
+    )
+    var quality: Double?
+
     @Option(name: .long, help: "Which preview to snapshot (0-based index)")
     var preview: Int = 0
 
-    @Option(name: .long, help: "Window width")
+    @Option(name: .long, help: "Window width (ephemeral session only)")
     var width: Int = 400
 
-    @Option(name: .long, help: "Window height")
+    @Option(name: .long, help: "Window height (ephemeral session only)")
     var height: Int = 600
 
     @Option(name: .long, help: "Target platform: 'macos' or 'ios' (auto-detected if omitted)")
@@ -41,7 +72,7 @@ struct SnapshotCommand: ParsableCommand {
     @Option(name: .long, help: "Simulator device UDID (for ios; auto-selects if omitted)")
     var device: String?
 
-    @Option(name: .long, help: "Color scheme: 'light' or 'dark'")
+    @Option(name: .long, help: "Color scheme: 'light' or 'dark' (ephemeral session only)")
     var colorScheme: String?
 
     @Option(name: .long, help: "Dynamic Type size (e.g., 'large', 'accessibility3')")
@@ -59,15 +90,8 @@ struct SnapshotCommand: ParsableCommand {
     @Option(name: .long, help: "Path to .previewsmcp.json config file (auto-discovered if omitted)")
     var config: String?
 
-    mutating func run() throws {
-        let fileURL = URL(fileURLWithPath: file).standardizedFileURL
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            throw ValidationError("File not found: \(file)")
-        }
-
-        let configResult = loadProjectConfig(explicit: config, fileURL: fileURL)
-        let projectConfig = configResult?.config
-
+    mutating func run() async throws {
+        // Validate traits locally so bad flags fail before hitting the daemon.
         do {
             _ = try PreviewTraits.validated(
                 colorScheme: colorScheme, dynamicTypeSize: dynamicTypeSize,
@@ -78,185 +102,250 @@ struct SnapshotCommand: ParsableCommand {
             throw ValidationError(error.localizedDescription)
         }
 
-        let resolvedPlatform: CLIPlatform = {
-            if let explicit = platform { return explicit }
-            if let cp = projectConfig?.platform { return cp == "ios" ? .ios : .macos }
-            if SPMBuildSystem.inferredPlatform(for: fileURL) == .iOS {
-                return .ios
-            }
-            return .macos
-        }()
+        // Resolve file argument — required unless the user passes --session
+        // and there's exactly one match (unambiguous).
+        if file == nil && session == nil {
+            throw ValidationError(
+                "Missing file argument. Pass a path or --session <uuid>."
+            )
+        }
 
-        switch resolvedPlatform {
-        case .ios:
-            runIOSSnapshot(fileURL: fileURL, configResult: configResult)
-        case .macos:
-            runMacOSSnapshot(fileURL: fileURL, configResult: configResult)
+        if let file {
+            let fileURL = URL(fileURLWithPath: file).standardizedFileURL
+            guard FileManager.default.fileExists(atPath: fileURL.path) else {
+                throw ValidationError("File not found: \(file)")
+            }
+        }
+
+        let client = try await DaemonClient.connect(clientName: "previewsmcp-snapshot") { client in
+            await client.onNotification(LogMessageNotification.self) { message in
+                if case .string(let text) = message.params.data {
+                    fputs("\(text)\n", stderr)
+                }
+            }
+        }
+
+        do {
+            let resolution = try await SessionResolver.resolve(
+                session: session,
+                file: file,
+                client: client
+            )
+
+            switch resolution {
+            case .found(let sessionID):
+                try await snapshotExisting(sessionID: sessionID, client: client)
+            case .notFound:
+                guard let file else {
+                    throw ValidationError(
+                        "Session \(session ?? "?") not found. "
+                            + "Pass a file path to create a new ephemeral session."
+                    )
+                }
+                try await snapshotEphemeral(file: file, client: client)
+            }
+            await client.disconnect()
+        } catch {
+            await client.disconnect()
+            throw error
         }
     }
 
-    private func runMacOSSnapshot(fileURL: URL, configResult: ProjectConfigLoader.Result?) {
-        let previewIndex = preview
-        let windowWidth = width
-        let windowHeight = height
-        let outputURL = URL(fileURLWithPath: output)
-        let projectPath = project
-        let schemeName = scheme
-        let configTraits = configResult?.config.traits?.toPreviewTraits() ?? PreviewTraits()
-        let explicitTraits = PreviewTraits(
-            colorScheme: colorScheme, dynamicTypeSize: dynamicTypeSize,
-            locale: locale, layoutDirection: layoutDirection,
-            legibilityWeight: legibilityWeight
-        )
-        let traits = configTraits.merged(with: explicitTraits)
-        let progress: any ProgressReporter = StderrProgressReporter(totalSteps: 4)
+    // MARK: - Execution paths
 
-        Task {
-            do {
-                let compiler = try await Compiler()
+    /// Snapshot a session that's already running. Trait flags are ignored;
+    /// we use whatever traits the session was configured with.
+    private func snapshotExisting(sessionID: String, client: Client) async throws {
+        if hasTraitFlags {
+            fputs(
+                "note: trait flags (--color-scheme / --dynamic-type-size / "
+                    + "--locale / --layout-direction / --legibility-weight) are "
+                    + "ignored when snapshotting an existing session; use "
+                    + "`previewsmcp configure` to change traits.\n",
+                stderr
+            )
+        }
 
-                // Detect build system
-                let projectRootURL = projectPath.map { URL(fileURLWithPath: $0) }
-                let buildContext = try await detectAndBuild(
-                    for: fileURL,
-                    projectRoot: projectRootURL,
-                    platform: .macOS,
-                    scheme: schemeName,
-                    progress: progress)
+        var args: [String: Value] = ["sessionID": .string(sessionID)]
+        args["quality"] = .double(resolvedQuality())
 
-                let setupResult = try await buildSetupFromConfig(configResult, platform: .macOS)
+        let response = try await client.callTool(name: "preview_snapshot", arguments: args)
+        try handleSnapshotResponse(response)
+    }
 
-                let session = PreviewSession(
-                    sourceFile: fileURL,
-                    previewIndex: previewIndex,
-                    compiler: compiler,
-                    buildContext: buildContext,
-                    traits: traits,
-                    setupModule: setupResult?.moduleName,
-                    setupType: setupResult?.typeName,
-                    setupCompilerFlags: setupResult?.compilerFlags ?? []
-                )
-
-                await progress.report(
-                    .compilingBridge, message: "Compiling \(fileURL.lastPathComponent)...")
-                let compileResult = try await session.compile()
-                let sessionID = session.id
-
-                let setupDylibPath = setupResult?.dylibPath
-                await MainActor.run {
-                    do {
-                        try App.host.loadPreview(
-                            sessionID: sessionID,
-                            dylibPath: compileResult.dylibPath,
-                            title: "Snapshot",
-                            size: NSSize(width: windowWidth, height: windowHeight),
-                            setupDylibPath: setupDylibPath
-                        )
-                    } catch {
-                        fputs("Failed to load preview: \(error)\n", stderr)
-                        NSApp.terminate(nil)
-                    }
-                }
-
-                // Wait for SwiftUI to lay out
-                try await Task.sleep(for: .milliseconds(500))
-
-                await progress.report(.capturingSnapshot, message: "Capturing snapshot...")
-                let resolvedQuality = configResult?.config.quality ?? 0.85
-                let snapshotFormat: Snapshot.ImageFormat =
-                    outputURL.pathExtension.lowercased() == "png"
-                    ? .png : .jpeg(quality: resolvedQuality)
-                await MainActor.run {
-                    do {
-                        guard let window = App.host.window(for: sessionID) else {
-                            fputs("No window found\n", stderr)
-                            NSApp.terminate(nil)
-                            return
-                        }
-                        try Snapshot.capture(window: window, format: snapshotFormat, to: outputURL)
-                        print(outputURL.path)
-                    } catch {
-                        fputs("Snapshot failed: \(error)\n", stderr)
-                    }
-                    NSApp.terminate(nil)
-                }
-            } catch {
-                fputs("Error: \(error)\n", stderr)
-                Darwin.exit(1)
-            }
+    /// Pick the quality value to request from the daemon.
+    ///
+    /// - Explicit `--quality` wins.
+    /// - Otherwise infer from the output file extension: `.png` → 1.0 (PNG);
+    ///   `.jpg`/`.jpeg` → 0.85 default (JPEG). The daemon uses `quality >= 1.0`
+    ///   as its PNG trigger.
+    /// - Unknown extensions fall through to 0.85 (JPEG).
+    private func resolvedQuality() -> Double {
+        if let quality { return quality }
+        let ext = (output as NSString).pathExtension.lowercased()
+        switch ext {
+        case "png": return 1.0
+        case "jpg", "jpeg": return 0.85
+        default: return 0.85
         }
     }
 
-    private func runIOSSnapshot(fileURL: URL, configResult: ProjectConfigLoader.Result?) {
-        let previewIndex = preview
-        let outputURL = URL(fileURLWithPath: output)
-        let deviceUDID = device ?? configResult?.config.device
-        let projectPath = project
-        let schemeName = scheme
-        let configTraits = configResult?.config.traits?.toPreviewTraits() ?? PreviewTraits()
-        let explicitTraits = PreviewTraits(
-            colorScheme: colorScheme, dynamicTypeSize: dynamicTypeSize,
-            locale: locale, layoutDirection: layoutDirection,
-            legibilityWeight: legibilityWeight
+    /// Create an ephemeral session for the target file, capture, tear down.
+    /// Trait flags are applied at start.
+    private func snapshotEphemeral(file: String, client: Client) async throws {
+        let fileURL = URL(fileURLWithPath: file).standardizedFileURL
+        let configResult = loadProjectConfig(explicit: config, fileURL: fileURL)
+        let resolvedPlatform = Self.resolvePlatform(
+            explicit: platform,
+            config: configResult?.config,
+            project: project,
+            fileURL: fileURL
         )
-        let traits = configTraits.merged(with: explicitTraits)
-        let progress: any ProgressReporter = StderrProgressReporter(totalSteps: 9)
 
-        Task {
-            do {
-                let compiler = try await Compiler(platform: .iOS)
-                let hostBuilder = try await IOSHostBuilder()
-                let simulatorManager = SimulatorManager()
+        var startArgs: [String: Value] = [
+            "filePath": .string(fileURL.path),
+            "previewIndex": .int(preview),
+            "width": .int(width),
+            "height": .int(height),
+            // Render off-screen — we only want the pixels, not a visible window.
+            "headless": .bool(true),
+            // Always resolve platform client-side so the daemon never has to
+            // run `swift package describe`. On xcodeproj/xcworkspace trees the
+            // daemon's inferredPlatform would otherwise walk up to the repo
+            // root and hang resolving the main package.
+            "platform": .string(resolvedPlatform.rawValue),
+        ]
+        if let project { startArgs["projectPath"] = .string(project) }
+        if let scheme { startArgs["scheme"] = .string(scheme) }
+        if let device { startArgs["deviceUDID"] = .string(device) }
+        if let colorScheme { startArgs["colorScheme"] = .string(colorScheme) }
+        if let dynamicTypeSize { startArgs["dynamicTypeSize"] = .string(dynamicTypeSize) }
+        if let locale { startArgs["locale"] = .string(locale) }
+        if let layoutDirection { startArgs["layoutDirection"] = .string(layoutDirection) }
+        if let legibilityWeight { startArgs["legibilityWeight"] = .string(legibilityWeight) }
+        if let config { startArgs["config"] = .string(config) }
 
-                // Resolve device
-                let udid = try await resolveDeviceUDID(provided: deviceUDID, using: simulatorManager)
+        let startResponse = try await client.callTool(name: "preview_start", arguments: startArgs)
+        if startResponse.isError == true {
+            let text = textFromContent(startResponse.content)
+            throw SnapshotCommandError.daemonError("Failed to start preview: \(text)")
+        }
 
-                // Detect build system
-                let projectRootURL = projectPath.map { URL(fileURLWithPath: $0) }
-                let buildContext = try await detectAndBuild(
-                    for: fileURL,
-                    projectRoot: projectRootURL,
-                    platform: .iOS,
-                    scheme: schemeName,
-                    progress: progress)
+        let sessionID = try extractSessionID(from: textFromContent(startResponse.content))
 
-                let setupResult = try await buildSetupFromConfig(configResult, platform: .iOS)
+        var snapshotArgs: [String: Value] = ["sessionID": .string(sessionID)]
+        snapshotArgs["quality"] = .double(resolvedQuality())
 
-                let session = IOSPreviewSession(
-                    sourceFile: fileURL,
-                    previewIndex: previewIndex,
-                    deviceUDID: udid,
-                    compiler: compiler,
-                    hostBuilder: hostBuilder,
-                    simulatorManager: simulatorManager,
-                    headless: true,
-                    buildContext: buildContext,
-                    traits: traits,
-                    setupModule: setupResult?.moduleName,
-                    setupType: setupResult?.typeName,
-                    setupCompilerFlags: setupResult?.compilerFlags ?? [],
-                    setupDylibPath: setupResult?.dylibPath,
-                    progress: progress
-                )
+        // Await the stop so the ephemeral session is actually torn down
+        // before this command exits. A fire-and-forget `Task` wouldn't
+        // complete in time, leaving an orphan session in the daemon that
+        // future snapshots of the same file would ambiguously match.
+        do {
+            let snapResponse = try await client.callTool(
+                name: "preview_snapshot", arguments: snapshotArgs
+            )
+            _ = try? await client.callTool(
+                name: "preview_stop",
+                arguments: ["sessionID": .string(sessionID)]
+            )
+            try handleSnapshotResponse(snapResponse)
+        } catch {
+            // Best-effort cleanup if the snapshot call itself threw.
+            _ = try? await client.callTool(
+                name: "preview_stop",
+                arguments: ["sessionID": .string(sessionID)]
+            )
+            throw error
+        }
+    }
 
-                _ = try await session.start()
+    // MARK: - Helpers
 
-                // Wait for the app to render
-                try await Task.sleep(for: .seconds(2))
+    private var hasTraitFlags: Bool {
+        colorScheme != nil || dynamicTypeSize != nil || locale != nil
+            || layoutDirection != nil || legibilityWeight != nil
+    }
 
-                await progress.report(.capturingSnapshot, message: "Capturing snapshot...")
-                let resolvedQuality = configResult?.config.quality ?? 0.85
-                let jpegQuality: Double =
-                    outputURL.pathExtension.lowercased() == "png" ? 1.0 : resolvedQuality
-                let imageData = try await session.screenshot(jpegQuality: jpegQuality)
-                try imageData.write(to: outputURL)
+    /// Pick the target platform client-side without hitting the daemon.
+    /// Order: explicit flag → config file → SPM-inferred (only when a project
+    /// flag doesn't point at an xcodeproj/xcworkspace) → macOS default.
+    ///
+    /// Skipping SPM-inference for xcodeproj/xcworkspace projects avoids a
+    /// previously-observed hang: `SPMBuildSystem.inferredPlatform` walks up
+    /// looking for Package.swift and falls through to the *repo* Package.swift
+    /// on xcodeproj sources, then runs `swift package describe` there. For
+    /// unrelated reasons that subprocess can hang indefinitely on loaded
+    /// machines. We don't need it anyway — xcodeproj/xcworkspace projects
+    /// aren't SPM packages.
+    static func resolvePlatform(
+        explicit: CLIPlatform?,
+        config: ProjectConfig?,
+        project: String?,
+        fileURL: URL
+    ) -> CLIPlatform {
+        if let explicit { return explicit }
+        if let cp = config?.platform { return cp == "ios" ? .ios : .macos }
+        let isXcodeLike =
+            project.map {
+                $0.hasSuffix(".xcodeproj") || $0.hasSuffix(".xcworkspace")
+            } ?? false
+        if !isXcodeLike, SPMBuildSystem.inferredPlatform(for: fileURL) == .iOS {
+            return .ios
+        }
+        return .macos
+    }
+
+    /// Write the image returned in the snapshot response to the output path.
+    /// Prints the output path to stdout (scriptable) on success.
+    private func handleSnapshotResponse(_ response: (content: [Tool.Content], isError: Bool?)) throws {
+        if response.isError == true {
+            let text = textFromContent(response.content)
+            throw SnapshotCommandError.daemonError("snapshot failed: \(text)")
+        }
+
+        for item in response.content {
+            if case .image(let base64, _, _) = item {
+                guard let data = Data(base64Encoded: base64) else {
+                    throw SnapshotCommandError.invalidImageData
+                }
+                let outputURL = URL(fileURLWithPath: output)
+                try data.write(to: outputURL)
                 print(outputURL.path)
-
-                await MainActor.run { NSApp.terminate(nil) }
-            } catch {
-                fputs("Error: \(error)\n", stderr)
-                Darwin.exit(1)
+                return
             }
+        }
+        throw SnapshotCommandError.noImageContent(textFromContent(response.content))
+    }
+
+    private func textFromContent(_ content: [Tool.Content]) -> String {
+        content.compactMap { item in
+            if case .text(let t) = item { return t }
+            return nil
+        }.joined(separator: "\n")
+    }
+
+    private func extractSessionID(from text: String) throws -> String {
+        let pattern = /Session ID: ([0-9a-fA-F-]{36})/
+        guard let match = text.firstMatch(of: pattern) else {
+            throw SnapshotCommandError.daemonError(
+                "no session ID in daemon response: \(text)"
+            )
+        }
+        return String(match.1)
+    }
+}
+
+enum SnapshotCommandError: Error, CustomStringConvertible {
+    case daemonError(String)
+    case invalidImageData
+    case noImageContent(String)
+
+    var description: String {
+        switch self {
+        case .daemonError(let text): return text
+        case .invalidImageData: return "daemon returned invalid (non-base64) image data"
+        case .noImageContent(let text):
+            return "daemon response contained no image content: \(text)"
         }
     }
 }

--- a/Sources/PreviewsCore/SPMBuildSystem.swift
+++ b/Sources/PreviewsCore/SPMBuildSystem.swift
@@ -64,14 +64,28 @@ public actor SPMBuildSystem: BuildSystem {
         return decodePlatforms(from: data)
     }
 
-    /// Walk up from a source file to find the nearest directory containing Package.swift.
+    /// Walk up from a source file to find the nearest directory containing
+    /// Package.swift — but only if the source file is genuinely part of that
+    /// SPM package. If the walk crosses an `.xcodeproj`, `.xcworkspace`, or
+    /// Bazel workspace first, the source belongs to that non-SPM project and
+    /// we return nil rather than falsely attributing it to an outer SPM
+    /// package (which for a repo containing `examples/xcodeproj/...` would
+    /// incorrectly pick the repo's own Package.swift and then run
+    /// `swift package describe` on it — expensive and pointless).
     public static func findPackageDirectory(from sourceFile: URL) -> URL? {
+        let fm = FileManager.default
         var dir = sourceFile.deletingLastPathComponent().standardizedFileURL
         let root = URL(fileURLWithPath: "/")
         while dir.path != root.path {
+            // If this directory looks like (or sits inside) a non-SPM project,
+            // stop before finding an outer Package.swift.
+            if directoryContainsNonSPMProject(dir, fm: fm) {
+                return nil
+            }
+
             let packageSwift = dir.appendingPathComponent("Package.swift")
             var isDir: ObjCBool = false
-            if FileManager.default.fileExists(atPath: packageSwift.path, isDirectory: &isDir),
+            if fm.fileExists(atPath: packageSwift.path, isDirectory: &isDir),
                 !isDir.boolValue
             {
                 return dir
@@ -79,6 +93,31 @@ public actor SPMBuildSystem: BuildSystem {
             dir = dir.deletingLastPathComponent()
         }
         return nil
+    }
+
+    /// True if the given directory contains a file/folder that marks it as a
+    /// non-SPM project (xcodeproj, xcworkspace, Bazel WORKSPACE/BUILD).
+    private static func directoryContainsNonSPMProject(
+        _ dir: URL, fm: FileManager
+    ) -> Bool {
+        guard
+            let entries = try? fm.contentsOfDirectory(
+                at: dir, includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )
+        else { return false }
+        for entry in entries {
+            let name = entry.lastPathComponent
+            if name.hasSuffix(".xcodeproj") || name.hasSuffix(".xcworkspace") {
+                return true
+            }
+            if name == "WORKSPACE" || name == "WORKSPACE.bazel"
+                || name == "MODULE.bazel"
+            {
+                return true
+            }
+        }
+        return false
     }
 
     /// Returns .iOS if the SPM package declares iOS but not macOS; nil otherwise.

--- a/Sources/PreviewsMacOS/HostApp.swift
+++ b/Sources/PreviewsMacOS/HostApp.swift
@@ -292,6 +292,11 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         sessions[sessionID]
     }
 
+    /// All active macOS sessions, keyed by session ID. Used by session
+    /// discovery (e.g., `snapshot <file>` looking for an existing session
+    /// that matches the target source file).
+    public var allSessions: [String: PreviewSession] { sessions }
+
     /// Get the window for a session (for snapshotting).
     public func window(for sessionID: String) -> NSWindow? {
         windows[sessionID]

--- a/Tests/CLIIntegrationTests/SnapshotCommandTests.swift
+++ b/Tests/CLIIntegrationTests/SnapshotCommandTests.swift
@@ -366,4 +366,56 @@ struct SnapshotCommandTests {
             try CLIRunner.assertValidPNG(at: outputPath)
         }
     }
+
+    /// Verifies the "magical reuse" behavior: when a `run` session is already
+    /// live for the target file, `snapshot` captures *that* session's window
+    /// instead of creating an ephemeral one. The observable proof is speed —
+    /// reuse skips compile + render and completes in well under a second,
+    /// whereas an ephemeral cold-start takes several seconds.
+    @Test(
+        "Snapshot reuses an already-running session instead of ephemeral",
+        .timeLimit(.minutes(2))
+    )
+    func snapshotReusesLiveSession() async throws {
+        try await DaemonTestLock.run {
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
+
+            // Start a long-running session in the daemon.
+            let runResult = try await CLIRunner.run(
+                "run",
+                arguments: [
+                    file, "--platform", "macos", "--config", configPath, "--detach",
+                ]
+            )
+            #expect(runResult.exitCode == 0, "detach stderr: \(runResult.stderr)")
+
+            // Snapshot. Reuse should be fast because no compile is needed.
+            let outputPath = tempDir.appendingPathComponent("reuse.png").path
+            let start = Date()
+            let snapResult = try await CLIRunner.run(
+                "snapshot",
+                arguments: [file, "-o", outputPath, "--platform", "macos"]
+            )
+            let elapsed = Date().timeIntervalSince(start)
+
+            #expect(snapResult.exitCode == 0, "stderr: \(snapResult.stderr)")
+            try CLIRunner.assertValidPNG(at: outputPath)
+
+            // Ephemeral snapshots take several seconds (compile + render).
+            // Reuse of a live session should complete in under 2 s on any
+            // reasonable machine — generous bound to tolerate CI load.
+            #expect(
+                elapsed < 2.0,
+                "snapshot should reuse live session (took \(elapsed)s; ephemeral would take >3s)"
+            )
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
+    }
 }

--- a/Tests/CLIIntegrationTests/SnapshotCommandTests.swift
+++ b/Tests/CLIIntegrationTests/SnapshotCommandTests.swift
@@ -8,92 +8,98 @@ struct SnapshotCommandTests {
 
     @Test("Basic macOS snapshot produces valid PNG", .timeLimit(.minutes(2)))
     func basicMacOSSnapshot() async throws {
-        let tempDir = try CLIRunner.makeTempDir()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try await DaemonTestLock.run {
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let outputPath = tempDir.appendingPathComponent("snapshot.png").path
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let outputPath = tempDir.appendingPathComponent("snapshot.png").path
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
 
-        let result = try await CLIRunner.run(
-            "snapshot",
-            arguments: [
-                file, "-o", outputPath, "--project", CLIRunner.spmExampleRoot.path,
-            ])
+            let result = try await CLIRunner.run(
+                "snapshot",
+                arguments: [
+                    file, "-o", outputPath, "--project", CLIRunner.spmExampleRoot.path,
+                ])
 
-        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
-        #expect(result.stdout.contains(outputPath), "stdout should print output path")
-        try CLIRunner.assertValidPNG(
-            at: outputPath, minSize: 10_000, expectedWidth: 400, expectedHeight: 600)
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+            #expect(result.stdout.contains(outputPath), "stdout should print output path")
+            try CLIRunner.assertValidPNG(
+                at: outputPath, minSize: 10_000, expectedWidth: 400, expectedHeight: 600)
+        }
     }
 
     @Test("Snapshot with --preview 1 produces different image", .timeLimit(.minutes(2)))
     func snapshotPreviewIndex1() async throws {
-        let tempDir = try CLIRunner.makeTempDir()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try await DaemonTestLock.run {
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let output0 = tempDir.appendingPathComponent("preview0.png").path
-        let output1 = tempDir.appendingPathComponent("preview1.png").path
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
-        let project = CLIRunner.spmExampleRoot.path
+            let output0 = tempDir.appendingPathComponent("preview0.png").path
+            let output1 = tempDir.appendingPathComponent("preview1.png").path
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let project = CLIRunner.spmExampleRoot.path
 
-        let result0 = try await CLIRunner.run(
-            "snapshot",
-            arguments: [
-                file, "-o", output0, "--project", project,
-            ])
-        #expect(result0.exitCode == 0, "preview 0 stderr: \(result0.stderr)")
+            let result0 = try await CLIRunner.run(
+                "snapshot",
+                arguments: [
+                    file, "-o", output0, "--project", project,
+                ])
+            #expect(result0.exitCode == 0, "preview 0 stderr: \(result0.stderr)")
 
-        let result1 = try await CLIRunner.run(
-            "snapshot",
-            arguments: [
-                file, "-o", output1, "--preview", "1", "--project", project,
-            ])
-        #expect(result1.exitCode == 0, "preview 1 stderr: \(result1.stderr)")
+            let result1 = try await CLIRunner.run(
+                "snapshot",
+                arguments: [
+                    file, "-o", output1, "--preview", "1", "--project", project,
+                ])
+            #expect(result1.exitCode == 0, "preview 1 stderr: \(result1.stderr)")
 
-        try CLIRunner.assertValidPNG(at: output0, minSize: 10_000)
-        try CLIRunner.assertValidPNG(at: output1)
+            try CLIRunner.assertValidPNG(at: output0, minSize: 10_000)
+            try CLIRunner.assertValidPNG(at: output1)
 
-        let size0 = try Data(contentsOf: URL(fileURLWithPath: output0)).count
-        let size1 = try Data(contentsOf: URL(fileURLWithPath: output1)).count
-        #expect(
-            size0 != size1,
-            "Preview 0 (\(size0) bytes) and preview 1 (\(size1) bytes) should differ"
-        )
+            let size0 = try Data(contentsOf: URL(fileURLWithPath: output0)).count
+            let size1 = try Data(contentsOf: URL(fileURLWithPath: output1)).count
+            #expect(
+                size0 != size1,
+                "Preview 0 (\(size0) bytes) and preview 1 (\(size1) bytes) should differ"
+            )
+        }
     }
 
     @Test("Snapshot with --color-scheme dark produces different image", .timeLimit(.minutes(2)))
     func snapshotDarkMode() async throws {
-        let tempDir = try CLIRunner.makeTempDir()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try await DaemonTestLock.run {
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let outputLight = tempDir.appendingPathComponent("light.png").path
-        let outputDark = tempDir.appendingPathComponent("dark.png").path
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
-        let project = CLIRunner.spmExampleRoot.path
+            let outputLight = tempDir.appendingPathComponent("light.png").path
+            let outputDark = tempDir.appendingPathComponent("dark.png").path
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let project = CLIRunner.spmExampleRoot.path
 
-        let resultLight = try await CLIRunner.run(
-            "snapshot",
-            arguments: [
-                file, "-o", outputLight, "--color-scheme", "light", "--project", project,
-            ])
-        #expect(resultLight.exitCode == 0, "light stderr: \(resultLight.stderr)")
+            let resultLight = try await CLIRunner.run(
+                "snapshot",
+                arguments: [
+                    file, "-o", outputLight, "--color-scheme", "light", "--project", project,
+                ])
+            #expect(resultLight.exitCode == 0, "light stderr: \(resultLight.stderr)")
 
-        let resultDark = try await CLIRunner.run(
-            "snapshot",
-            arguments: [
-                file, "-o", outputDark, "--color-scheme", "dark", "--project", project,
-            ])
-        #expect(resultDark.exitCode == 0, "dark stderr: \(resultDark.stderr)")
+            let resultDark = try await CLIRunner.run(
+                "snapshot",
+                arguments: [
+                    file, "-o", outputDark, "--color-scheme", "dark", "--project", project,
+                ])
+            #expect(resultDark.exitCode == 0, "dark stderr: \(resultDark.stderr)")
 
-        try CLIRunner.assertValidPNG(at: outputLight)
-        try CLIRunner.assertValidPNG(at: outputDark)
+            try CLIRunner.assertValidPNG(at: outputLight)
+            try CLIRunner.assertValidPNG(at: outputDark)
 
-        let lightData = try Data(contentsOf: URL(fileURLWithPath: outputLight))
-        let darkData = try Data(contentsOf: URL(fileURLWithPath: outputDark))
-        #expect(lightData != darkData, "Light and dark snapshots should produce different images")
+            let lightData = try Data(contentsOf: URL(fileURLWithPath: outputLight))
+            let darkData = try Data(contentsOf: URL(fileURLWithPath: outputDark))
+            #expect(lightData != darkData, "Light and dark snapshots should produce different images")
+        }
     }
 
     @Test(
@@ -101,243 +107,263 @@ struct SnapshotCommandTests {
         .timeLimit(.minutes(2))
     )
     func snapshotDynamicTypeSize() async throws {
-        let tempDir = try CLIRunner.makeTempDir()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try await DaemonTestLock.run {
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let outputPath = tempDir.appendingPathComponent("a11y3.png").path
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let outputPath = tempDir.appendingPathComponent("a11y3.png").path
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
 
-        let result = try await CLIRunner.run(
-            "snapshot",
-            arguments: [
-                file, "-o", outputPath,
-                "--dynamic-type-size", "accessibility3",
-                "--project", CLIRunner.spmExampleRoot.path,
-            ])
+            let result = try await CLIRunner.run(
+                "snapshot",
+                arguments: [
+                    file, "-o", outputPath,
+                    "--dynamic-type-size", "accessibility3",
+                    "--project", CLIRunner.spmExampleRoot.path,
+                ])
 
-        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
-        try CLIRunner.assertValidPNG(at: outputPath)
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+            try CLIRunner.assertValidPNG(at: outputPath)
+        }
     }
 
     @Test("Snapshot with JPEG output produces valid JPEG", .timeLimit(.minutes(2)))
     func snapshotJPEGOutput() async throws {
-        let tempDir = try CLIRunner.makeTempDir()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try await DaemonTestLock.run {
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let outputPath = tempDir.appendingPathComponent("snapshot.jpg").path
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let outputPath = tempDir.appendingPathComponent("snapshot.jpg").path
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
 
-        let result = try await CLIRunner.run(
-            "snapshot",
-            arguments: [
-                file, "-o", outputPath, "--project", CLIRunner.spmExampleRoot.path,
-            ])
+            let result = try await CLIRunner.run(
+                "snapshot",
+                arguments: [
+                    file, "-o", outputPath, "--project", CLIRunner.spmExampleRoot.path,
+                ])
 
-        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
-        try CLIRunner.assertValidJPEG(at: outputPath)
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+            try CLIRunner.assertValidJPEG(at: outputPath)
+        }
     }
 
     @Test("Snapshot of PreviewProvider file produces valid PNG", .timeLimit(.minutes(2)))
     func snapshotPreviewProvider() async throws {
-        let tempDir = try CLIRunner.makeTempDir()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try await DaemonTestLock.run {
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let outputPath = tempDir.appendingPathComponent("provider.png").path
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoProviderPreview.swift").path
+            let outputPath = tempDir.appendingPathComponent("provider.png").path
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoProviderPreview.swift").path
 
-        let result = try await CLIRunner.run(
-            "snapshot",
-            arguments: [
-                file, "-o", outputPath, "--project", CLIRunner.spmExampleRoot.path,
-            ])
+            let result = try await CLIRunner.run(
+                "snapshot",
+                arguments: [
+                    file, "-o", outputPath, "--project", CLIRunner.spmExampleRoot.path,
+                ])
 
-        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
-        try CLIRunner.assertValidPNG(at: outputPath)
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+            try CLIRunner.assertValidPNG(at: outputPath)
+        }
     }
 
     // MARK: - Error cases
 
     @Test("Snapshot with invalid --preview 99 returns non-zero exit", .timeLimit(.minutes(2)))
     func snapshotInvalidPreviewIndex() async throws {
-        let tempDir = try CLIRunner.makeTempDir()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try await DaemonTestLock.run {
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let outputPath = tempDir.appendingPathComponent("bad.png").path
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let outputPath = tempDir.appendingPathComponent("bad.png").path
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
 
-        let result = try await CLIRunner.run(
-            "snapshot",
-            arguments: [
-                file, "-o", outputPath, "--preview", "99",
-                "--project", CLIRunner.spmExampleRoot.path,
-            ])
+            let result = try await CLIRunner.run(
+                "snapshot",
+                arguments: [
+                    file, "-o", outputPath, "--preview", "99",
+                    "--project", CLIRunner.spmExampleRoot.path,
+                ])
 
-        #expect(result.exitCode != 0, "Should fail with invalid preview index")
-        #expect(result.stderr.contains("Error"), "stderr should contain error message")
+            #expect(result.exitCode != 0, "Should fail with invalid preview index")
+            #expect(result.stderr.contains("Error"), "stderr should contain error message")
+        }
     }
 
     @Test("Snapshot with invalid --dynamic-type-size returns non-zero exit")
     func snapshotInvalidDynamicTypeSize() async throws {
-        let tempDir = try CLIRunner.makeTempDir()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try await DaemonTestLock.run {
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let outputPath = tempDir.appendingPathComponent("bad.png").path
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let outputPath = tempDir.appendingPathComponent("bad.png").path
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
 
-        let result = try await CLIRunner.run(
-            "snapshot",
-            arguments: [
-                file, "-o", outputPath, "--dynamic-type-size", "bananas",
-                "--project", CLIRunner.spmExampleRoot.path,
-            ])
+            let result = try await CLIRunner.run(
+                "snapshot",
+                arguments: [
+                    file, "-o", outputPath, "--dynamic-type-size", "bananas",
+                    "--project", CLIRunner.spmExampleRoot.path,
+                ])
 
-        #expect(result.exitCode != 0, "Should fail with invalid dynamic type size")
+            #expect(result.exitCode != 0, "Should fail with invalid dynamic type size")
+        }
     }
 
     @Test("Snapshot of nonexistent file returns non-zero exit")
     func snapshotNonexistentFile() async throws {
-        let tempDir = try CLIRunner.makeTempDir()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try await DaemonTestLock.run {
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let outputPath = tempDir.appendingPathComponent("bad.png").path
+            let outputPath = tempDir.appendingPathComponent("bad.png").path
 
-        let result = try await CLIRunner.run(
-            "snapshot",
-            arguments: [
-                "/nonexistent/file.swift", "-o", outputPath,
-            ])
+            let result = try await CLIRunner.run(
+                "snapshot",
+                arguments: [
+                    "/nonexistent/file.swift", "-o", outputPath,
+                ])
 
-        #expect(result.exitCode != 0, "Should fail with nonexistent file")
+            #expect(result.exitCode != 0, "Should fail with nonexistent file")
+        }
     }
 
     // MARK: - Build system tests (gated)
 
     @Test("Snapshot of xcodeproj example with --project", .timeLimit(.minutes(3)))
     func snapshotXcodeproj() async throws {
-        guard await CLIRunner.toolAvailable("mint") else {
-            print("Mint not available — skipping xcodeproj snapshot test")
-            return
+        try await DaemonTestLock.run {
+            guard await CLIRunner.toolAvailable("mint") else {
+                print("Mint not available — skipping xcodeproj snapshot test")
+                return
+            }
+
+            // Generate Xcode project
+            let genResult = try await CLIRunner.runExternal(
+                "/usr/bin/env", arguments: ["mint", "run", "xcodegen", "generate"],
+                workingDirectory: CLIRunner.xcodeprojExampleRoot
+            )
+            guard genResult.exitCode == 0 else {
+                print("XcodeGen failed — skipping: \(genResult.stderr)")
+                return
+            }
+
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            let outputPath = tempDir.appendingPathComponent("xcodeproj.png").path
+            let file = CLIRunner.xcodeprojExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+
+            let result = try await CLIRunner.run(
+                "snapshot",
+                arguments: [
+                    file, "-o", outputPath, "--project", CLIRunner.xcodeprojExampleRoot.path,
+                ])
+
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+            try CLIRunner.assertValidPNG(at: outputPath)
         }
-
-        // Generate Xcode project
-        let genResult = try await CLIRunner.runExternal(
-            "/usr/bin/env", arguments: ["mint", "run", "xcodegen", "generate"],
-            workingDirectory: CLIRunner.xcodeprojExampleRoot
-        )
-        guard genResult.exitCode == 0 else {
-            print("XcodeGen failed — skipping: \(genResult.stderr)")
-            return
-        }
-
-        let tempDir = try CLIRunner.makeTempDir()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
-
-        let outputPath = tempDir.appendingPathComponent("xcodeproj.png").path
-        let file = CLIRunner.xcodeprojExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
-
-        let result = try await CLIRunner.run(
-            "snapshot",
-            arguments: [
-                file, "-o", outputPath, "--project", CLIRunner.xcodeprojExampleRoot.path,
-            ])
-
-        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
-        try CLIRunner.assertValidPNG(at: outputPath)
     }
 
     @Test("Snapshot of xcworkspace example with --project", .timeLimit(.minutes(3)))
     func snapshotXcworkspace() async throws {
-        guard await CLIRunner.toolAvailable("mint") else {
-            print("Mint not available — skipping xcworkspace snapshot test")
-            return
+        try await DaemonTestLock.run {
+            guard await CLIRunner.toolAvailable("mint") else {
+                print("Mint not available — skipping xcworkspace snapshot test")
+                return
+            }
+
+            let genResult = try await CLIRunner.runExternal(
+                "/usr/bin/env", arguments: ["mint", "run", "xcodegen", "generate"],
+                workingDirectory: CLIRunner.xcworkspaceExampleRoot
+            )
+            guard genResult.exitCode == 0 else {
+                print("XcodeGen failed — skipping: \(genResult.stderr)")
+                return
+            }
+
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            let outputPath = tempDir.appendingPathComponent("xcworkspace.png").path
+            let file = CLIRunner.xcworkspaceExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+
+            let result = try await CLIRunner.run(
+                "snapshot",
+                arguments: [
+                    file, "-o", outputPath, "--project", CLIRunner.xcworkspaceExampleRoot.path,
+                ])
+
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+            try CLIRunner.assertValidPNG(at: outputPath)
         }
-
-        let genResult = try await CLIRunner.runExternal(
-            "/usr/bin/env", arguments: ["mint", "run", "xcodegen", "generate"],
-            workingDirectory: CLIRunner.xcworkspaceExampleRoot
-        )
-        guard genResult.exitCode == 0 else {
-            print("XcodeGen failed — skipping: \(genResult.stderr)")
-            return
-        }
-
-        let tempDir = try CLIRunner.makeTempDir()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
-
-        let outputPath = tempDir.appendingPathComponent("xcworkspace.png").path
-        let file = CLIRunner.xcworkspaceExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
-
-        let result = try await CLIRunner.run(
-            "snapshot",
-            arguments: [
-                file, "-o", outputPath, "--project", CLIRunner.xcworkspaceExampleRoot.path,
-            ])
-
-        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
-        try CLIRunner.assertValidPNG(at: outputPath)
     }
 
     @Test("Snapshot of Bazel example with --project", .timeLimit(.minutes(5)))
     func snapshotBazel() async throws {
-        var hasBazel = await CLIRunner.toolAvailable("bazelisk")
-        if !hasBazel { hasBazel = await CLIRunner.toolAvailable("bazel") }
-        guard hasBazel else {
-            print("Bazel not available — skipping bazel snapshot test")
-            return
+        try await DaemonTestLock.run {
+            var hasBazel = await CLIRunner.toolAvailable("bazelisk")
+            if !hasBazel { hasBazel = await CLIRunner.toolAvailable("bazel") }
+            guard hasBazel else {
+                print("Bazel not available — skipping bazel snapshot test")
+                return
+            }
+
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            let outputPath = tempDir.appendingPathComponent("bazel.png").path
+            let file = CLIRunner.bazelExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+
+            let result = try await CLIRunner.run(
+                "snapshot",
+                arguments: [
+                    file, "-o", outputPath, "--project", CLIRunner.bazelExampleRoot.path,
+                ])
+
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+            try CLIRunner.assertValidPNG(at: outputPath)
         }
-
-        let tempDir = try CLIRunner.makeTempDir()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
-
-        let outputPath = tempDir.appendingPathComponent("bazel.png").path
-        let file = CLIRunner.bazelExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
-
-        let result = try await CLIRunner.run(
-            "snapshot",
-            arguments: [
-                file, "-o", outputPath, "--project", CLIRunner.bazelExampleRoot.path,
-            ])
-
-        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
-        try CLIRunner.assertValidPNG(at: outputPath)
     }
 
     // MARK: - iOS snapshot (gated)
 
     @Test("Snapshot with --platform ios produces valid image", .timeLimit(.minutes(3)))
     func snapshotIOS() async throws {
-        let simResult = try await CLIRunner.runExternal(
-            "/usr/bin/xcrun",
-            arguments: ["simctl", "list", "devices", "available"]
-        )
-        guard simResult.exitCode == 0, simResult.stdout.contains("iPhone") else {
-            print("No available iOS simulator — skipping iOS snapshot test")
-            return
+        try await DaemonTestLock.run {
+            let simResult = try await CLIRunner.runExternal(
+                "/usr/bin/xcrun",
+                arguments: ["simctl", "list", "devices", "available"]
+            )
+            guard simResult.exitCode == 0, simResult.stdout.contains("iPhone") else {
+                print("No available iOS simulator — skipping iOS snapshot test")
+                return
+            }
+
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            let outputPath = tempDir.appendingPathComponent("ios.png").path
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+
+            let result = try await CLIRunner.run(
+                "snapshot",
+                arguments: [
+                    file, "-o", outputPath, "--platform", "ios",
+                    "--project", CLIRunner.spmExampleRoot.path,
+                ])
+
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+            try CLIRunner.assertValidPNG(at: outputPath)
         }
-
-        let tempDir = try CLIRunner.makeTempDir()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
-
-        let outputPath = tempDir.appendingPathComponent("ios.png").path
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
-
-        let result = try await CLIRunner.run(
-            "snapshot",
-            arguments: [
-                file, "-o", outputPath, "--platform", "ios",
-                "--project", CLIRunner.spmExampleRoot.path,
-            ])
-
-        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
-        try CLIRunner.assertValidPNG(at: outputPath)
     }
 }

--- a/Tests/PreviewsCoreTests/BuildSystemTests.swift
+++ b/Tests/PreviewsCoreTests/BuildSystemTests.swift
@@ -893,6 +893,62 @@ struct BuildSystemTests {
         #expect(found == nil)
     }
 
+    /// Regression guard: before the fix, a source file inside an xcodeproj
+    /// directory tree would cause `findPackageDirectory` to walk past the
+    /// xcodeproj boundary and attribute the file to whatever outer
+    /// Package.swift it eventually hit (typically the repo's own). This
+    /// triggered a hang where `swift package describe` ran against the
+    /// wrong package. The fix short-circuits when the walk crosses an
+    /// xcodeproj/xcworkspace/WORKSPACE marker before finding Package.swift.
+    @Test("findPackageDirectory returns nil when walk crosses xcodeproj before Package.swift")
+    func findPackageDirectoryStopsAtXcodeproj() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-test-\(UUID().uuidString)")
+        // Layout:
+        //   tmpDir/Package.swift                   ← outer SPM package
+        //   tmpDir/xcodeproj-child/                ← contains xcodeproj
+        //     Foo.xcodeproj
+        //     Sources/MyTarget/MyView.swift        ← source we test
+        let outerPackageSwift = tmpDir.appendingPathComponent("Package.swift")
+        let projectDir = tmpDir.appendingPathComponent("xcodeproj-child")
+        let xcodeproj = projectDir.appendingPathComponent("Foo.xcodeproj")
+        let sourceDir = projectDir.appendingPathComponent("Sources/MyTarget")
+        try FileManager.default.createDirectory(at: xcodeproj, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: sourceDir, withIntermediateDirectories: true)
+        try "// swift-tools-version: 6.0".write(
+            to: outerPackageSwift, atomically: true, encoding: .utf8)
+        let sourceFile = sourceDir.appendingPathComponent("MyView.swift")
+        try "import SwiftUI".write(to: sourceFile, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        // Without the xcodeproj-boundary check, this would walk up from
+        // MyTarget → Sources → xcodeproj-child → tmpDir and return tmpDir
+        // (because tmpDir/Package.swift exists). With the fix, it hits
+        // xcodeproj-child/Foo.xcodeproj first and returns nil.
+        let found = SPMBuildSystem.findPackageDirectory(from: sourceFile)
+        #expect(found == nil, "xcodeproj sibling should stop the walk")
+    }
+
+    @Test("findPackageDirectory returns nil when walk crosses WORKSPACE (Bazel)")
+    func findPackageDirectoryStopsAtBazelWorkspace() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-test-\(UUID().uuidString)")
+        let outerPackageSwift = tmpDir.appendingPathComponent("Package.swift")
+        let bazelDir = tmpDir.appendingPathComponent("bazel-child")
+        let workspace = bazelDir.appendingPathComponent("WORKSPACE")
+        let sourceDir = bazelDir.appendingPathComponent("lib")
+        try FileManager.default.createDirectory(at: sourceDir, withIntermediateDirectories: true)
+        try "// swift-tools-version: 6.0".write(
+            to: outerPackageSwift, atomically: true, encoding: .utf8)
+        try "".write(to: workspace, atomically: true, encoding: .utf8)
+        let sourceFile = sourceDir.appendingPathComponent("lib.swift")
+        try "import SwiftUI".write(to: sourceFile, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let found = SPMBuildSystem.findPackageDirectory(from: sourceFile)
+        #expect(found == nil, "Bazel WORKSPACE should stop the walk")
+    }
+
     // MARK: - SPMBuildSystem.detectPlatforms
 
     @Test("detectPlatforms returns platforms from real SPM package")


### PR DESCRIPTION
## Summary

Third PR in the [CLI/MCP parity stack](../blob/main/docs/cli-mcp-parity-spec.md). \`snapshot\` becomes a thin daemon client that **reuses an existing preview session** when one is running for the target file, and falls back to an ephemeral session otherwise.

- New \`SessionResolver\`: maps CLI flags (\`--session\` / \`--file\` / no flag) to a session ID via a new \`session_list\` MCP tool.
- New \`session_list\` MCP tool: one tab-delimited line per active session.
- \`SnapshotCommand\` rewrite: \`AsyncParsableCommand\` using \`DaemonClient\`. Handles both reuse and ephemeral paths. Format inferred from output file extension.
- Bug fix: platform auto-detection hung on xcodeproj sources because \`findPackageDirectory\` walked up to the repo root's Package.swift. Fixed by short-circuiting when the walk crosses an xcodeproj/xcworkspace/WORKSPACE boundary.
- MCP tool arg-name fixes: \`project\` → \`projectPath\`, \`device\` → \`deviceUDID\`. RunCommand had the same bug (PR 2); fixed here too.
- \`PreviewsMacOS.PreviewHost.allSessions\` exposed so \`session_list\` enumerates macOS sessions alongside iOS.
- \`DaemonTestLock\` wraps every \`SnapshotCommandTests\` case for cross-suite serialization.
- \`SnapshotCommand\` + \`RunCommand\` no longer live in the \"needs NSApplication\" branch.

## Observed behavior

Live-session reuse is ~80× faster than cold ephemeral:
- Ephemeral snapshot: ~30 s (compile + render)
- Reuse of live session: ~0.4 s (capture only)

## Test plan

- [x] 13 existing \`SnapshotCommandTests\` pass (now through the daemon path)
- [x] Manual: \`run --detach\` then \`snapshot <same file>\` reuses the live window
- [x] 243/243 non-iOS tests pass in the concurrent full sweep

## Related

- Stacks on #98 (PR 2 — \`run\` migration)
- Feature branch: #97
- Spec: [docs/cli-mcp-parity-spec.md](../blob/main/docs/cli-mcp-parity-spec.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)