### PR TITLE
Close variants test gaps: iOS session + exit-code unit tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -79,6 +79,10 @@ let package = Package(
             dependencies: []
         ),
         .testTarget(
+            name: "PreviewsCLITests",
+            dependencies: ["PreviewsCLI"]
+        ),
+        .testTarget(
             name: "MCPIntegrationTests",
             dependencies: [
                 .product(name: "MCP", package: "swift-sdk")

--- a/Sources/PreviewsCLI/VariantsCommand.swift
+++ b/Sources/PreviewsCLI/VariantsCommand.swift
@@ -329,16 +329,26 @@ struct VariantsCommand: AsyncParsableCommand {
         return 0.85
     }
 
+    /// Map (success, fail) counts to the documented exit codes.
+    ///   * 0 — all variants captured
+    ///   * 1 — partial failure (at least one success, at least one fail)
+    ///   * 2 — total failure (every variant failed)
+    /// Pure + `static` so it can be unit-tested without a daemon round-trip.
+    static func exitCode(successCount: Int, failCount: Int) -> Int32 {
+        if failCount == 0 { return 0 }
+        return failCount == (successCount + failCount) ? 2 : 1
+    }
+
     private func summarize(successCount: Int, failCount: Int) -> Int32 {
         let total = successCount + failCount
         if failCount == 0 {
             fputs("Captured \(successCount)/\(total) variants.\n", stderr)
-            return 0
+        } else {
+            fputs(
+                "Captured \(successCount)/\(total) variants (\(failCount) failed). "
+                    + "See stderr for details.\n", stderr)
         }
-        fputs(
-            "Captured \(successCount)/\(total) variants (\(failCount) failed). "
-                + "See stderr for details.\n", stderr)
-        return failCount == total ? 2 : 1
+        return Self.exitCode(successCount: successCount, failCount: failCount)
     }
 
     /// Match the daemon's success preamble: exactly `[N] <label>:` with

--- a/Tests/CLIIntegrationTests/VariantsCommandTests.swift
+++ b/Tests/CLIIntegrationTests/VariantsCommandTests.swift
@@ -120,6 +120,60 @@ struct VariantsCommandTests {
         }
     }
 
+    /// Happy path against an iOS simulator session. The macOS tests exercise
+    /// the `App.host.session(for:)` + AppKit render path; this one exercises
+    /// `iosState.getSession` + simulator screenshots, which is a separate
+    /// branch in `handlePreviewVariants`. Gated on simulator availability.
+    @Test(
+        "Captures multiple presets against an iOS simulator session",
+        .timeLimit(.minutes(5))
+    )
+    func capturesIOSVariants() async throws {
+        try await DaemonTestLock.run {
+            let simResult = try await CLIRunner.runExternal(
+                "/usr/bin/xcrun",
+                arguments: ["simctl", "list", "devices", "available"]
+            )
+            guard simResult.exitCode == 0, simResult.stdout.contains("iPhone") else {
+                print("No available iOS simulator — skipping iOS variants test")
+                return
+            }
+
+            try await Self.cleanSlate()
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            let file = CLIRunner.spmExampleRoot
+                .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+            let configPath = CLIRunner.repoRoot
+                .appendingPathComponent("examples/.previewsmcp.json").path
+
+            let result = try await CLIRunner.run(
+                "variants",
+                arguments: [
+                    file,
+                    "--variant", "light",
+                    "--variant", "dark",
+                    "-o", tempDir.path,
+                    "--platform", "ios",
+                    "--project", CLIRunner.spmExampleRoot.path,
+                    "--config", configPath,
+                ])
+
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+            #expect(
+                result.stderr.contains("Captured 2/2 variants"),
+                "stderr: \(result.stderr)"
+            )
+            try CLIRunner.assertValidJPEG(
+                at: tempDir.appendingPathComponent("light.jpg").path)
+            try CLIRunner.assertValidJPEG(
+                at: tempDir.appendingPathComponent("dark.jpg").path)
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
+    }
+
     /// When a session is already running for the target file, `variants`
     /// should reuse it rather than spinning up an ephemeral one. Observable
     /// proof: after the variants run, the session is still alive (stop

--- a/Tests/PreviewsCLITests/VariantsExitCodeTests.swift
+++ b/Tests/PreviewsCLITests/VariantsExitCodeTests.swift
@@ -1,0 +1,38 @@
+import Testing
+
+@testable import PreviewsCLI
+
+/// Unit tests for `VariantsCommand.exitCode(successCount:failCount:)`.
+/// The doc comment commits to three branches:
+///   * 0 — all variants captured
+///   * 1 — partial failure (≥1 success, ≥1 fail)
+///   * 2 — total failure (every variant failed)
+/// Forcing deterministic per-variant failures through the real daemon
+/// is expensive, so pin the mapping directly.
+@Suite("variants exitCode mapping")
+struct VariantsExitCodeTests {
+
+    @Test("all success → 0")
+    func allSuccess() {
+        #expect(VariantsCommand.exitCode(successCount: 3, failCount: 0) == 0)
+    }
+
+    @Test("partial failure → 1")
+    func partialFailure() {
+        #expect(VariantsCommand.exitCode(successCount: 2, failCount: 1) == 1)
+        #expect(VariantsCommand.exitCode(successCount: 1, failCount: 2) == 1)
+    }
+
+    @Test("total failure → 2")
+    func totalFailure() {
+        #expect(VariantsCommand.exitCode(successCount: 0, failCount: 3) == 2)
+        #expect(VariantsCommand.exitCode(successCount: 0, failCount: 1) == 2)
+    }
+
+    /// Defensive: zero/zero is not a real runtime state (local validation
+    /// rejects zero variants), but the pure function should still behave.
+    @Test("zero variants → 0")
+    func zeroVariants() {
+        #expect(VariantsCommand.exitCode(successCount: 0, failCount: 0) == 0)
+    }
+}


### PR DESCRIPTION
## Summary
Two gaps called out on PR #113's deferred list.

### iOS variants
All existing happy-path variants tests run against a macOS session (`App.host.session(for:)` + AppKit render path). Added a simulator-gated test that exercises the iOS branch of `handlePreviewVariants` — `iosState.getSession` + `iosSession.screenshot` + trait-restore loop. Passes in ~17s on machines with an available simulator.

### exitCode unit tests
`VariantsCommand`'s documented exit-code semantics (0 all success, 1 partial, 2 total failure) were untested because forcing deterministic per-variant daemon failures is expensive to construct. Extracted the pure mapping into a static `VariantsCommand.exitCode(successCount:failCount:)` so it can be unit-tested without a daemon round-trip.

Added a new `PreviewsCLITests` target that `@testable import`s `PreviewsCLI` (SPM supports this on executable targets) and pins all three branches plus a defensive 0/0 case.

## Test plan
- [x] `swift build`
- [x] `swift test --filter 'VariantsExitCodeTests'` — 4 unit tests green in ~1ms
- [x] `swift test --filter 'VariantsCommandTests/capturesIOSVariants'` — iOS round-trip green in ~17s

🤖 Generated with [Claude Code](https://claude.com/claude-code)