### PR TITLE
Make MCP hot-reload test diagnosable; split by reload path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,9 @@ jobs:
           --skip "iosCLIWorkflow"
 
       - name: MCP integration tests
-        timeout-minutes: 10
+        # 15m > per-test .timeLimit(.minutes(10)) so test-level timeouts fire first
+        # with a source-located Testing error instead of a bare GHA step kill.
+        timeout-minutes: 15
         env:
           NSUnbufferedIO: "YES"
         run: swift test --filter "MCPIntegrationTests" --skip "IOSMCPTests"

--- a/Tests/MCPIntegrationTests/MCPTestServer.swift
+++ b/Tests/MCPIntegrationTests/MCPTestServer.swift
@@ -30,15 +30,20 @@ final class MCPTestServer: @unchecked Sendable {
     private let client: Client
     private let stdinPipe: Pipe
     private let stdoutPipe: Pipe
+    /// Path to the per-instance log file that captures the server subprocess's stderr.
+    /// Persists on disk after `stop()` so post-mortem inspection is possible.
+    let stderrLogPath: URL
 
     private init(
         process: Process, client: Client,
-        stdinPipe: Pipe, stdoutPipe: Pipe
+        stdinPipe: Pipe, stdoutPipe: Pipe,
+        stderrLogPath: URL
     ) {
         self.process = process
         self.client = client
         self.stdinPipe = stdinPipe
         self.stdoutPipe = stdoutPipe
+        self.stderrLogPath = stderrLogPath
     }
 
     // MARK: - Lifecycle
@@ -58,15 +63,24 @@ final class MCPTestServer: @unchecked Sendable {
         let stdoutPipe = Pipe()
         process.standardInput = stdinPipe
         process.standardOutput = stdoutPipe
-        // Discard server stderr. Two earlier approaches both caused CI hangs on macOS 15:
+        // Capture server stderr to a per-instance file. Two earlier approaches caused
+        // CI hangs on macOS 15:
         //  1. Pipe + readabilityHandler — the dispatch source persisted in the test
         //     binary's CFRunLoop after the subprocess died, blocking process exit.
         //  2. Sharing FileHandle.standardError with the child — caused previewsmcp's
         //     own startup to hang on subsequent test runs (cause unclear; possibly
         //     related to NSApplication's stderr handling).
-        // /dev/null is the only configuration that avoids both bugs. We lose visibility
-        // into server diagnostics but gain reliable test cleanup.
-        process.standardError = FileHandle.nullDevice
+        // Writing to a plain file handle avoids both: no dispatch source (so nothing
+        // to persist in the parent's CFRunLoop) and an isolated fd (so the child
+        // doesn't inherit the parent's stderr). This restores the diagnostics that
+        // were previously lost to /dev/null.
+        let stderrLogPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-test-\(UUID().uuidString).log")
+        FileManager.default.createFile(atPath: stderrLogPath.path, contents: nil)
+        guard let stderrHandle = FileHandle(forWritingAtPath: stderrLogPath.path) else {
+            throw MCPTestError.cannotCreateStderrLog(stderrLogPath.path)
+        }
+        process.standardError = stderrHandle
 
         try process.run()
 
@@ -79,7 +93,8 @@ final class MCPTestServer: @unchecked Sendable {
 
         let server = MCPTestServer(
             process: process, client: client,
-            stdinPipe: stdinPipe, stdoutPipe: stdoutPipe
+            stdinPipe: stdinPipe, stdoutPipe: stdoutPipe,
+            stderrLogPath: stderrLogPath
         )
 
         // Detect unexpected server termination so pending callTool requests fail fast
@@ -133,6 +148,24 @@ final class MCPTestServer: @unchecked Sendable {
         arguments: [String: Value]? = nil
     ) async throws -> (content: [Tool.Content], isError: Bool?) {
         try await client.callTool(name: name, arguments: arguments)
+    }
+
+    /// Call an MCP tool bounded by `timeout`. On timeout, dumps the captured
+    /// server stderr via `Issue.record` so the hang has diagnostic context,
+    /// then rethrows `MCPTestError.timedOut`.
+    func callToolWithTimeout(
+        name: String,
+        arguments: [String: Value]? = nil,
+        timeout: Duration = .seconds(30)
+    ) async throws -> (content: [Tool.Content], isError: Bool?) {
+        do {
+            return try await Self.withTimeout(timeout) { [self] in
+                try await client.callTool(name: name, arguments: arguments)
+            }
+        } catch is TestTimeoutSentinel {
+            Issue.record("callTool(\(name)) timed out after \(timeout). Server stderr:\n\(stderrLog())")
+            throw MCPTestError.timedOut(operation: "callTool(\(name))", duration: timeout)
+        }
     }
 
     /// Call an MCP tool and return the full `CallTool.Result` including
@@ -246,13 +279,103 @@ final class MCPTestServer: @unchecked Sendable {
         return (w, h)
     }
 
+    // MARK: - Stderr capture
+
+    /// Return the current contents of the server's captured stderr log.
+    /// Safe to call at any time; reads may trail in-flight writes slightly.
+    func stderrLog() -> String {
+        (try? String(contentsOfFile: stderrLogPath.path, encoding: .utf8)) ?? ""
+    }
+
+    /// Poll the server's stderr log until it contains `needle`, up to `timeout`.
+    /// On timeout, dumps the log via `Issue.record` and throws.
+    /// Poll cadence mirrors CLIIntegrationTests/RunCommandTests.waitForStderrMatch (100ms).
+    func awaitStderrContains(
+        _ needle: String,
+        timeout: Duration
+    ) async throws {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if stderrLog().contains(needle) { return }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        Issue.record(
+            "Stderr did not contain \(needle.debugDescription) within \(timeout). Server stderr:\n\(stderrLog())")
+        throw MCPTestError.timedOut(operation: "awaitStderrContains(\(needle.debugDescription))", duration: timeout)
+    }
+
+    // MARK: - Snapshot helpers
+
+    /// Capture a snapshot and return its raw image bytes. Decodes via the existing
+    /// `extractImageData` helper; ignores mimeType (JPEG/PNG differ naturally across
+    /// quality settings, but byte equality is sufficient for change-detection).
+    func snapshotBytes(sessionID: String, timeout: Duration = .seconds(30)) async throws -> Data {
+        let (content, isError) = try await callToolWithTimeout(
+            name: "preview_snapshot",
+            arguments: ["sessionID": .string(sessionID)],
+            timeout: timeout
+        )
+        if isError == true {
+            Issue.record("preview_snapshot returned an error. Content: \(Self.extractText(from: content))")
+            throw MCPTestError.snapshotFailed
+        }
+        return try Self.extractImageData(from: content).data
+    }
+
+    /// Poll `preview_snapshot` until the returned bytes differ from `baseline`, up to `timeout`.
+    /// Guards against false-positive passing tests where a reload silently no-ops and the
+    /// pre-edit window pixels are returned unchanged.
+    func awaitSnapshotChange(
+        sessionID: String,
+        baseline: Data,
+        timeout: Duration
+    ) async throws -> Data {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            let current = try await snapshotBytes(sessionID: sessionID)
+            if current != baseline { return current }
+            try await Task.sleep(for: .milliseconds(200))
+        }
+        Issue.record("Snapshot bytes did not change within \(timeout). Server stderr:\n\(stderrLog())")
+        throw MCPTestError.timedOut(operation: "awaitSnapshotChange(sessionID: \(sessionID))", duration: timeout)
+    }
+
+    // MARK: - Timeout primitive
+
+    /// Race `body` against a timer; throw `TestTimeoutSentinel` if the timer wins.
+    /// Caller is expected to catch the sentinel and add operation-specific context.
+    static func withTimeout<T: Sendable>(
+        _ duration: Duration,
+        _ body: @Sendable @escaping () async throws -> T
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask { try await body() }
+            group.addTask {
+                try await Task.sleep(for: duration)
+                throw TestTimeoutSentinel()
+            }
+            defer { group.cancelAll() }
+            guard let result = try await group.next() else {
+                throw TestTimeoutSentinel()
+            }
+            return result
+        }
+    }
+
 }
