### PR TITLE
Migrate variants to daemon client

### DIFF
--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -24,10 +24,9 @@ struct PreviewsMCPApp {
             PreviewsMCPCommand.exit(withError: error)
         }
 
-        // Commands that don't need NSApplication (list, help, status,
-        // kill-daemon, run, and snapshot — all now daemon clients).
-        // Only serve and variants still drive AppKit in-process.
-        if !(command is ServeCommand || command is VariantsCommand) {
+        // Every CLI subcommand except `serve` is now a daemon client.
+        // Only `serve` drives AppKit directly (it *is* the daemon).
+        if !(command is ServeCommand) {
             // Handle async commands: the MCP SDK's NetworkTransport schedules
             // NWConnection callbacks on DispatchQueue.main, so we can't just
             // block main with a semaphore — the callbacks would never fire.
@@ -60,14 +59,9 @@ struct PreviewsMCPApp {
         // Commands needing UI: start NSApplication
         let app = NSApplication.shared
 
-        let mode: PreviewHost.Mode
-        if command is ServeCommand {
-            mode = .serve
-        } else if command is SnapshotCommand || command is VariantsCommand {
-            mode = .snapshot
-        } else {
-            mode = .interactive
-        }
+        // `serve` is the only command that runs AppKit in-process, so
+        // the mode is always `.serve` here.
+        let mode: PreviewHost.Mode = .serve
 
         let host = PreviewHost(mode: mode)
         App.host = host

--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -59,11 +59,8 @@ struct PreviewsMCPApp {
         // Commands needing UI: start NSApplication
         let app = NSApplication.shared
 
-        // `serve` is the only command that runs AppKit in-process, so
-        // the mode is always `.serve` here.
-        let mode: PreviewHost.Mode = .serve
-
-        let host = PreviewHost(mode: mode)
+        // `serve` is the only command that runs AppKit in-process.
+        let host = PreviewHost(mode: .serve)
         App.host = host
         app.delegate = host
 

--- a/Sources/PreviewsCLI/VariantsCommand.swift
+++ b/Sources/PreviewsCLI/VariantsCommand.swift
@@ -1,23 +1,43 @@
-import AppKit
 import ArgumentParser
 import Foundation
+import MCP
 import PreviewsCore
-import PreviewsIOS
-import PreviewsMacOS
 
+/// Capture multiple snapshots of a SwiftUI preview under different trait
+/// configurations by delegating to the daemon's `preview_variants` MCP
+/// tool.
+///
+/// Magical resolution (matches `snapshot`):
+///   * `--session <id>` — use that specific session.
+///   * positional file — reuse an existing session for that file, or
+///     spin up an ephemeral one for the capture.
+///   * no flags — use the sole running session when unambiguous.
+///
 /// Exit codes:
 ///   0 — all variants captured
-///   1 — partial failure (some variants captured, others failed) or setup/validation error
+///   1 — partial failure (some variants captured, others failed) or
+///       setup / validation error
 ///   2 — total failure (every variant failed)
-struct VariantsCommand: ParsableCommand {
+struct VariantsCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "variants",
         abstract:
-            "Capture multiple snapshots of a SwiftUI preview under different trait configurations"
+            "Capture multiple snapshots of a SwiftUI preview under different trait configurations",
+        discussion: """
+            Reuses an existing preview session if one is running for the
+            target file (or if you pass --session). Otherwise starts an
+            ephemeral session, captures every variant, and cleans up.
+
+            Each --variant is either a preset name (light, dark,
+            xSmall…accessibility5, rtl, ltr, boldText) or a JSON object
+            string with trait fields (colorScheme, dynamicTypeSize,
+            locale, layoutDirection, legibilityWeight) and an optional
+            label that determines the output filename.
+            """
     )
 
     @Argument(help: "Path to Swift source file containing #Preview")
-    var file: String
+    var file: String?
 
     @Option(
         name: .long,
@@ -41,13 +61,13 @@ struct VariantsCommand: ParsableCommand {
     @Option(name: .long, help: "JPEG quality 0.0–1.0 (ignored for PNG; default from config or 0.85)")
     var quality: Double?
 
-    @Option(name: .long, help: "Which preview to capture (0-based index)")
+    @Option(name: .long, help: "Which preview to capture (0-based index, ephemeral only)")
     var preview: Int = 0
 
-    @Option(name: .long, help: "Window width")
+    @Option(name: .long, help: "Window width (ephemeral session only)")
     var width: Int = 400
 
-    @Option(name: .long, help: "Window height")
+    @Option(name: .long, help: "Window height (ephemeral session only)")
     var height: Int = 600
 
     @Option(name: .long, help: "Target platform: 'macos' or 'ios' (auto-detected if omitted)")
@@ -56,8 +76,20 @@ struct VariantsCommand: ParsableCommand {
     @Option(name: .long, help: "Project root path (auto-detected if omitted)")
     var project: String?
 
+    @Option(
+        name: .long,
+        help: "Xcode scheme name (only for .xcodeproj / .xcworkspace projects with multiple schemes)"
+    )
+    var scheme: String?
+
     @Option(name: .long, help: "Simulator device UDID (for ios; auto-selects if omitted)")
     var device: String?
+
+    @Option(
+        name: .long,
+        help: "Target a specific running session by UUID instead of resolving by file"
+    )
+    var session: String?
 
     @Option(name: .long, help: "Path to .previewsmcp.json config file (auto-discovered if omitted)")
     var config: String?
@@ -66,76 +98,235 @@ struct VariantsCommand: ParsableCommand {
         case jpeg, png
     }
 
-    mutating func run() throws {
-        let fileURL = URL(fileURLWithPath: file).standardizedFileURL
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            throw ValidationError("File not found: \(file)")
-        }
-
-        let configResult = loadProjectConfig(explicit: config, fileURL: fileURL)
-        let projectConfig = configResult?.config
-
+    mutating func run() async throws {
         guard !variant.isEmpty else {
             throw ValidationError("At least one --variant is required")
         }
+        if file == nil && session == nil {
+            throw ValidationError(
+                "Missing file argument. Pass a path or --session <uuid>."
+            )
+        }
+        if let file {
+            let fileURL = URL(fileURLWithPath: file).standardizedFileURL
+            guard FileManager.default.fileExists(atPath: fileURL.path) else {
+                throw ValidationError("File not found: \(file)")
+            }
+        }
 
-        // Resolve all variants up front — validation errors are setup-time failures (exit 1).
-        let resolved: [PreviewTraits.Variant]
+        // Parse and dedupe-label-check variants locally so validation
+        // errors fail before we pay the daemon roundtrip.
+        let resolvedVariants: [PreviewTraits.Variant]
         do {
-            resolved = try variant.map(PreviewTraits.parseVariantString)
+            resolvedVariants = try variant.map(PreviewTraits.parseVariantString)
         } catch {
             throw ValidationError(error.localizedDescription)
         }
-
-        // Reject duplicate labels — they would silently overwrite each other on disk.
         var seen: [String: Int] = [:]
-        for (index, variant) in resolved.enumerated() {
-            if let prior = seen[variant.label] {
+        for (index, v) in resolvedVariants.enumerated() {
+            if let prior = seen[v.label] {
                 throw ValidationError(
-                    "Duplicate variant label '\(variant.label)' at indices \(prior) and \(index). "
+                    "Duplicate variant label '\(v.label)' at indices \(prior) and \(index). "
                         + "Provide a unique 'label' field in JSON variants.")
             }
-            seen[variant.label] = index
+            seen[v.label] = index
         }
 
         let outputDirURL = URL(fileURLWithPath: outputDir)
         try FileManager.default.createDirectory(
             at: outputDirURL, withIntermediateDirectories: true)
 
-        let resolvedPlatform: CLIPlatform = {
-            if let explicit = platform { return explicit }
-            if let cp = configResult?.config.platform { return cp == "ios" ? .ios : .macos }
-            if SPMBuildSystem.inferredPlatform(for: fileURL) == .iOS {
-                return .ios
+        let client = try await DaemonClient.connect(clientName: "previewsmcp-variants") { client in
+            await client.onNotification(LogMessageNotification.self) { message in
+                if case .string(let text) = message.params.data {
+                    fputs("\(text)\n", stderr)
+                }
             }
-            return .macos
-        }()
+        }
 
-        switch resolvedPlatform {
-        case .ios:
-            runIOSVariants(
-                fileURL: fileURL, resolved: resolved, outputDirURL: outputDirURL,
-                configResult: configResult
+        let exitCode: Int32
+        do {
+            let resolution = try await SessionResolver.resolve(
+                session: session,
+                file: file,
+                client: client
             )
-        case .macos:
-            runMacOSVariants(
-                fileURL: fileURL, resolved: resolved, outputDirURL: outputDirURL,
-                configResult: configResult
+
+            switch resolution {
+            case .found(let sessionID):
+                exitCode = try await captureVariants(
+                    sessionID: sessionID,
+                    labels: resolvedVariants.map(\.label),
+                    outputDir: outputDirURL,
+                    client: client,
+                    isEphemeral: false
+                )
+            case .notFound:
+                guard let file else {
+                    throw ValidationError(
+                        "Session \(session ?? "?") not found. "
+                            + "Pass a file path to create a new ephemeral session."
+                    )
+                }
+                exitCode = try await captureEphemeral(
+                    file: file,
+                    labels: resolvedVariants.map(\.label),
+                    outputDir: outputDirURL,
+                    client: client
+                )
+            }
+            await client.disconnect()
+        } catch {
+            await client.disconnect()
+            throw error
+        }
+
+        if exitCode != 0 { throw ExitCode(exitCode) }
+    }
+
+    // MARK: - Execution paths
+
+    private func captureEphemeral(
+        file: String,
+        labels: [String],
+        outputDir: URL,
+        client: Client
+    ) async throws -> Int32 {
+        let fileURL = URL(fileURLWithPath: file).standardizedFileURL
+        let configResult = loadProjectConfig(explicit: config, fileURL: fileURL)
+        let resolvedPlatform = SnapshotCommand.resolvePlatform(
+            explicit: platform,
+            config: configResult?.config,
+            project: project,
+            fileURL: fileURL
+        )
+
+        var startArgs: [String: Value] = [
+            "filePath": .string(fileURL.path),
+            "previewIndex": .int(preview),
+            "width": .int(width),
+            "height": .int(height),
+            // Capture only — never show a window during variant rendering.
+            "headless": .bool(true),
+            "platform": .string(resolvedPlatform.rawValue),
+        ]
+        if let project { startArgs["projectPath"] = .string(project) }
+        if let scheme { startArgs["scheme"] = .string(scheme) }
+        if let device { startArgs["deviceUDID"] = .string(device) }
+        if let config { startArgs["config"] = .string(config) }
+
+        let startResponse = try await client.callTool(name: "preview_start", arguments: startArgs)
+        if startResponse.isError == true {
+            throw VariantsCommandError.daemonError(
+                "Failed to start preview: \(startResponse.content.joinedText())"
             )
+        }
+        let sessionID = try extractSessionID(from: startResponse.content.joinedText())
+
+        do {
+            let code = try await captureVariants(
+                sessionID: sessionID,
+                labels: labels,
+                outputDir: outputDir,
+                client: client,
+                isEphemeral: true
+            )
+            await stopEphemeralSession(sessionID: sessionID, client: client)
+            return code
+        } catch {
+            await stopEphemeralSession(sessionID: sessionID, client: client)
+            throw error
         }
     }
 
-    private func outputURL(in dir: URL, label: String) -> URL {
+    /// Call `preview_variants`, decode each image block, write to disk,
+    /// and surface any per-variant error text to stderr.
+    private func captureVariants(
+        sessionID: String,
+        labels: [String],
+        outputDir: URL,
+        client: Client,
+        isEphemeral: Bool
+    ) async throws -> Int32 {
+        let requestedQuality = resolvedQuality()
+
+        let arguments: [String: Value] = [
+            "sessionID": .string(sessionID),
+            "variants": .array(variant.map { .string($0) }),
+            "quality": .double(requestedQuality),
+        ]
+        let response = try await client.callTool(name: "preview_variants", arguments: arguments)
+
+        // Walk content items in order. The daemon emits, per variant,
+        // either `[N] <label>:` followed by an image block (success) or
+        // a single `[N] <label>: ERROR — <reason>` text block (failure).
+        var successCount = 0
+        var failCount = 0
+        var pendingLabel: String?
         let ext = format == .png ? "png" : "jpg"
-        return dir.appendingPathComponent("\(label).\(ext)")
+
+        for item in response.content {
+            switch item {
+            case .text(let text):
+                if let label = parseVariantLabel(from: text) {
+                    if text.contains("ERROR") {
+                        fputs("\(text)\n", stderr)
+                        failCount += 1
+                        pendingLabel = nil
+                    } else {
+                        pendingLabel = label
+                    }
+                }
+            case .image(let base64, _, _):
+                guard let label = pendingLabel else { continue }
+                guard let data = Data(base64Encoded: base64) else {
+                    fputs("[error] \(label): invalid base64 from daemon\n", stderr)
+                    failCount += 1
+                    pendingLabel = nil
+                    continue
+                }
+                let outURL = outputDir.appendingPathComponent("\(label).\(ext)")
+                do {
+                    try data.write(to: outURL)
+                    print(outURL.path)
+                    successCount += 1
+                } catch {
+                    fputs("[error] \(label): \(error.localizedDescription)\n", stderr)
+                    failCount += 1
+                }
+                pendingLabel = nil
+            default:
+                continue
+            }
+        }
+
+        // Labels expected but never matched imply the daemon dropped a
+        // variant entirely — count them as failures so the exit code
+        // reflects reality.
+        let accounted = successCount + failCount
+        if accounted < labels.count {
+            let missing = labels.count - accounted
+            fputs(
+                "warning: daemon returned \(accounted) results for \(labels.count) variants\n",
+                stderr
+            )
+            failCount += missing
+        }
+        _ = isEphemeral
+
+        return summarize(successCount: successCount, failCount: failCount)
     }
 
-    /// Print a per-variant failure to stderr in the same format as the MCP `preview_variants` tool.
-    private func reportVariantFailure(index: Int, label: String, error: Error) {
-        fputs("[\(index)] \(label): ERROR — \(error.localizedDescription)\n", stderr)
+    // MARK: - Helpers
+
+    private func resolvedQuality() -> Double {
+        // Explicit --format png overrides quality → ask daemon for PNG
+        // (quality >= 1.0 is its PNG trigger).
+        if format == .png { return 1.0 }
+        if let quality { return quality }
+        return 0.85
     }
 
-    /// Print a final summary line and return the appropriate exit code.
     private func summarize(successCount: Int, failCount: Int) -> Int32 {
         let total = successCount + failCount
         if failCount == 0 {
@@ -148,215 +339,45 @@ struct VariantsCommand: ParsableCommand {
         return failCount == total ? 2 : 1
     }
 
-    private func runMacOSVariants(
-        fileURL: URL,
-        resolved: [PreviewTraits.Variant],
-        outputDirURL: URL,
-        configResult: ProjectConfigLoader.Result?
-    ) {
-        let previewIndex = preview
-        let windowWidth = width
-        let windowHeight = height
-        let projectPath = project
-        let resolvedQuality = quality ?? configResult?.config.quality ?? 0.85
-        let snapshotFormat: Snapshot.ImageFormat =
-            format == .png ? .png : .jpeg(quality: resolvedQuality)
-        // Setup: detect + build (2 steps) + per variant: compile + capture (2 × N)
-        let progress: any ProgressReporter = StderrProgressReporter(
-            totalSteps: 2 + 2 * resolved.count)
-
-        Task {
-            // Setup phase — any failure here is a hard exit (no variants can be captured).
-            let session: PreviewSession
-            let sessionID: String
-            let setupDylibPath: URL?
-            do {
-                let compiler = try await Compiler()
-                let projectRootURL = projectPath.map { URL(fileURLWithPath: $0) }
-                let buildContext = try await detectAndBuild(
-                    for: fileURL, projectRoot: projectRootURL, platform: .macOS,
-                    progress: progress)
-
-                let setupResult = try await buildSetupFromConfig(configResult, platform: .macOS)
-                setupDylibPath = setupResult?.dylibPath
-
-                session = PreviewSession(
-                    sourceFile: fileURL,
-                    previewIndex: previewIndex,
-                    compiler: compiler,
-                    buildContext: buildContext,
-                    traits: resolved[0].traits,
-                    setupModule: setupResult?.moduleName,
-                    setupType: setupResult?.typeName,
-                    setupCompilerFlags: setupResult?.compilerFlags ?? []
-                )
-                sessionID = session.id
-            } catch {
-                fputs("Error: \(error.localizedDescription)\n", stderr)
-                Darwin.exit(2)
-            }
-
-            // Per-variant phase — collect failures, continue past them, stream successes.
-            var successCount = 0
-            var failCount = 0
-
-            for (index, variant) in resolved.enumerated() {
-                do {
-                    await progress.report(
-                        .compilingBridge,
-                        message: "Recompiling for variant \"\(variant.label)\"...")
-                    let compileResult = try await session.setTraits(variant.traits)
-
-                    try await MainActor.run {
-                        try App.host.loadPreview(
-                            sessionID: sessionID,
-                            dylibPath: compileResult.dylibPath,
-                            title: "Variant: \(variant.label)",
-                            size: NSSize(width: windowWidth, height: windowHeight),
-                            setupDylibPath: setupDylibPath
-                        )
-                    }
-
-                    // Wait for SwiftUI layout
-                    try await Task.sleep(for: .milliseconds(500))
-
-                    await progress.report(
-                        .capturingSnapshot,
-                        message:
-                            "Capturing variant \(index + 1)/\(resolved.count) \"\(variant.label)\"..."
-                    )
-                    let outURL = outputURL(in: outputDirURL, label: variant.label)
-                    try await MainActor.run {
-                        guard let window = App.host.window(for: sessionID) else {
-                            throw VariantsCommandError.captureFailed(label: variant.label)
-                        }
-                        try Snapshot.capture(
-                            window: window, format: snapshotFormat, to: outURL)
-                    }
-                    print(outURL.path)
-                    successCount += 1
-                } catch {
-                    failCount += 1
-                    reportVariantFailure(
-                        index: index, label: variant.label, error: error)
-                }
-            }
-
-            let exitCode = summarize(successCount: successCount, failCount: failCount)
-            await MainActor.run { NSApp.terminate(nil) }
-            // NSApp.terminate sends an event; explicit exit ensures the right code propagates.
-            Darwin.exit(exitCode)
-        }
+    /// Parse a `[N] label:` or `[N] label: ERROR …` prefix into the label.
+    private func parseVariantLabel(from text: String) -> String? {
+        // Accept `[<digits>] <label>:` optionally followed by more text.
+        let pattern = /\[\d+\]\s+(.+?):/
+        guard let match = text.firstMatch(of: pattern) else { return nil }
+        return String(match.1)
     }
 
-    private func runIOSVariants(
-        fileURL: URL,
-        resolved: [PreviewTraits.Variant],
-        outputDirURL: URL,
-        configResult: ProjectConfigLoader.Result?
-    ) {
-        let previewIndex = preview
-        let deviceUDID = device ?? configResult?.config.device
-        let projectPath = project
-        let resolvedQuality = quality ?? configResult?.config.quality ?? 0.85
-        let jpegQuality: Double = format == .png ? 1.0 : resolvedQuality
-        // Setup: detect + build (2) + iOS start (6) = 8; first variant: capture only (1); rest: compile + capture (2 × (N-1))
-        let progress: any ProgressReporter = StderrProgressReporter(
-            totalSteps: 7 + 2 * resolved.count)
+    private func extractSessionID(from text: String) throws -> String {
+        let pattern = /Session ID: ([0-9a-fA-F-]{36})/
+        guard let match = text.firstMatch(of: pattern) else {
+            throw VariantsCommandError.daemonError(
+                "no session ID in daemon response: \(text)"
+            )
+        }
+        return String(match.1)
+    }
 
-        Task {
-            // Setup phase — any failure here is a hard exit (no variants can be captured).
-            let session: IOSPreviewSession
-            do {
-                let compiler = try await Compiler(platform: .iOS)
-                let hostBuilder = try await IOSHostBuilder()
-                let simulatorManager = SimulatorManager()
-
-                let udid = try await resolveDeviceUDID(
-                    provided: deviceUDID, using: simulatorManager)
-
-                let projectRootURL = projectPath.map { URL(fileURLWithPath: $0) }
-                let buildContext = try await detectAndBuild(
-                    for: fileURL, projectRoot: projectRootURL, platform: .iOS,
-                    progress: progress)
-
-                let setupResult = try await buildSetupFromConfig(configResult, platform: .iOS)
-
-                session = IOSPreviewSession(
-                    sourceFile: fileURL,
-                    previewIndex: previewIndex,
-                    deviceUDID: udid,
-                    compiler: compiler,
-                    hostBuilder: hostBuilder,
-                    simulatorManager: simulatorManager,
-                    headless: true,
-                    buildContext: buildContext,
-                    traits: resolved[0].traits,
-                    setupModule: setupResult?.moduleName,
-                    setupType: setupResult?.typeName,
-                    setupCompilerFlags: setupResult?.compilerFlags ?? [],
-                    setupDylibPath: setupResult?.dylibPath,
-                    progress: progress
-                )
-
-                _ = try await session.start()
-                try await Task.sleep(for: .seconds(2))
-            } catch {
-                fputs("Error: \(error.localizedDescription)\n", stderr)
-                Darwin.exit(2)
-            }
-
-            // Per-variant phase. Whatever happens, stop the session before exiting so we
-            // don't leak the simulator's preview app.
-            var successCount = 0
-            var failCount = 0
-            var first = true
-
-            for (index, variant) in resolved.enumerated() {
-                do {
-                    if !first {
-                        await progress.report(
-                            .compilingBridge,
-                            message: "Recompiling for variant \"\(variant.label)\"...")
-                        try await session.setTraits(variant.traits)
-                        try await Task.sleep(for: .seconds(1))
-                    }
-                    first = false
-
-                    await progress.report(
-                        .capturingSnapshot,
-                        message:
-                            "Capturing variant \(index + 1)/\(resolved.count) \"\(variant.label)\"..."
-                    )
-                    let imageData = try await session.screenshot(jpegQuality: jpegQuality)
-                    let outURL = outputURL(in: outputDirURL, label: variant.label)
-                    try imageData.write(to: outURL)
-                    print(outURL.path)
-                    successCount += 1
-                } catch {
-                    failCount += 1
-                    reportVariantFailure(
-                        index: index, label: variant.label, error: error)
-                    // Reset `first` so the next iteration tries to apply its traits.
-                    first = false
-                }
-            }
-
-            await session.stop()
-            let exitCode = summarize(successCount: successCount, failCount: failCount)
-            await MainActor.run { NSApp.terminate(nil) }
-            Darwin.exit(exitCode)
+    private func stopEphemeralSession(sessionID: String, client: Client) async {
+        do {
+            _ = try await client.callTool(
+                name: "preview_stop",
+                arguments: ["sessionID": .string(sessionID)]
+            )
+        } catch {
+            fputs(
+                "warning: failed to stop ephemeral session \(sessionID): \(error)\n",
+                stderr
+            )
         }
     }
 }
 
-enum VariantsCommandError: Error, LocalizedError {
-    case captureFailed(label: String)
+enum VariantsCommandError: Error, CustomStringConvertible {
+    case daemonError(String)
 
-    var errorDescription: String? {
+    var description: String {
         switch self {
-        case .captureFailed(let label):
-            return "Failed to capture variant '\(label)': no preview window found."
+        case .daemonError(let text): return text
         }
     }
 }

--- a/Sources/PreviewsCLI/VariantsCommand.swift
+++ b/Sources/PreviewsCLI/VariantsCommand.swift
@@ -102,6 +102,15 @@ struct VariantsCommand: AsyncParsableCommand {
         guard !variant.isEmpty else {
             throw ValidationError("At least one --variant is required")
         }
+        // Guard the JPEG-quality footgun: the daemon treats quality >=
+        // 1.0 as "emit PNG", which would silently write PNG bytes into
+        // a .jpg file. Reject upfront so the user can either drop
+        // --quality or switch to --format png.
+        if format == .jpeg, let quality, quality >= 1.0 {
+            throw ValidationError(
+                "--quality must be < 1.0 when --format jpeg; use --format png for lossless output."
+            )
+        }
         if file == nil && session == nil {
             throw ValidationError(
                 "Missing file argument. Pass a path or --session <uuid>."
@@ -158,8 +167,7 @@ struct VariantsCommand: AsyncParsableCommand {
                     sessionID: sessionID,
                     labels: resolvedVariants.map(\.label),
                     outputDir: outputDirURL,
-                    client: client,
-                    isEphemeral: false
+                    client: client
                 )
             case .notFound:
                 guard let file else {
@@ -228,8 +236,7 @@ struct VariantsCommand: AsyncParsableCommand {
                 sessionID: sessionID,
                 labels: labels,
                 outputDir: outputDir,
-                client: client,
-                isEphemeral: true
+                client: client
             )
             await stopEphemeralSession(sessionID: sessionID, client: client)
             return code
@@ -245,8 +252,7 @@ struct VariantsCommand: AsyncParsableCommand {
         sessionID: String,
         labels: [String],
         outputDir: URL,
-        client: Client,
-        isEphemeral: Bool
+        client: Client
     ) async throws -> Int32 {
         let requestedQuality = resolvedQuality()
 
@@ -268,17 +274,26 @@ struct VariantsCommand: AsyncParsableCommand {
         for item in response.content {
             switch item {
             case .text(let text):
-                if let label = parseVariantLabel(from: text) {
-                    if text.contains("ERROR") {
-                        fputs("\(text)\n", stderr)
-                        failCount += 1
-                        pendingLabel = nil
-                    } else {
-                        pendingLabel = label
-                    }
+                // Prefer the failure pattern first — it's a strict
+                // superset of the success preamble. A label that happens
+                // to contain the substring "ERROR" (e.g. a JSON variant
+                // labeled "ERROR_STATE") must still bucket as success
+                // unless ` ERROR — ` follows the colon.
+                if parseFailurePreamble(from: text) != nil {
+                    fputs("\(text)\n", stderr)
+                    failCount += 1
+                    pendingLabel = nil
+                } else if let label = parseSuccessPreamble(from: text) {
+                    pendingLabel = label
                 }
             case .image(let base64, _, _):
-                guard let label = pendingLabel else { continue }
+                guard let label = pendingLabel else {
+                    fputs(
+                        "warning: daemon returned image block with no preceding label preamble — dropping\n",
+                        stderr
+                    )
+                    continue
+                }
                 guard let data = Data(base64Encoded: base64) else {
                     fputs("[error] \(label): invalid base64 from daemon\n", stderr)
                     failCount += 1
@@ -312,8 +327,6 @@ struct VariantsCommand: AsyncParsableCommand {
             )
             failCount += missing
         }
-        _ = isEphemeral
-
         return summarize(successCount: successCount, failCount: failCount)
     }
 
@@ -339,10 +352,21 @@ struct VariantsCommand: AsyncParsableCommand {
         return failCount == total ? 2 : 1
     }
 
-    /// Parse a `[N] label:` or `[N] label: ERROR …` prefix into the label.
-    private func parseVariantLabel(from text: String) -> String? {
-        // Accept `[<digits>] <label>:` optionally followed by more text.
-        let pattern = /\[\d+\]\s+(.+?):/
+    /// Match the daemon's success preamble: exactly `[N] <label>:` with
+    /// no trailing content. Labels are sanitized upstream (no path
+    /// traversal, no leading dots) so we don't need to validate them
+    /// here beyond the structural match.
+    private func parseSuccessPreamble(from text: String) -> String? {
+        let pattern = /^\[\d+\]\s+(.+?):\s*$/
+        guard let match = text.firstMatch(of: pattern) else { return nil }
+        return String(match.1)
+    }
+
+    /// Match the daemon's failure text: `[N] <label>: ERROR — <reason>`.
+    /// Anchored to the literal separator so a variant whose *label*
+    /// contains "ERROR" is not mis-bucketed as a failure.
+    private func parseFailurePreamble(from text: String) -> String? {
+        let pattern = /^\[\d+\]\s+(.+?):\s+ERROR\s+—\s/
         guard let match = text.firstMatch(of: pattern) else { return nil }
         return String(match.1)
     }

--- a/Tests/CLIIntegrationTests/VariantsCommandTests.swift
+++ b/Tests/CLIIntegrationTests/VariantsCommandTests.swift
@@ -4,207 +4,316 @@ import Testing
 @Suite("CLI variants command", .serialized)
 struct VariantsCommandTests {
 
+    private static func cleanSlate() async throws {
+        _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        let home = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".previewsmcp")
+        try? FileManager.default.removeItem(at: home.appendingPathComponent("serve.sock"))
+        try? FileManager.default.removeItem(at: home.appendingPathComponent("serve.pid"))
+    }
+
     // MARK: - Happy paths
 
     @Test("Captures multiple presets to distinct files", .timeLimit(.minutes(2)))
     func capturesMultiplePresets() async throws {
-        let tempDir = try CLIRunner.makeTempDir()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
 
-        let result = try await CLIRunner.run(
-            "variants",
-            arguments: [
-                file,
-                "--variant", "light",
-                "--variant", "dark",
-                "-o", tempDir.path,
-                "--project", CLIRunner.spmExampleRoot.path,
-            ])
+            let result = try await CLIRunner.run(
+                "variants",
+                arguments: [
+                    file,
+                    "--variant", "light",
+                    "--variant", "dark",
+                    "-o", tempDir.path,
+                    "--platform", "macos",
+                    "--project", CLIRunner.spmExampleRoot.path,
+                    "--config", configPath,
+                ])
 
-        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
-        #expect(
-            result.stderr.contains("Captured 2/2 variants"),
-            "Expected success summary in stderr: \(result.stderr)")
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+            #expect(
+                result.stderr.contains("Captured 2/2 variants"),
+                "Expected success summary in stderr: \(result.stderr)")
 
-        let lightPath = tempDir.appendingPathComponent("light.jpg").path
-        let darkPath = tempDir.appendingPathComponent("dark.jpg").path
-        try CLIRunner.assertValidJPEG(at: lightPath)
-        try CLIRunner.assertValidJPEG(at: darkPath)
+            let lightPath = tempDir.appendingPathComponent("light.jpg").path
+            let darkPath = tempDir.appendingPathComponent("dark.jpg").path
+            try CLIRunner.assertValidJPEG(at: lightPath)
+            try CLIRunner.assertValidJPEG(at: darkPath)
 
-        // light and dark should produce visually different images
-        let lightData = try Data(contentsOf: URL(fileURLWithPath: lightPath))
-        let darkData = try Data(contentsOf: URL(fileURLWithPath: darkPath))
-        #expect(lightData != darkData, "light and dark variants should differ")
+            // light and dark should produce visually different images
+            let lightData = try Data(contentsOf: URL(fileURLWithPath: lightPath))
+            let darkData = try Data(contentsOf: URL(fileURLWithPath: darkPath))
+            #expect(lightData != darkData, "light and dark variants should differ")
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
     }
 
     @Test("JSON variant uses custom label as filename", .timeLimit(.minutes(2)))
     func jsonVariantUsesCustomLabel() async throws {
-        let tempDir = try CLIRunner.makeTempDir()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
 
-        let result = try await CLIRunner.run(
-            "variants",
-            arguments: [
-                file,
-                "--variant",
-                #"{"colorScheme":"dark","dynamicTypeSize":"large","label":"my-custom-label"}"#,
-                "-o", tempDir.path,
-                "--project", CLIRunner.spmExampleRoot.path,
-            ])
+            let result = try await CLIRunner.run(
+                "variants",
+                arguments: [
+                    file,
+                    "--variant",
+                    #"{"colorScheme":"dark","dynamicTypeSize":"large","label":"my-custom-label"}"#,
+                    "-o", tempDir.path,
+                    "--platform", "macos",
+                    "--project", CLIRunner.spmExampleRoot.path,
+                    "--config", configPath,
+                ])
 
-        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
-        let outPath = tempDir.appendingPathComponent("my-custom-label.jpg").path
-        try CLIRunner.assertValidJPEG(at: outPath)
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+            let outPath = tempDir.appendingPathComponent("my-custom-label.jpg").path
+            try CLIRunner.assertValidJPEG(at: outPath)
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
     }
 
     @Test("PNG format produces valid PNG files", .timeLimit(.minutes(2)))
     func pngFormat() async throws {
-        let tempDir = try CLIRunner.makeTempDir()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
 
-        let result = try await CLIRunner.run(
-            "variants",
-            arguments: [
-                file,
-                "--variant", "light",
-                "--format", "png",
-                "-o", tempDir.path,
-                "--project", CLIRunner.spmExampleRoot.path,
-            ])
+            let result = try await CLIRunner.run(
+                "variants",
+                arguments: [
+                    file,
+                    "--variant", "light",
+                    "--format", "png",
+                    "-o", tempDir.path,
+                    "--platform", "macos",
+                    "--project", CLIRunner.spmExampleRoot.path,
+                    "--config", configPath,
+                ])
 
-        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
-        try CLIRunner.assertValidPNG(at: tempDir.appendingPathComponent("light.png").path)
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+            try CLIRunner.assertValidPNG(at: tempDir.appendingPathComponent("light.png").path)
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
     }
 
-    // MARK: - Validation errors (exit 1)
+    /// When a session is already running for the target file, `variants`
+    /// should reuse it rather than spinning up an ephemeral one. Observable
+    /// proof: after the variants run, the session is still alive (stop
+    /// --all reports it).
+    @Test(
+        "variants reuses an already-running session",
+        .timeLimit(.minutes(2))
+    )
+    func variantsReusesLiveSession() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
+
+            let runResult = try await CLIRunner.run(
+                "run",
+                arguments: [
+                    file, "--platform", "macos", "--config", configPath, "--detach",
+                ]
+            )
+            #expect(runResult.exitCode == 0, "detach stderr: \(runResult.stderr)")
+
+            let result = try await CLIRunner.run(
+                "variants",
+                arguments: [
+                    file,
+                    "--variant", "light",
+                    "--variant", "dark",
+                    "-o", tempDir.path,
+                    "--platform", "macos",
+                    "--config", configPath,
+                ])
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+
+            // The session should still exist after variants finishes.
+            let stopResult = try await CLIRunner.run(
+                "stop", arguments: ["--all"]
+            )
+            #expect(stopResult.exitCode == 0)
+            #expect(
+                !stopResult.stderr.contains("No active sessions to stop"),
+                "session should have survived variants capture: \(stopResult.stderr)"
+            )
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
+    }
+
+    // MARK: - Validation errors (local, no daemon required)
 
     @Test("Missing --variant returns non-zero exit")
     func missingVariant() async throws {
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
 
-        let result = try await CLIRunner.run("variants", arguments: [file])
+            let result = try await CLIRunner.run("variants", arguments: [file])
 
-        #expect(result.exitCode != 0, "Should fail without --variant")
-        #expect(
-            result.stderr.contains("At least one --variant is required"),
-            "stderr: \(result.stderr)")
+            #expect(result.exitCode != 0, "Should fail without --variant")
+            #expect(
+                result.stderr.contains("At least one --variant is required"),
+                "stderr: \(result.stderr)")
+        }
     }
 
     @Test("Invalid preset name returns non-zero exit and lists valid presets")
     func invalidPreset() async throws {
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
 
-        let result = try await CLIRunner.run(
-            "variants", arguments: [file, "--variant", "neon"])
+            let result = try await CLIRunner.run(
+                "variants", arguments: [file, "--variant", "neon"])
 
-        #expect(result.exitCode != 0, "Should fail with invalid preset")
-        #expect(
-            result.stderr.contains("Unknown variant 'neon'"),
-            "stderr should name the bad variant: \(result.stderr)")
-        #expect(
-            result.stderr.contains("light"),
-            "stderr should list valid presets: \(result.stderr)")
+            #expect(result.exitCode != 0, "Should fail with invalid preset")
+            #expect(
+                result.stderr.contains("Unknown variant 'neon'"),
+                "stderr should name the bad variant: \(result.stderr)")
+            #expect(
+                result.stderr.contains("light"),
+                "stderr should list valid presets: \(result.stderr)")
+        }
     }
 
     @Test("Path traversal in label is rejected")
     func pathTraversalLabelRejected() async throws {
-        let tempDir = try CLIRunner.makeTempDir()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
 
-        let result = try await CLIRunner.run(
-            "variants",
-            arguments: [
-                file,
-                "--variant", #"{"colorScheme":"dark","label":"../escape"}"#,
-                "-o", tempDir.path,
-            ])
+            let result = try await CLIRunner.run(
+                "variants",
+                arguments: [
+                    file,
+                    "--variant", #"{"colorScheme":"dark","label":"../escape"}"#,
+                    "-o", tempDir.path,
+                ])
 
-        #expect(result.exitCode != 0, "Should fail with path-traversal label")
-        #expect(
-            result.stderr.contains("Invalid variant label"),
-            "stderr should explain rejection: \(result.stderr)")
+            #expect(result.exitCode != 0, "Should fail with path-traversal label")
+            #expect(
+                result.stderr.contains("Invalid variant label"),
+                "stderr should explain rejection: \(result.stderr)")
+        }
     }
 
     @Test("Leading-dot label is rejected")
     func leadingDotLabelRejected() async throws {
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
 
-        let result = try await CLIRunner.run(
-            "variants",
-            arguments: [
-                file,
-                "--variant", #"{"colorScheme":"dark","label":".hidden"}"#,
-            ])
+            let result = try await CLIRunner.run(
+                "variants",
+                arguments: [
+                    file,
+                    "--variant", #"{"colorScheme":"dark","label":".hidden"}"#,
+                ])
 
-        #expect(result.exitCode != 0, "Should reject hidden-file label")
-        #expect(
-            result.stderr.contains("cannot start with '.'"),
-            "stderr: \(result.stderr)")
+            #expect(result.exitCode != 0, "Should reject hidden-file label")
+            #expect(
+                result.stderr.contains("cannot start with '.'"),
+                "stderr: \(result.stderr)")
+        }
     }
 
     @Test("Duplicate label is rejected with both indices")
     func duplicateLabelRejected() async throws {
-        let tempDir = try CLIRunner.makeTempDir()
-        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
 
-        let result = try await CLIRunner.run(
-            "variants",
-            arguments: [
-                file,
-                "--variant", "dark",
-                "--variant", #"{"colorScheme":"light","label":"dark"}"#,
-                "-o", tempDir.path,
-            ])
+            let result = try await CLIRunner.run(
+                "variants",
+                arguments: [
+                    file,
+                    "--variant", "dark",
+                    "--variant", #"{"colorScheme":"light","label":"dark"}"#,
+                    "-o", tempDir.path,
+                ])
 
-        #expect(result.exitCode != 0, "Should reject duplicate label")
-        #expect(
-            result.stderr.contains("Duplicate variant label 'dark'"),
-            "stderr: \(result.stderr)")
-        #expect(
-            result.stderr.contains("indices 0 and 1"),
-            "stderr should name conflicting indices: \(result.stderr)")
+            #expect(result.exitCode != 0, "Should reject duplicate label")
+            #expect(
+                result.stderr.contains("Duplicate variant label 'dark'"),
+                "stderr: \(result.stderr)")
+            #expect(
+                result.stderr.contains("indices 0 and 1"),
+                "stderr should name conflicting indices: \(result.stderr)")
+        }
     }
 
     @Test("Empty JSON variant object is rejected")
     func emptyJsonVariantRejected() async throws {
-        let file = CLIRunner.spmExampleRoot
-            .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
 
-        let result = try await CLIRunner.run(
-            "variants",
-            arguments: [file, "--variant", "{}"])
+            let result = try await CLIRunner.run(
+                "variants",
+                arguments: [file, "--variant", "{}"])
 
-        #expect(result.exitCode != 0, "Should reject empty JSON variant")
-        #expect(
-            result.stderr.contains("at least one trait"),
-            "stderr: \(result.stderr)")
+            #expect(result.exitCode != 0, "Should reject empty JSON variant")
+            #expect(
+                result.stderr.contains("at least one trait"),
+                "stderr: \(result.stderr)")
+        }
     }
 
     @Test("Nonexistent file returns non-zero exit")
     func nonexistentFile() async throws {
-        let result = try await CLIRunner.run(
-            "variants",
-            arguments: ["/nonexistent/file.swift", "--variant", "light"])
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let result = try await CLIRunner.run(
+                "variants",
+                arguments: ["/nonexistent/file.swift", "--variant", "light"])
 
-        #expect(result.exitCode != 0, "Should fail with nonexistent file")
-        #expect(result.stderr.contains("File not found"), "stderr: \(result.stderr)")
+            #expect(result.exitCode != 0, "Should fail with nonexistent file")
+            #expect(result.stderr.contains("File not found"), "stderr: \(result.stderr)")
+        }
     }
 }

--- a/Tests/CLIIntegrationTests/VariantsCommandTests.swift
+++ b/Tests/CLIIntegrationTests/VariantsCommandTests.swift
@@ -173,7 +173,74 @@ struct VariantsCommandTests {
         }
     }
 
+    /// Regression: previously, the CLI parser used a loose ERROR
+    /// substring check that mis-bucketed any variant whose label
+    /// happened to contain "ERROR" as a failure — silently dropping
+    /// the image. Pin the label format so a variant labeled
+    /// "ERROR_STATE" still captures successfully.
+    @Test(
+        "Label containing 'ERROR' is not mis-bucketed as failure",
+        .timeLimit(.minutes(2))
+    )
+    func labelContainingErrorStillCapturesSuccessfully() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
+
+            let result = try await CLIRunner.run(
+                "variants",
+                arguments: [
+                    file,
+                    "--variant", #"{"colorScheme":"dark","label":"ERROR_STATE"}"#,
+                    "-o", tempDir.path,
+                    "--platform", "macos",
+                    "--project", CLIRunner.spmExampleRoot.path,
+                    "--config", configPath,
+                ])
+
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+            #expect(
+                result.stderr.contains("Captured 1/1 variants"),
+                "stderr: \(result.stderr)"
+            )
+            try CLIRunner.assertValidJPEG(
+                at: tempDir.appendingPathComponent("ERROR_STATE.jpg").path
+            )
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
+    }
+
     // MARK: - Validation errors (local, no daemon required)
