### PR TITLE
Consolidate per-command daemon-error enums into shared DaemonToolError

### DIFF
--- a/Sources/PreviewsCLI/ConfigureCommand.swift
+++ b/Sources/PreviewsCLI/ConfigureCommand.swift
@@ -104,7 +104,7 @@ struct ConfigureCommand: AsyncParsableCommand {
             )
             if response.isError == true {
                 let text = response.content.joinedText()
-                throw ConfigureCommandError.daemonError(text)
+                throw DaemonToolError.daemonError(text)
             }
 
             // Surface the daemon's response (typically a summary of what
@@ -153,12 +153,3 @@ struct ConfigureCommand: AsyncParsableCommand {
 
 }
 
-enum ConfigureCommandError: Error, CustomStringConvertible {
-    case daemonError(String)
-
-    var description: String {
-        switch self {
-        case .daemonError(let text): return text
-        }
-    }
-}

--- a/Sources/PreviewsCLI/DaemonToolError.swift
+++ b/Sources/PreviewsCLI/DaemonToolError.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Shared error type for CLI commands that forward to an MCP tool in
+/// the daemon. Carries the text the daemon returned (whether in an
+/// `isError: true` response, a missing session sentinel, or a protocol
+/// violation) so the user sees it verbatim instead of a generic
+/// "command failed".
+///
+/// Commands with additional failure modes beyond "the daemon said no"
+/// (e.g. `SnapshotCommand`'s invalid-base64 branch) keep their own
+/// error types and route their daemon-sourced cases through this one.
+enum DaemonToolError: Error, CustomStringConvertible {
+    case daemonError(String)
+
+    var description: String {
+        switch self {
+        case .daemonError(let text): return text
+        }
+    }
+}

--- a/Sources/PreviewsCLI/ElementsCommand.swift
+++ b/Sources/PreviewsCLI/ElementsCommand.swift
@@ -77,7 +77,7 @@ struct ElementsCommand: AsyncParsableCommand {
                 ]
             )
             if response.isError == true {
-                throw ElementsCommandError.daemonError(response.content.joinedText())
+                throw DaemonToolError.daemonError(response.content.joinedText())
             }
 
             // The daemon returns the tree as a single text blob (JSON).
@@ -95,12 +95,3 @@ struct ElementsCommand: AsyncParsableCommand {
     }
 }
 
-enum ElementsCommandError: Error, CustomStringConvertible {
-    case daemonError(String)
-
-    var description: String {
-        switch self {
-        case .daemonError(let text): return text
-        }
-    }
-}

