### PR TITLE
Add switch command for changing active #Preview in a live session

### DIFF
--- a/Sources/PreviewsCLI/ConfigureCommand.swift
+++ b/Sources/PreviewsCLI/ConfigureCommand.swift
@@ -103,13 +103,13 @@ struct ConfigureCommand: AsyncParsableCommand {
                 name: "preview_configure", arguments: args
             )
             if response.isError == true {
-                let text = textFromContent(response.content)
+                let text = response.content.joinedText()
                 throw ConfigureCommandError.daemonError(text)
             }
 
             // Surface the daemon's response (typically a summary of what
             // changed) to the user.
-            let text = textFromContent(response.content)
+            let text = response.content.joinedText()
             if !text.isEmpty { fputs("\(text)\n", stderr) }
 
             await client.disconnect()
@@ -151,12 +151,6 @@ struct ConfigureCommand: AsyncParsableCommand {
         return value
     }
 
-    private func textFromContent(_ content: [Tool.Content]) -> String {
-        content.compactMap { item in
-            if case .text(let t) = item { return t }
-            return nil
-        }.joined(separator: "\n")
-    }
 }
 
 enum ConfigureCommandError: Error, CustomStringConvertible {

--- a/Sources/PreviewsCLI/MCPContentHelpers.swift
+++ b/Sources/PreviewsCLI/MCPContentHelpers.swift
@@ -1,0 +1,13 @@
+import MCP
+
+extension Array where Element == Tool.Content {
+    /// Concatenate all text items in a tool result's content with newlines,
+    /// skipping image and other non-text items. Convenient for CLI commands
+    /// that want to display the daemon's human-readable response.
+    func joinedText() -> String {
+        compactMap { item in
+            if case .text(let t) = item { return t }
+            return nil
+        }.joined(separator: "\n")
+    }
+}

--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -117,7 +117,7 @@ struct PreviewsMCPCommand: ParsableCommand {
         version: version,
         subcommands: [
             RunCommand.self, ListCommand.self, SnapshotCommand.self, VariantsCommand.self,
-            ConfigureCommand.self,
+            ConfigureCommand.self, SwitchCommand.self,
             ServeCommand.self, StatusCommand.self, KillDaemonCommand.self,
         ],
         defaultSubcommand: RunCommand.self

--- a/Sources/PreviewsCLI/RunCommand.swift
+++ b/Sources/PreviewsCLI/RunCommand.swift
@@ -111,13 +111,13 @@ struct RunCommand: AsyncParsableCommand {
         }
 
         if response.isError == true {
-            let text = textFromContent(response.content)
+            let text = response.content.joinedText()
             fputs("Preview start failed: \(text)\n", stderr)
             await client.disconnect()
             throw ExitCode(1)
         }
 
-        let text = textFromContent(response.content)
+        let text = response.content.joinedText()
         guard let sessionID = extractSessionID(from: text) else {
             fputs("Unexpected daemon response (no session ID): \(text)\n", stderr)
             await client.disconnect()
@@ -180,13 +180,6 @@ struct RunCommand: AsyncParsableCommand {
         if headless { args["headless"] = .bool(true) }
         if let config { args["config"] = .string(config) }
         return args
-    }
-
-    private func textFromContent(_ content: [Tool.Content]) -> String {
-        content.compactMap { item in
-            if case .text(let t) = item { return t }
-            return nil
-        }.joined(separator: "\n")
     }
 
     private func extractSessionID(from text: String) -> String? {

--- a/Sources/PreviewsCLI/SessionResolver.swift
+++ b/Sources/PreviewsCLI/SessionResolver.swift
@@ -74,10 +74,10 @@ enum SessionResolver {
         let response = try await client.callTool(name: "session_list", arguments: [:])
         if response.isError == true {
             throw SessionResolverError.daemonError(
-                textFromContent(response.content)
+                response.content.joinedText()
             )
         }
-        let text = textFromContent(response.content)
+        let text = response.content.joinedText()
         return parseSessionList(text)
     }
 
@@ -95,12 +95,6 @@ enum SessionResolver {
         }
     }
 
-    private static func textFromContent(_ content: [Tool.Content]) -> String {
-        content.compactMap { item in
-            if case .text(let t) = item { return t }
-            return nil
-        }.joined(separator: "\n")
-    }
 }
 
 extension SessionResolver {

--- a/Sources/PreviewsCLI/SnapshotCommand.swift
+++ b/Sources/PreviewsCLI/SnapshotCommand.swift
@@ -227,11 +227,11 @@ struct SnapshotCommand: AsyncParsableCommand {
 
         let startResponse = try await client.callTool(name: "preview_start", arguments: startArgs)
         if startResponse.isError == true {
-            let text = textFromContent(startResponse.content)
+            let text = startResponse.content.joinedText()
             throw SnapshotCommandError.daemonError("Failed to start preview: \(text)")
         }
 
-        let sessionID = try extractSessionID(from: textFromContent(startResponse.content))
+        let sessionID = try extractSessionID(from: startResponse.content.joinedText())
 
         var snapshotArgs: [String: Value] = ["sessionID": .string(sessionID)]
         snapshotArgs["quality"] = .double(resolvedQuality())
@@ -312,7 +312,7 @@ struct SnapshotCommand: AsyncParsableCommand {
     /// Prints the output path to stdout (scriptable) on success.
     private func handleSnapshotResponse(_ response: (content: [Tool.Content], isError: Bool?)) throws {
         if response.isError == true {
-            let text = textFromContent(response.content)
+            let text = response.content.joinedText()
             throw SnapshotCommandError.daemonError("snapshot failed: \(text)")
         }
 
@@ -327,14 +327,7 @@ struct SnapshotCommand: AsyncParsableCommand {
                 return
             }
         }
-        throw SnapshotCommandError.noImageContent(textFromContent(response.content))
-    }
-
-    private func textFromContent(_ content: [Tool.Content]) -> String {
-        content.compactMap { item in
-            if case .text(let t) = item { return t }
-            return nil
-        }.joined(separator: "\n")
+        throw SnapshotCommandError.noImageContent(response.content.joinedText())
     }
 
     private func extractSessionID(from text: String) throws -> String {

--- a/Sources/PreviewsCLI/SwitchCommand.swift
+++ b/Sources/PreviewsCLI/SwitchCommand.swift
@@ -75,10 +75,10 @@ struct SwitchCommand: AsyncParsableCommand {
                 ]
             )
             if response.isError == true {
-                throw SwitchCommandError.daemonError(textFromContent(response.content))
+                throw SwitchCommandError.daemonError(response.content.joinedText())
             }
 
-            let text = textFromContent(response.content)
+            let text = response.content.joinedText()
             if !text.isEmpty { fputs("\(text)\n", stderr) }
 
             await client.disconnect()
@@ -88,12 +88,6 @@ struct SwitchCommand: AsyncParsableCommand {
         }
     }
 
-    private func textFromContent(_ content: [Tool.Content]) -> String {
-        content.compactMap { item in
-            if case .text(let t) = item { return t }
-            return nil
-        }.joined(separator: "\n")
-    }
 }
 
 enum SwitchCommandError: Error, CustomStringConvertible {

--- a/Sources/PreviewsCLI/SwitchCommand.swift
+++ b/Sources/PreviewsCLI/SwitchCommand.swift
@@ -1,0 +1,107 @@
+import ArgumentParser
+import Foundation
+import MCP
+
+/// Switch which `#Preview` block is rendered in a running session.
+///
+/// Forwards to the daemon's `preview_switch` MCP tool. The daemon
+/// recompiles the affected session (which resets `@State`); traits persist
+/// across the switch.
+///
+/// Session targeting mirrors `configure` and `snapshot`: `--session <id>` >
+/// `--file <path>` > the sole running session. As with `configure`, there
+/// is no ephemeral fallback — switching a session that doesn't exist is an
+/// error.
+struct SwitchCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "switch",
+        abstract: "Switch which #Preview block is active in a running session",
+        discussion: """
+            Selects a different #Preview block to render. Use
+            `previewsmcp list <file>` to enumerate available previews.
+
+            Targets the session using the same resolution rules as
+            `configure` and `snapshot`: pass --session for a specific
+            session, --file to look up by source path, or no flag when
+            exactly one session is running.
+
+            @State is reset on each switch; traits (color scheme, dynamic
+            type, locale, etc.) persist.
+            """
+    )
+
+    @Argument(help: "0-based index of the #Preview block to render")
+    var previewIndex: Int
+
+    @Option(name: .long, help: "Target a specific running session by UUID")
+    var session: String?
+
+    @Option(name: .long, help: "Resolve session by source file path")
+    var file: String?
+
+    mutating func run() async throws {
+        guard previewIndex >= 0 else {
+            throw ValidationError("Preview index must be non-negative.")
+        }
+
+        let client = try await DaemonClient.connect(clientName: "previewsmcp-switch") { client in
+            await client.onNotification(LogMessageNotification.self) { message in
+                if case .string(let text) = message.params.data {
+                    fputs("\(text)\n", stderr)
+                }
+            }
+        }
+
+        do {
+            let resolution = try await SessionResolver.resolve(
+                session: session,
+                file: file,
+                client: client
+            )
+
+            guard case .found(let sessionID) = resolution else {
+                throw ValidationError(
+                    "No session found to switch. Start one with "
+                        + "`previewsmcp run <file> --detach` or pass an "
+                        + "explicit --session <uuid>."
+                )
+            }
+
+            let response = try await client.callTool(
+                name: "preview_switch",
+                arguments: [
+                    "sessionID": .string(sessionID),
+                    "previewIndex": .int(previewIndex),
+                ]
+            )
+            if response.isError == true {
+                throw SwitchCommandError.daemonError(textFromContent(response.content))
+            }
+
+            let text = textFromContent(response.content)
+            if !text.isEmpty { fputs("\(text)\n", stderr) }
+
+            await client.disconnect()
+        } catch {
+            await client.disconnect()
+            throw error
+        }
+    }
+
+    private func textFromContent(_ content: [Tool.Content]) -> String {
+        content.compactMap { item in
+            if case .text(let t) = item { return t }
+            return nil
+        }.joined(separator: "\n")
+    }
+}
+
+enum SwitchCommandError: Error, CustomStringConvertible {
+    case daemonError(String)
+
+    var description: String {
+        switch self {
+        case .daemonError(let text): return text
+        }
+    }
+}

--- a/Tests/CLIIntegrationTests/SwitchCommandTests.swift
+++ b/Tests/CLIIntegrationTests/SwitchCommandTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+
+/// Integration tests for the `switch` subcommand.
+@Suite(.serialized)
+struct SwitchCommandTests {
+
+    private static func cleanSlate() async throws {
+        _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        let home = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".previewsmcp")
+        try? FileManager.default.removeItem(at: home.appendingPathComponent("serve.sock"))
+        try? FileManager.default.removeItem(at: home.appendingPathComponent("serve.pid"))
+    }
+
+    @Test("switch with negative index fails locally")
+    func switchRejectsNegativeIndex() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let result = try await CLIRunner.run("switch", arguments: ["--", "-1"])
+            #expect(result.exitCode != 0)
+            #expect(result.stderr.contains("non-negative"))
+        }
+    }
+
+    @Test("switch errors when no session is running")
+    func switchNoSession() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let result = try await CLIRunner.run("switch", arguments: ["0"])
+            #expect(result.exitCode != 0)
+            #expect(result.stderr.contains("No session found to switch"))
+        }
+    }
+
+    /// Full round-trip: start a session showing preview 0, switch to preview
+    /// 1, snapshot both, and confirm the rendered output differs. Preview 0
+    /// in the SPM example renders a populated ToDo list; preview 1 renders
+    /// the empty state.
+    @Test(
+        "switch changes the active preview in a live session",
+        .timeLimit(.minutes(2))
+    )
+    func switchChangesActivePreview() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
+            let before = tempDir.appendingPathComponent("preview0.png").path
+            let after = tempDir.appendingPathComponent("preview1.png").path
+
+            let runResult = try await CLIRunner.run(
+                "run",
+                arguments: [
+                    file, "--platform", "macos", "--config", configPath, "--detach",
+                ]
+            )
+            #expect(runResult.exitCode == 0, "detach stderr: \(runResult.stderr)")
+
+            // Snapshot the default (preview 0).
+            let beforeResult = try await CLIRunner.run(
+                "snapshot",
+                arguments: [file, "-o", before, "--platform", "macos"]
+            )
+            #expect(beforeResult.exitCode == 0)
+
+            // Switch to preview 1.
+            let switchResult = try await CLIRunner.run(
+                "switch", arguments: ["1"]
+            )
+            #expect(switchResult.exitCode == 0, "stderr: \(switchResult.stderr)")
+            // Daemon response lists the new active preview.
+            #expect(
+                switchResult.stderr.contains("<- active"),
+                "daemon summary should mark the newly active preview: \(switchResult.stderr)"
+            )
+
+            // Snapshot preview 1.
+            let afterResult = try await CLIRunner.run(
+                "snapshot",
+                arguments: [file, "-o", after, "--platform", "macos"]
+            )
+            #expect(afterResult.exitCode == 0)
+
+            let beforeData = try Data(contentsOf: URL(fileURLWithPath: before))
+            let afterData = try Data(contentsOf: URL(fileURLWithPath: after))
+            #expect(
+                beforeData != afterData,
+                "preview 0 and preview 1 should produce different snapshots"
+            )
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
+    }
+
+    /// `switch` with an out-of-range preview index should surface the daemon's
+    /// error message cleanly.
+    @Test(
+        "switch with out-of-range index reports an error",
+        .timeLimit(.minutes(2))
+    )
+    func switchOutOfRange() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
+
+            let runResult = try await CLIRunner.run(
+                "run",
+                arguments: [
+                    file, "--platform", "macos", "--config", configPath, "--detach",
+                ]
+            )
+            #expect(runResult.exitCode == 0)
+
+            // ToDoView only has 2 previews (indices 0 and 1).
+            let result = try await CLIRunner.run("switch", arguments: ["99"])
+            #expect(result.exitCode != 0)
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fifth PR in the [CLI/MCP parity stack](../blob/main/docs/cli-mcp-parity-spec.md). Adds \`previewsmcp switch <index>\` — forwards to the daemon's existing \`preview_switch\` MCP tool to recompile the session with a different \`#Preview\` block selected.

- \`@State\` resets; traits (color scheme, dynamic type, locale, …) persist.
- Session resolution mirrors \`configure\`/\`snapshot\` (\`--session\` > \`--file\` > sole-running).
- No ephemeral fallback — switching a session that doesn't exist is an error.
- Client-side validation rejects negative indices before the RPC.

## Test plan

4 new tests in \`SwitchCommandTests\`:
- [x] Negative index rejected locally
- [x] No session → descriptive error
- [x] Happy-path round-trip — snapshot preview 0, switch to preview 1, snapshot, assert byte diff
- [x] Out-of-range index surfaces the daemon's error

Regression:
- [x] All daemon-touching suites still green

## Stack

- Feature branch: #97 \`cli-mcp-parity\`
- Depends on: #98, #102, #103 (all merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)