### PR TITLE
Add configure command for live trait changes

### DIFF
--- a/Sources/PreviewsCLI/ConfigureCommand.swift
+++ b/Sources/PreviewsCLI/ConfigureCommand.swift
@@ -1,0 +1,170 @@
+import ArgumentParser
+import Foundation
+import MCP
+import PreviewsCore
+
+/// Change rendering traits on a live preview session.
+///
+/// Forwards to the daemon's `preview_configure` MCP tool. The daemon
+/// triggers a recompile on the affected session (which resets `@State`).
+///
+/// Session targeting follows the same rules as `snapshot`:
+/// `--session <id>` > `--file <path>` > sole-running session. Unlike
+/// `snapshot`, there's no ephemeral fallback — configuring a non-existent
+/// session is an error.
+///
+/// Pass an empty string to clear a trait (e.g., `--locale ""` to remove
+/// an earlier locale override).
+struct ConfigureCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "configure",
+        abstract: "Change rendering traits on a running preview session",
+        discussion: """
+            Targets the session using the same resolution rules as
+            `snapshot`: pass --session for a specific session, --file to
+            look up by source path, or no flag when exactly one session
+            is running.
+
+            Traits apply cumulatively — unspecified traits keep their
+            current values. Pass an empty string to clear a trait.
+
+            Note: dynamicTypeSize only has a visible effect on iOS
+            simulator — macOS does not scale fonts in response to this
+            modifier.
+            """
+    )
+
+    @Option(name: .long, help: "Target a specific running session by UUID")
+    var session: String?
+
+    @Option(name: .long, help: "Resolve session by source file path")
+    var file: String?
+
+    @Option(name: .long, help: "Color scheme: 'light' or 'dark' (empty to clear)")
+    var colorScheme: String?
+
+    @Option(name: .long, help: "Dynamic Type size, e.g., 'large' or 'accessibility3' (empty to clear)")
+    var dynamicTypeSize: String?
+
+    @Option(name: .long, help: "BCP 47 locale identifier (e.g., 'en', 'ar', 'ja-JP') (empty to clear)")
+    var locale: String?
+
+    @Option(name: .long, help: "Layout direction: 'leftToRight' or 'rightToLeft' (empty to clear)")
+    var layoutDirection: String?
+
+    @Option(name: .long, help: "Legibility weight: 'regular' or 'bold' (empty to clear)")
+    var legibilityWeight: String?
+
+    mutating func run() async throws {
+        // Validate traits locally so bad values fail before touching the daemon.
+        // Empty strings are allowed here (they mean "clear this trait") and are
+        // forwarded to the daemon, which also accepts them as the clear signal.
+        if !anyTraitSpecified {
+            throw ValidationError(
+                "No traits specified. Pass at least one of "
+                    + "--color-scheme / --dynamic-type-size / --locale / "
+                    + "--layout-direction / --legibility-weight."
+            )
+        }
+
+        try validateTraitValues()
+
+        let client = try await DaemonClient.connect(clientName: "previewsmcp-configure") { client in
+            await client.onNotification(LogMessageNotification.self) { message in
+                if case .string(let text) = message.params.data {
+                    fputs("\(text)\n", stderr)
+                }
+            }
+        }
+
+        do {
+            let resolution = try await SessionResolver.resolve(
+                session: session,
+                file: file,
+                client: client
+            )
+
+            guard case .found(let sessionID) = resolution else {
+                throw ValidationError(
+                    "No session found to configure. Start one with "
+                        + "`previewsmcp run <file> --detach` or pass an explicit "
+                        + "--session <uuid>."
+                )
+            }
+
+            var args: [String: Value] = ["sessionID": .string(sessionID)]
+            if let colorScheme { args["colorScheme"] = .string(colorScheme) }
+            if let dynamicTypeSize { args["dynamicTypeSize"] = .string(dynamicTypeSize) }
+            if let locale { args["locale"] = .string(locale) }
+            if let layoutDirection { args["layoutDirection"] = .string(layoutDirection) }
+            if let legibilityWeight { args["legibilityWeight"] = .string(legibilityWeight) }
+
+            let response = try await client.callTool(
+                name: "preview_configure", arguments: args
+            )
+            if response.isError == true {
+                let text = textFromContent(response.content)
+                throw ConfigureCommandError.daemonError(text)
+            }
+
+            // Surface the daemon's response (typically a summary of what
+            // changed) to the user.
+            let text = textFromContent(response.content)
+            if !text.isEmpty { fputs("\(text)\n", stderr) }
+
+            await client.disconnect()
+        } catch {
+            await client.disconnect()
+            throw error
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var anyTraitSpecified: Bool {
+        colorScheme != nil || dynamicTypeSize != nil || locale != nil
+            || layoutDirection != nil || legibilityWeight != nil
+    }
+
+    /// Validate trait values client-side. Matches the daemon's validation
+    /// so the user gets a clear error before the RPC round-trip.
+    /// Empty strings are the "clear" signal and are always valid.
+    private func validateTraitValues() throws {
+        do {
+            _ = try PreviewTraits.validated(
+                colorScheme: nonEmpty(colorScheme),
+                dynamicTypeSize: nonEmpty(dynamicTypeSize),
+                locale: nonEmpty(locale),
+                layoutDirection: nonEmpty(layoutDirection),
+                legibilityWeight: nonEmpty(legibilityWeight)
+            )
+        } catch {
+            throw ValidationError(error.localizedDescription)
+        }
+    }
+
+    /// Treat empty strings as nil for validation purposes — the daemon
+    /// uses them as the "clear this trait" signal, and PreviewTraits.validated
+    /// would reject them as invalid values.
+    private func nonEmpty(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
+    }
+
+    private func textFromContent(_ content: [Tool.Content]) -> String {
+        content.compactMap { item in
+            if case .text(let t) = item { return t }
+            return nil
+        }.joined(separator: "\n")
+    }
+}
+
+enum ConfigureCommandError: Error, CustomStringConvertible {
+    case daemonError(String)
+
+    var description: String {
+        switch self {
+        case .daemonError(let text): return text
+        }
+    }
+}

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -572,7 +572,9 @@ private func handlePreviewStart(params: CallTool.Parameters, macCompiler: Compil
         platformStr = "macos"
     }
 
-    let (explicitTraits, traitsError) = parseTraits(from: params)
+    // preview_start ignores clearedFields — traits start from empty so there's
+    // nothing to clear. Only preview_configure treats clearing meaningfully.
+    let (explicitTraits, _, traitsError) = parseTraits(from: params)
     if let traitsError { return traitsError }
     let configTraits = config?.traits?.toPreviewTraits() ?? PreviewTraits()
     let resolvedTraits = configTraits.merged(with: explicitTraits)
@@ -986,9 +988,18 @@ private func handleSessionList() async -> CallTool.Result {
 
 // MARK: - Trait Helpers
 
-/// Parse and validate trait parameters. Returns (traits, nil) on success or (default traits, error result) on failure.
-/// Callers should check the second element first; the traits value is meaningless when an error is returned.
-private func parseTraits(from params: CallTool.Parameters) -> (PreviewTraits, CallTool.Result?) {
+/// Parse and validate trait parameters. Returns (traits, clearedFields, nil) on
+/// success or (default traits, [], error result) on failure. Callers should
+/// check the last element first; the other values are meaningless on error.
+///
+/// `clearedFields` names the fields the client explicitly passed as an empty
+/// string (the "clear this trait" signal documented in the MCP tool schema).
+/// Without this, empty strings would be indistinguishable from absent fields
+/// after `PreviewTraits.validated` normalizes them to nil.
+private func parseTraits(
+    from params: CallTool.Parameters
+) -> (PreviewTraits, Set<PreviewTraits.Field>, CallTool.Result?) {
+    let cleared = clearedTraitFields(in: params)
     do {
         let traits = try PreviewTraits.validated(
             colorScheme: extractOptionalString("colorScheme", from: params),
@@ -997,10 +1008,28 @@ private func parseTraits(from params: CallTool.Parameters) -> (PreviewTraits, Ca
             layoutDirection: extractOptionalString("layoutDirection", from: params),
             legibilityWeight: extractOptionalString("legibilityWeight", from: params)
         )
-        return (traits, nil)
+        return (traits, cleared, nil)
     } catch {
-        return (PreviewTraits(), CallTool.Result(content: [.text(error.localizedDescription)], isError: true))
+        return (
+            PreviewTraits(), [],
+            CallTool.Result(content: [.text(error.localizedDescription)], isError: true)
+        )
     }
+}
+
+/// Returns the set of trait fields that the client passed as an empty string
+/// ("" — the documented clear signal). Does not touch fields that were absent
+/// from the params entirely.
+private func clearedTraitFields(
+    in params: CallTool.Parameters
+) -> Set<PreviewTraits.Field> {
+    var cleared: Set<PreviewTraits.Field> = []
+    for field in PreviewTraits.Field.allCases {
+        if case .string("") = params.arguments?[field.rawValue] {
+            cleared.insert(field)
+        }
+    }
+    return cleared
 }
 
 private func traitsSummary(_ traits: PreviewTraits) -> String {
@@ -1020,10 +1049,11 @@ private func handlePreviewConfigure(params: CallTool.Parameters, server: Server)
     }
 
     // Parse and validate traits
-    let (traits, validationError) = parseTraits(from: params)
+    let (traits, clearedFields, validationError) = parseTraits(from: params)
     if let validationError { return validationError }
 
-    if traits.isEmpty {
+    // "No-op" = no fields were set AND no fields were requested to be cleared.
+    if traits.isEmpty && clearedFields.isEmpty {
         return CallTool.Result(content: [.text("No configuration changes specified.")])
     }
 
@@ -1032,7 +1062,7 @@ private func handlePreviewConfigure(params: CallTool.Parameters, server: Server)
     // iOS path
     if let iosSession = await iosState.getSession(sessionID) {
         await progress.report(.compilingBridge, message: "Recompiling with new traits...")
-        try await iosSession.reconfigure(traits: traits)
+        try await iosSession.reconfigure(traits: traits, clearing: clearedFields)
         let activeTraits = await iosSession.currentTraits
         return CallTool.Result(content: [
             .text(
@@ -1048,7 +1078,9 @@ private func handlePreviewConfigure(params: CallTool.Parameters, server: Server)
     }
 
     await progress.report(.compilingBridge, message: "Recompiling with new traits...")
-    let compileResult = try await session.reconfigure(traits: traits)
+    let compileResult = try await session.reconfigure(
+        traits: traits, clearing: clearedFields
+    )
     try await MainActor.run {
         try App.host.loadPreview(sessionID: sessionID, dylibPath: compileResult.dylibPath)
     }

--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -117,6 +117,7 @@ struct PreviewsMCPCommand: ParsableCommand {
         version: version,
         subcommands: [
             RunCommand.self, ListCommand.self, SnapshotCommand.self, VariantsCommand.self,
+            ConfigureCommand.self,
             ServeCommand.self, StatusCommand.self, KillDaemonCommand.self,
         ],
         defaultSubcommand: RunCommand.self

--- a/Sources/PreviewsCore/PreviewSession.swift
+++ b/Sources/PreviewsCore/PreviewSession.swift
@@ -174,8 +174,18 @@ public actor PreviewSession {
     }
 
     /// Update traits and recompile. Returns the new dylib. @State is lost.
-    public func reconfigure(traits: PreviewTraits) async throws -> CompileResult {
-        self.traits = self.traits.merged(with: traits)
+    ///
+    /// - Parameters:
+    ///   - traits: values to set on the session's current traits (merged —
+    ///     non-nil values override, nil leaves the current value alone).
+    ///   - clearing: fields to explicitly null out after the merge. This is
+    ///     the only way to revert a previously-set trait; merging a nil
+    ///     value preserves the old one.
+    public func reconfigure(
+        traits: PreviewTraits,
+        clearing: Set<PreviewTraits.Field> = []
+    ) async throws -> CompileResult {
+        self.traits = self.traits.merged(with: traits).clearing(clearing)
         return try await compile()
     }
 

--- a/Sources/PreviewsCore/PreviewTraits.swift
+++ b/Sources/PreviewsCore/PreviewTraits.swift
@@ -39,6 +39,30 @@ public struct PreviewTraits: Sendable, Equatable {
         )
     }
 
+    /// Identifies a single trait field. Used with `clearing(_:)` to null out
+    /// a specific override without touching the others.
+    public enum Field: String, Sendable, CaseIterable {
+        case colorScheme
+        case dynamicTypeSize
+        case locale
+        case layoutDirection
+        case legibilityWeight
+    }
+
+    /// Return a copy with the given fields set to nil. Needed because
+    /// `merged(with:)` alone can't clear — `other.x ?? self.x` preserves
+    /// `self.x` when `other.x` is nil. Callers (e.g., the daemon's
+    /// `preview_configure` handler) must explicitly ask to clear.
+    public func clearing(_ fields: Set<Field>) -> PreviewTraits {
+        PreviewTraits(
+            colorScheme: fields.contains(.colorScheme) ? nil : colorScheme,
+            dynamicTypeSize: fields.contains(.dynamicTypeSize) ? nil : dynamicTypeSize,
+            locale: fields.contains(.locale) ? nil : locale,
+            layoutDirection: fields.contains(.layoutDirection) ? nil : layoutDirection,
+            legibilityWeight: fields.contains(.legibilityWeight) ? nil : legibilityWeight
+        )
+    }
+
     public static let validColorSchemes: Set<String> = ["light", "dark"]
 
     public static let validDynamicTypeSizes: Set<String> = [

--- a/Sources/PreviewsIOS/IOSPreviewSession.swift
+++ b/Sources/PreviewsIOS/IOSPreviewSession.swift
@@ -302,8 +302,14 @@ public actor IOSPreviewSession {
     }
 
     /// Update traits and recompile. Signals the host app to reload. @State is lost.
-    public func reconfigure(traits: PreviewTraits) async throws {
-        self.traits = self.traits.merged(with: traits)
+    ///
+    /// See `PreviewSession.reconfigure(traits:clearing:)` for the semantics
+    /// of `clearing`.
+    public func reconfigure(
+        traits: PreviewTraits,
+        clearing: Set<PreviewTraits.Field> = []
+    ) async throws {
+        self.traits = self.traits.merged(with: traits).clearing(clearing)
         try await reload()
     }
 

--- a/Tests/CLIIntegrationTests/ConfigureCommandTests.swift
+++ b/Tests/CLIIntegrationTests/ConfigureCommandTests.swift
@@ -130,6 +130,58 @@ struct ConfigureCommandTests {
         }
     }
 
+    /// `--color-scheme ""` is the documented signal to clear a trait. The
+    /// daemon's response summary lists the session's *active* traits after
+    /// the change, so an empty summary proves the trait actually went from
+    /// set to unset (rather than the old no-op "empty is ignored" bug).
+    @Test(
+        "configure --color-scheme empty-string clears the trait",
+        .timeLimit(.minutes(2))
+    )
+    func configureClearsTrait() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
+
+            let runResult = try await CLIRunner.run(
+                "run",
+                arguments: [
+                    file, "--platform", "macos", "--config", configPath, "--detach",
+                ]
+            )
+            #expect(runResult.exitCode == 0)
+
+            // Set the trait so there's something non-default to clear.
+            let setResult = try await CLIRunner.run(
+                "configure",
+                arguments: ["--color-scheme", "dark"]
+            )
+            #expect(setResult.exitCode == 0)
+            #expect(
+                setResult.stderr.contains("colorScheme=dark"),
+                "daemon summary should show the set value: \(setResult.stderr)"
+            )
+
+            // Clear it. After, the daemon summary for the session's active
+            // traits should no longer mention colorScheme.
+            let clearResult = try await CLIRunner.run(
+                "configure",
+                arguments: ["--color-scheme", ""]
+            )
+            #expect(clearResult.exitCode == 0, "stderr: \(clearResult.stderr)")
+            #expect(
+                !clearResult.stderr.contains("colorScheme="),
+                "daemon summary should not mention colorScheme after clear: \(clearResult.stderr)"
+            )
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
+    }
+
     /// Verifies --session <uuid> takes priority over any file-based lookup
     /// and that the daemon identifies the session in its response.
     @Test(

--- a/Tests/CLIIntegrationTests/ConfigureCommandTests.swift
+++ b/Tests/CLIIntegrationTests/ConfigureCommandTests.swift
@@ -1,0 +1,170 @@
+import Foundation
+import Testing
+
+/// Integration tests for the `configure` subcommand. Covers session
+/// resolution, trait application (verified via snapshot diff), and error
+/// paths. Uses DaemonTestLock so we don't race with other daemon-touching
+/// suites across test targets.
+@Suite(.serialized)
+struct ConfigureCommandTests {
+
+    private static func cleanSlate() async throws {
+        _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        let home = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".previewsmcp")
+        try? FileManager.default.removeItem(at: home.appendingPathComponent("serve.sock"))
+        try? FileManager.default.removeItem(at: home.appendingPathComponent("serve.pid"))
+    }
+
+    // MARK: - Validation (no daemon required)
+
+    @Test("configure without any trait flag fails with a useful message")
+    func configureRequiresAtLeastOneTrait() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+
+            let result = try await CLIRunner.run("configure")
+            #expect(result.exitCode != 0)
+            #expect(
+                result.stderr.contains("No traits specified"),
+                "stderr: \(result.stderr)"
+            )
+        }
+    }
+
+    @Test("configure with invalid color scheme fails locally")
+    func configureRejectsInvalidTrait() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+
+            let result = try await CLIRunner.run(
+                "configure",
+                arguments: ["--color-scheme", "plaid"]
+            )
+            #expect(result.exitCode != 0)
+            #expect(result.stderr.lowercased().contains("color scheme"))
+        }
+    }
+
+    // MARK: - No-session error path
+
+    @Test("configure errors when no session is running")
+    func configureNoSession() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+
+            let result = try await CLIRunner.run(
+                "configure",
+                arguments: ["--color-scheme", "dark"]
+            )
+            #expect(result.exitCode != 0)
+            #expect(result.stderr.contains("No session found to configure"))
+        }
+    }
+
+    // MARK: - Happy path
+
+    /// Full round trip: start a session, configure it to dark mode,
+    /// verify the session is actually reconfigured by snapshotting
+    /// before and after and asserting the PNG output differs.
+    @Test(
+        "configure dark mode changes the rendered snapshot",
+        .timeLimit(.minutes(2))
+    )
+    func configureChangesRenderedOutput() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
+            let beforePath = tempDir.appendingPathComponent("before.png").path
+            let afterPath = tempDir.appendingPathComponent("after.png").path
+
+            // Start a live session via run --detach.
+            let runResult = try await CLIRunner.run(
+                "run",
+                arguments: [
+                    file, "--platform", "macos", "--config", configPath, "--detach",
+                ]
+            )
+            #expect(runResult.exitCode == 0, "detach stderr: \(runResult.stderr)")
+
+            // Snapshot before config change — uses session's current (light) traits.
+            let beforeResult = try await CLIRunner.run(
+                "snapshot",
+                arguments: [file, "-o", beforePath, "--platform", "macos"]
+            )
+            #expect(beforeResult.exitCode == 0, "before stderr: \(beforeResult.stderr)")
+
+            // Configure to dark.
+            let configResult = try await CLIRunner.run(
+                "configure",
+                arguments: ["--color-scheme", "dark"]
+            )
+            #expect(configResult.exitCode == 0, "configure stderr: \(configResult.stderr)")
+            #expect(
+                configResult.stderr.contains("Configured session"),
+                "configure should report what changed: \(configResult.stderr)"
+            )
+
+            // Snapshot after config change — should differ from before.
+            let afterResult = try await CLIRunner.run(
+                "snapshot",
+                arguments: [file, "-o", afterPath, "--platform", "macos"]
+            )
+            #expect(afterResult.exitCode == 0, "after stderr: \(afterResult.stderr)")
+
+            let beforeData = try Data(contentsOf: URL(fileURLWithPath: beforePath))
+            let afterData = try Data(contentsOf: URL(fileURLWithPath: afterPath))
+            let diffMessage =
+                "dark-mode snapshot (\(afterData.count) bytes) should differ from "
+                + "light-mode snapshot (\(beforeData.count) bytes)"
+            #expect(beforeData != afterData, Comment(rawValue: diffMessage))
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
+    }
+
+    /// Verifies --session <uuid> takes priority over any file-based lookup
+    /// and that the daemon identifies the session in its response.
+    @Test(
+        "configure --session targets a specific session by UUID",
+        .timeLimit(.minutes(2))
+    )
+    func configureExplicitSession() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
+
+            let runResult = try await CLIRunner.run(
+                "run",
+                arguments: [
+                    file, "--platform", "macos", "--config", configPath, "--detach",
+                ]
+            )
+            #expect(runResult.exitCode == 0)
+            let sessionID = runResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            let result = try await CLIRunner.run(
+                "configure",
+                arguments: ["--session", sessionID, "--color-scheme", "dark"]
+            )
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+            #expect(
+                result.stderr.contains(sessionID),
+                "daemon response should reference the explicit session UUID"
+            )
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fourth PR in the [CLI/MCP parity stack](../blob/main/docs/cli-mcp-parity-spec.md). Adds \`previewsmcp configure\` — changes rendering traits on a running preview session.

- Forwards to the daemon's existing \`preview_configure\` MCP tool (triggers recompile on the affected session; \`@State\` is reset).
- Session resolution mirrors \`snapshot\` (\`--session\` / \`--file\` / sole-running).
- Unlike \`snapshot\`, no ephemeral fallback — configuring a missing session is an error.
- Pass an empty string to clear a trait.
- Client-side validation via \`PreviewTraits.validated\` so bad values fail before the RPC.

## Supported traits

\`--color-scheme\`, \`--dynamic-type-size\`, \`--locale\`, \`--layout-direction\`, \`--legibility-weight\`.

## Test plan

5 new tests in \`ConfigureCommandTests\`:
- [x] No-traits argument rejects with a clear message
- [x] Invalid trait value rejected locally
- [x] No session → descriptive error
- [x] Dark-mode round-trip — snapshot before + snapshot after verifies the change actually took effect
- [x] \`--session <uuid>\` explicit targeting

Regression coverage:
- [x] 30/30 daemon-touching tests pass (DaemonLifecycle + Run + Snapshot + Configure)

## Stack

- Feature branch: #97 \`cli-mcp-parity\`
- Depends on: #98 (merged), #102 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)