### PR TITLE
Audit MCP handlers for silent success on missing sessions

### DIFF
--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -820,7 +820,19 @@ private func handlePreviewSnapshot(params: CallTool.Parameters) async throws -> 
         ])
     }
 
-    // macOS path
+    // macOS path. Verify existence upfront so a typo'd sessionID
+    // surfaces as a clean "No session found" rather than the misleading
+    // "capture failed" from `window(for:)` returning nil.
+    let isMacOSSession = await MainActor.run {
+        App.host.allSessions[sessionID] != nil
+    }
+    guard isMacOSSession else {
+        return CallTool.Result(
+            content: [.text("No session found for \(sessionID).")],
+            isError: true
+        )
+    }
+
     try await Task.sleep(for: .milliseconds(300))
 
     let format: Snapshot.ImageFormat = usePNG ? .png : .jpeg(quality: quality)

--- a/Tests/MCPIntegrationTests/MacOSMCPTests.swift
+++ b/Tests/MCPIntegrationTests/MacOSMCPTests.swift
@@ -194,6 +194,23 @@ struct MacOSMCPTests {
             fakeStopText.contains("No session found"),
             "Should surface a 'No session found' message: \(fakeStopText)"
         )
+
+        // --- preview_snapshot nonexistent session ---
+        // Before this fix, a typo'd UUID fell through to `window(for:)`
+        // which returned nil and threw `SnapshotError.captureFailed` —
+        // a misleading message that suggested a capture failure rather
+        // than a missing session. Must now be a clean isError with a
+        // clear message.
+        let (fakeSnap, fakeSnapIsError) = try await server.callTool(
+            name: "preview_snapshot",
+            arguments: ["sessionID": .string("00000000-0000-0000-0000-000000000000")]
+        )
+        #expect(fakeSnapIsError == true, "Snapshotting a nonexistent session must return isError")
+        let fakeSnapText = MCPTestServer.extractText(from: fakeSnap)
+        #expect(
+            fakeSnapText.contains("No session found"),
+            "Should surface a 'No session found' message: \(fakeSnapText)"
+        )
     }
 
     // MARK: - preview_variants


### PR DESCRIPTION
## Summary
Follow-up audit to PR #108's fix for `handlePreviewStop`. Walked every MCP handler that accepts a sessionID to find others that would silently succeed (or fail with a misleading error) for an unknown UUID.

**Findings:**
- `preview_stop` — already fixed in #108
- `preview_elements`, `preview_touch` — iOS-only, already guard with `iosState.getSession` + isError
- `preview_configure`, `preview_variants`, `preview_switch` — already guard both branches with explicit isError
- `preview_snapshot` — **had the hole**. macOS path threw `SnapshotError.captureFailed` from `window(for:)` on unknown sessionIDs, surfacing as a misleading "capture failed" error instead of "No session found"

## Fix
Mirror `handlePreviewStop`: verify `App.host.allSessions[sessionID] != nil` upfront, return `isError: true` with "No session found for <id>." if missing.

Added an MCP-level regression test alongside the existing `preview_stop` nonexistent assertion so both invariants are pinned.

## Test plan
- [x] `swift build`
- [x] `swift test --filter MacOSMCPTests` (3 tests, all green, ~46s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)