### PR TITLE
Add touch command for tap and swipe injection

### DIFF
--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -118,7 +118,7 @@ struct PreviewsMCPCommand: ParsableCommand {
         subcommands: [
             RunCommand.self, ListCommand.self, SnapshotCommand.self, VariantsCommand.self,
             ConfigureCommand.self, SwitchCommand.self, ElementsCommand.self,
-            ServeCommand.self, StatusCommand.self, KillDaemonCommand.self,
+            TouchCommand.self, ServeCommand.self, StatusCommand.self, KillDaemonCommand.self,
         ],
         defaultSubcommand: RunCommand.self
     )

--- a/Sources/PreviewsCLI/TouchCommand.swift
+++ b/Sources/PreviewsCLI/TouchCommand.swift
@@ -1,0 +1,130 @@
+import ArgumentParser
+import Foundation
+import MCP
+
+/// Inject a tap or swipe into a running iOS simulator preview.
+///
+/// Forwards to the daemon's `preview_touch` MCP tool. Coordinates are in
+/// device points; (0, 0) is the top-left corner of the simulator window.
+/// Defaults to a tap; pass `--to-x` and `--to-y` together to perform a
+/// swipe with an optional `--duration`.
+///
+/// iOS simulator only. Session targeting mirrors the other session-
+/// scoped commands: `--session` > `--file` > the sole running session.
+struct TouchCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "touch",
+        abstract: "Inject a tap or swipe into an iOS simulator preview",
+        discussion: """
+            Sends a synthetic touch event to a running iOS session.
+            Coordinates are in device points; pair with `previewsmcp
+            elements` to resolve labels to frames.
+
+                previewsmcp touch 120 200
+                previewsmcp touch 40 300 --to-x 300 --to-y 300
+                previewsmcp touch 40 300 --to-x 300 --to-y 300 --duration 0.5
+
+            Only available for iOS simulator sessions — this command
+            errors against a macOS session.
+            """
+    )
+
+    @Argument(help: "X coordinate in points (start point for swipe)")
+    var x: Double
+
+    @Argument(help: "Y coordinate in points (start point for swipe)")
+    var y: Double
+
+    @Option(name: .long, help: "End X coordinate — pair with --to-y to swipe instead of tap")
+    var toX: Double?
+
+    @Option(name: .long, help: "End Y coordinate — pair with --to-x to swipe instead of tap")
+    var toY: Double?
+
+    @Option(name: .long, help: "Swipe duration in seconds (default: 0.3)")
+    var duration: Double?
+
+    @Option(name: .long, help: "Target a specific running session by UUID")
+    var session: String?
+
+    @Option(name: .long, help: "Resolve session by source file path")
+    var file: String?
+
+    mutating func run() async throws {
+        // Validate swipe endpoints before opening a daemon connection.
+        let isSwipe: Bool
+        switch (toX, toY) {
+        case (nil, nil):
+            isSwipe = false
+        case (.some, .some):
+            isSwipe = true
+        default:
+            throw ValidationError("--to-x and --to-y must be provided together for a swipe.")
+        }
+        if !isSwipe, duration != nil {
+            throw ValidationError("--duration only applies to swipes (provide --to-x and --to-y).")
+        }
+
+        let client = try await DaemonClient.connect(clientName: "previewsmcp-touch") { client in
+            await client.onNotification(LogMessageNotification.self) { message in
+                if case .string(let text) = message.params.data {
+                    fputs("\(text)\n", stderr)
+                }
+            }
+        }
+
+        do {
+            let resolution = try await SessionResolver.resolve(
+                session: session,
+                file: file,
+                client: client
+            )
+
+            guard case .found(let sessionID) = resolution else {
+                throw ValidationError(
+                    "No session found. Start an iOS session with "
+                        + "`previewsmcp run <file> --platform ios --detach` or "
+                        + "pass an explicit --session <uuid>."
+                )
+            }
+
+            var arguments: [String: Value] = [
+                "sessionID": .string(sessionID),
+                "x": .double(x),
+                "y": .double(y),
+            ]
+            if isSwipe, let toX, let toY {
+                arguments["action"] = .string("swipe")
+                arguments["toX"] = .double(toX)
+                arguments["toY"] = .double(toY)
+                if let duration { arguments["duration"] = .double(duration) }
+            }
+
+            let response = try await client.callTool(
+                name: "preview_touch",
+                arguments: arguments
+            )
+            if response.isError == true {
+                throw TouchCommandError.daemonError(response.content.joinedText())
+            }
+
+            let text = response.content.joinedText()
+            if !text.isEmpty { fputs("\(text)\n", stderr) }
+
+            await client.disconnect()
+        } catch {
+            await client.disconnect()
+            throw error
+        }
+    }
+}
+
+enum TouchCommandError: Error, CustomStringConvertible {
+    case daemonError(String)
+
+    var description: String {
+        switch self {
+        case .daemonError(let text): return text
+        }
+    }
+}