+
+/// Internal sentinel thrown by `MCPTestServer.withTimeout`. Callers catch and
+/// rethrow `MCPTestError.timedOut` with their own operation string.
+private struct TestTimeoutSentinel: Error {}
 
 enum MCPTestError: Error, LocalizedError {
     case noSessionID(String)
     case invalidBase64
     case noImageContent
     case noStructuredContent
+    case cannotCreateStderrLog(String)
+    case timedOut(operation: String, duration: Duration)
+    case snapshotFailed
 
     var errorDescription: String? {
         switch self {
@@ -260,6 +383,9 @@ enum MCPTestError: Error, LocalizedError {
         case .invalidBase64: "Invalid base64 image data"
         case .noImageContent: "No image content in tool result"
         case .noStructuredContent: "No structuredContent in tool result"
+        case .cannotCreateStderrLog(let path): "Could not open stderr log for writing at \(path)"
+        case .timedOut(let operation, let duration): "\(operation) timed out after \(duration)"
+        case .snapshotFailed: "preview_snapshot returned isError=true"
         }
     }
 }

--- a/Tests/MCPIntegrationTests/MacOSMCPTests.swift
+++ b/Tests/MCPIntegrationTests/MacOSMCPTests.swift
@@ -445,10 +445,13 @@ struct MacOSMCPTests {
         )
     }
 
