### PR TITLE
Add elements command for iOS accessibility tree dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 xcuserdata/
 DerivedData/
 .claude/worktrees/
+.claude/scheduled_tasks.lock

--- a/Sources/PreviewsCLI/ElementsCommand.swift
+++ b/Sources/PreviewsCLI/ElementsCommand.swift
@@ -81,8 +81,11 @@ struct ElementsCommand: AsyncParsableCommand {
             }
 
             // The daemon returns the tree as a single text blob (JSON).
-            // Print to stdout so the caller can pipe into `jq`.
-            print(response.content.joinedText())
+            // Print to stdout so the caller can pipe into `jq`. Skip the
+            // trailing newline when the payload is empty so downstream
+            // parsers don't see a stray `\n`.
+            let text = response.content.joinedText()
+            if !text.isEmpty { print(text) }
 
             await client.disconnect()
         } catch {

--- a/Sources/PreviewsCLI/ElementsCommand.swift
+++ b/Sources/PreviewsCLI/ElementsCommand.swift
@@ -1,0 +1,103 @@
+import ArgumentParser
+import Foundation
+import MCP
+
+/// Dump the accessibility tree of a running iOS simulator preview.
+///
+/// Forwards to the daemon's `preview_elements` MCP tool. Writes the tree
+/// as JSON to stdout — convenient for piping into `jq` or consuming from
+/// a script. The tree contains each element's label, frame, and traits
+/// so callers can target taps/swipes by matching against it.
+///
+/// iOS simulator only. Resolves the session with the same rules as
+/// `configure` / `switch`.
+struct ElementsCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "elements",
+        abstract: "Dump the accessibility tree of an iOS simulator preview as JSON",
+        discussion: """
+            Writes a JSON document to stdout describing the current
+            accessibility tree of a running iOS preview. Each element has
+            its label, frame, and traits, so you can target taps or swipes
+            by matching against the structure.
+
+            Only available for iOS simulator sessions — this command
+            errors against a macOS session. Use `--filter interactable`
+            or `--filter labeled` to narrow the tree.
+            """
+    )
+
+    @Option(name: .long, help: "Target a specific running session by UUID")
+    var session: String?
+
+    @Option(name: .long, help: "Resolve session by source file path")
+    var file: String?
+
+    @Option(
+        name: .long,
+        help: "Filter mode: 'all' (default), 'interactable', or 'labeled'"
+    )
+    var filter: Filter = .all
+
+    enum Filter: String, ExpressibleByArgument, CaseIterable {
+        case all
+        case interactable
+        case labeled
+    }
+
+    mutating func run() async throws {
+        let client = try await DaemonClient.connect(clientName: "previewsmcp-elements") { client in
+            await client.onNotification(LogMessageNotification.self) { message in
+                if case .string(let text) = message.params.data {
+                    fputs("\(text)\n", stderr)
+                }
+            }
+        }
+
+        do {
+            let resolution = try await SessionResolver.resolve(
+                session: session,
+                file: file,
+                client: client
+            )
+
+            guard case .found(let sessionID) = resolution else {
+                throw ValidationError(
+                    "No session found. Start an iOS session with "
+                        + "`previewsmcp run <file> --platform ios --detach` or "
+                        + "pass an explicit --session <uuid>."
+                )
+            }
+
+            let response = try await client.callTool(
+                name: "preview_elements",
+                arguments: [
+                    "sessionID": .string(sessionID),
+                    "filter": .string(filter.rawValue),
+                ]
+            )
+            if response.isError == true {
+                throw ElementsCommandError.daemonError(response.content.joinedText())
+            }
+
+            // The daemon returns the tree as a single text blob (JSON).
+            // Print to stdout so the caller can pipe into `jq`.
+            print(response.content.joinedText())
+
+            await client.disconnect()
+        } catch {
+            await client.disconnect()
+            throw error
+        }
+    }
+}
+
+enum ElementsCommandError: Error, CustomStringConvertible {
+    case daemonError(String)
+
+    var description: String {
+        switch self {
+        case .daemonError(let text): return text
+        }
+    }
+}

--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -117,7 +117,7 @@ struct PreviewsMCPCommand: ParsableCommand {
         version: version,
         subcommands: [
             RunCommand.self, ListCommand.self, SnapshotCommand.self, VariantsCommand.self,
-            ConfigureCommand.self, SwitchCommand.self,
+            ConfigureCommand.self, SwitchCommand.self, ElementsCommand.self,
             ServeCommand.self, StatusCommand.self, KillDaemonCommand.self,
         ],
         defaultSubcommand: RunCommand.self

--- a/Tests/CLIIntegrationTests/ElementsCommandTests.swift
+++ b/Tests/CLIIntegrationTests/ElementsCommandTests.swift
@@ -57,8 +57,8 @@ struct ElementsCommandTests {
             let result = try await CLIRunner.run("elements")
             #expect(result.exitCode != 0)
             #expect(
-                result.stderr.lowercased().contains("ios"),
-                "macOS session should surface an iOS-only error: \(result.stderr)"
+                result.stderr.contains("only available for iOS simulator previews"),
+                "macOS session should surface the daemon's iOS-only error: \(result.stderr)"
             )
 
             _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])