+
+    @Test("--format jpeg with --quality 1.0 is rejected")
+    func jpegQualityOneRejected() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+
+            let result = try await CLIRunner.run(
+                "variants",
+                arguments: [
+                    file, "--variant", "light",
+                    "--format", "jpeg", "--quality", "1.0",
+                ])
+
+            #expect(result.exitCode != 0)
+            #expect(
+                result.stderr.contains("--quality must be < 1.0 when --format jpeg"),
+                "stderr: \(result.stderr)"
+            )
+        }
+    }
+
 
     @Test("Missing --variant returns non-zero exit")
     func missingVariant() async throws {


### PR DESCRIPTION
## Summary
- Rewrites `VariantsCommand` as an `AsyncParsableCommand` that delegates to the daemon's `preview_variants` MCP tool — closes the last CLI/MCP parity gap.
- Matches `SnapshotCommand`'s "magical" session resolution: reuse an existing session for the file (or `--session <uuid>`), otherwise spin up an ephemeral session and tear it down after the capture.
- Walks the daemon's response stream (alternating `[N] label:` text + base64 image blocks, or `[N] label: ERROR — ...`) and writes each image to `<outputDir>/<label>.<ext>`.
- Exit codes preserved: 0 = all success, 1 = partial failure / validation error, 2 = total failure.
- `serve` is now the only subcommand that drives NSApplication in-process — dropped the VariantsCommand special case from `PreviewsMCPApp.swift`.

## Test plan
- [x] `swift build`
- [x] `swift test --filter VariantsCommandTests` — all 11 tests green (3 ephemeral captures, 1 session-reuse, 7 validation). ~33s.
- [x] Smoke-tested ephemeral path end-to-end: two-variant light/dark capture produces distinct JPGs.
- [x] Net diff: -423 / +547 lines (net +124), replacing 360+ lines of in-process AppKit code with a thin daemon client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)