--- a/Sources/PreviewsCLI/TouchCommand.swift
+++ b/Sources/PreviewsCLI/TouchCommand.swift
@@ -64,6 +64,9 @@ struct TouchCommand: AsyncParsableCommand {
         if !isSwipe, duration != nil {
             throw ValidationError("--duration only applies to swipes (provide --to-x and --to-y).")
         }
+        if let duration, duration <= 0 {
+            throw ValidationError("--duration must be positive.")
+        }
 
         let client = try await DaemonClient.connect(clientName: "previewsmcp-touch") { client in
             await client.onNotification(LogMessageNotification.self) { message in

--- a/Tests/CLIIntegrationTests/TouchCommandTests.swift
+++ b/Tests/CLIIntegrationTests/TouchCommandTests.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Testing
+
+/// Integration tests for the `touch` subcommand. Covers local validation,
+/// error paths, and — gated on simulator availability — a happy-path tap
+/// + swipe round trip against an iOS session.
+@Suite(.serialized)
+struct TouchCommandTests {
+
+    private static func cleanSlate() async throws {
+        _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        let home = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".previewsmcp")
+        try? FileManager.default.removeItem(at: home.appendingPathComponent("serve.sock"))
+        try? FileManager.default.removeItem(at: home.appendingPathComponent("serve.pid"))
+    }
+
+    // MARK: - Local validation (no daemon required)
+
+    @Test("touch rejects partial swipe endpoints")
+    func touchRejectsPartialSwipe() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+
+            let result = try await CLIRunner.run(
+                "touch", arguments: ["100", "200", "--to-x", "300"]
+            )
+            #expect(result.exitCode != 0)
+            #expect(
+                result.stderr.contains("must be provided together"),
+                "stderr: \(result.stderr)"
+            )
+        }
+    }
+
+    @Test("touch rejects --duration without swipe endpoints")
+    func touchRejectsDurationWithoutSwipe() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+
+            let result = try await CLIRunner.run(
+                "touch", arguments: ["100", "200", "--duration", "0.5"]
+            )
+            #expect(result.exitCode != 0)
+            #expect(
+                result.stderr.contains("--duration only applies to swipes"),
+                "stderr: \(result.stderr)"
+            )
+        }
+    }
+
+    // MARK: - No-session error path
+
+    @Test("touch errors when no session is running")
+    func touchNoSession() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+
+            let result = try await CLIRunner.run(
+                "touch", arguments: ["100", "200"]
+            )
+            #expect(result.exitCode != 0)
+            #expect(
+                result.stderr.contains("No session found"),
+                "stderr: \(result.stderr)"
+            )
+        }
+    }
+
+    /// The daemon's `preview_touch` tool is iOS-only. Against a running
+    /// macOS session it should surface the iOS-only error.
+    @Test(
+        "touch against a macOS session surfaces an iOS-only error",
+        .timeLimit(.minutes(2))
+    )
+    func touchRejectsMacOSSession() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
+
+            let runResult = try await CLIRunner.run(
+                "run",
+                arguments: [
+                    file, "--platform", "macos", "--config", configPath, "--detach",
+                ]
+            )
+            #expect(runResult.exitCode == 0, "detach stderr: \(runResult.stderr)")
+
+            let result = try await CLIRunner.run(
+                "touch", arguments: ["100", "200"]
+            )
+            #expect(result.exitCode != 0)
+            #expect(
+                result.stderr.contains("only supported for iOS simulator previews"),
+                "macOS session should surface the daemon's iOS-only error: \(result.stderr)"
+            )
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
+    }
+
+    /// Happy path: start an iOS session, send a tap and a swipe, assert
+    /// the daemon reports both as successful.
+    @Test(
+        "touch sends tap and swipe to an iOS session",
+        .timeLimit(.minutes(5))
+    )
+    func touchIOSHappyPath() async throws {
+        try await DaemonTestLock.run {
+            let simResult = try await CLIRunner.runExternal(
+                "/usr/bin/xcrun",
+                arguments: ["simctl", "list", "devices", "available"]
+            )
+            guard simResult.exitCode == 0, simResult.stdout.contains("iPhone") else {
+                print("No available iOS simulator — skipping touch iOS test")
+                return
+            }
+
+            try await Self.cleanSlate()
+
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
+
+            let runResult = try await CLIRunner.run(
+                "run",
+                arguments: [
+                    file, "--platform", "ios", "--config", configPath, "--detach",
+                ]
+            )
+            #expect(runResult.exitCode == 0, "detach stderr: \(runResult.stderr)")
+
+            // Tap.
+            let tapResult = try await CLIRunner.run(
+                "touch", arguments: ["120", "200"]
+            )
+            #expect(tapResult.exitCode == 0, "tap stderr: \(tapResult.stderr)")
+            #expect(
+                tapResult.stderr.contains("Tap sent"),
+                "daemon should report tap: \(tapResult.stderr)"
+            )
+
+            // Swipe.
+            let swipeResult = try await CLIRunner.run(
+                "touch",
+                arguments: [
+                    "40", "300", "--to-x", "300", "--to-y", "300", "--duration", "0.4",
+                ]
+            )
+            #expect(swipeResult.exitCode == 0, "swipe stderr: \(swipeResult.stderr)")
+            #expect(
+                swipeResult.stderr.contains("Swipe"),
+                "daemon should report swipe: \(swipeResult.stderr)"
+            )
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
+    }
+}

