### PR TITLE
Share --session/--file flags via @OptionGroup; drop dead PreviewHost.Mode

### DIFF
--- a/Sources/PreviewsCLI/ConfigureCommand.swift
+++ b/Sources/PreviewsCLI/ConfigureCommand.swift
@@ -34,11 +34,7 @@ struct ConfigureCommand: AsyncParsableCommand {
             """
     )
 
-    @Option(name: .long, help: "Target a specific running session by UUID")
-    var session: String?
-
-    @Option(name: .long, help: "Resolve session by source file path")
-    var file: String?
+    @OptionGroup var target: SessionTargetingOptions
 
     @Option(name: .long, help: "Color scheme: 'light' or 'dark' (empty to clear)")
     var colorScheme: String?
@@ -71,8 +67,8 @@ struct ConfigureCommand: AsyncParsableCommand {
 
         try await DaemonClient.withDaemonClient(name: "previewsmcp-configure") { client in
             let resolution = try await SessionResolver.resolve(
-                session: session,
-                file: file,
+                session: target.session,
+                file: target.file,
                 client: client
             )
 

--- a/Sources/PreviewsCLI/ElementsCommand.swift
+++ b/Sources/PreviewsCLI/ElementsCommand.swift
@@ -27,11 +27,7 @@ struct ElementsCommand: AsyncParsableCommand {
             """
     )
 