--- a/Sources/PreviewsCLI/SimulatorsCommand.swift
+++ b/Sources/PreviewsCLI/SimulatorsCommand.swift
@@ -39,7 +39,7 @@ struct SimulatorsCommand: AsyncParsableCommand {
         do {
             let response = try await client.callTool(name: "simulator_list", arguments: [:])
             if response.isError == true {
-                throw SimulatorsCommandError.daemonError(response.content.joinedText())
+                throw DaemonToolError.daemonError(response.content.joinedText())
             }
 
             // Unlike elements (where empty stdout is plausible),
@@ -56,12 +56,3 @@ struct SimulatorsCommand: AsyncParsableCommand {
     }
 }
 
-enum SimulatorsCommandError: Error, CustomStringConvertible {
-    case daemonError(String)
-
-    var description: String {
-        switch self {
-        case .daemonError(let text): return text
-        }
-    }
-}

--- a/Sources/PreviewsCLI/SnapshotCommand.swift
+++ b/Sources/PreviewsCLI/SnapshotCommand.swift
@@ -228,7 +228,7 @@ struct SnapshotCommand: AsyncParsableCommand {
         let startResponse = try await client.callTool(name: "preview_start", arguments: startArgs)
         if startResponse.isError == true {
             let text = startResponse.content.joinedText()
-            throw SnapshotCommandError.daemonError("Failed to start preview: \(text)")
+            throw DaemonToolError.daemonError("Failed to start preview: \(text)")
         }
 
         let sessionID = try extractSessionID(from: startResponse.content.joinedText())
@@ -313,7 +313,7 @@ struct SnapshotCommand: AsyncParsableCommand {
     private func handleSnapshotResponse(_ response: (content: [Tool.Content], isError: Bool?)) throws {
         if response.isError == true {
             let text = response.content.joinedText()
-            throw SnapshotCommandError.daemonError("snapshot failed: \(text)")
+            throw DaemonToolError.daemonError("snapshot failed: \(text)")
         }
 
         for item in response.content {
@@ -333,7 +333,7 @@ struct SnapshotCommand: AsyncParsableCommand {
     private func extractSessionID(from text: String) throws -> String {
         let pattern = /Session ID: ([0-9a-fA-F-]{36})/
         guard let match = text.firstMatch(of: pattern) else {
-            throw SnapshotCommandError.daemonError(
+            throw DaemonToolError.daemonError(
                 "no session ID in daemon response: \(text)"
             )
         }
@@ -342,13 +342,11 @@ struct SnapshotCommand: AsyncParsableCommand {
 }
 
 enum SnapshotCommandError: Error, CustomStringConvertible {
-    case daemonError(String)
     case invalidImageData
     case noImageContent(String)
 
     var description: String {
         switch self {
-        case .daemonError(let text): return text
         case .invalidImageData: return "daemon returned invalid (non-base64) image data"
         case .noImageContent(let text):
             return "daemon response contained no image content: \(text)"

--- a/Sources/PreviewsCLI/StopCommand.swift
+++ b/Sources/PreviewsCLI/StopCommand.swift
@@ -83,7 +83,7 @@ struct StopCommand: AsyncParsableCommand {
     private func stopAll(client: Client) async throws {
         let response = try await client.callTool(name: "session_list", arguments: [:])
         if response.isError == true {
-            throw StopCommandError.daemonError(response.content.joinedText())
+            throw DaemonToolError.daemonError(response.content.joinedText())
         }
         let sessions = SessionResolver.parseSessionList(response.content.joinedText())
 
@@ -117,19 +117,10 @@ struct StopCommand: AsyncParsableCommand {
             arguments: ["sessionID": .string(sessionID)]
         )
         if response.isError == true {
-            throw StopCommandError.daemonError(response.content.joinedText())
+            throw DaemonToolError.daemonError(response.content.joinedText())
         }
         let text = response.content.joinedText()
         if !text.isEmpty { fputs("\(text)\n", stderr) }
     }
 }
 
-enum StopCommandError: Error, CustomStringConvertible {
-    case daemonError(String)
-
-    var description: String {
-        switch self {
-        case .daemonError(let text): return text
-        }
-    }
-}

--- a/Sources/PreviewsCLI/SwitchCommand.swift
+++ b/Sources/PreviewsCLI/SwitchCommand.swift
@@ -75,7 +75,7 @@ struct SwitchCommand: AsyncParsableCommand {
                 ]
             )
             if response.isError == true {
-                throw SwitchCommandError.daemonError(response.content.joinedText())
+                throw DaemonToolError.daemonError(response.content.joinedText())
             }
 
             let text = response.content.joinedText()
@@ -90,12 +90,3 @@ struct SwitchCommand: AsyncParsableCommand {
 
 }
 
-enum SwitchCommandError: Error, CustomStringConvertible {
-    case daemonError(String)
-
-    var description: String {
-        switch self {
-        case .daemonError(let text): return text
-        }
-    }
-}

--- a/Sources/PreviewsCLI/TouchCommand.swift
+++ b/Sources/PreviewsCLI/TouchCommand.swift
@@ -108,7 +108,7 @@ struct TouchCommand: AsyncParsableCommand {
                 arguments: arguments
             )
             if response.isError == true {
-                throw TouchCommandError.daemonError(response.content.joinedText())
+                throw DaemonToolError.daemonError(response.content.joinedText())
             }
 
             let text = response.content.joinedText()
@@ -122,12 +122,3 @@ struct TouchCommand: AsyncParsableCommand {
     }
 }
 
-enum TouchCommandError: Error, CustomStringConvertible {
-    case daemonError(String)
-
-    var description: String {
-        switch self {
-        case .daemonError(let text): return text
-        }
-    }
-}

--- a/Sources/PreviewsCLI/VariantsCommand.swift
+++ b/Sources/PreviewsCLI/VariantsCommand.swift
@@ -225,7 +225,7 @@ struct VariantsCommand: AsyncParsableCommand {
 
         let startResponse = try await client.callTool(name: "preview_start", arguments: startArgs)
         if startResponse.isError == true {
-            throw VariantsCommandError.daemonError(
+            throw DaemonToolError.daemonError(
                 "Failed to start preview: \(startResponse.content.joinedText())"
             )
         }
@@ -374,7 +374,7 @@ struct VariantsCommand: AsyncParsableCommand {
     private func extractSessionID(from text: String) throws -> String {
         let pattern = /Session ID: ([0-9a-fA-F-]{36})/
         guard let match = text.firstMatch(of: pattern) else {
-            throw VariantsCommandError.daemonError(
+            throw DaemonToolError.daemonError(
                 "no session ID in daemon response: \(text)"
             )
         }
@@ -396,12 +396,3 @@ struct VariantsCommand: AsyncParsableCommand {
     }
 }
 
-enum VariantsCommandError: Error, CustomStringConvertible {
-    case daemonError(String)
-
-    var description: String {
-        switch self {
-        case .daemonError(let text): return text
-        }
-    }
-}


### PR DESCRIPTION
## Summary
Every daemon-client command had its own single-case `XxxCommandError.daemonError(String)` with an identical `description` implementation — 8 copies of the same enum across ~80 lines. Replaces them with one shared `DaemonToolError`.

- Deleted: `ElementsCommandError`, `SwitchCommandError`, `ConfigureCommandError`, `TouchCommandError`, `SimulatorsCommandError`, `StopCommandError`, `VariantsCommandError`.
- `SnapshotCommandError` keeps its two snapshot-specific cases (`invalidImageData`, `noImageContent`) but its daemon-error throws now route through `DaemonToolError`.

Net: +32 / -77 lines. No behavior change — the thrown messages are byte-for-byte identical.

## Test plan
- [x] `swift build`
- [x] `swift test --filter 'ElementsCommandTests|SwitchCommandTests|ConfigureCommandTests|TouchCommandTests|SimulatorsCommandTests|StopCommandTests|VariantsCommandTests'` (41 tests across 7 suites, all green, ~2m)

🤖 Generated with [Claude Code](https://claude.com/claude-code)