### PR TITLE
Skip variants trait-restore when session was explicitly stopped

### DIFF
--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -1142,6 +1142,16 @@ private func resolveVariant(_ value: Value) throws -> PreviewTraits.Variant {
     return try PreviewTraits.parseVariantString(str)
 }
 
+/// Capture a screenshot under each of N trait configurations.
+///
+/// **Concurrent-modification caveat:** `PreviewSession` is an actor so
+/// its state transitions are serialized, but a second client calling
+/// `preview_configure` or `preview_switch` against the same session
+/// while variants is mid-loop will interleave its trait changes into
+/// our capture stream — subsequent variant screenshots would reflect
+/// the other client's mutation. The daemon does not hold a per-session
+/// lock across tool calls. Callers that want deterministic variants
+/// should ensure they own the session for the duration.
 private func handlePreviewVariants(params: CallTool.Parameters, server: Server) async throws -> CallTool.Result {
     let sessionID: String
     let variantValues: [Value]
@@ -1196,9 +1206,15 @@ private func handlePreviewVariants(params: CallTool.Parameters, server: Server) 
             }
         }
 
-        // Restore original traits if they changed
+        // Restore original traits if they changed — but only if the
+        // session is still registered. A concurrent `preview_stop`
+        // during the capture loop will remove the session from
+        // iosState; attempting to setTraits on the stopped simulator
+        // produces a misleading "failed to restore" warning when the
+        // user explicitly asked for the stop.
+        let stillRegistered = await iosState.getSession(sessionID) != nil
         let currentTraits = await iosSession.currentTraits
-        if savedTraits != currentTraits {
+        if stillRegistered, savedTraits != currentTraits {
             do {
                 try await iosSession.setTraits(savedTraits)
             } catch {
@@ -1250,9 +1266,17 @@ private func handlePreviewVariants(params: CallTool.Parameters, server: Server) 
         }
     }
 
-    // Restore original traits if they changed
+    // Restore original traits if they changed — but only if the
+    // session is still registered. A concurrent `preview_stop` during
+    // the capture loop would remove the session from App.host;
+    // `loadPreview` would then throw and the user would see a
+    // misleading "failed to restore" warning when they explicitly
+    // asked for the stop.
+    let stillRegistered = await MainActor.run {
+        App.host.allSessions[sessionID] != nil
+    }
     let currentTraits = await session.currentTraits
-    if savedTraits != currentTraits {
+    if stillRegistered, savedTraits != currentTraits {
         do {
             let restoreResult = try await session.setTraits(savedTraits)
             try await MainActor.run {


### PR DESCRIPTION
## Summary
Wave 1-C from the deferred-items list on #113: race-condition audit across every MCP handler.

### Audit findings
**No new bugs found.** `PreviewSession` is an actor so within-session state transitions are serialized, and the `preview_snapshot` hole for missing sessions is already fixed in #112.

### One defensive improvement landed
When a concurrent `preview_stop` fires mid-variants-loop, the trait-restore-at-end block would fire against a now-stopped session, producing a misleading *"Warning: failed to restore original traits"* message for a user who explicitly asked for the stop. Skip the restore when the session is no longer in the registry (`iosState` for iOS, `App.host.allSessions` for macOS). No user-visible change for the happy path; the spurious warning goes away for the concurrent-stop case.

### Documented caveat
Added a doc comment on `handlePreviewVariants` spelling out the remaining concurrent-modification limitation: a second client mutating the same session via `preview_configure` / `preview_switch` while variants is mid-loop will interleave its trait change into our capture stream. The daemon intentionally does not hold a per-session lock across tool calls (more invasive architectural change); callers that want deterministic variants should own the session for the duration.

## Test plan
- [x] `swift build`
- [x] `swift test --filter VariantsCommandTests` — 14 integration tests pass unchanged (~60s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)