### PR TITLE
Extract PreviewsEngine library target from PreviewsCLI monolith

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
         ),
         .target(
             name: "PreviewsEngine",
-            dependencies: ["PreviewsCore", "PreviewsMacOS", "PreviewsIOS"]
+            dependencies: ["PreviewsCore", "PreviewsIOS"]
         ),
         .executableTarget(
             name: "PreviewsCLI",

--- a/Package.swift
+++ b/Package.swift
@@ -43,12 +43,17 @@ let package = Package(
             dependencies: ["PreviewsCore", "SimulatorBridge"],
             resources: [.copy("AppIcon.png")]
         ),
+        .target(
+            name: "PreviewsEngine",
+            dependencies: ["PreviewsCore", "PreviewsMacOS", "PreviewsIOS"]
+        ),
         .executableTarget(
             name: "PreviewsCLI",
             dependencies: [
                 "PreviewsCore",
                 "PreviewsMacOS",
                 "PreviewsIOS",
+                "PreviewsEngine",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "MCP", package: "swift-sdk"),
             ],

--- a/Sources/PreviewsCLI/DaemonListener.swift
+++ b/Sources/PreviewsCLI/DaemonListener.swift
@@ -2,6 +2,7 @@ import Foundation
 import MCP
 import Network
 import PreviewsCore
+import PreviewsEngine
 import PreviewsMacOS
 
 /// Runs the MCP server daemon on a Unix domain socket.
@@ -24,11 +25,13 @@ enum DaemonListener {
         // already verified via DaemonProbe that no live daemon is listening.
         try? FileManager.default.removeItem(at: DaemonPaths.socket)
 
-        // Build the shared compiler once. Each accepted connection creates its
-        // own MCP.Server but reuses this compiler (and the module-level
-        // IOSState / ConfigCache), avoiding the ~seconds of per-connection
-        // xcrun / SDK resolution cost.
+        // Build shared resources once. Each accepted connection creates its
+        // own MCP.Server but reuses these instances, avoiding per-connection
+        // xcrun / SDK resolution cost and ensuring sessions persist across
+        // CLI invocations.
         let sharedCompiler = try await Compiler()
+        let iosManager = IOSSessionManager()
+        let configCache = ConfigCache()
 
         let params = NWParameters.tcp
         params.requiredLocalEndpoint = NWEndpoint.unix(path: DaemonPaths.socket.path)
@@ -38,7 +41,10 @@ enum DaemonListener {
 
         listener.newConnectionHandler = { connection in
             Task {
-                await handleConnection(connection, compiler: sharedCompiler, host: host)
+                await handleConnection(
+                    connection, compiler: sharedCompiler,
+                    host: host, iosManager: iosManager, configCache: configCache
+                )
             }
         }
 
@@ -70,11 +76,15 @@ enum DaemonListener {
     /// Handle one client connection. Creates a per-connection MCP Server
     /// sharing the given compiler and module-level state with other connections.
     private static func handleConnection(
-        _ connection: NWConnection, compiler: Compiler, host: PreviewHost
+        _ connection: NWConnection, compiler: Compiler,
+        host: PreviewHost, iosManager: IOSSessionManager, configCache: ConfigCache
     ) async {
         do {
             let transport = NetworkTransport(connection: connection)
-            let (server, _) = try await configureMCPServer(host: host, sharedCompiler: compiler)
+            let (server, _) = try await configureMCPServer(
+                host: host, iosManager: iosManager,
+                configCache: configCache, sharedCompiler: compiler
+            )
             try await server.start(transport: transport)
             // `start` returns when the transport closes (client disconnected).
         } catch {

--- a/Sources/PreviewsCLI/DaemonListener.swift
+++ b/Sources/PreviewsCLI/DaemonListener.swift
@@ -8,9 +8,9 @@ import PreviewsMacOS
 /// Runs the MCP server daemon on a Unix domain socket.
 ///
 /// Accepts multiple concurrent client connections. Each connection gets its own
-/// `MCP.Server` instance, but all connections share the module-level actors in
-/// `MCPServer.swift` (`IOSState`, `ConfigCache`) and a single `Compiler` built
-/// at daemon startup — so preview sessions persist across CLI invocations and
+/// `MCP.Server` instance, but all connections share a single
+/// `IOSSessionManager`, `ConfigCache`, and `Compiler` created at daemon
+/// startup — so preview sessions persist across CLI invocations and
 /// simultaneous clients see consistent state.
 enum DaemonListener {
 

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -1537,5 +1537,3 @@ private func extractArray(_ key: String, from params: CallTool.Parameters) throw
     guard case .array(let arr) = value else { throw ParamError.wrongType(key: key, expected: "an array") }
     return arr
 }
-
-/// Remove stale previewsmcp temp directories older than 24 hours.

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MCP
 import PreviewsCore
+import PreviewsEngine
 import PreviewsIOS
 import PreviewsMacOS
 import os
@@ -20,79 +21,12 @@ private enum ToolName: String {
     case sessionList = "session_list"
 }
 
-/// Tracks active iOS preview sessions and lazily creates shared iOS resources.
-private actor IOSState {
-    let simulatorManager = SimulatorManager()
-    private var compiler: Compiler?
-    private var hostBuilder: IOSHostBuilder?
-    private var sessions: [String: IOSPreviewSession] = [:]
-    private var fileWatchers: [String: FileWatcher] = [:]
-
-    func getCompiler() async throws -> Compiler {
-        if let c = compiler { return c }
-        let c = try await Compiler(platform: .iOS)
-        compiler = c
-        return c
-    }
-
-    func getHostBuilder() async throws -> IOSHostBuilder {
-        if let b = hostBuilder { return b }
-        let b = try await IOSHostBuilder()
-        hostBuilder = b
-        return b
-    }
-
-    func addSession(_ session: IOSPreviewSession) {
-        sessions[session.id] = session
-    }
-
-    func getSession(_ id: String) -> IOSPreviewSession? {
-        sessions[id]
-    }
-
-    func removeSession(_ id: String) {
-        sessions.removeValue(forKey: id)
-        fileWatchers[id]?.stop()
-        fileWatchers.removeValue(forKey: id)
-    }
-
-    func setFileWatcher(_ id: String, _ watcher: FileWatcher) {
-        fileWatchers[id] = watcher
-    }
-
-    func allSessionIDs() -> [String] {
-        Array(sessions.keys)
-    }
-
-    /// Pairs of (sessionID, sourceFile) for every active iOS session.
-    /// Used by the `session_list` MCP tool for session discovery.
-    func allSessionsInfo() -> [(id: String, sourceFile: URL)] {
-        sessions.map { ($0.key, $0.value.sourceFile) }
-    }
-}
-
-private let iosState = IOSState()
-private let configCache = ConfigCache()
-
-/// The macOS preview host, injected by `configureMCPServer(host:)`.
-/// Replaces the previous cross-file `App.host` global. File-private
-/// so only MCPServer.swift handler functions can access it. Set once
-/// per daemon lifetime before any tool calls can arrive.
+/// File-private references to the shared engine-layer instances.
+/// Set once per daemon lifetime by `configureMCPServer(host:iosManager:configCache:)`.
+/// All handler functions reference these instead of globals.
 @MainActor private var host: PreviewHost!
-
-private actor ConfigCache {
-    private var cache: [String: ProjectConfigLoader.Result?] = [:]
-
-    func load(for fileURL: URL) -> ProjectConfigLoader.Result? {
-        let dir = fileURL.deletingLastPathComponent().standardizedFileURL.path
-        if let cached = cache[dir] {
-            return cached
-        }
-        let result = ProjectConfigLoader.find(from: fileURL.deletingLastPathComponent())
-        cache[dir] = result
-        return result
-    }
-}
+nonisolated(unsafe) private var iosState: IOSSessionManager!
+nonisolated(unsafe) private var configCache: ConfigCache!
 
 /// MCP progress reporter that sends progress notifications and log messages to the client.
 final class MCPProgressReporter: ProgressReporter, @unchecked Sendable {
@@ -147,12 +81,18 @@ private func mcpReporter(
 ///   connection gets its own `Server` but they all share one compiler). When
 ///   nil, a fresh compiler is built — appropriate for single-connection modes
 ///   like stdio.
-func configureMCPServer(host previewHost: PreviewHost, sharedCompiler: Compiler? = nil) async throws -> (Server, Compiler) {
+func configureMCPServer(
+    host previewHost: PreviewHost,
+    iosManager: IOSSessionManager,
+    configCache cache: ConfigCache,
+    sharedCompiler: Compiler? = nil
+) async throws -> (Server, Compiler) {
     await MainActor.run {
         if host == nil { host = previewHost }
     }
+    if iosState == nil { iosState = iosManager }
+    if configCache == nil { configCache = cache }
 
-    // Clean up stale temp directories from previous sessions (older than 24 hours)
     cleanupStaleTempDirs()
 
     let compiler: Compiler
@@ -691,14 +631,14 @@ private func handleIOSPreviewStart(
     let deviceUDID: String
     let providedUDID = extractOptionalString("deviceUDID", from: params) ?? config?.device
     do {
-        deviceUDID = try await resolveDeviceUDID(provided: providedUDID, using: iosState.simulatorManager)
+        deviceUDID = try await resolveDeviceUDID(provided: providedUDID, using: await iosState.simulatorManager)
     } catch {
         return CallTool.Result(content: [.text(error.localizedDescription)], isError: true)
     }
 
     let iosCompiler = try await iosState.getCompiler()
     let hostBuilder = try await iosState.getHostBuilder()
-    let simulatorManager = iosState.simulatorManager
+    let simulatorManager = await iosState.simulatorManager
 
     let headless = extractOptionalBool("headless", from: params) ?? true
 
@@ -1048,7 +988,7 @@ private func detectBuildContext(
 }
 
 private func handleSimulatorList() async throws -> CallTool.Result {
-    let manager = iosState.simulatorManager
+    let manager = await iosState.simulatorManager
     let devices = try await manager.listDevices()
     let available = devices.filter { $0.isAvailable }
 
@@ -1177,16 +1117,6 @@ private func clearedTraitFields(
         }
     }
     return cleared
-}
-
-private func traitsSummary(_ traits: PreviewTraits) -> String {
-    var parts: [String] = []
-    if let cs = traits.colorScheme { parts.append("colorScheme=\(cs)") }
-    if let dts = traits.dynamicTypeSize { parts.append("dynamicTypeSize=\(dts)") }
-    if let loc = traits.locale { parts.append("locale=\(loc)") }
-    if let ld = traits.layoutDirection { parts.append("layoutDirection=\(ld)") }
-    if let lw = traits.legibilityWeight { parts.append("legibilityWeight=\(lw)") }
-    return parts.joined(separator: ", ")
 }
 
 private func handlePreviewConfigure(params: CallTool.Parameters, server: Server) async throws -> CallTool.Result {
@@ -1545,15 +1475,6 @@ private func handlePreviewSwitch(params: CallTool.Parameters, server: Server) as
     )
 }
 
-private func formatPreviewList(previews: [PreviewInfo], activeIndex: Int) -> String {
-    var lines: [String] = ["Available previews:"]
-    for preview in previews {
-        let name = preview.name ?? "Preview"
-        let marker = preview.index == activeIndex ? " <- active" : ""
-        lines.append("  [\(preview.index)] \(name) (line \(preview.line)): \(preview.snippet)\(marker)")
-    }
-    return lines.joined(separator: "\n")
-}
 
 // MARK: - Parameter Extraction Helpers
 
@@ -1618,20 +1539,3 @@ private func extractArray(_ key: String, from params: CallTool.Parameters) throw
 }
 
 /// Remove stale previewsmcp temp directories older than 24 hours.
-private func cleanupStaleTempDirs() {
-    let tempBase = FileManager.default.temporaryDirectory.appendingPathComponent("previewsmcp")
-    guard
-        let contents = try? FileManager.default.contentsOfDirectory(
-            at: tempBase, includingPropertiesForKeys: [.contentModificationDateKey])
-    else { return }
-
-    let cutoff = Date().addingTimeInterval(-24 * 60 * 60)
-    for dir in contents {
-        guard let attrs = try? dir.resourceValues(forKeys: [.contentModificationDateKey]),
-            let modDate = attrs.contentModificationDate,
-            modDate < cutoff
-        else { continue }
-        try? FileManager.default.removeItem(at: dir)
-        fputs("MCP: Cleaned up stale temp dir: \(dir.lastPathComponent)\n", stderr)
-    }
-}

--- a/Sources/PreviewsCLI/ServeCommand.swift
+++ b/Sources/PreviewsCLI/ServeCommand.swift
@@ -2,6 +2,7 @@ import AppKit
 import ArgumentParser
 import Foundation
 import MCP
+import PreviewsEngine
 import PreviewsMacOS
 
 struct ServeCommand: ParsableCommand {
@@ -57,7 +58,10 @@ struct ServeCommand: ParsableCommand {
         Task { @MainActor in
             let host = Self.sharedHost!
             do {
-                let (server, _) = try await configureMCPServer(host: host)
+                let (server, _) = try await configureMCPServer(
+                    host: host, iosManager: IOSSessionManager(),
+                    configCache: ConfigCache()
+                )
                 fputs("MCP server starting on stdio...\n", stderr)
                 let transport = StdioTransport()
                 try await server.start(transport: transport)

--- a/Sources/PreviewsCLI/SnapshotCommand.swift
+++ b/Sources/PreviewsCLI/SnapshotCommand.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Foundation
 import MCP
 import PreviewsCore
+import PreviewsEngine
 
 /// Capture a screenshot of a preview.
 ///

--- a/Sources/PreviewsCLI/VariantsCommand.swift
+++ b/Sources/PreviewsCLI/VariantsCommand.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Foundation
 import MCP
 import PreviewsCore
+import PreviewsEngine
 
 /// Capture multiple snapshots of a SwiftUI preview under different trait
 /// configurations by delegating to the daemon's `preview_variants` MCP

--- a/Sources/PreviewsEngine/BuildHelpers.swift
+++ b/Sources/PreviewsEngine/BuildHelpers.swift
@@ -93,6 +93,6 @@ public func resolveDeviceUDID(
     }
 }
 
-public struct NoSimulatorError: Error, CustomStringConvertible {
-    public var description: String { "No available iOS simulator devices found" }
+public struct NoSimulatorError: LocalizedError {
+    public var errorDescription: String? { "No available iOS simulator devices found" }
 }

--- a/Sources/PreviewsEngine/BuildHelpers.swift
+++ b/Sources/PreviewsEngine/BuildHelpers.swift
@@ -1,15 +1,18 @@
-import ArgumentParser
 import Foundation
 import PreviewsCore
 import PreviewsIOS
 import os
 
 /// CLI progress reporter that prints `[X/Y] message` to stderr.
-struct StderrProgressReporter: ProgressReporter {
-    let totalSteps: Int
+public struct StderrProgressReporter: ProgressReporter {
+    public let totalSteps: Int
     private let counter = OSAllocatedUnfairLock(initialState: 0)
 
-    func report(_ phase: BuildPhase, message: String) async {
+    public init(totalSteps: Int) {
+        self.totalSteps = totalSteps
+    }
+
+    public func report(_ phase: BuildPhase, message: String) async {
         let step = counter.withLock { value -> Int in
             value += 1
             return value
@@ -19,7 +22,7 @@ struct StderrProgressReporter: ProgressReporter {
 }
 
 /// Load project config from explicit path or auto-discover from source file directory.
-func loadProjectConfig(explicit configPath: String?, fileURL: URL) -> ProjectConfigLoader.Result? {
+public func loadProjectConfig(explicit configPath: String?, fileURL: URL) -> ProjectConfigLoader.Result? {
     if let configPath {
         let url = URL(fileURLWithPath: configPath)
         let dir = url.deletingLastPathComponent()
@@ -35,7 +38,7 @@ func loadProjectConfig(explicit configPath: String?, fileURL: URL) -> ProjectCon
 }
 
 /// Build the setup package if configured in a ProjectConfig.
-func buildSetupFromConfig(
+public func buildSetupFromConfig(
     _ configResult: ProjectConfigLoader.Result?,
     platform: PreviewPlatform
 ) async throws -> SetupBuilder.Result? {
@@ -47,7 +50,7 @@ func buildSetupFromConfig(
 }
 
 /// Detect the build system for a source file and build it, reporting progress.
-func detectAndBuild(
+public func detectAndBuild(
     for fileURL: URL,
     projectRoot projectRootURL: URL?,
     platform: PreviewPlatform,
@@ -71,7 +74,7 @@ func detectAndBuild(
 }
 
 /// Resolve a simulator device UDID: provided > booted > first available.
-func resolveDeviceUDID(
+public func resolveDeviceUDID(
     provided: String?,
     using simulatorManager: SimulatorManager
 ) async throws -> String {
@@ -84,8 +87,12 @@ func resolveDeviceUDID(
     } catch {
         let devices = try await simulatorManager.listDevices()
         guard let first = devices.first(where: { $0.isAvailable }) else {
-            throw ValidationError("No available iOS simulator devices found")
+            throw NoSimulatorError()
         }
         return first.udid
     }
+}
+
+public struct NoSimulatorError: Error, CustomStringConvertible {
+    public var description: String { "No available iOS simulator devices found" }
 }

--- a/Sources/PreviewsEngine/ConfigCache.swift
+++ b/Sources/PreviewsEngine/ConfigCache.swift
@@ -1,0 +1,21 @@
+import Foundation
+import PreviewsCore
+
+/// Caches project config lookups by directory so repeated tool calls
+/// against the same project don't hit the filesystem each time. One
+/// instance is shared across all daemon connections.
+public actor ConfigCache {
+    private var cache: [String: ProjectConfigLoader.Result?] = [:]
+
+    public init() {}
+
+    public func load(for fileURL: URL) -> ProjectConfigLoader.Result? {
+        let dir = fileURL.deletingLastPathComponent().standardizedFileURL.path
+        if let cached = cache[dir] {
+            return cached
+        }
+        let result = ProjectConfigLoader.find(from: fileURL.deletingLastPathComponent())
+        cache[dir] = result
+        return result
+    }
+}

--- a/Sources/PreviewsEngine/IOSSessionManager.swift
+++ b/Sources/PreviewsEngine/IOSSessionManager.swift
@@ -1,0 +1,56 @@
+import Foundation
+import PreviewsCore
+import PreviewsIOS
+
+/// Tracks active iOS preview sessions and lazily creates shared iOS
+/// resources (compiler, host builder). One instance is shared across
+/// all daemon connections so sessions persist across CLI invocations.
+public actor IOSSessionManager {
+    public let simulatorManager = SimulatorManager()
+    private var compiler: Compiler?
+    private var hostBuilder: IOSHostBuilder?
+    private var sessions: [String: IOSPreviewSession] = [:]
+    private var fileWatchers: [String: FileWatcher] = [:]
+
+    public init() {}
+
+    public func getCompiler() async throws -> Compiler {
+        if let c = compiler { return c }
+        let c = try await Compiler(platform: .iOS)
+        compiler = c
+        return c
+    }
+
+    public func getHostBuilder() async throws -> IOSHostBuilder {
+        if let b = hostBuilder { return b }
+        let b = try await IOSHostBuilder()
+        hostBuilder = b
+        return b
+    }
+
+    public func addSession(_ session: IOSPreviewSession) {
+        sessions[session.id] = session
+    }
+
+    public func getSession(_ id: String) -> IOSPreviewSession? {
+        sessions[id]
+    }
+
+    public func removeSession(_ id: String) {
+        sessions.removeValue(forKey: id)
+        fileWatchers[id]?.stop()
+        fileWatchers.removeValue(forKey: id)
+    }
+
+    public func setFileWatcher(_ id: String, _ watcher: FileWatcher) {
+        fileWatchers[id] = watcher
+    }
+
+    public func allSessionIDs() -> [String] {
+        Array(sessions.keys)
+    }
+
+    public func allSessionsInfo() -> [(id: String, sourceFile: URL)] {
+        sessions.map { ($0.key, $0.value.sourceFile) }
+    }
+}

--- a/Sources/PreviewsEngine/TempDirCleanup.swift
+++ b/Sources/PreviewsEngine/TempDirCleanup.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Remove temp directories older than 24 hours from previous sessions.
+public func cleanupStaleTempDirs() {
+    let tempBase = FileManager.default.temporaryDirectory.appendingPathComponent("previewsmcp")
+    guard
+        let contents = try? FileManager.default.contentsOfDirectory(
+            at: tempBase, includingPropertiesForKeys: [.contentModificationDateKey])
+    else { return }
+
+    let cutoff = Date().addingTimeInterval(-24 * 60 * 60)
+    for dir in contents {
+        guard let attrs = try? dir.resourceValues(forKeys: [.contentModificationDateKey]),
+            let modDate = attrs.contentModificationDate,
+            modDate < cutoff
+        else { continue }
+        try? FileManager.default.removeItem(at: dir)
+        fputs("Cleaned up stale temp dir: \(dir.lastPathComponent)\n", stderr)
+    }
+}

--- a/Sources/PreviewsEngine/TraitHelpers.swift
+++ b/Sources/PreviewsEngine/TraitHelpers.swift
@@ -1,0 +1,23 @@
+import PreviewsCore
+
+/// Human-readable one-line summary of active traits.
+public func traitsSummary(_ traits: PreviewTraits) -> String {
+    var parts: [String] = []
+    if let cs = traits.colorScheme { parts.append("colorScheme=\(cs)") }
+    if let dts = traits.dynamicTypeSize { parts.append("dynamicTypeSize=\(dts)") }
+    if let loc = traits.locale { parts.append("locale=\(loc)") }
+    if let ld = traits.layoutDirection { parts.append("layoutDirection=\(ld)") }
+    if let lw = traits.legibilityWeight { parts.append("legibilityWeight=\(lw)") }
+    return parts.joined(separator: ", ")
+}
+
+/// Formatted preview list with `<- active` marker on the active index.
+public func formatPreviewList(previews: [PreviewInfo], activeIndex: Int) -> String {
+    var lines: [String] = ["Available previews:"]
+    for preview in previews {
+        let name = preview.name ?? "Preview"
+        let marker = preview.index == activeIndex ? " <- active" : ""
+        lines.append("  [\(preview.index)] \(name) (line \(preview.line)): \(preview.snippet)\(marker)")
+    }
+    return lines.joined(separator: "\n")
+}


### PR DESCRIPTION
## Summary
PR 1 of the package rearchitecture (plan at `.claude/plans/package-rearchitecture.md`). Creates a new `PreviewsEngine` library target containing business logic that has no MCP or ArgumentParser dependency.

### What moved to PreviewsEngine
- `IOSState` → `IOSSessionManager` (public actor)
- `ConfigCache` (public actor)
- `traitsSummary`, `formatPreviewList` (public functions)
- `cleanupStaleTempDirs` (public function)
- `BuildHelpers.swift` (entire file: `StderrProgressReporter`, `loadProjectConfig`, `detectAndBuild`, `resolveDeviceUDID`, `buildSetupFromConfig`)

### What stays in PreviewsCLI
- MCPServer.swift (handler functions, MCP wiring, param extraction — all depend on MCP types)
- All CLI commands, DaemonClient, daemon infrastructure

### Dependency graph
```
PreviewsEngine → PreviewsCore, PreviewsMacOS, PreviewsIOS  (NO MCP, NO ArgumentParser)
PreviewsCLI → PreviewsEngine, MCP, ArgumentParser
```

### Injection
- `configureMCPServer(host:iosManager:configCache:sharedCompiler:)` — all engine instances injected
- `DaemonListener.start` creates ONE shared `IOSSessionManager` + `ConfigCache` for all connections
- `ServeCommand.runStdio` creates its own instances (single-connection)

## Test plan
- [x] `swift build` — clean
- [x] Manual smoke: `simulators`, `list --json`, `status` all work through the daemon
- [ ] Full test suite running in background (~5m)

🤖 Generated with [Claude Code](https://claude.com/claude-code)