-    // MARK: - Hot reload (separate test — modifies source file)
+    // MARK: - Hot reload (separate tests — modify source file)
 
-    @Test("File edit triggers hot reload", .timeLimit(.minutes(10)))
-    func hotReload() async throws {
+    /// Literal-only fast path: change a string literal, which the DesignTimeStore
+    /// tracker in PreviewSession.tryLiteralUpdate applies without recompiling.
+    /// Sync target: "Literal-only change:" log line from HostApp.swift.
+    @Test("File edit triggers hot reload (literal-only fast path)", .timeLimit(.minutes(10)))
+    func hotReloadLiteralOnly() async throws {
         let server = try await MCPTestServer.start()
         defer { server.stop() }
 
@@ -458,7 +461,7 @@ struct MacOSMCPTests {
             try? originalContent.write(toFile: filePath, atomically: true, encoding: .utf8)
         }
 
-        let (startContent, _) = try await server.callTool(
+        let (startContent, _) = try await server.callToolWithTimeout(
             name: "preview_start",
             arguments: [
                 "filePath": .string(filePath),
@@ -467,25 +470,67 @@ struct MacOSMCPTests {
         )
         let sessionID = try MCPTestServer.extractSessionID(from: startContent)
 
-        try await Task.sleep(for: .milliseconds(500))
+        let baseline = try await server.snapshotBytes(sessionID: sessionID)
 
-        // Edit source file
-        let modified = originalContent.replacingOccurrences(of: "\"My Items\"", with: "\"Tasks\"")
+        // "Progress" is in the first SummaryCard (page 0 of the TabView), visibly
+        // rendered in headless NSHostingView — required for the byte-diff assertion.
+        let modified = originalContent.replacingOccurrences(of: "\"Progress\"", with: "\"Totals\"")
         #expect(modified != originalContent, "Replacement should have changed the content")
         try modified.write(
             to: URL(fileURLWithPath: filePath), atomically: false, encoding: .utf8)
 
-        // Wait for file watcher to detect change and reload.
-        // File watcher polls every 0.5s; recompilation takes a few seconds.
-        try await Task.sleep(for: .seconds(5))
-        let (snapshotContent, snapshotError) = try await server.callTool(
-            name: "preview_snapshot",
+        try await server.awaitStderrContains("Literal-only change:", timeout: .seconds(30))
+        _ = try await server.awaitSnapshotChange(
+            sessionID: sessionID, baseline: baseline, timeout: .seconds(10)
+        )
+
+        _ = try await server.callToolWithTimeout(
+            name: "preview_stop",
             arguments: ["sessionID": .string(sessionID)]
         )
-        #expect(snapshotError != true, "Snapshot should succeed after hot reload")
-        try MCPTestServer.assertValidImage(snapshotContent)
+    }
 
-        _ = try await server.callTool(
+    /// Structural slow path: add a new view modifier call, which the literal differ
+    /// cannot fast-path, forcing a full swiftc recompile and dylib reload.
+    /// Sync target: "Compiled:" log line from HostApp.swift after swiftc finishes.
+    @Test("File edit triggers hot reload (structural recompile path)", .timeLimit(.minutes(10)))
+    func hotReloadStructural() async throws {
+        let server = try await MCPTestServer.start()
+        defer { server.stop() }
+
+        let filePath = MCPTestServer.toDoViewPath
+        let originalContent = try String(contentsOfFile: filePath, encoding: .utf8)
+        defer {
+            try? originalContent.write(toFile: filePath, atomically: true, encoding: .utf8)
+        }
+
+        let (startContent, _) = try await server.callToolWithTimeout(
+            name: "preview_start",
+            arguments: [
+                "filePath": .string(filePath),
+                "projectPath": .string(MCPTestServer.spmExampleRoot.path),
+            ]
+        )
+        let sessionID = try MCPTestServer.extractSessionID(from: startContent)
+
+        let baseline = try await server.snapshotBytes(sessionID: sessionID)
+
+        // Add a new view modifier — adding a call node forces .structural from LiteralDiffer.
+        let modified = originalContent.replacingOccurrences(
+            of: ".navigationTitle(\"My Items\")",
+            with: ".navigationTitle(\"My Items\").padding(32)"
+        )
+        #expect(modified != originalContent, "Replacement should have changed the content")
+        try modified.write(
+            to: URL(fileURLWithPath: filePath), atomically: false, encoding: .utf8)
+
+        // CI swiftc on cold caches is slow; AGENTS.md notes daemon startup alone is 5–10s.
+        try await server.awaitStderrContains("Compiled:", timeout: .seconds(90))
+        _ = try await server.awaitSnapshotChange(
+            sessionID: sessionID, baseline: baseline, timeout: .seconds(15)
+        )
+
+        _ = try await server.callToolWithTimeout(
             name: "preview_stop",
             arguments: ["sessionID": .string(sessionID)]
         )


### PR DESCRIPTION
## Summary

PR #124's CI hang (10-min timeout, 9+ min of zero output from `hotReload` in `MacOSMCPTests`) was a flake, but the test's design made it effectively undebuggable: the server subprocess's stderr was sent to `/dev/null`, synchronization was a blind 5s sleep, the step and per-test timeouts raced, and `assertValidImage` only checked header bytes — a silent no-op reload would pass. This PR addresses all four.

### Test harness (`MCPTestServer.swift`)
- **Capture subprocess stderr to a per-instance temp file.** A plain file handle avoids both pitfalls documented in the prior `/dev/null` comment (dispatch-source retention; shared-fd NSApplication interference).
- **Signal-based sync helpers:** `awaitStderrContains` + `stderrLog` let tests wait on a real event and surface diagnostics on timeout via `Issue.record`.
- **`withTimeout` primitive + `callToolWithTimeout`** so any single MCP call localizes a hang instead of voiding the whole test.
- **`snapshotBytes` + `awaitSnapshotChange`** so reload tests can assert rendered pixels actually changed, not just that the snapshot endpoint works.

### Test split (`MacOSMCPTests.swift`)
The original test edited a string literal (`"My Items"` → `"Tasks"`), which hits the DesignTimeStore fast path and never exercises `swiftc`. Now split into:
- **`hotReloadLiteralOnly`** — edits `"Progress"` → `"Totals"` (a literal in a visibly-rendered SummaryCard), waits for `"Literal-only change:"`, asserts bytes differ.
- **`hotReloadStructural`** — appends `.padding(32)` after `.navigationTitle`, forcing `.structural` from `LiteralDiffer`, waits for `"Compiled:"`, asserts bytes differ.

### CI (`ci.yml`)
- Bump `MCP integration tests` step timeout 10 → 15 min so `.timeLimit(.minutes(10))` fires first on future hangs with a source-located Testing-library error.

## Test plan
- [x] `swift test --filter "MacOSMCPTests"` locally — 5 tests pass in 59s total.
- [x] Inspected a `/tmp/previewsmcp-test-*.log` from a run: captures "MCP server starting on stdio…", "Literal-only change: 1 value(s)", "Applied 1 literal change(s)…".
- [x] Forced a failure (temporarily mis-targeted the byte-diff) and confirmed the `Issue.record` dump printed the full server stderr log, not a blanket GHA timeout.
- [ ] CI passes.

Follow-up: #125 (inline snapshots in terminals) is unchanged by this PR.