--- a/Tests/CLIIntegrationTests/TouchCommandTests.swift
+++ b/Tests/CLIIntegrationTests/TouchCommandTests.swift
@@ -33,6 +33,25 @@ struct TouchCommandTests {
         }
     }
 
+    @Test("touch rejects non-positive --duration")
+    func touchRejectsNonPositiveDuration() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+
+            let result = try await CLIRunner.run(
+                "touch",
+                arguments: [
+                    "100", "200", "--to-x", "300", "--to-y", "400", "--duration", "0",
+                ]
+            )
+            #expect(result.exitCode != 0)
+            #expect(
+                result.stderr.contains("--duration must be positive"),
+                "stderr: \(result.stderr)"
+            )
+        }
+    }
+
     @Test("touch rejects --duration without swipe endpoints")
     func touchRejectsDurationWithoutSwipe() async throws {
         try await DaemonTestLock.run {
@@ -135,17 +154,19 @@ struct TouchCommandTests {
             )
             #expect(runResult.exitCode == 0, "detach stderr: \(runResult.stderr)")
 
-            // Tap.
+            // Tap. Pin the assertion to the full coordinate string so
+            // that a regression mis-wiring x/y still fails.
             let tapResult = try await CLIRunner.run(
                 "touch", arguments: ["120", "200"]
             )
             #expect(tapResult.exitCode == 0, "tap stderr: \(tapResult.stderr)")
             #expect(
-                tapResult.stderr.contains("Tap sent"),
-                "daemon should report tap: \(tapResult.stderr)"
+                tapResult.stderr.contains("Tap sent at (120, 200)"),
+                "daemon should echo the tap coordinates: \(tapResult.stderr)"
             )
 
-            // Swipe.
+            // Swipe. Same: require the endpoints so a lost toX/toY wiring
+            // can't slip through.
             let swipeResult = try await CLIRunner.run(
                 "touch",
                 arguments: [
@@ -154,8 +175,8 @@ struct TouchCommandTests {
             )
             #expect(swipeResult.exitCode == 0, "swipe stderr: \(swipeResult.stderr)")
             #expect(
-                swipeResult.stderr.contains("Swipe"),
-                "daemon should report swipe: \(swipeResult.stderr)"
+                swipeResult.stderr.contains("Swipe from (40,300) to (300,300)"),
+                "daemon should echo the full swipe endpoints: \(swipeResult.stderr)"
             )
 
             _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])


### PR DESCRIPTION
## Summary
- Adds `previewsmcp touch <x> <y>` as a daemon client for the `preview_touch` MCP tool.
- Defaults to a tap; pair `--to-x` / `--to-y` to swipe, with optional `--duration`.
- Session targeting uses the shared `SessionResolver`: `--session <uuid>` > `--file <path>` > sole running session.
- Validates swipe-endpoint pairing and duration-without-swipe locally before opening the daemon connection.

## Test plan
- [x] `swift build`
- [x] `swift test --filter TouchCommandTests` (all 5 tests pass locally; iOS happy-path ~13s)
- [x] Smoke-tested `--help`, partial swipe rejection, no-session error

🤖 Generated with [Claude Code](https://claude.com/claude-code)