-    @Option(name: .long, help: "Target a specific running session by UUID")
-    var session: String?
-
-    @Option(name: .long, help: "Resolve session by source file path")
-    var file: String?
+    @OptionGroup var target: SessionTargetingOptions
 
     @Option(
         name: .long,
@@ -48,8 +44,8 @@ struct ElementsCommand: AsyncParsableCommand {
     mutating func run() async throws {
         try await DaemonClient.withDaemonClient(name: "previewsmcp-elements") { client in
             let resolution = try await SessionResolver.resolve(
-                session: session,
-                file: file,
+                session: target.session,
+                file: target.file,
                 client: client
             )
 

--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -56,17 +56,15 @@ struct PreviewsMCPApp {
             return
         }
 
-        // Commands needing UI: start NSApplication
+        // `serve` is the only command that runs AppKit in-process — every
+        // other subcommand is now a daemon client.
         let app = NSApplication.shared
-
-        // `serve` is the only command that runs AppKit in-process.
-        let host = PreviewHost(mode: .serve)
+        let host = PreviewHost()
         App.host = host
         app.delegate = host
 
-        if host.headless {
-            app.setActivationPolicy(.accessory)
-        }
+        // Always headless: no Dock icon, windows positioned off-screen.
+        app.setActivationPolicy(.accessory)
 
         host.onLaunch = {
             Task { @MainActor in

--- a/Sources/PreviewsCLI/SessionTargetingOptions.swift
+++ b/Sources/PreviewsCLI/SessionTargetingOptions.swift
@@ -1,0 +1,17 @@
+import ArgumentParser
+
+/// Shared `--session` / `--file` flags for commands that operate on a
+/// running preview session (`configure`, `switch`, `elements`, `touch`,
+/// `stop`, `variants`).
+///
+/// Resolution rules (enforced by `SessionResolver`):
+///   * `--session <uuid>` wins outright.
+///   * `--file <path>` selects the sole session whose source file matches.
+///   * Neither flag: use the sole running session when unambiguous.
+struct SessionTargetingOptions: ParsableArguments {
+    @Option(name: .long, help: "Target a specific running session by UUID")
+    var session: String?
+
+    @Option(name: .long, help: "Resolve session by source file path")
+    var file: String?
+}

--- a/Sources/PreviewsCLI/StopCommand.swift
+++ b/Sources/PreviewsCLI/StopCommand.swift
@@ -27,17 +27,13 @@ struct StopCommand: AsyncParsableCommand {
             """
     )
 
-    @Option(name: .long, help: "Target a specific running session by UUID")
-    var session: String?
-
-    @Option(name: .long, help: "Resolve session by source file path")
-    var file: String?
+    @OptionGroup var target: SessionTargetingOptions
 
     @Flag(name: .long, help: "Stop every active session in the daemon")
     var all: Bool = false
 
     mutating func run() async throws {
-        if all, session != nil || file != nil {
+        if all, target.session != nil || target.file != nil {
             throw ValidationError("--all cannot be combined with --session or --file.")
         }
 
@@ -52,8 +48,8 @@ struct StopCommand: AsyncParsableCommand {
 
     private func stopOne(client: Client) async throws {
         let resolution = try await SessionResolver.resolve(
-            session: session,
-            file: file,
+            session: target.session,
+            file: target.file,
             client: client
         )
 

--- a/Sources/PreviewsCLI/SwitchCommand.swift
+++ b/Sources/PreviewsCLI/SwitchCommand.swift
@@ -33,11 +33,7 @@ struct SwitchCommand: AsyncParsableCommand {
     @Argument(help: "0-based index of the #Preview block to render")
     var previewIndex: Int
 
-    @Option(name: .long, help: "Target a specific running session by UUID")
-    var session: String?
-
-    @Option(name: .long, help: "Resolve session by source file path")
-    var file: String?
+    @OptionGroup var target: SessionTargetingOptions
 
     mutating func run() async throws {
         guard previewIndex >= 0 else {
@@ -46,8 +42,8 @@ struct SwitchCommand: AsyncParsableCommand {
 
         try await DaemonClient.withDaemonClient(name: "previewsmcp-switch") { client in
             let resolution = try await SessionResolver.resolve(
-                session: session,
-                file: file,
+                session: target.session,
+                file: target.file,
                 client: client
             )
 

--- a/Sources/PreviewsCLI/TouchCommand.swift
+++ b/Sources/PreviewsCLI/TouchCommand.swift
@@ -44,11 +44,7 @@ struct TouchCommand: AsyncParsableCommand {
     @Option(name: .long, help: "Swipe duration in seconds (default: 0.3)")
     var duration: Double?
 
-    @Option(name: .long, help: "Target a specific running session by UUID")
-    var session: String?
-
-    @Option(name: .long, help: "Resolve session by source file path")
-    var file: String?
+    @OptionGroup var target: SessionTargetingOptions
 
     mutating func run() async throws {
         // Validate swipe endpoints before opening a daemon connection.
@@ -70,8 +66,8 @@ struct TouchCommand: AsyncParsableCommand {
 
         try await DaemonClient.withDaemonClient(name: "previewsmcp-touch") { client in
             let resolution = try await SessionResolver.resolve(
-                session: session,
-                file: file,
+                session: target.session,
+                file: target.file,
                 client: client
             )
 

--- a/Sources/PreviewsMacOS/HostApp.swift
+++ b/Sources/PreviewsMacOS/HostApp.swift
@@ -3,20 +3,15 @@ import PreviewsCore
 import SwiftUI
 
 /// Manages preview windows. Loads compiled dylibs and displays views in NSWindows.
+///
+/// Only one runtime shape remains since the CLI/MCP parity migration:
+/// `serve` is the sole subcommand that ever constructs a PreviewHost, and
+/// it always wants headless windows plus a daemon that stays alive after
+/// the last window closes. Earlier `.interactive` and `.snapshot` modes
+/// were removed once every non-`serve` CLI command moved to the daemon
+/// client path.
 @MainActor
 public class PreviewHost: NSObject, NSApplicationDelegate {
-
-    /// How the host app presents itself.
-    public enum Mode: Sendable {
-        /// Interactive window with Dock icon (run command).
-        case interactive
-        /// Headless background service that stays alive (MCP serve).
-        case serve
-        /// Headless one-shot capture (snapshot command).
-        case snapshot
-    }
-
-    public let mode: Mode
 
     private var windows: [String: NSWindow] = [:]
     private var loaders: [String: DylibLoader] = [:]
@@ -33,16 +28,12 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     /// Callback invoked after NSApplication finishes launching.
     public var onLaunch: (@MainActor () -> Void)?
 
-    public init(mode: Mode = .interactive) {
-        self.mode = mode
+    public override init() {
         super.init()
     }
 
-    /// Whether windows are positioned off-screen with no Dock icon.
-    public var headless: Bool { mode != .interactive }
-
-    /// Whether the app stays alive after all windows close.
-    public var keepAliveWithoutWindows: Bool { mode == .serve }
+    /// Windows are positioned off-screen with no Dock icon.
+    public let headless: Bool = true
 
     private var fileWatchers: [String: FileWatcher] = [:]
     private var retainedFileWatchers: [FileWatcher] = []
@@ -62,7 +53,9 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     }
 
     public func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        return !keepAliveWithoutWindows
+        // The daemon must stay alive after all preview windows close so
+        // it can accept new session requests without a cold restart.
+        return false
     }
 
     /// Load a dylib and display its preview view in a window.

--- a/Tests/PreviewsMacOSTests/PreviewHostTests.swift
+++ b/Tests/PreviewsMacOSTests/PreviewHostTests.swift
@@ -19,7 +19,7 @@ struct PreviewHostTests {
     /// should go red.
     @Test("retainFileWatcher keeps a watcher alive past the creating scope")
     func retainFileWatcherKeepsWatcherAlive() async throws {
-        let host = PreviewHost(mode: .interactive)
+        let host = PreviewHost()
 
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("preview-host-test-\(UUID().uuidString)")


### PR DESCRIPTION
## Summary
Two cleanups deferred on PR #113.

### `SessionTargetingOptions`
- Shared `@OptionGroup` with `--session <uuid>` and `--file <path>`.
- Adopted by **configure**, **switch**, **elements**, **touch**, **stop** — 5 commands whose session-resolution flags were literally duplicated with identical help text.
- `Variants` and `Snapshot` keep their positional `file` argument (doubles as source-for-ephemeral-session) plus their own `--session` Option; the OptionGroup's `--file` Option would collide with the positional.

### `PreviewHost.Mode` cleanup
- `.interactive` and `.snapshot` became unreachable after the variants migration in #109; only `.serve` was ever constructed.
- Delete the `Mode` enum entirely. `PreviewHost` is now a zero-argument init.
- `headless` collapses to a constant `true`; `keepAliveWithoutWindows` collapses into `applicationShouldTerminateAfterLastWindowClosed` returning `false` unconditionally.
- Updated the one remaining test call site.

## Test plan
- [x] `swift build`
- [x] `swift test --filter 'ElementsCommandTests|SwitchCommandTests|ConfigureCommandTests|TouchCommandTests|StopCommandTests|PreviewHostTests'` — 28 tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)