### PR TITLE
Remove unnecessary await on sync callTool overload

### DIFF
--- a/Sources/PreviewsCLI/MCPContentHelpers.swift
+++ b/Sources/PreviewsCLI/MCPContentHelpers.swift
@@ -41,7 +41,7 @@ extension Client {
         name: String,
         arguments: [String: Value]? = nil
     ) async throws -> CallTool.Result {
-        let context: RequestContext<CallTool.Result> = try await callTool(
+        let context: RequestContext<CallTool.Result> = try callTool(
             name: name, arguments: arguments
         )
         return try await context.value


### PR DESCRIPTION
## Summary
- The `RequestContext<CallTool.Result>`-returning overload of `callTool` is synchronous; the async work happens when accessing `context.value`.
- The spurious `await` in `callToolStructured` produced a `no 'async' operations occur within 'await' expression` warning on every clean build.

## Test plan
- [x] `swift package clean && swift build` — no warnings
- [ ] CI passes