--- a/Tests/CLIIntegrationTests/ElementsCommandTests.swift
+++ b/Tests/CLIIntegrationTests/ElementsCommandTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+
+/// Integration tests for the `elements` subcommand. Covers local
+/// validation, error paths, and (if a simulator is available) a happy-path
+/// iOS round trip that confirms the daemon returns a JSON accessibility
+/// tree.
+@Suite(.serialized)
+struct ElementsCommandTests {
+
+    private static func cleanSlate() async throws {
+        _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        let home = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".previewsmcp")
+        try? FileManager.default.removeItem(at: home.appendingPathComponent("serve.sock"))
+        try? FileManager.default.removeItem(at: home.appendingPathComponent("serve.pid"))
+    }
+
+    @Test("elements errors when no session is running")
+    func elementsNoSession() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+
+            let result = try await CLIRunner.run("elements")
+            #expect(result.exitCode != 0)
+            #expect(
+                result.stderr.contains("No session found"),
+                "stderr: \(result.stderr)"
+            )
+        }
+    }
+
+    /// The daemon's `preview_elements` tool is iOS-only. Exercising it
+    /// against a running macOS session should surface the daemon's error
+    /// cleanly.
+    @Test(
+        "elements against a macOS session surfaces an iOS-only error",
+        .timeLimit(.minutes(2))
+    )
+    func elementsRejectsMacOSSession() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
+
+            let runResult = try await CLIRunner.run(
+                "run",
+                arguments: [
+                    file, "--platform", "macos", "--config", configPath, "--detach",
+                ]
+            )
+            #expect(runResult.exitCode == 0, "detach stderr: \(runResult.stderr)")
+
+            let result = try await CLIRunner.run("elements")
+            #expect(result.exitCode != 0)
+            #expect(
+                result.stderr.lowercased().contains("ios"),
+                "macOS session should surface an iOS-only error: \(result.stderr)"
+            )
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
+    }
+
+    /// Happy path: start an iOS session, dump the accessibility tree,
+    /// confirm stdout is well-formed JSON with the expected shape. Gated
+    /// on a simulator being available so local developer machines without
+    /// simulators don't fail.
+    @Test(
+        "elements returns a JSON accessibility tree for an iOS session",
+        .timeLimit(.minutes(5))
+    )
+    func elementsReturnsJSONTree() async throws {
+        try await DaemonTestLock.run {
+            let simResult = try await CLIRunner.runExternal(
+                "/usr/bin/xcrun",
+                arguments: ["simctl", "list", "devices", "available"]
+            )
+            guard simResult.exitCode == 0, simResult.stdout.contains("iPhone") else {
+                print("No available iOS simulator — skipping elements iOS test")
+                return
+            }
+
+            try await Self.cleanSlate()
+
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
+
+            let runResult = try await CLIRunner.run(
+                "run",
+                arguments: [
+                    file, "--platform", "ios", "--config", configPath, "--detach",
+                ]
+            )
+            #expect(runResult.exitCode == 0, "detach stderr: \(runResult.stderr)")
+
+            let result = try await CLIRunner.run("elements")
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+
+            guard let data = result.stdout.data(using: .utf8) else {
+                Issue.record("stdout was not UTF-8: \(result.stdout)")
+                return
+            }
+            let parsed = try JSONSerialization.jsonObject(with: data)
+            #expect(
+                parsed is [String: Any] || parsed is [Any],
+                "elements stdout should be a JSON object or array: \(result.stdout.prefix(200))"
+            )
+
+            // Filter mode should still produce valid JSON.
+            let filterResult = try await CLIRunner.run(
+                "elements", arguments: ["--filter", "interactable"]
+            )
+            #expect(filterResult.exitCode == 0, "filter stderr: \(filterResult.stderr)")
+            if let filterData = filterResult.stdout.data(using: .utf8) {
+                _ = try JSONSerialization.jsonObject(with: filterData)
+            }
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `previewsmcp elements` as a daemon client for the `preview_elements` MCP tool.
- Prints the accessibility tree as JSON to stdout (pipe into `jq`); log messages go to stderr.
- Session targeting uses the shared `SessionResolver` rules: `--session <uuid>` > `--file <path>` > sole running session.
- `--filter {all,interactable,labeled}` narrows the tree via the daemon.
- Also gitignores `.claude/scheduled_tasks.lock` so it no longer shows up as untracked.

## Test plan
- [x] `swift build`
- [x] `swift test --filter 'ElementsCommandTests/elementsNoSession'` (passes locally)
- [x] `swift test --filter 'ElementsCommandTests/elementsRejectsMacOSSession'` (passes locally, ~5s)
- [ ] Gated iOS happy-path test runs on machines with an available simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)