### PR TITLE
Add simulators command for listing iOS devices

### DIFF
--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -118,7 +118,8 @@ struct PreviewsMCPCommand: ParsableCommand {
         subcommands: [
             RunCommand.self, ListCommand.self, SnapshotCommand.self, VariantsCommand.self,
             ConfigureCommand.self, SwitchCommand.self, ElementsCommand.self,
-            TouchCommand.self, ServeCommand.self, StatusCommand.self, KillDaemonCommand.self,
+            TouchCommand.self, SimulatorsCommand.self,
+            ServeCommand.self, StatusCommand.self, KillDaemonCommand.self,
         ],
         defaultSubcommand: RunCommand.self
     )

--- a/Sources/PreviewsCLI/SimulatorsCommand.swift
+++ b/Sources/PreviewsCLI/SimulatorsCommand.swift
@@ -42,8 +42,11 @@ struct SimulatorsCommand: AsyncParsableCommand {
                 throw SimulatorsCommandError.daemonError(response.content.joinedText())
             }
 
-            let text = response.content.joinedText()
-            if !text.isEmpty { print(text) }
+            // Unlike elements (where empty stdout is plausible),
+            // `simulator_list` always returns either device lines or the
+            // sentinel "No available simulator devices found." — so
+            // always surface the daemon's reply verbatim.
+            print(response.content.joinedText())
 
             await client.disconnect()
         } catch {

--- a/Sources/PreviewsCLI/SimulatorsCommand.swift
+++ b/Sources/PreviewsCLI/SimulatorsCommand.swift
@@ -1,0 +1,64 @@
+import ArgumentParser
+import Foundation
+import MCP
+
+/// List available iOS simulator devices with their UDIDs and runtimes.
+///
+/// Forwards to the daemon's `simulator_list` MCP tool. Output is one
+/// line per available device:
+///
+///     iPhone 15 Pro — <udid> [BOOTED] (iOS 17.5)
+///
+/// Useful for resolving a device UDID to pass as `--device` to a run /
+/// snapshot invocation, or for quickly confirming which simulator is
+/// currently booted.
+struct SimulatorsCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "simulators",
+        abstract: "List available iOS simulator devices",
+        discussion: """
+            Writes one line per available device to stdout in the form:
+
+                <name> — <udid> [BOOTED] (<runtime>)
+
+            The `[BOOTED]` marker is present only for currently booted
+            devices. Pipe through grep or fzf to pick a UDID for
+            `--device` on run / snapshot.
+            """
+    )
+
+    mutating func run() async throws {
+        let client = try await DaemonClient.connect(clientName: "previewsmcp-simulators") { client in
+            await client.onNotification(LogMessageNotification.self) { message in
+                if case .string(let text) = message.params.data {
+                    fputs("\(text)\n", stderr)
+                }
+            }
+        }
+
+        do {
+            let response = try await client.callTool(name: "simulator_list", arguments: [:])
+            if response.isError == true {
+                throw SimulatorsCommandError.daemonError(response.content.joinedText())
+            }
+
+            let text = response.content.joinedText()
+            if !text.isEmpty { print(text) }
+
+            await client.disconnect()
+        } catch {
+            await client.disconnect()
+            throw error
+        }
+    }
+}
+
+enum SimulatorsCommandError: Error, CustomStringConvertible {
+    case daemonError(String)
+
+    var description: String {
+        switch self {
+        case .daemonError(let text): return text
+        }
+    }
+}

--- a/Tests/CLIIntegrationTests/SimulatorsCommandTests.swift
+++ b/Tests/CLIIntegrationTests/SimulatorsCommandTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+
+/// Integration tests for the `simulators` subcommand. Verifies that the
+/// CLI auto-starts the daemon and surfaces the `simulator_list` tool's
+/// human-readable output on stdout.
+@Suite(.serialized)
+struct SimulatorsCommandTests {
+
+    private static func cleanSlate() async throws {
+        _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        let home = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".previewsmcp")
+        try? FileManager.default.removeItem(at: home.appendingPathComponent("serve.sock"))
+        try? FileManager.default.removeItem(at: home.appendingPathComponent("serve.pid"))
+    }
+
+    /// Happy path: run against the real `simctl`. Gated on a simulator
+    /// actually being available so machines without Xcode simulators
+    /// (e.g. stripped CI runners) don't fail — the daemon would still
+    /// print "No available simulator devices found." in that case.
+    @Test(
+        "simulators prints one line per available device on stdout",
+        .timeLimit(.minutes(2))
+    )
+    func simulatorsPrintsAvailableDevices() async throws {
+        try await DaemonTestLock.run {
+            let simResult = try await CLIRunner.runExternal(
+                "/usr/bin/xcrun",
+                arguments: ["simctl", "list", "devices", "available"]
+            )
+            guard simResult.exitCode == 0, simResult.stdout.contains("iPhone") else {
+                print("No available iOS simulator — skipping simulators test")
+                return
+            }
+
+            try await Self.cleanSlate()
+
+            let result = try await CLIRunner.run("simulators")
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+
+            let lines = result.stdout
+                .split(separator: "\n", omittingEmptySubsequences: true)
+                .map(String.init)
+            #expect(!lines.isEmpty, "should list at least one device: \(result.stdout)")
+
+            // Daemon formats each line as "<name> — <udid> [BOOTED]? (<runtime>)".
+            // The em-dash plus parentheses are the structural markers; require
+            // them so a regression that dropped fields would be caught.
+            for line in lines {
+                #expect(
+                    line.contains(" — ") && line.contains("(") && line.contains(")"),
+                    "line should contain name, em-dash, udid and runtime: \(line)"
+                )
+            }
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
+    }
+}

