### PR TITLE
Introduce withDaemonClient helper to eliminate connect/disconnect boilerplate

### DIFF
--- a/Sources/PreviewsCLI/ConfigureCommand.swift
+++ b/Sources/PreviewsCLI/ConfigureCommand.swift
@@ -69,15 +69,7 @@ struct ConfigureCommand: AsyncParsableCommand {
 
         try validateTraitValues()
 
-        let client = try await DaemonClient.connect(clientName: "previewsmcp-configure") { client in
-            await client.onNotification(LogMessageNotification.self) { message in
-                if case .string(let text) = message.params.data {
-                    fputs("\(text)\n", stderr)
-                }
-            }
-        }
-
-        do {
+        try await DaemonClient.withDaemonClient(name: "previewsmcp-configure") { client in
             let resolution = try await SessionResolver.resolve(
                 session: session,
                 file: file,
@@ -111,11 +103,6 @@ struct ConfigureCommand: AsyncParsableCommand {
             // changed) to the user.
             let text = response.content.joinedText()
             if !text.isEmpty { fputs("\(text)\n", stderr) }
-
-            await client.disconnect()
-        } catch {
-            await client.disconnect()
-            throw error
         }
     }
 

--- a/Sources/PreviewsCLI/DaemonClient.swift
+++ b/Sources/PreviewsCLI/DaemonClient.swift
@@ -47,6 +47,49 @@ enum DaemonClient {
         return client
     }
 
+    /// Connect, register the default stderr log-forwarder, run `body`, and
+    /// disconnect — regardless of whether the body returns or throws.
+    ///
+    /// Every CLI subcommand that talks to the daemon needs the same three
+    /// things: connect + forward `LogMessageNotification` to stderr +
+    /// disconnect on both success and error paths. Skipping any of these
+    /// is a subtle footgun (notifications registered after `connect()`
+    /// miss handshake-phase messages, a missed `disconnect()` leaks the
+    /// transport). This helper enforces the right shape in one place.
+    ///
+    /// Extra handlers can be registered via `configure`; they run before
+    /// the handshake alongside the default log forwarder.
+    static func withDaemonClient<T>(
+        name: String,
+        configure: ((Client) async -> Void)? = nil,
+        body: (Client) async throws -> T
+    ) async throws -> T {
+        let client = try await connect(clientName: name) { client in
+            await registerStderrLogForwarder(on: client)
+            await configure?(client)
+        }
+        do {
+            let result = try await body(client)
+            await client.disconnect()
+            return result
+        } catch {
+            await client.disconnect()
+            throw error
+        }
+    }
+
+    /// Register the MCP LogMessageNotification → stderr bridge that every
+    /// CLI command shares. Daemon-side progress messages and warnings
+    /// are surfaced as MCP notifications; without this bridge they'd be
+    /// silently dropped on the client.
+    private static func registerStderrLogForwarder(on client: Client) async {
+        await client.onNotification(LogMessageNotification.self) { message in
+            if case .string(let text) = message.params.data {
+                fputs("\(text)\n", stderr)
+            }
+        }
+    }
+
     /// Spawn the daemon as an independent child process. We don't wait for it —
     /// the daemon keeps running after this function returns and after the
     /// parent CLI exits.

--- a/Sources/PreviewsCLI/ElementsCommand.swift
+++ b/Sources/PreviewsCLI/ElementsCommand.swift
@@ -46,15 +46,7 @@ struct ElementsCommand: AsyncParsableCommand {
     }
 
     mutating func run() async throws {
-        let client = try await DaemonClient.connect(clientName: "previewsmcp-elements") { client in
-            await client.onNotification(LogMessageNotification.self) { message in
-                if case .string(let text) = message.params.data {
-                    fputs("\(text)\n", stderr)
-                }
-            }
-        }
-
-        do {
+        try await DaemonClient.withDaemonClient(name: "previewsmcp-elements") { client in
             let resolution = try await SessionResolver.resolve(
                 session: session,
                 file: file,
@@ -86,11 +78,6 @@ struct ElementsCommand: AsyncParsableCommand {
             // parsers don't see a stray `\n`.
             let text = response.content.joinedText()
             if !text.isEmpty { print(text) }
-
-            await client.disconnect()
-        } catch {
-            await client.disconnect()
-            throw error
         }
     }
 }

--- a/Sources/PreviewsCLI/RunCommand.swift
+++ b/Sources/PreviewsCLI/RunCommand.swift
@@ -89,74 +89,60 @@ struct RunCommand: AsyncParsableCommand {
             throw ValidationError(error.localizedDescription)
         }
 
-        // Register the log handler *before* the MCP initialize handshake so
-        // we don't miss notifications emitted during early server startup.
-        let client = try await DaemonClient.connect(clientName: "previewsmcp-run") { client in
-            await client.onNotification(LogMessageNotification.self) { message in
-                if case .string(let text) = message.params.data {
-                    fputs("\(text)\n", stderr)
-                }
+        try await DaemonClient.withDaemonClient(name: "previewsmcp-run") { client in
+            let arguments = buildPreviewStartArguments(fileURL: fileURL)
+
+            let response: (content: [Tool.Content], isError: Bool?)
+            do {
+                response = try await client.callTool(name: "preview_start", arguments: arguments)
+            } catch {
+                fputs("Failed to start preview: \(error)\n", stderr)
+                throw ExitCode(1)
+            }
+
+            if response.isError == true {
+                fputs("Preview start failed: \(response.content.joinedText())\n", stderr)
+                throw ExitCode(1)
+            }
+
+            let text = response.content.joinedText()
+            guard let sessionID = extractSessionID(from: text) else {
+                fputs("Unexpected daemon response (no session ID): \(text)\n", stderr)
+                throw ExitCode(1)
+            }
+
+            if detach {
+                // Scriptable: print session ID to stdout, human line to stderr.
+                print(sessionID)
+                fputs("session \(sessionID) started in daemon\n", stderr)
+                return
+            }
+
+            // Attached: print the daemon's response once for user feedback,
+            // then block until Ctrl+C. On signal, stop the session and
+            // exit cleanly.
+            fputs("\(text)\n", stderr)
+            fputs("Press Ctrl+C to stop the preview.\n", stderr)
+
+            await blockUntilSignal()
+
+            do {
+                _ = try await client.callTool(
+                    name: "preview_stop",
+                    arguments: ["sessionID": .string(sessionID)]
+                )
+            } catch {
+                // Best-effort — the session may still be alive in the daemon.
+                // Surface the session ID so the user can target it with `stop`
+                // or fall back to `kill-daemon` to wipe everything.
+                fputs(
+                    "warning: failed to stop session \(sessionID): \(error)\n"
+                        + "  session may still be running in the daemon; "
+                        + "run `previewsmcp kill-daemon` to clean up.\n",
+                    stderr
+                )
             }
         }
-
-        let arguments = buildPreviewStartArguments(fileURL: fileURL)
-
-        let response: (content: [Tool.Content], isError: Bool?)
-        do {
-            response = try await client.callTool(name: "preview_start", arguments: arguments)
-        } catch {
-            fputs("Failed to start preview: \(error)\n", stderr)
-            await client.disconnect()
-            throw ExitCode(1)
-        }
-
-        if response.isError == true {
-            let text = response.content.joinedText()
-            fputs("Preview start failed: \(text)\n", stderr)
-            await client.disconnect()
-            throw ExitCode(1)
-        }
-
-        let text = response.content.joinedText()
-        guard let sessionID = extractSessionID(from: text) else {
-            fputs("Unexpected daemon response (no session ID): \(text)\n", stderr)
-            await client.disconnect()
-            throw ExitCode(1)
-        }
-
-        if detach {
-            // Scriptable: print session ID to stdout, human line to stderr.
-            print(sessionID)
-            fputs("session \(sessionID) started in daemon\n", stderr)
-            await client.disconnect()
-            return
-        }
-
-        // Attached: print the daemon's response once for user feedback, then
-        // block until Ctrl+C. On signal, stop the session and exit cleanly.
-        fputs("\(text)\n", stderr)
-        fputs("Press Ctrl+C to stop the preview.\n", stderr)
-
-        await blockUntilSignal()
-
-        do {
-            _ = try await client.callTool(
-                name: "preview_stop",
-                arguments: ["sessionID": .string(sessionID)]
-            )
-        } catch {
-            // Best-effort — the session may still be alive in the daemon.
-            // Surface the session ID so the user can target it with `stop`
-            // (once that command ships) or fall back to `kill-daemon` to
-            // wipe everything.
-            fputs(
-                "warning: failed to stop session \(sessionID): \(error)\n"
-                    + "  session may still be running in the daemon; "
-                    + "run `previewsmcp kill-daemon` to clean up.\n",
-                stderr
-            )
-        }
-        await client.disconnect()
     }
 
     // MARK: - Helpers

--- a/Sources/PreviewsCLI/SimulatorsCommand.swift
+++ b/Sources/PreviewsCLI/SimulatorsCommand.swift
@@ -28,15 +28,7 @@ struct SimulatorsCommand: AsyncParsableCommand {
     )
 
     mutating func run() async throws {
-        let client = try await DaemonClient.connect(clientName: "previewsmcp-simulators") { client in
-            await client.onNotification(LogMessageNotification.self) { message in
-                if case .string(let text) = message.params.data {
-                    fputs("\(text)\n", stderr)
-                }
-            }
-        }
-
-        do {
+        try await DaemonClient.withDaemonClient(name: "previewsmcp-simulators") { client in
             let response = try await client.callTool(name: "simulator_list", arguments: [:])
             if response.isError == true {
                 throw DaemonToolError.daemonError(response.content.joinedText())
@@ -47,11 +39,6 @@ struct SimulatorsCommand: AsyncParsableCommand {
             // sentinel "No available simulator devices found." — so
             // always surface the daemon's reply verbatim.
             print(response.content.joinedText())
-
-            await client.disconnect()
-        } catch {
-            await client.disconnect()
-            throw error
         }
     }
 }

--- a/Sources/PreviewsCLI/SnapshotCommand.swift
+++ b/Sources/PreviewsCLI/SnapshotCommand.swift
@@ -117,15 +117,7 @@ struct SnapshotCommand: AsyncParsableCommand {
             }
         }
 
-        let client = try await DaemonClient.connect(clientName: "previewsmcp-snapshot") { client in
-            await client.onNotification(LogMessageNotification.self) { message in
-                if case .string(let text) = message.params.data {
-                    fputs("\(text)\n", stderr)
-                }
-            }
-        }
-
-        do {
+        try await DaemonClient.withDaemonClient(name: "previewsmcp-snapshot") { client in
             let resolution = try await SessionResolver.resolve(
                 session: session,
                 file: file,
@@ -144,10 +136,6 @@ struct SnapshotCommand: AsyncParsableCommand {
                 }
                 try await snapshotEphemeral(file: file, client: client)
             }
-            await client.disconnect()
-        } catch {
-            await client.disconnect()
-            throw error
         }
     }
 

--- a/Sources/PreviewsCLI/StopCommand.swift
+++ b/Sources/PreviewsCLI/StopCommand.swift
@@ -41,24 +41,12 @@ struct StopCommand: AsyncParsableCommand {
             throw ValidationError("--all cannot be combined with --session or --file.")
         }
 
-        let client = try await DaemonClient.connect(clientName: "previewsmcp-stop") { client in
-            await client.onNotification(LogMessageNotification.self) { message in
-                if case .string(let text) = message.params.data {
-                    fputs("\(text)\n", stderr)
-                }
-            }
-        }
-
-        do {
+        try await DaemonClient.withDaemonClient(name: "previewsmcp-stop") { client in
             if all {
                 try await stopAll(client: client)
             } else {
                 try await stopOne(client: client)
             }
-            await client.disconnect()
-        } catch {
-            await client.disconnect()
-            throw error
         }
     }
 

--- a/Sources/PreviewsCLI/SwitchCommand.swift
+++ b/Sources/PreviewsCLI/SwitchCommand.swift
@@ -44,15 +44,7 @@ struct SwitchCommand: AsyncParsableCommand {
             throw ValidationError("Preview index must be non-negative.")
         }
 
-        let client = try await DaemonClient.connect(clientName: "previewsmcp-switch") { client in
-            await client.onNotification(LogMessageNotification.self) { message in
-                if case .string(let text) = message.params.data {
-                    fputs("\(text)\n", stderr)
-                }
-            }
-        }
-
-        do {
+        try await DaemonClient.withDaemonClient(name: "previewsmcp-switch") { client in
             let resolution = try await SessionResolver.resolve(
                 session: session,
                 file: file,
@@ -80,11 +72,6 @@ struct SwitchCommand: AsyncParsableCommand {
 
             let text = response.content.joinedText()
             if !text.isEmpty { fputs("\(text)\n", stderr) }
-
-            await client.disconnect()
-        } catch {
-            await client.disconnect()
-            throw error
         }
     }
 

--- a/Sources/PreviewsCLI/TouchCommand.swift
+++ b/Sources/PreviewsCLI/TouchCommand.swift
@@ -68,15 +68,7 @@ struct TouchCommand: AsyncParsableCommand {
             throw ValidationError("--duration must be positive.")
         }
 
-        let client = try await DaemonClient.connect(clientName: "previewsmcp-touch") { client in
-            await client.onNotification(LogMessageNotification.self) { message in
-                if case .string(let text) = message.params.data {
-                    fputs("\(text)\n", stderr)
-                }
-            }
-        }
-
-        do {
+        try await DaemonClient.withDaemonClient(name: "previewsmcp-touch") { client in
             let resolution = try await SessionResolver.resolve(
                 session: session,
                 file: file,
@@ -113,11 +105,6 @@ struct TouchCommand: AsyncParsableCommand {
 
             let text = response.content.joinedText()
             if !text.isEmpty { fputs("\(text)\n", stderr) }
-
-            await client.disconnect()
-        } catch {
-            await client.disconnect()
-            throw error
         }
     }
 }

--- a/Sources/PreviewsCLI/VariantsCommand.swift
+++ b/Sources/PreviewsCLI/VariantsCommand.swift
@@ -145,16 +145,9 @@ struct VariantsCommand: AsyncParsableCommand {
         try FileManager.default.createDirectory(
             at: outputDirURL, withIntermediateDirectories: true)
 
-        let client = try await DaemonClient.connect(clientName: "previewsmcp-variants") { client in
-            await client.onNotification(LogMessageNotification.self) { message in
-                if case .string(let text) = message.params.data {
-                    fputs("\(text)\n", stderr)
-                }
-            }
-        }
-
-        let exitCode: Int32
-        do {
+        let exitCode: Int32 = try await DaemonClient.withDaemonClient(
+            name: "previewsmcp-variants"
+        ) { client in
             let resolution = try await SessionResolver.resolve(
                 session: session,
                 file: file,
@@ -163,7 +156,7 @@ struct VariantsCommand: AsyncParsableCommand {
 
             switch resolution {
             case .found(let sessionID):
-                exitCode = try await captureVariants(
+                return try await captureVariants(
                     sessionID: sessionID,
                     labels: resolvedVariants.map(\.label),
                     outputDir: outputDirURL,
@@ -176,17 +169,13 @@ struct VariantsCommand: AsyncParsableCommand {
                             + "Pass a file path to create a new ephemeral session."
                     )
                 }
-                exitCode = try await captureEphemeral(
+                return try await captureEphemeral(
                     file: file,
                     labels: resolvedVariants.map(\.label),
                     outputDir: outputDirURL,
                     client: client
                 )
             }
-            await client.disconnect()
-        } catch {
-            await client.disconnect()
-            throw error
         }
 
         if exitCode != 0 { throw ExitCode(exitCode) }


### PR DESCRIPTION
## Summary
Every daemon-client command repeated the same 15-line connect/register/disconnect dance. Three parts of that dance are load-bearing:
- Log forwarder MUST be registered *before* `client.connect()` or handshake-phase notifications are dropped (footgun we hit early in the stack).
- `disconnect()` MUST run on both success and error paths or the transport leaks.
- The stderr log-forwarder is identical across all commands.

This PR adds `DaemonClient.withDaemonClient(name:configure:body:)` that enforces the shape once:
- Connects with the clientName.
- Registers the stderr log-forwarder by default.
- Disconnects on both success and error.
- Extra notification handlers can still be registered via `configure`.

Refactored all 9 daemon-client commands: `Run`, `Snapshot`, `Configure`, `Switch`, `Elements`, `Touch`, `Simulators`, `Stop`, `Variants`. Net: +102 / -173 lines. Each command loses ~12 lines of boilerplate and gains safety — the disconnect-on-every-path invariant is now a property of the helper, not something each command has to remember.

## Test plan
- [x] `swift build`
- [x] All 59 daemon-client tests across 9 suites pass (~3m)

🤖 Generated with [Claude Code](https://claude.com/claude-code)