--- a/Tests/CLIIntegrationTests/SimulatorsCommandTests.swift
+++ b/Tests/CLIIntegrationTests/SimulatorsCommandTests.swift
@@ -15,42 +15,49 @@ struct SimulatorsCommandTests {
         try? FileManager.default.removeItem(at: home.appendingPathComponent("serve.pid"))
     }
 
-    /// Happy path: run against the real `simctl`. Gated on a simulator
-    /// actually being available so machines without Xcode simulators
-    /// (e.g. stripped CI runners) don't fail — the daemon would still
-    /// print "No available simulator devices found." in that case.
+    /// Runs on every machine: whether or not any simulators exist, the
+    /// command must succeed with a non-empty payload on stdout. When a
+    /// simulator is available we tighten the assertion to the per-line
+    /// structural format; otherwise we check the daemon's "no devices"
+    /// sentinel. This also implicitly verifies daemon auto-start.
     @Test(
-        "simulators prints one line per available device on stdout",
+        "simulators succeeds with either device lines or the no-devices sentinel",
         .timeLimit(.minutes(2))
     )
-    func simulatorsPrintsAvailableDevices() async throws {
+    func simulatorsAlwaysProducesOutput() async throws {
         try await DaemonTestLock.run {
-            let simResult = try await CLIRunner.runExternal(
-                "/usr/bin/xcrun",
-                arguments: ["simctl", "list", "devices", "available"]
-            )
-            guard simResult.exitCode == 0, simResult.stdout.contains("iPhone") else {
-                print("No available iOS simulator — skipping simulators test")
-                return
-            }
-
             try await Self.cleanSlate()
 
             let result = try await CLIRunner.run("simulators")
             #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+            let stdout = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            #expect(!stdout.isEmpty, "simulators must emit something on stdout: \(result.stdout)")
 
-            let lines = result.stdout
-                .split(separator: "\n", omittingEmptySubsequences: true)
-                .map(String.init)
-            #expect(!lines.isEmpty, "should list at least one device: \(result.stdout)")
+            let simResult = try await CLIRunner.runExternal(
+                "/usr/bin/xcrun",
+                arguments: ["simctl", "list", "devices", "available"]
+            )
+            let hasSimulator = simResult.exitCode == 0 && simResult.stdout.contains("iPhone")
 
-            // Daemon formats each line as "<name> — <udid> [BOOTED]? (<runtime>)".
-            // The em-dash plus parentheses are the structural markers; require
-            // them so a regression that dropped fields would be caught.
-            for line in lines {
+            if hasSimulator {
+                let lines = stdout
+                    .split(separator: "\n", omittingEmptySubsequences: true)
+                    .map(String.init)
+                #expect(!lines.isEmpty, "should list at least one device: \(stdout)")
+
+                // Daemon formats each line as "<name> — <udid> [BOOTED]? (<runtime>)".
+                // The em-dash plus parentheses are the structural markers; require
+                // them so a regression that dropped fields would be caught.
+                for line in lines {
+                    #expect(
+                        line.contains(" — ") && line.contains("(") && line.contains(")"),
+                        "line should contain name, em-dash, udid and runtime: \(line)"
+                    )
+                }
+            } else {
                 #expect(
-                    line.contains(" — ") && line.contains("(") && line.contains(")"),
-                    "line should contain name, em-dash, udid and runtime: \(line)"
+                    stdout.contains("No available simulator devices found"),
+                    "should surface the no-devices sentinel verbatim: \(stdout)"
                 )
             }
 


### PR DESCRIPTION
## Summary
- Adds `previewsmcp simulators` as a daemon client for the `simulator_list` MCP tool.
- Prints one line per available device to stdout: `<name> — <udid> [BOOTED] (<runtime>)`.
- Intended for piping into grep / fzf to pick a UDID for `--device` on `run` / `snapshot`.

## Test plan
- [x] `swift build`
- [x] `swift test --filter SimulatorsCommandTests` (passes locally)
- [x] Smoke-tested against real `simctl` — correctly lists all booted and shutdown devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)