### PR TITLE
Add preview_record: spec, plan, and Slice 1 core primitives

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,221 @@
+# preview_record — Spec
+
+**Status:** Draft (2026-04-19, updated: drop ScreenCaptureKit in favor of timer-polled Snapshot.capture)
+**Branch:** `worktree-preview-record-spec`
+**Author:** Jason + Claude (Opus 4.6)
+
+## Objective
+
+Add animation capture and session video recording to PreviewsMCP, targeting two agentic-development pain points:
+
+1. **Animation debugging.** An agent needs to verify that an interaction produces the right animated response — spring settles, transitions, state changes mid-flight. Today it can only read still frames, so anything time-dependent is invisible. The agent should be able to say "tap this, show me what happens" and get a sequence of keyframes it can reason about inline.
+
+2. **Stakeholder demo recording.** A human working with an agent wants to hand a stakeholder an `.mov` of a feature in motion. Today they'd leave the tool, open `Simulator.app`, screen-record manually, trim in QuickTime. The agent should be able to record a scripted multi-step flow and produce a shareable video with a synced action timeline.
+
+These are distinct enough in shape (atomic vs. session, inline frames vs. file path) that they warrant separate tools rather than one tool with a `mode` param.
+
+## Non-goals
+
+- **Semantic animation inspection.** Chrome DevTools' Animation panel shows easing curves and lets you scrub CAAnimations by name. We cannot match this without private API sniffing of SwiftUI's animation engine. Keyframes are a weak visual substitute; we acknowledge the gap and do not try to bolt "which spring animation fired" onto frame output.
+- **Visual regression testing.** Chromatic/Percy explicitly freeze animations for determinism. This tool does the opposite — captures motion. Do not let assertion/diff workflows creep in.
+- **Rolling/continuous retroactive capture.** Rejected: preview sessions are deterministic up to `@State`, and re-triggering an interaction is one tool call. Cheaper to retry than to maintain an always-on 60fps buffer with memory pressure, teardown races against hot-reload, and new state to reason about.
+- **Audio.** SwiftUI previews have no audio path worth capturing.
+
+## Tools
+
+Three new MCP tools. All require a running session from `preview_start`.
+
+### `preview_record`
+
+Atomic capture of an animation bracketed by a trigger. Returns keyframes inline.
+
+**Inputs:**
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `sessionID` | string | required | |
+| `trigger` | object | required | Same shape as `preview_touch` input — `{type: "tap"/"swipe"/"longPress"/"multiTouch", ...coords}` |
+| `maxDurationMs` | int | 3000 | Safety cap if settle detection never fires |
+| `frameCount` | int | 6 | Target keyframes to return. Hard-capped at 12 |
+| `format` | enum | `"sequence"` | `"sequence"` (array of images) or `"spritesheet"` (single composite grid) |
+| `quality` | float | 0.85 | JPEG quality, matches `preview_snapshot` convention |
+
+**Pipeline:**
+1. Start frame capture at ~30fps. macOS: timer-polled `Snapshot.capture` (reuses existing `bitmapImageRepForCachingDisplay` + `cacheDisplay` code path — works headless, no TCC permissions, no new frameworks). iOS: `simctl io booted recordVideo`, decoded to frames via `AVAssetReader` after stop. All frames stored as `CGImage` (platform-agnostic, no AppKit dependency in PreviewsCore).
+2. Fire the trigger via the same code path as `preview_touch`, recording the tap coordinates into an in-memory touch log with monotonic timestamps.
+3. Compute SSIM frame diff on 128×128 downsampled frames (not 64×64 — too coarse under font antialiasing noise; not pHash — robustness under compositing jitter matters). Store per-frame diff-to-previous in a buffer.
+4. **Auto-trim** using ffmpeg-style scene-detect semantics, not cumulative-diff heuristics:
+   - `motionStartFrame` = first frame where `diff > motionThreshold`
+   - `motionEndFrame` = first frame where `diff < stillThreshold` sustained for ≥100ms after `motionStartFrame`
+   - Fallback: if no settle, use `maxDurationMs` as end.
+5. **Keyframe selection** inside `[motionStartFrame, motionEndFrame]`:
+   - Pairwise threshold-gated scene detect (emit frame when diff crosses `keyframeThreshold`).
+   - `minGapMs = 80` between emitted frames (flicker-fusion ~60–80ms; UIKit/SwiftUI default animation ~350ms → ~4 frames per typical transition; 50ms oversamples into 60fps noise, 200ms misses mid-transition on snappy interactions).
+   - Force-emit first and last frames of the motion window.
+   - If more frames cross the threshold than `frameCount`, prefer the highest-diff among them.
+   - If fewer, fill by the next-highest pairwise diffs.
+6. Composite touch indicators over each selected frame via CoreGraphics (`CGContext` draw on CGImage). Fading circle at tap coordinates, alpha curve ≈ 1.0 → 0 over 500ms. Simple, no AVFoundation for single-frame overlays.
+7. Encode keyframes as JPEG at `quality`, return inline via `CallTool.Result(content: [.image(...), .image(...), ...])` matching `preview_snapshot`'s format. For `spritesheet` format, composite the N frames into a grid (ceil(√N) columns) and return as a single image.
+8. Return structured metadata alongside images: `{durationMs, motionStartMs, motionEndMs, framesReturned, warning?}`.
+
+**No-motion branch:** if the auto-trim step finds no frame where `diff > motionThreshold` within `maxDurationMs`, return a single frame (the last captured) plus `warning: "no motion detected within maxDurationMs — interaction may not have produced an animation"`. Do not return 6 identical frames.
+
+**Out-of-scope parameters (deliberately omitted):**
+- `outputDirectory` — matches `preview_snapshot`'s inline-only convention. If a future PR adds disk output, it should land on `preview_snapshot`, `preview_variants`, and `preview_record` together as a pure refactor with a clear rubric, not bolted onto this feature.
+
+### `preview_record_start`
+
+Begins session-scoped video capture. Non-blocking — returns immediately.
+
+**Inputs:**
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `sessionID` | string | required | |
+| `codec` | enum | `"h264"` | `"h264"` or `"hevc"` |
+
+**Behavior:**
+- Opens a recording context attached to the preview session.
+- macOS: starts a timer-polled `Snapshot.capture` loop at ~30fps, piping each frame (as `CVPixelBuffer` via `AVAssetWriterInputPixelBufferAdaptor`) to an `AVAssetWriter` that encodes the `.mov` live. Reuses the same `bitmapImageRepForCachingDisplay` + `cacheDisplay` code path as `preview_snapshot` — works headless, no TCC permissions, no cursor captured (view-hierarchy render, not screen capture).
+- iOS: shells out to `xcrun simctl io booted recordVideo --codec <codec> <temp path>`, tracks the PID, terminates with SIGINT on stop (simctl's required signal to finalize the container).
+- Attaches a middleware interceptor to the MCP tool dispatcher: every subsequent tool call against `sessionID` is appended to the active session's action log with `{tMs, tool, params, causedRecompile}`. `tMs` is wall-clock milliseconds from capture start (monotonic clock). This is one touch point at the dispatch layer — not per-tool-handler logging — so adding tool #11 later cannot forget to hook in. (Playwright's `tracing.start()` follows the same pattern for the same reason.)
+- Returns `{recordingID}` as confirmation.
+
+**Error:** if a recording is already active on this session, return error. One recording per session at a time.
+
+**Interaction with `preview_stop`:** calling `preview_stop` on a session with an active recording implicitly finalizes the recording first. The `preview_stop` result includes the finalized recording path in addition to its normal output. No orphaned recordings, no "you forgot to call stop first" errors.
+
+### `preview_record_stop`
+
+Finalizes the recording. Blocking — returns when the `.mov` is fully written.
+
+**Inputs:**
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `sessionID` | string | required | |
+
+**Behavior:**
+1. Stop capture (iOS: SIGINT to simctl; macOS: stop the polling timer, finalize `AVAssetWriter`).
+2. Composite touch indicators from the action log into the final video via a single `AVMutableVideoComposition` + `AVVideoCompositionCoreAnimationTool` pass. Fading circle overlay at each tap/swipe coordinate, alpha 1.0 → 0 over 500ms. (Same approach as QuickTime Player's click rings, Loom, Appium's screenrecord plugins.) One AVFoundation export, GPU-backed, roughly real-time on Apple Silicon. No per-frame CPU decode.
+3. Write final `.mov` to `NSTemporaryDirectory()/previewsmcp-<sessionID>-<uuid>.mov` (absolute path). Return the path to the caller — they can `mv` it wherever they like. Rationale: user-specified paths are footguns (permissions, accidental overwrites); working-directory output pollutes repos; temp is the Unix answer.
+4. Detach the dispatcher middleware.
+5. Return structured result:
+   ```json
+   {
+     "path": "/tmp/previewsmcp-<id>.mov",
+     "durationMs": 12340,
+     "actions": [
+       {"tMs": 0, "tool": "preview_touch", "params": {"type": "tap", "x": 100, "y": 200}, "causedRecompile": false},
+       {"tMs": 850, "tool": "preview_switch", "params": {"previewIndex": 1}, "causedRecompile": true},
+       {"tMs": 3200, "tool": "preview_touch", "params": {"type": "swipe", ...}, "causedRecompile": false}
+     ]
+   }
+   ```
+
+The action timeline is load-bearing. Playwright beat Cypress because it correlates video with a scrubbable action trace — video alone tells stakeholders *what* but not *why*. The action log is what a human (or follow-up agent) uses to understand a recorded demo.
+
+## Architecture
+
+```
+Sources/
+├── PreviewsCore/
+│   └── Recording/
+│       ├── FrameDiff.swift          # SSIM on 128×128 downsample, operates on CGImage (platform-agnostic)
+│       ├── KeyframeSelector.swift   # scene-detect + min-gap + force-endpoints
+│       ├── ActionLog.swift          # Sendable struct for timeline entries
+│       ├── TouchOverlay.swift       # CoreGraphics fading-circle composite on CGImage
+│       └── MovieDecoder.swift       # AVAssetReader → [CGImage] (used by iOS preview_record)
+├── PreviewsMacOS/
+│   └── Recording/
+│       └── SnapshotRecorder.swift   # Timer-polled Snapshot.capture — atomic (CGImage buffer) or session (AVAssetWriter)
+├── PreviewsIOS/
+│   └── Recording/
+│       └── SimctlRecorder.swift     # simctl io recordVideo wrapper, PID tracking, SIGINT finalize
+└── PreviewsCLI/
+    ├── MCPServer.swift              # dispatcher middleware + 3 tool handlers
+    ├── MCPToolSchemas.swift          # ToolName enum + tool schema definitions
+    ├── DaemonProtocol.swift          # RecordResult, RecordStartResult, RecordStopResult DTOs
+    ├── RecordCommand.swift           # CLI: previewsmcp record (daemon client)
+    ├── RecordStartCommand.swift      # CLI: previewsmcp record-start (daemon client)
+    └── RecordStopCommand.swift       # CLI: previewsmcp record-stop (daemon client)
+```
+
+- **Platform split matches existing convention.** `PreviewsCore` holds the diff/keyframe/overlay logic — it's pure Swift with CGImage as the common frame type (CoreGraphics, no AppKit or SimulatorBridge imports). macOS capture reuses the existing `Snapshot.capture` code path (timer-polled `bitmapImageRepForCachingDisplay`). iOS capture shells out to `simctl io recordVideo`.
+- **No ScreenCaptureKit.** `Snapshot.capture` already works headless, captures only the view hierarchy (no cursor, no TCC permissions), and is fast enough at 30fps for a 400×600 window (<1ms per frame on Apple Silicon). ScreenCaptureKit would add a framework dependency, TCC permission requirement, and macOS 12.3+ constraint for no measurable benefit.
+- **Dispatcher middleware lives in `MCPServer.swift`** — it's a single function that wraps the existing tool dispatch table, checks for an active recording on the called `sessionID`, and appends to the action log before forwarding. No per-handler changes.
+- **CLI/MCP parity** — each MCP tool has a corresponding CLI command that connects to the daemon via `DaemonClient`. Tool schemas live in `MCPToolSchemas.swift`; structured payloads use `DaemonProtocol` DTOs.
+
+## Implementation notes
+
+- **macOS capture is timer-polled `Snapshot.capture`.** For atomic recording (`preview_record`), the timer fires at ~30fps and stores `CGImage` frames in an in-memory buffer. For session recording (`preview_record_start/stop`), each frame is converted to `CVPixelBuffer` and piped to an `AVAssetWriter` via `AVAssetWriterInputPixelBufferAdaptor` for live `.mov` encoding. The `Snapshot` type is `@MainActor` — the timer callback must dispatch to the main actor for each capture.
+- **Common frame type is `CGImage`.** `FrameDiff`, `KeyframeSelector`, and `TouchOverlay` in PreviewsCore all operate on `CGImage`, which is CoreGraphics (available on both macOS and iOS, no AppKit import). macOS: `NSBitmapImageRep.cgImage`. iOS: `AVAssetReader` → `CVPixelBuffer` → `CGImage` via `CGImage(width:height:bitsPerComponent:bitsPerPixel:bytesPerRow:space:bitmapInfo:provider:...)` or `CIContext.createCGImage`.
+- **`simctl io recordVideo` finalization.** Requires SIGINT (not SIGTERM, not SIGKILL) to close the container properly. Document this in `SimctlRecorder.swift`.
+- **Frame diff on iOS.** The raw simctl `.mov` must be decoded via `AVAssetReader` to get frames for SSIM. This is only needed for `preview_record` (animation mode), not `preview_record_start/stop` (which just needs the final `.mov`).
+- **SSIM at 128×128.** Grayscale conversion before diff. Standard SSIM window = 8×8. Reference the canonical Wang et al. formulation; do not reinvent.
+- **Touch overlays differ by tool.** For `preview_record` (keyframes): `CoreGraphics` draw directly on each selected `CGImage` — simple, no AVFoundation. For `preview_record_stop` (session `.mov`): `AVMutableVideoComposition` + `AVVideoCompositionCoreAnimationTool` for a single GPU-backed export pass over the raw `.mov`.
+- **Spritesheet layout.** For `format: "spritesheet"`, use `ceil(sqrt(N))` columns, row-major. Draw frame index in the corner of each cell in a contrasting color — aids LLM reasoning ("frame 3 shows...").
+- **Recompile detection for `causedRecompile` flag.** `preview_configure` and any tool that changes `previewIndex`/traits triggers a recompile. The dispatcher middleware can statically tag these tools — no runtime detection needed.
+- **30fps is sufficient.** For animation diff detection, 30fps gives ~10 frames across a typical 350ms SwiftUI animation — plenty for scene-detect + keyframe selection. For stakeholder demo `.mov` output, 30fps is standard for screen recordings (Loom, QuickTime both default to 30fps). 60fps would require sub-16ms capture cadence, which may stall the main run loop during complex SwiftUI layout.
+- **Session `.mov` output is variable frame rate (VFR).** Timer-polled frames will not arrive at exactly 33ms intervals. `AVAssetWriter` handles this correctly — presentation timestamps are derived from `ContinuousClock.Instant` deltas, producing VFR-encoded video. This is fine for playback in QuickTime, VLC, and web browsers. Note: downstream tools that assume constant frame rate (e.g., `ffmpeg` without `-vsync vfr`) may exhibit frame drift. Document in the tool result or README if this becomes a user issue.
+- **Use `DispatchSource.makeTimerSource(queue: .main)` for the capture timer.** Not `Timer.scheduledTimer` — `NSTimer` is subject to run-loop-mode coalescing during tracking events (e.g., scroll drags), which can bunch or skip frames. `DispatchSource` timers fire reliably regardless of run-loop mode.
+
+## Testing strategy
+
+Add to the existing test suite structure.
+
+**Unit tests (`Tests/PreviewsCoreTests/`):**
+- `FrameDiffTests.swift` — SSIM on synthetic frames (identical → 1.0, inverted → 0, known deltas).
+- `KeyframeSelectorTests.swift` — given a synthetic diff-per-frame array, verify selected indices respect threshold, min-gap, forced endpoints, and fallback cases (no motion, all motion, fewer candidates than `frameCount`).
+- `ActionLogTests.swift` — timeline ordering, monotonic timestamps, serialization round-trip.
+
+**Integration tests (`Tests/MCPIntegrationTests/`):**
+- `PreviewRecordMacOSTests.swift` — start a macOS preview session, call `preview_record` with a tap on a known button, assert:
+  - frame count ≤ 12
+  - at least one frame differs measurably from the first
+  - `warning` absent
+  - metadata `durationMs` within expected range
+- `PreviewRecordSessionMacOSTests.swift` — start session, record, issue 3 mixed tool calls (tap, switch, configure), stop, assert action log length, order, `causedRecompile` flags, `.mov` exists at returned path and is decodable by `AVAssetReader`.
+- `PreviewRecordIOSTests.swift` — same shape on the iOS simulator path (slow — boots a sim).
+- **No-motion test:** trigger on a non-interactive region, assert single frame + warning.
+- **Trait-change-during-recording test:** start recording, call `preview_configure` to flip colorScheme, stop recording, assert the action log contains the configure call with `causedRecompile: true` and the `.mov` is well-formed. The recompile produces a visible cut; that is expected and the action timeline is how viewers understand it.
+- **Implicit-stop-on-preview_stop test:** start recording, call `preview_stop`, assert the returned result includes the finalized recording path and no recording state remains for the session.
+
+**Fixture:** add a tiny `TestPreviews/AnimatedButton.swift` with a known animation (0.5s ease-out scale transform) so frame-diff behavior is reproducible.
+
+## Boundaries
+
+**Always do:**
+- Auto-trim by frame diff. Never return fixed-length windows padded with still frames.
+- Return inline images matching `preview_snapshot`'s convention (JPEG base64, `.image(...)` content type).
+- Composite touch indicators in both tools. Without them the output is ambiguous (tap vs. background timer tick) — this is load-bearing, not gilding.
+- Log every tool call during an active session to the action timeline, including ones that cause recompiles. The `causedRecompile` flag tells stakeholders *why* there's a visual gap.
+
+**Ask first about:**
+- Changing `frameCount` default above 6 or the hard cap above 12. Inline image budget in MCP responses has real limits (Claude API: 100 images/request, 5MB each post-decode, but practically >~10 images per tool result hurts context/latency). 6 keyframes × ~150KB JPEG ≈ 900KB — comfortable. Above 12, require disk output (which does not yet exist).
+- Adding `outputDirectory` to *only* this tool. If users need disk output, it should land on `preview_snapshot`, `preview_variants`, and `preview_record` together as a follow-up PR with a clear rubric.
+- Adding a rolling/continuous buffer. Retry-based reproduction is the current stance; only revisit if users hit non-reproducible glitches that retry can't reach.
+- Capturing anything other than the preview window on macOS. Capturing the whole display risks leaking user desktop content into demo recordings.
+
+**Never do:**
+- **Gate any tool from running during an active recording.** Every tool call during a session is allowed and logged. Recompile-causing tools (`preview_configure`, `preview_switch`, `preview_variants`) produce visible cuts in the recording; the action timeline is the mechanism that explains those cuts to viewers. Hard cuts in product demos are normal — film cuts every few seconds — and legitimate flows ("here's light mode, now dark mode") must not be artificially forbidden. If the timeline is doing its job, gating is redundant; if it isn't, we should fix the timeline. Trust the timeline.
+- **Write to user-specified paths.** Only `NSTemporaryDirectory()`. Permission errors, accidental overwrites, and repo pollution are all avoidable by making the caller `mv` from temp.
+- **Decode-and-re-encode `.mov` frame-by-frame to composite touch overlays.** Use `AVVideoCompositionCoreAnimationTool` for a single GPU-backed export pass on session video. For keyframe overlays, use CoreGraphics (direct draw on CGImage, no AVFoundation needed).
+- **Invent a semantic animation inspection story.** No CAAnimation name sniffing, no spring-curve introspection, no "which `.animation()` modifier fired." Frames only. Defer semantic tooling until there's a concrete use case and a non-private-API path.
+- **Reinvent `xcrun simctl io recordVideo` on iOS.** Shell out. The interesting work is on the keyframe extraction side, not the capture side.
+- **Dispatch logging per-tool.** One middleware wrapper at the dispatcher. Touching every handler is how you forget tool #11 six months from now.
+
+## Open questions
+
+None remaining from design review. Implementation-time discoveries (e.g., `bitmapImageRepForCachingDisplay` performance at 30fps under complex SwiftUI layouts, simctl finalization races) will be addressed as they arise.
+
+## Prior art consulted
+
+- `xcrun simctl io recordVideo` — flags, codec, mask options, SIGINT finalization behavior
+- Xcode Simulator built-in screen record — user complaints about file size, no trim, no interaction markers
+- Playwright video + trace viewer — action/video correlation is the killer feature; confirmed the dispatcher-middleware approach
+- Cypress video — cautionary tale; video without action log is "I see something's wrong but can't tell what"
+- Maestro record + studio — flow-file replay pattern informs action log structure
+- Chromatic/Percy — visual regression explicitly freezes animations; confirms we're in uncontested territory and should not bolt assertion workflows on
+- Chrome DevTools Animation panel — semantic inspection baseline we acknowledge we cannot match without private API
+- Chrome DevTools Performance screenshot strip — ~100ms sampling feels slightly coarse; 80ms min-gap default is the correction
+- ffmpeg `select='gt(scene,X)'` — canonical pairwise-diff scene detect; our keyframe selector matches its semantics
+- Loom, QuickTime Player click rings, Appium screenrecord plugins — informs the `AVVideoCompositionCoreAnimationTool` touch overlay approach
+- Anthropic computer-use / browser-use — no prior art for returning animation sequences to models; we are slightly ahead of the field, which argues for conservatism on scope

--- a/Sources/PreviewsCore/Recording/ActionLog.swift
+++ b/Sources/PreviewsCore/Recording/ActionLog.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// A single entry in the recording action timeline.
+///
+/// Captures a tool call that occurred during an active recording session,
+/// with its timestamp relative to recording start and a flag indicating
+/// whether the call caused a recompile (visible as a cut in the video).
+public struct ActionLogEntry: Sendable, Codable, Equatable {
+    /// Milliseconds from recording start (monotonic clock).
+    public let tMs: Int
+    /// MCP tool name that was called.
+    public let tool: String
+    /// String-typed parameters for the tool call.
+    public let params: [String: String]
+    /// Whether this tool call caused a preview recompile.
+    public let causedRecompile: Bool
+
+    public init(tMs: Int, tool: String, params: [String: String], causedRecompile: Bool) {
+        self.tMs = tMs
+        self.tool = tool
+        self.params = params
+        self.causedRecompile = causedRecompile
+    }
+}
+
+/// Thread-safe action log for recording sessions.
+///
+/// Accumulates tool calls that occur while a recording session is active.
+/// Entries are appended from the dispatcher middleware and retrieved on stop.
+public actor ActionLog {
+
+    private var log: [ActionLogEntry] = []
+
+    public init() {}
+
+    /// Append a new entry to the log.
+    public func append(
+        tMs: Int, tool: String, params: [String: String], causedRecompile: Bool
+    ) {
+        log.append(
+            ActionLogEntry(
+                tMs: tMs, tool: tool, params: params, causedRecompile: causedRecompile
+            ))
+    }
+
+    /// Return all entries in insertion order.
+    public func entries() -> [ActionLogEntry] {
+        log
+    }
+}

--- a/Sources/PreviewsCore/Recording/FrameDiff.swift
+++ b/Sources/PreviewsCore/Recording/FrameDiff.swift
@@ -1,0 +1,109 @@
+import CoreGraphics
+import Foundation
+
+/// Computes Structural Similarity Index (SSIM) between two images.
+///
+/// Both images are downsampled to 128×128 grayscale before comparison.
+/// Uses the canonical Wang et al. formulation with 8×8 sliding window.
+///
+/// Reference: Z. Wang, A.C. Bovik, H.R. Sheikh, E.P. Simoncelli,
+/// "Image Quality Assessment: From Error Visibility to Structural Similarity,"
+/// IEEE Transactions on Image Processing, 2004.
+public enum FrameDiff {
+
+    /// Compare two images and return their SSIM (0.0 = completely different, 1.0 = identical).
+    public static func ssim(_ a: CGImage, _ b: CGImage) -> Double {
+        let size = 128
+        let pixelsA = downsampleToGrayscale(a, size: size)
+        let pixelsB = downsampleToGrayscale(b, size: size)
+        return computeSSIM(pixelsA, pixelsB, width: size, height: size)
+    }
+
+    // MARK: - Internal
+
+    /// Downsample a CGImage to `size×size` grayscale, returning pixel values as [Double] in 0...255.
+    static func downsampleToGrayscale(_ image: CGImage, size: Int) -> [Double] {
+        let bytesPerRow = size
+        var grayscale = [UInt8](repeating: 0, count: size * size)
+        guard
+            let context = CGContext(
+                data: &grayscale,
+                width: size,
+                height: size,
+                bitsPerComponent: 8,
+                bytesPerRow: bytesPerRow,
+                space: CGColorSpaceCreateDeviceGray(),
+                bitmapInfo: CGImageAlphaInfo.none.rawValue
+            )
+        else {
+            return [Double](repeating: 0, count: size * size)
+        }
+        context.interpolationQuality = .medium
+        context.draw(image, in: CGRect(x: 0, y: 0, width: size, height: size))
+        return grayscale.map { Double($0) }
+    }
+
+    /// Compute mean SSIM over 8×8 non-overlapping windows.
+    ///
+    /// SSIM(x,y) = (2·μx·μy + C1)(2·σxy + C2) / ((μx² + μy² + C1)(σx² + σy² + C2))
+    /// where C1 = (K1·L)², C2 = (K2·L)², L = 255, K1 = 0.01, K2 = 0.03
+    private static func computeSSIM(
+        _ a: [Double], _ b: [Double],
+        width: Int, height: Int
+    ) -> Double {
+        let windowSize = 8
+        let l: Double = 255.0
+        let k1: Double = 0.01
+        let k2: Double = 0.03
+        let c1 = (k1 * l) * (k1 * l)
+        let c2 = (k2 * l) * (k2 * l)
+
+        var ssimSum: Double = 0
+        var windowCount = 0
+
+        let stepsX = width / windowSize
+        let stepsY = height / windowSize
+
+        for wy in 0..<stepsY {
+            for wx in 0..<stepsX {
+                let startX = wx * windowSize
+                let startY = wy * windowSize
+                let n = Double(windowSize * windowSize)
+
+                var sumA: Double = 0
+                var sumB: Double = 0
+                var sumA2: Double = 0
+                var sumB2: Double = 0
+                var sumAB: Double = 0
+
+                for dy in 0..<windowSize {
+                    for dx in 0..<windowSize {
+                        let idx = (startY + dy) * width + (startX + dx)
+                        let pa = a[idx]
+                        let pb = b[idx]
+                        sumA += pa
+                        sumB += pb
+                        sumA2 += pa * pa
+                        sumB2 += pb * pb
+                        sumAB += pa * pb
+                    }
+                }
+
+                let muA = sumA / n
+                let muB = sumB / n
+                let sigmaA2 = sumA2 / n - muA * muA
+                let sigmaB2 = sumB2 / n - muB * muB
+                let sigmaAB = sumAB / n - muA * muB
+
+                let numerator = (2.0 * muA * muB + c1) * (2.0 * sigmaAB + c2)
+                let denominator = (muA * muA + muB * muB + c1) * (sigmaA2 + sigmaB2 + c2)
+
+                ssimSum += numerator / denominator
+                windowCount += 1
+            }
+        }
+
+        guard windowCount > 0 else { return 0 }
+        return ssimSum / Double(windowCount)
+    }
+}

--- a/Sources/PreviewsCore/Recording/KeyframeSelector.swift
+++ b/Sources/PreviewsCore/Recording/KeyframeSelector.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+/// Selects keyframes from a sequence of per-frame SSIM diffs using
+/// ffmpeg-style scene-detect semantics: pairwise threshold-gated emission
+/// with a minimum gap between frames and forced endpoints.
+public enum KeyframeSelector {
+
+    /// Result of keyframe selection.
+    public struct KeyframeSelection: Sendable {
+        /// Index of the first frame where motion was detected, or nil if no motion.
+        public let motionStartFrame: Int?
+        /// Index of the last frame of the motion window, or nil if no motion.
+        public let motionEndFrame: Int?
+        /// Sorted indices of selected keyframes within the diff array.
+        public let selectedIndices: [Int]
+    }
+
+    /// Select keyframes from a per-frame diff array.
+    ///
+    /// - Parameters:
+    ///   - diffs: Per-frame SSIM difference from the previous frame (1.0 - SSIM).
+    ///            Index 0 is the diff between frame 0 and frame 1.
+    ///   - frameCount: Target number of keyframes to return.
+    ///   - minGapMs: Minimum gap between selected frames in milliseconds.
+    ///   - fps: Capture frame rate (used to convert minGapMs to frame count).
+    ///   - motionThreshold: Diff value above which a frame is considered "in motion".
+    ///   - stillThreshold: Diff value below which a frame is considered "settled".
+    /// - Returns: A `KeyframeSelection` with the motion window and selected indices.
+    public static func select(
+        diffs: [Double],
+        frameCount: Int,
+        minGapMs: Int,
+        fps: Int,
+        motionThreshold: Double,
+        stillThreshold: Double
+    ) -> KeyframeSelection {
+        guard !diffs.isEmpty else {
+            return KeyframeSelection(
+                motionStartFrame: nil, motionEndFrame: nil, selectedIndices: [])
+        }
+
+        // 1. Find motion window
+        guard let motionStart = findMotionStart(diffs: diffs, threshold: motionThreshold) else {
+            return KeyframeSelection(
+                motionStartFrame: nil, motionEndFrame: nil, selectedIndices: [])
+        }
+
+        let motionEnd = findMotionEnd(
+            diffs: diffs, startFrame: motionStart,
+            stillThreshold: stillThreshold, settleFrames: settleFrameCount(fps: fps)
+        )
+
+        // 2. Select keyframes within the motion window
+        let minGapFrames = max(1, Int(ceil(Double(minGapMs) / 1000.0 * Double(fps))))
+
+        let selected = selectKeyframes(
+            diffs: diffs,
+            start: motionStart,
+            end: motionEnd,
+            frameCount: frameCount,
+            minGapFrames: minGapFrames,
+            motionThreshold: motionThreshold
+        )
+
+        return KeyframeSelection(
+            motionStartFrame: motionStart,
+            motionEndFrame: motionEnd,
+            selectedIndices: selected
+        )
+    }
+
+    // MARK: - Motion detection
+
+    /// Find the first frame where diff exceeds the motion threshold.
+    private static func findMotionStart(diffs: [Double], threshold: Double) -> Int? {
+        diffs.firstIndex { $0 > threshold }
+    }
+
+    /// Find the end of the motion window: the first frame after `startFrame`
+    /// where diff drops below `stillThreshold` for `settleFrames` consecutive frames.
+    /// Falls back to the last diff index if motion never settles.
+    private static func findMotionEnd(
+        diffs: [Double], startFrame: Int,
+        stillThreshold: Double, settleFrames: Int
+    ) -> Int {
+        var consecutiveStill = 0
+        for i in (startFrame + 1)..<diffs.count {
+            if diffs[i] < stillThreshold {
+                consecutiveStill += 1
+                if consecutiveStill >= settleFrames {
+                    return i - settleFrames + 1
+                }
+            } else {
+                consecutiveStill = 0
+            }
+        }
+        return diffs.count - 1
+    }
+
+    /// Number of consecutive "still" frames needed to declare settle (~100ms).
+    private static func settleFrameCount(fps: Int) -> Int {
+        max(1, Int(ceil(Double(fps) * 0.1)))
+    }
+
+    // MARK: - Keyframe selection
+
+    /// Select up to `frameCount` keyframes from the motion window,
+    /// respecting `minGapFrames` between each pair.
+    ///
+    /// Strategy:
+    /// 1. Collect all frames that cross `motionThreshold` (candidates).
+    /// 2. Force-include first and last frames of the motion window.
+    /// 3. Greedily pick candidates by descending diff, skipping any that
+    ///    violate the min-gap constraint against already-selected frames.
+    /// 4. If we have fewer than `frameCount`, fill with the highest-diff
+    ///    non-candidate frames that respect the gap constraint.
+    private static func selectKeyframes(
+        diffs: [Double],
+        start: Int,
+        end: Int,
+        frameCount: Int,
+        minGapFrames: Int,
+        motionThreshold: Double
+    ) -> [Int] {
+        guard start <= end else { return [start] }
+
+        var selected = Set<Int>()
+
+        // Force endpoints
+        selected.insert(start)
+        selected.insert(end)
+
+        // All frames in the window, sorted by diff (descending)
+        let windowFrames = (start...end).map { ($0, diffs[$0]) }
+        let sortedByDiff = windowFrames.sorted { $0.1 > $1.1 }
+
+        // Greedily pick frames by highest diff, respecting min-gap
+        for (idx, diff) in sortedByDiff {
+            if selected.count >= frameCount { break }
+            if diff <= 0 { continue }
+            if selected.contains(idx) { continue }
+            if respectsGap(idx, against: selected, minGap: minGapFrames) {
+                selected.insert(idx)
+            }
+        }
+
+        return selected.sorted()
+    }
+
+    /// Check if `candidate` is at least `minGap` frames away from all frames in `selected`.
+    private static func respectsGap(
+        _ candidate: Int, against selected: Set<Int>, minGap: Int
+    ) -> Bool {
+        for s in selected {
+            if abs(candidate - s) < minGap { return false }
+        }
+        return true
+    }
+}

--- a/Tests/PreviewsCoreTests/ActionLogTests.swift
+++ b/Tests/PreviewsCoreTests/ActionLogTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+
+@testable import PreviewsCore
+
+@Suite("ActionLog")
+struct ActionLogTests {
+
+    @Test("Entries are returned in insertion order")
+    func insertionOrder() async {
+        let log = ActionLog()
+        await log.append(
+            tMs: 0, tool: "preview_touch",
+            params: ["x": "100", "y": "200"], causedRecompile: false
+        )
+        await log.append(
+            tMs: 500, tool: "preview_switch",
+            params: ["previewIndex": "1"], causedRecompile: true
+        )
+        await log.append(
+            tMs: 1200, tool: "preview_configure",
+            params: ["colorScheme": "dark"], causedRecompile: true
+        )
+        let entries = await log.entries()
+        #expect(entries.count == 3)
+        #expect(entries[0].tool == "preview_touch")
+        #expect(entries[1].tool == "preview_switch")
+        #expect(entries[2].tool == "preview_configure")
+    }
+
+    @Test("Timestamps are monotonic")
+    func monotonicTimestamps() async {
+        let log = ActionLog()
+        await log.append(tMs: 100, tool: "a", params: [:], causedRecompile: false)
+        await log.append(tMs: 200, tool: "b", params: [:], causedRecompile: false)
+        await log.append(tMs: 300, tool: "c", params: [:], causedRecompile: false)
+        let entries = await log.entries()
+        for i in 1..<entries.count {
+            #expect(entries[i].tMs >= entries[i - 1].tMs)
+        }
+    }
+
+    @Test("causedRecompile flag is preserved")
+    func recompileFlag() async {
+        let log = ActionLog()
+        await log.append(tMs: 0, tool: "preview_touch", params: [:], causedRecompile: false)
+        await log.append(tMs: 100, tool: "preview_configure", params: [:], causedRecompile: true)
+        let entries = await log.entries()
+        #expect(entries[0].causedRecompile == false)
+        #expect(entries[1].causedRecompile == true)
+    }
+
+    @Test("Params are preserved")
+    func paramsPreserved() async {
+        let log = ActionLog()
+        await log.append(
+            tMs: 0, tool: "preview_touch",
+            params: ["x": "100", "y": "200", "action": "tap"],
+            causedRecompile: false
+        )
+        let entries = await log.entries()
+        #expect(entries[0].params["x"] == "100")
+        #expect(entries[0].params["y"] == "200")
+        #expect(entries[0].params["action"] == "tap")
+    }
+
+    @Test("JSON round-trip preserves all fields")
+    func jsonRoundTrip() async throws {
+        let log = ActionLog()
+        await log.append(
+            tMs: 42, tool: "preview_touch",
+            params: ["x": "100"], causedRecompile: false
+        )
+        await log.append(
+            tMs: 850, tool: "preview_switch",
+            params: ["previewIndex": "1"], causedRecompile: true
+        )
+        let entries = await log.entries()
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(entries)
+        let decoded = try JSONDecoder().decode([ActionLogEntry].self, from: data)
+
+        #expect(decoded.count == entries.count)
+        for (original, roundTripped) in zip(entries, decoded) {
+            #expect(original.tMs == roundTripped.tMs)
+            #expect(original.tool == roundTripped.tool)
+            #expect(original.params == roundTripped.params)
+            #expect(original.causedRecompile == roundTripped.causedRecompile)
+        }
+    }
+
+    @Test("Empty log returns empty array")
+    func emptyLog() async {
+        let log = ActionLog()
+        let entries = await log.entries()
+        #expect(entries.isEmpty)
+    }
+}

--- a/Tests/PreviewsCoreTests/FrameDiffTests.swift
+++ b/Tests/PreviewsCoreTests/FrameDiffTests.swift
@@ -1,0 +1,156 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import PreviewsCore
+
+@Suite("FrameDiff")
+struct FrameDiffTests {
+
+    // MARK: - Helpers
+
+    /// Create a solid-color CGImage at the given dimensions.
+    private func solidImage(
+        width: Int = 64, height: Int = 64,
+        r: UInt8, g: UInt8, b: UInt8
+    ) -> CGImage {
+        let bytesPerPixel = 4
+        let bytesPerRow = width * bytesPerPixel
+        var pixels = [UInt8](repeating: 0, count: width * height * bytesPerPixel)
+        for i in 0..<(width * height) {
+            pixels[i * bytesPerPixel + 0] = r
+            pixels[i * bytesPerPixel + 1] = g
+            pixels[i * bytesPerPixel + 2] = b
+            pixels[i * bytesPerPixel + 3] = 255
+        }
+        let data = Data(pixels)
+        let provider = CGDataProvider(data: data as CFData)!
+        return CGImage(
+            width: width, height: height,
+            bitsPerComponent: 8, bitsPerPixel: 32,
+            bytesPerRow: bytesPerRow,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
+            provider: provider,
+            decode: nil, shouldInterpolate: false,
+            intent: .defaultIntent
+        )!
+    }
+
+    /// Create a horizontal gradient from black to white.
+    private func gradientImage(width: Int = 128, height: Int = 128) -> CGImage {
+        let bytesPerPixel = 4
+        let bytesPerRow = width * bytesPerPixel
+        var pixels = [UInt8](repeating: 0, count: width * height * bytesPerPixel)
+        for y in 0..<height {
+            for x in 0..<width {
+                let val = UInt8(Double(x) / Double(width - 1) * 255)
+                let i = (y * width + x) * bytesPerPixel
+                pixels[i + 0] = val
+                pixels[i + 1] = val
+                pixels[i + 2] = val
+                pixels[i + 3] = 255
+            }
+        }
+        let data = Data(pixels)
+        let provider = CGDataProvider(data: data as CFData)!
+        return CGImage(
+            width: width, height: height,
+            bitsPerComponent: 8, bitsPerPixel: 32,
+            bytesPerRow: bytesPerRow,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
+            provider: provider,
+            decode: nil, shouldInterpolate: false,
+            intent: .defaultIntent
+        )!
+    }
+
+    /// Create a shifted gradient (offset by some pixels).
+    private func shiftedGradientImage(
+        width: Int = 128, height: Int = 128, shiftPixels: Int = 16
+    ) -> CGImage {
+        let bytesPerPixel = 4
+        let bytesPerRow = width * bytesPerPixel
+        var pixels = [UInt8](repeating: 0, count: width * height * bytesPerPixel)
+        for y in 0..<height {
+            for x in 0..<width {
+                let shifted = (x + shiftPixels) % width
+                let val = UInt8(Double(shifted) / Double(width - 1) * 255)
+                let i = (y * width + x) * bytesPerPixel
+                pixels[i + 0] = val
+                pixels[i + 1] = val
+                pixels[i + 2] = val
+                pixels[i + 3] = 255
+            }
+        }
+        let data = Data(pixels)
+        let provider = CGDataProvider(data: data as CFData)!
+        return CGImage(
+            width: width, height: height,
+            bitsPerComponent: 8, bitsPerPixel: 32,
+            bytesPerRow: bytesPerRow,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
+            provider: provider,
+            decode: nil, shouldInterpolate: false,
+            intent: .defaultIntent
+        )!
+    }
+
+    // MARK: - Tests
+
+    @Test("Identical images produce SSIM ≈ 1.0")
+    func identicalImages() {
+        let img = solidImage(r: 128, g: 128, b: 128)
+        let ssim = FrameDiff.ssim(img, img)
+        #expect(abs(ssim - 1.0) < 1e-6)
+    }
+
+    @Test("Inverted images produce low SSIM")
+    func invertedImages() {
+        let white = solidImage(r: 255, g: 255, b: 255)
+        let black = solidImage(r: 0, g: 0, b: 0)
+        let ssim = FrameDiff.ssim(white, black)
+        // Solid images have zero variance, so SSIM is based on luminance only.
+        // For black vs white, SSIM should be very low.
+        #expect(ssim < 0.1)
+    }
+
+    @Test("Slightly different images produce high but not perfect SSIM")
+    func slightDifference() {
+        let a = solidImage(r: 128, g: 128, b: 128)
+        let b = solidImage(r: 140, g: 140, b: 140)
+        let ssim = FrameDiff.ssim(a, b)
+        #expect(ssim > 0.9)
+        #expect(ssim < 1.0)
+    }
+
+    @Test("Gradient vs shifted gradient produces intermediate SSIM")
+    func gradientShift() {
+        let a = gradientImage()
+        let b = shiftedGradientImage(shiftPixels: 16)
+        let ssim = FrameDiff.ssim(a, b)
+        // Should be measurably different but not completely dissimilar
+        #expect(ssim > 0.3)
+        #expect(ssim < 0.95)
+    }
+
+    @Test("SSIM is symmetric")
+    func symmetry() {
+        let a = solidImage(r: 100, g: 150, b: 200)
+        let b = solidImage(r: 200, g: 100, b: 50)
+        let ssimAB = FrameDiff.ssim(a, b)
+        let ssimBA = FrameDiff.ssim(b, a)
+        #expect(abs(ssimAB - ssimBA) < 1e-6)
+    }
+
+    @Test("Different sized images are handled by downsampling both to 128×128")
+    func differentSizes() {
+        let small = solidImage(width: 32, height: 32, r: 128, g: 128, b: 128)
+        let large = solidImage(width: 400, height: 600, r: 128, g: 128, b: 128)
+        let ssim = FrameDiff.ssim(small, large)
+        // Same color → should be very high after downsampling
+        #expect(ssim > 0.99)
+    }
+}

--- a/Tests/PreviewsCoreTests/KeyframeSelectorTests.swift
+++ b/Tests/PreviewsCoreTests/KeyframeSelectorTests.swift
@@ -1,0 +1,151 @@
+import Foundation
+import Testing
+
+@testable import PreviewsCore
+
+@Suite("KeyframeSelector")
+struct KeyframeSelectorTests {
+
+    // MARK: - Helpers
+
+    /// Generate a diff array of `count` values, all set to `value`.
+    private func uniformDiffs(count: Int, value: Double) -> [Double] {
+        [Double](repeating: value, count: count)
+    }
+
+    /// Generate a diff array simulating an ease-out animation:
+    /// high diff at the start, decaying exponentially.
+    private func easeOutDiffs(count: Int, peak: Double = 0.8, decay: Double = 0.85) -> [Double] {
+        (0..<count).map { i in peak * pow(decay, Double(i)) }
+    }
+
+    /// Generate a diff array with a single spike at `spikeIndex`.
+    private func spikeDiffs(count: Int, spikeIndex: Int, spikeValue: Double = 0.8) -> [Double] {
+        var diffs = [Double](repeating: 0.01, count: count)
+        diffs[spikeIndex] = spikeValue
+        return diffs
+    }
+
+    // MARK: - Tests
+
+    @Test("No motion — all diffs below threshold")
+    func noMotion() {
+        let diffs = uniformDiffs(count: 90, value: 0.01)  // 3s at 30fps
+        let result = KeyframeSelector.select(
+            diffs: diffs, frameCount: 6, minGapMs: 80, fps: 30,
+            motionThreshold: 0.05, stillThreshold: 0.02
+        )
+        #expect(result.selectedIndices.isEmpty)
+        #expect(result.motionStartFrame == nil)
+        #expect(result.motionEndFrame == nil)
+    }
+
+    @Test("All motion — diffs always above threshold, never settles")
+    func allMotion() {
+        let diffs = uniformDiffs(count: 90, value: 0.5)
+        let result = KeyframeSelector.select(
+            diffs: diffs, frameCount: 6, minGapMs: 80, fps: 30,
+            motionThreshold: 0.05, stillThreshold: 0.02
+        )
+        // Motion detected from start, never settles → uses full range
+        #expect(result.motionStartFrame != nil)
+        #expect(result.selectedIndices.count <= 6)
+        #expect(result.selectedIndices.count >= 2)  // at least first+last
+        // First and last of motion window must be included
+        if let start = result.motionStartFrame, let end = result.motionEndFrame {
+            #expect(result.selectedIndices.contains(start))
+            #expect(result.selectedIndices.contains(end))
+        }
+    }
+
+    @Test("Single spike — selects around the spike")
+    func singleSpike() {
+        let diffs = spikeDiffs(count: 90, spikeIndex: 45)
+        let result = KeyframeSelector.select(
+            diffs: diffs, frameCount: 6, minGapMs: 80, fps: 30,
+            motionThreshold: 0.05, stillThreshold: 0.02
+        )
+        #expect(result.motionStartFrame == 45)
+        // The spike is a single frame, so motion window is narrow
+        #expect(result.selectedIndices.contains(45))
+    }
+
+    @Test("Ease-out decay — first and last frames of motion window included")
+    func easeOutDecay() {
+        let diffs = easeOutDiffs(count: 90, peak: 0.8, decay: 0.85)
+        let result = KeyframeSelector.select(
+            diffs: diffs, frameCount: 6, minGapMs: 80, fps: 30,
+            motionThreshold: 0.05, stillThreshold: 0.02
+        )
+        #expect(result.motionStartFrame != nil)
+        #expect(result.motionEndFrame != nil)
+        if let start = result.motionStartFrame, let end = result.motionEndFrame {
+            #expect(result.selectedIndices.contains(start))
+            #expect(result.selectedIndices.contains(end))
+        }
+    }
+
+    @Test("Min gap is respected — no two frames closer than minGapMs")
+    func minGapRespected() {
+        // High diffs on every frame, forcing the selector to skip some
+        let diffs = uniformDiffs(count: 90, value: 0.5)
+        let result = KeyframeSelector.select(
+            diffs: diffs, frameCount: 12, minGapMs: 80, fps: 30,
+            motionThreshold: 0.05, stillThreshold: 0.02
+        )
+        let sorted = result.selectedIndices.sorted()
+        let minGapFrames = Int(ceil(Double(80) / 1000.0 * Double(30)))  // ~3 frames at 30fps
+        for i in 1..<sorted.count {
+            #expect(sorted[i] - sorted[i - 1] >= minGapFrames)
+        }
+    }
+
+    @Test("Frame count budget — fewer candidates than budget fills with next-highest diffs")
+    func budgetUnderflow() {
+        // Sustained motion window with only 2 big spikes, asking for 6.
+        // The motion window spans [10, 50] because diffs stay above stillThreshold.
+        var diffs = uniformDiffs(count: 90, value: 0.03)  // above stillThreshold (0.02)
+        diffs[10] = 0.5  // spike — above motionThreshold
+        diffs[40] = 0.5  // spike — above motionThreshold
+        // Set frames after 50 to below stillThreshold so motion window ends
+        for i in 51..<90 { diffs[i] = 0.01 }
+        let result = KeyframeSelector.select(
+            diffs: diffs, frameCount: 6, minGapMs: 80, fps: 30,
+            motionThreshold: 0.05, stillThreshold: 0.02
+        )
+        // Both spikes should be selected, plus forced endpoints
+        #expect(result.selectedIndices.contains(10))
+        #expect(result.selectedIndices.contains(40))
+        #expect(result.motionStartFrame == 10)
+    }
+
+    @Test("Frame count budget — more candidates than budget prefers highest diffs")
+    func budgetOverflow() {
+        // Many frames cross the threshold, we only want 4
+        let diffs = easeOutDiffs(count: 90, peak: 0.8, decay: 0.95)
+        let result = KeyframeSelector.select(
+            diffs: diffs, frameCount: 4, minGapMs: 80, fps: 30,
+            motionThreshold: 0.05, stillThreshold: 0.02
+        )
+        #expect(result.selectedIndices.count <= 4)
+    }
+
+    @Test("Selected indices are sorted")
+    func sortedOutput() {
+        let diffs = easeOutDiffs(count: 90)
+        let result = KeyframeSelector.select(
+            diffs: diffs, frameCount: 6, minGapMs: 80, fps: 30,
+            motionThreshold: 0.05, stillThreshold: 0.02
+        )
+        #expect(result.selectedIndices == result.selectedIndices.sorted())
+    }
+
+    @Test("Empty diffs returns no selection")
+    func emptyDiffs() {
+        let result = KeyframeSelector.select(
+            diffs: [], frameCount: 6, minGapMs: 80, fps: 30,
+            motionThreshold: 0.05, stillThreshold: 0.02
+        )
+        #expect(result.selectedIndices.isEmpty)
+    }
+}

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,0 +1,382 @@
+# preview_record — Implementation Plan
+
+**Spec:** [`SPEC.md`](../SPEC.md)
+**Date:** 2026-04-19 (updated for daemon architecture, rebased on main)
+**Branch:** `worktree-preview-record-spec`
+
+## Architecture context (post-rebase)
+
+Since the original plan was written, the project adopted a daemon-based architecture (#113). Key impacts:
+
+- **CLI/MCP parity:** every MCP tool has a corresponding CLI subcommand that connects to the daemon via `DaemonClient.withDaemonClient` over a Unix domain socket. New recording tools need CLI commands too.
+- **Tool schemas extracted to `MCPToolSchemas.swift`** — `ToolName` enum and schema definitions live there, not inline in `MCPServer.swift`.
+- **Structured content:** tool handlers emit `DaemonProtocol` DTOs via `structuredContent` alongside text content blocks. New tools need DTOs.
+- **Session resolution:** CLI commands use `SessionResolver` + `SessionTargetingOptions` for `--session`/`--file` targeting. Recording commands reuse this.
+- **Test serialization:** daemon-touching tests use `DaemonTestLock` (flock) for cross-suite ordering. New integration tests must acquire this lock.
+- **Command registration:** new subcommands register in `PreviewsMCPApp.swift`.
+- **Output conventions:** read-oriented commands get `--json`; imperative commands write confirmations to stderr only.
+
+The dispatch switch in `MCPServer.swift:100-128` is structurally unchanged — middleware still plugs in there.
+
+## Approach
+
+Vertical slicing. Each slice ends with a shippable, testable end-to-end path — not a horizontal layer.
+
+Six slices, with human review checkpoints at the end of slices 1, 2, and 4.
+
+## Dependency graph
+
+```
+                ┌─────────────────────────────────────────┐
+                │  Slice 1: Core primitives               │
+                │  FrameDiff · KeyframeSelector · ActionLog │
+                │  (pure Swift, unit-tested in isolation) │
+                └─────────────────────────────────────────┘
+                       │                          │
+                       ▼                          ▼
+  ┌────────────────────────────────┐   (ActionLog unused until Slice 4)
+  │ Slice 2: macOS preview_record  │
+  │ SnapshotRecorder · TouchOverlay   │
+  │ + RecordCommand CLI            │
+  │ + DaemonProtocol.RecordResult  │
+  │ (atomic keyframe capture,      │
+  │  end-to-end on macOS)          │
+  └────────────────────────────────┘
+                       │
+                       ▼
+  ┌────────────────────────────────┐
+  │ Slice 3: iOS preview_record    │
+  │ SimctlRecorder · AVAssetReader │
+  │ (iOS parity — reuses diff,     │
+  │  selector, overlay from S1/S2) │
+  └────────────────────────────────┘
+                       │
+                       ▼
+  ┌────────────────────────────────────────────────────────┐
+  │ Slice 4: macOS session recording                       │
+  │ RecordingState · Dispatcher middleware                 │
+  │ preview_record_start/stop handlers                     │
+  │ RecordStartCommand + RecordStopCommand CLI              │
+  │ DaemonProtocol.RecordStartResult/RecordStopResult DTOs │
+  │ AVVideoCompositionCoreAnimationTool overlay             │
+  │ Implicit finalize on preview_stop                      │
+  └────────────────────────────────────────────────────────┘
+                       │
+                       ▼
+  ┌────────────────────────────────┐
+  │ Slice 5: iOS session recording │
+  │ (reuses S4 middleware + state, │
+  │  adds iOS recorder to handlers)│
+  └────────────────────────────────┘
+                       │
+                       ▼
+  ┌────────────────────────────────┐
+  │ Slice 6: Polish                │
+  │ Spritesheet format             │
+  │ no-motion branch               │
+  │ frame index overlay on sheet   │
+  └────────────────────────────────┘
+```
+
+## Slices
+
+### Slice 1 — Core primitives
+
+**Goal:** Ship pure Swift algorithms for frame diff, keyframe selection, and action log. Zero platform dependencies. Fully unit-testable.
+
+**Why first:** Everything downstream depends on these. They have no I/O and no platform surface, so we can iterate on algorithm correctness without ever touching a simulator or a window.
+
+**Changes:**
+- `Sources/PreviewsCore/Recording/FrameDiff.swift`
+  - `struct FrameDiff { static func ssim(_ a: CGImage, _ b: CGImage) -> Double }`
+  - Grayscale conversion to 128×128, 8×8 window SSIM per Wang et al. (reference, do not reinvent).
+  - Inputs as `CGImage` — the common frame type across macOS (`NSBitmapImageRep.cgImage`) and iOS (`AVAssetReader` → `CVPixelBuffer` → `CGImage`). CoreGraphics only, no AppKit dependency.
+- `Sources/PreviewsCore/Recording/KeyframeSelector.swift`
+  - `struct KeyframeSelector { static func select(diffs: [Double], frameCount: Int, minGapMs: Int, fps: Int, motionThreshold: Double, stillThreshold: Double) -> KeyframeSelection }`
+  - Returns `(motionStartFrame, motionEndFrame, selectedIndices)`. Pairwise threshold-gated scene detect + min-gap + forced endpoints. No cumulative-diff.
+- `Sources/PreviewsCore/Recording/ActionLog.swift`
+  - `public struct ActionLogEntry: Sendable, Codable { let tMs: Int; let tool: String; let params: [String: AnyCodable]; let causedRecompile: Bool }`
+  - `public actor ActionLog { append(...); entries() -> [ActionLogEntry] }`
+  - Sendable for cross-isolation use. Serialization round-trip tested.
+  - For `AnyCodable`, use `MCP.Value` from the swift-sdk (already a dependency) rather than a custom wrapper or new dependency.
+- `Tests/PreviewsCoreTests/FrameDiffTests.swift`
+  - Identical frames → SSIM = 1.0 (±1e-6)
+  - Inverted frames → SSIM near 0
+  - Known gradient shifts → SSIM in expected bounds
+- `Tests/PreviewsCoreTests/KeyframeSelectorTests.swift`
+  - Synthetic diff arrays: all-zero (no motion), all-high (continuous motion), single spike, ease-out decay
+  - Min-gap respected (no two frames closer than `minGapMs`)
+  - First/last frame of motion window always included
+  - `frameCount` budget: fewer candidates than budget → fill with next-highest; more candidates → prefer highest diff
+- `Tests/PreviewsCoreTests/ActionLogTests.swift`
+  - Ordering preserved on concurrent appends
+  - Monotonic timestamps (no reordering on serialize)
+  - JSON round-trip equality
+
+**Acceptance criteria:**
+- `swift test --filter FrameDiff` passes
+- `swift test --filter KeyframeSelector` passes
+- `swift test --filter ActionLog` passes
+- No new warnings under strict concurrency
+- `swift build` still succeeds for all existing targets
+
+**Verification:**
+```bash
+swift test --filter "FrameDiff|KeyframeSelector|ActionLog"
+swift build
+```
+
+**→ CHECKPOINT 1: Human review.** Algorithm correctness is frozen here. Next slices layer I/O on top.
+
+---
+
+### Slice 2 — macOS `preview_record` (end-to-end, atomic)
+
+**Goal:** A working `preview_record` MCP tool + `record` CLI subcommand on macOS. Tap an animated button, get 6 keyframes with touch overlays back inline. No session recording yet.
+
+**Why second:** Proves the full pipeline (capture → diff → select → overlay → encode → return) on the cheaper platform before paying iOS decode cost. Most likely place for surprises (timer-polled `Snapshot.capture` edge cases, window targeting, encoding latency) — surface them now.
+
+**Changes:**
+- `Sources/PreviewsMacOS/Recording/SnapshotRecorder.swift`
+  - `@MainActor class SnapshotRecorder { init(window: NSWindow); func start(fps: Int); func stop() -> [(CGImage, ContinuousClock.Instant)] }`
+  - Timer-polled `Snapshot.capture` at ~30fps (reuses existing `bitmapImageRepForCachingDisplay` + `cacheDisplay` code path).
+  - Use `DispatchSource.makeTimerSource(queue: .main)` (not `Timer.scheduledTimer`) to avoid run-loop-mode coalescing during tracking events that could bunch frames.
+  - In-memory frame buffer of `(CGImage, ContinuousClock.Instant)` tuples. No new frameworks, no TCC permissions, works headless.
+- `Sources/PreviewsCore/Recording/TouchOverlay.swift`
+  - `struct TouchOverlay { static func composite(onto: CGImage, taps: [TouchEvent], atFrameTime: Int) -> CGImage }`
+  - CoreGraphics `CGContext` draw (single-frame use — used for keyframe output in slices 2 & 3).
+  - Fading circle, alpha 1.0 → 0 over 500ms relative to tap time.
+- `Sources/PreviewsCLI/MCPToolSchemas.swift`
+  - Add `ToolName.previewRecord = "preview_record"` to the enum.
+  - Add tool schema to `mcpToolSchemas()` return array.
+- `Sources/PreviewsCLI/MCPServer.swift`
+  - Add `case .previewRecord` to the dispatch switch.
+  - `handlePreviewRecord(params:)` for macOS: target window from `App.host.window(for: sessionID)`, instantiate `SnapshotRecorder`, start capture, fire trigger via existing touch code path, record tap event into a local `[TouchEvent]`, stop capture, run `FrameDiff` on adjacent pairs, run `KeyframeSelector`, composite overlays via `TouchOverlay`, JPEG-encode, return inline `.image(...)` content matching `preview_snapshot` convention.
+  - iOS path returns `isError: true` with "iOS preview_record not yet supported" message.
+  - Emit `structuredContent` via `DaemonProtocol.RecordResult` DTO alongside images.
+- `Sources/PreviewsCLI/DaemonProtocol.swift`
+  - Add `RecordResult` DTO: `{ durationMs: Int, motionStartMs: Int, motionEndMs: Int, framesReturned: Int, warning: String? }`.
+- `Sources/PreviewsCLI/RecordCommand.swift` **(new file)**
+  - CLI subcommand: `previewsmcp record <x> <y> [--session|--file] [--output <dir>] [--frame-count 6] [--max-duration 3000] [--format sequence|spritesheet] [--quality 0.85] [--json]`
+  - Daemon client pattern: `DaemonClient.withDaemonClient` → `SessionResolver.resolve` → `client.callToolStructured("preview_record", ...)`.
+  - Read-oriented → supports `--json` (emits `RecordResult` + frame file paths to stdout).
+  - Writes frames to disk at `--output` directory (CLI-specific; the MCP tool returns inline).
+  - Uses `@OptionGroup var target: SessionTargetingOptions`.
+- `Sources/PreviewsCLI/PreviewsMCPApp.swift`
+  - Register `RecordCommand` as a subcommand.
+- `Tests/MCPIntegrationTests/PreviewRecordMacOSTests.swift`
+  - New fixture: `TestPreviews/AnimatedButton.swift` — button that, on tap, animates `scaleEffect(pressed ? 0.8 : 1.0)` with a 0.5s ease-out.
+  - Start a macOS preview session, call `preview_record` with tap on the button, assert:
+    - Response content has ≥2 and ≤12 images
+    - `structuredContent` decodes to `RecordResult` with `durationMs` in expected range
+    - No `warning` field
+  - No-motion test: tap on a blank region, assert single frame + `warning` present.
+  - Uses `DaemonTestLock` for cross-suite serialization.
+
+**Acceptance criteria:**
+- `swift test --filter PreviewRecordMacOS` passes
+- `preview_record` tool appears in `ListTools` output
+- `previewsmcp record` CLI subcommand works against the daemon
+- iOS call returns a clear "not yet supported" error, not a crash
+- `previewsmcp record --json` emits valid JSON to stdout
+
+**Verification:**
+```bash
+swift test --filter "PreviewRecordMacOS"
+swift build && .build/debug/previewsmcp record --help
+```
+
+**Risks:**
+- `bitmapImageRepForCachingDisplay` is `@MainActor`. The capture timer callback must dispatch to the main actor, which means frame capture competes with SwiftUI layout/render. At 30fps for a 400×600 window this is <1ms per frame — negligible. But very complex layouts may cause occasional frame drops. Mitigation: allow dropped frames in the diff buffer (the algorithm tolerates gaps).
+- Touch overlay timing: the tap event fires between frames. Pick "nearest frame by wall-clock" for overlay anchoring, not interpolation.
+
+**→ CHECKPOINT 2: Human review.** End-to-end UX is testable. Decide if keyframe quality, overlay appearance, and return format are right before replicating the pattern on iOS.
+
+---
+
+### Slice 3 — iOS `preview_record`
+
+**Goal:** iOS parity for `preview_record`. Reuses everything from Slices 1 & 2 except the capture path and an AVAssetReader decode step. CLI command already works (daemon routes to the iOS handler; `RecordCommand` doesn't need changes).
+
+**Why third:** iOS capture is the expensive path (simctl serializes to a .mov file, which must be decoded frame-by-frame to get `CVPixelBuffer`s for SSIM). Isolating it here means we're only debugging one new thing — the decode pipeline — not also the algorithm or the overlay.
+
+**Changes:**
+- `Sources/PreviewsIOS/Recording/SimctlRecorder.swift`
+  - `actor SimctlRecorder { init(deviceUDID: String); func start(codec: String); func stop() -> URL }`
+  - Forks `xcrun simctl io <udid> recordVideo --codec <codec> <temp path>`, tracks `Process`, terminates with SIGINT (not SIGTERM — simctl requires SIGINT to close the container).
+  - Returns the .mov file path on stop.
+- `Sources/PreviewsCore/Recording/MovieDecoder.swift`
+  - `struct MovieDecoder { static func decodeFrames(at: URL) async throws -> [CGImage] }`
+  - `AVAssetReader` + `AVAssetReaderTrackOutput` with `kCVPixelFormatType_32BGRA` output. Converts each `CVPixelBuffer` → `CGImage` internally (via `CGContext`-backed render from the buffer's base address). Returns `[CGImage]` so downstream code (FrameDiff, KeyframeSelector, TouchOverlay) consumes the common type directly — no conversion step needed at the call site.
+- `Sources/PreviewsCLI/MCPServer.swift`
+  - Fill in the iOS branch of `handlePreviewRecord`:
+    - Get iOS session → `SimctlRecorder`
+    - Start → fire trigger via existing iOS touch path (recording tap event locally) → stop
+    - `MovieDecoder.decodeFrames(at:)` → pixel buffer array
+    - Same FrameDiff → KeyframeSelector → TouchOverlay → JPEG → inline image pipeline as macOS
+- `Tests/MCPIntegrationTests/PreviewRecordIOSTests.swift`
+  - Mirror of `PreviewRecordMacOSTests` on the iOS path. Slow — boots a real sim.
+  - Minimum: one happy-path test (tap animated button, get keyframes) + one no-motion test.
+  - Uses `DaemonTestLock`.
+
+**Acceptance criteria:**
+- `swift test --filter "PreviewRecordIOS"` passes (slow, ~30s)
+- `previewsmcp record` CLI works against an iOS session
+- No regression in existing iOS tests (`swift test --filter "IOSPreviewSession"`)
+
+**Verification:**
+```bash
+swift test --filter "PreviewRecordIOS|IOSPreviewSession"
+```
+
+**Risks:**
+- `simctl` finalization race: sending SIGINT too early truncates the container. Mitigation: sleep 100ms after stopping capture before SIGINT, verify file is non-zero after `waitpid`.
+- AVAssetReader pixel format: iOS simulator may emit `kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange`. Force BGRA via `AVAssetReaderTrackOutput` settings.
+
+---
+
+### Slice 4 — macOS session recording (`preview_record_start` / `preview_record_stop`)
+
+**Goal:** Session-scoped video recording on macOS. Shipping `preview_record_start`, `preview_record_stop` MCP tools + CLI commands, the dispatcher middleware, the action log integration, AVFoundation overlay compositing at stop time, and implicit finalize on `preview_stop`.
+
+**Why fourth:** This is the biggest slice and the most architecturally invasive (it touches the dispatch layer, adds new global state, and introduces AVFoundation composition). It must land after the atomic `preview_record` slices because it reuses `SnapshotRecorder` and `ActionLog`.
+
+**Changes:**
+- `Sources/PreviewsCLI/RecordingState.swift`
+  - `actor RecordingState { struct ActiveRecording { let recorder: any Recorder; let actionLog: ActionLog; let startedAt: ContinuousClock.Instant } }`
+  - Keyed by `sessionID`. Methods: `start(sessionID:recorder:)`, `isActive(sessionID:)`, `log(sessionID:tool:params:)`, `stop(sessionID:) -> (URL, [ActionLogEntry])`.
+- `Sources/PreviewsCore/Recording/Recorder.swift`
+  - `protocol Recorder: Sendable { func start() async throws; func stop() async throws -> URL }`
+  - Abstraction over SnapshotRecorder (macOS) and SimctlRecorder (iOS, slice 5). macOS session variant uses `AVAssetWriter` + `AVAssetWriterInputPixelBufferAdaptor` to encode each timer-polled `Snapshot.capture` frame into a `.mov` live.
+- `Sources/PreviewsMacOS/Recording/PixelBufferConverter.swift`
+  - `struct PixelBufferConverter { static func convert(_ image: CGImage, pool: CVPixelBufferPool) -> CVPixelBuffer }`
+  - Creates a `CGContext` backed by the `CVPixelBuffer`'s base address, draws the `CGImage` into it. Used by `SnapshotRecorder`'s session mode to feed `AVAssetWriterInputPixelBufferAdaptor`. The pixel buffer pool is created once per recording session from the `AVAssetWriter`.
+- `Sources/PreviewsCore/Recording/SessionOverlay.swift`
+  - `struct SessionOverlay { static func composite(rawVideo: URL, actions: [ActionLogEntry], output: URL) async throws }`
+  - Builds a CALayer tree with fading-circle overlays per tap/swipe event, uses `AVVideoCompositionCoreAnimationTool`, exports via `AVAssetExportSession`.
+- `Sources/PreviewsCLI/MCPToolSchemas.swift`
+  - Add `ToolName.previewRecordStart` and `ToolName.previewRecordStop` to enum.
+  - Add tool schemas to `mcpToolSchemas()`.
+- `Sources/PreviewsCLI/MCPServer.swift`
+  - Add `case .previewRecordStart, .previewRecordStop` to dispatch switch.
+  - **Dispatcher middleware:** wrap the existing switch body into a helper; after the handler returns, check `recordingState.isActive(sessionID:)` and log to the action timeline if active. One touch point at the dispatch layer — not per-handler.
+  - Static set: `recompileCausingTools: Set<String> = ["preview_configure", "preview_switch", "preview_variants"]`.
+  - `handlePreviewRecordStart(params:)` — create session recorder for the macOS window, start, register in `RecordingState`, return `{recordingID}`. Error if already active. Emit `structuredContent` via `RecordStartResult` DTO.
+  - `handlePreviewRecordStop(params:)` — `recordingState.stop(sessionID:)`, overlay composition pass, write to `NSTemporaryDirectory()/previewsmcp-<sessionID>-<uuid>.mov`, return `{path, durationMs, actions}`. Emit `structuredContent` via `RecordStopResult` DTO.
+  - **Modify `handlePreviewStop`:** before running normal stop logic, check `recordingState.isActive(sessionID:)`; if true, finalize the recording first and merge its result into the stop response.
+- `Sources/PreviewsCLI/DaemonProtocol.swift`
+  - Add `RecordStartResult` DTO: `{ recordingID: String, sessionID: String }`.
+  - Add `RecordStopResult` DTO: `{ path: String, durationMs: Int, actions: [ActionLogEntryDTO] }`.
+  - Add `ActionLogEntryDTO`: `{ tMs: Int, tool: String, causedRecompile: Bool }`.
+- `Sources/PreviewsCLI/RecordStartCommand.swift` **(new file)**
+  - CLI subcommand: `previewsmcp record-start [--session|--file] [--codec h264|hevc]`
+  - Imperative → stderr confirmation only (no `--json`), following `configure`/`switch`/`touch` pattern.
+  - `DaemonClient.withDaemonClient` → `SessionResolver.resolve` → `client.callTool("preview_record_start", ...)`.
+- `Sources/PreviewsCLI/RecordStopCommand.swift` **(new file)**
+  - CLI subcommand: `previewsmcp record-stop [--session|--file]`
+  - Read-oriented → supports `--json` (emits `RecordStopResult` including path and action log).
+  - Prints the finalized `.mov` path to stdout.
+- `Sources/PreviewsCLI/PreviewsMCPApp.swift`
+  - Register `RecordStartCommand` and `RecordStopCommand`.
+- `Tests/MCPIntegrationTests/PreviewRecordSessionMacOSTests.swift`
+  - Start recording → 3 mixed tool calls (tap, switch, configure) → stop. Assert:
+    - Action log length and `causedRecompile` flags correct
+    - `.mov` exists, is decodable by `AVAssetReader`, duration is sane
+  - Implicit-stop test: start recording → `preview_stop`, assert result includes recording path.
+  - Uses `DaemonTestLock`.
+
+**Acceptance criteria:**
+- `swift test --filter "PreviewRecordSessionMacOS"` passes
+- Middleware does not break any existing tool (run full test suite, zero regressions)
+- `previewsmcp record-start` and `previewsmcp record-stop` CLI commands work
+- Manual smoke test: record a demo, inspect the .mov in QuickTime
+
+**Verification:**
+```bash
+swift test  # full suite — middleware is global
+swift build && .build/debug/previewsmcp record-start --help && .build/debug/previewsmcp record-stop --help
+```
+
+**Risks:**
+- Session `SnapshotRecorder` for live `.mov` encoding uses `AVAssetWriter` wrapping the timer-polled `Snapshot.capture` feed. This is a different mode from the atomic recorder in slice 2 (which stores `CGImage`s in memory). `SnapshotRecorder` should support both modes (atomic: in-memory buffer; session: live AVAssetWriter encoding) — the timer loop is the same, only the frame sink differs.
+- `AVVideoCompositionCoreAnimationTool` gotcha: video layer must be a *child* of the container layer, and the container layer must not be in any visible view hierarchy.
+- Middleware sessionID extraction: some tools don't take a `sessionID` (e.g., `preview_list`, `simulator_list`, `session_list`). Skip logging for those.
+
+**→ CHECKPOINT 3: Human review.** Session recording contract is frozen. iOS is now a copy of a known-good pattern.
+
+---
+
+### Slice 5 — iOS session recording
+
+**Goal:** iOS parity for `preview_record_start`/`preview_record_stop`. Reuses middleware, `RecordingState`, `ActionLog`, `SessionOverlay`, and CLI commands from slice 4. Adds an iOS-flavored recorder.
+
+**Changes:**
+- `Sources/PreviewsIOS/Recording/SessionSimctlRecorder.swift`
+  - Conforms to `Recorder` protocol. Wraps `SimctlRecorder` from slice 3 (or extends it if the shape already fits).
+  - `start()` forks simctl, `stop()` sends SIGINT and waits for file finalization, returns the raw .mov path.
+- `Sources/PreviewsCLI/MCPServer.swift`
+  - In `handlePreviewRecordStart`, branch on iOS session and use `SessionSimctlRecorder`.
+  - Overlay composition pass is already platform-agnostic.
+- `Tests/MCPIntegrationTests/PreviewRecordSessionIOSTests.swift`
+  - Mirror of the macOS session test on iOS. Slow. One happy-path + one implicit-stop test minimum.
+  - Uses `DaemonTestLock`.
+
+**Acceptance criteria:**
+- `swift test --filter "PreviewRecordSessionIOS"` passes
+- No regression in existing iOS tests or in slice 4 macOS session tests
+- `previewsmcp record-start` / `record-stop` work against an iOS session
+
+**Verification:**
+```bash
+swift test --filter "PreviewRecordSession|IOSPreviewSession"
+```
+
+---
+
+### Slice 6 — Polish
+
+**Goal:** Close the remaining spec items. No new architecture, just wrapping up.
+
+**Changes:**
+- `Sources/PreviewsCore/Recording/Spritesheet.swift`
+  - `struct Spritesheet { static func compose(frames: [CGImage], columns: Int) -> CGImage }`
+  - `ceil(sqrt(N))` columns, row-major. Draw frame index in corner (small, contrasting).
+- `Sources/PreviewsCLI/MCPServer.swift`
+  - In `handlePreviewRecord`, branch on `format` parameter: `"sequence"` → multiple `.image(...)` entries (existing), `"spritesheet"` → single `.image(...)` with the composed grid.
+- `Tests/MCPIntegrationTests/PreviewRecordSpritesheetTests.swift`
+  - Call `preview_record` with `format: "spritesheet"`, assert single image in response.
+- Documentation:
+  - Update `README.md` tool list + CLI subcommands table to include the three new tools / commands.
+  - Update `AGENTS.md` `## MCP Server` tools section, `### CLI subcommands` table, and `### Structured output` list.
+  - Add a `## Recording` section to `AGENTS.md` matching the style of `## Trait Injection` and `## Multi-Preview Support`.
+
+**Acceptance criteria:**
+- `swift test` — all passing
+- README and AGENTS.md updated
+- Manual smoke test of spritesheet output
+
+**Verification:**
+```bash
+swift test
+swift-format lint --strict --recursive Sources/ Tests/
+swiftlint lint --quiet Sources/ Tests/
+```
+
+## Non-task items (explicitly deferred)
+
+- `outputDirectory` parameter on any tool — deferred to a follow-up PR that lands it on `preview_snapshot`, `preview_variants`, and `preview_record` uniformly.
+- Rolling/continuous buffer — rejected per spec.
+- Audio capture — rejected per spec.
+- Semantic animation inspection (CAAnimation sniffing) — rejected per spec.
+
+## Testing strategy recap
+
+- **Unit tests** (`Tests/PreviewsCoreTests/`) — slice 1 only. Fast, no simulators, run in CI.
+- **MCP integration tests — macOS** (`Tests/MCPIntegrationTests/PreviewRecord*MacOSTests.swift`) — slices 2, 4, 6. Uses daemon (requires `DaemonTestLock`).
+- **MCP integration tests — iOS** (`Tests/MCPIntegrationTests/PreviewRecord*IOSTests.swift`) — slices 3, 5. Slow (simulator boot). Uses `DaemonTestLock`.
+- **CLI tests** — daemon-touching; can share the macOS integration test suite or have dedicated `Tests/CLIIntegrationTests/RecordCommandTests.swift`.
+- **Fixture:** `TestPreviews/AnimatedButton.swift` lives in the test support directory, shared across macOS and iOS record tests.
+
+## Rollback
+
+Each slice is a separate commit (or set of commits). If a slice lands and is later found broken, revert the commit range. No slice crosses a platform boundary alone, so a revert of one slice never leaves a half-built feature.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,83 @@
+# preview_record — Task List
+
+Companion to [`plan.md`](plan.md). Updated 2026-04-19 for daemon architecture.
+
+## Slice 1 — Core primitives
+
+- [x] `FrameDiff.swift` — SSIM on 128×128 grayscale downsample (Wang et al.)
+- [x] `FrameDiffTests.swift` — identical → 1.0, inverted → ~0, known gradients, symmetry, different sizes
+- [x] `KeyframeSelector.swift` — pairwise threshold + min-gap + forced endpoints
+- [x] `KeyframeSelectorTests.swift` — all-zero, all-high, single spike, ease-out decay, budget, gap, sorted
+- [x] `ActionLog.swift` — Sendable actor, Codable entries (`[String: String]` params — PreviewsCore can't import MCP)
+- [x] `ActionLogTests.swift` — ordering, monotonic timestamps, JSON round-trip, flag preservation
+- [x] `swift test --filter "FrameDiff|KeyframeSelector|ActionLog"` passes (21 tests, 3 suites)
+- [x] `swift build` clean under strict concurrency
+- [ ] **CHECKPOINT 1** — human review of core algorithms
+
+## Slice 2 — macOS `preview_record`
+
+- [ ] `SnapshotRecorder.swift` — timer-polled `Snapshot.capture` at ~30fps, in-memory CGImage buffer
+- [ ] `TouchOverlay.swift` — single-frame CoreGraphics composite, fading circle
+- [ ] `MCPToolSchemas.swift` — add `previewRecord` to `ToolName` + `mcpToolSchemas()`
+- [ ] `DaemonProtocol.swift` — add `RecordResult` DTO
+- [ ] `MCPServer.swift` — `handlePreviewRecord` for macOS (iOS returns "not yet supported")
+- [ ] `MCPServer.swift` — emit `structuredContent` via `RecordResult`
+- [ ] `RecordCommand.swift` — CLI daemon client, `--json`, `SessionTargetingOptions`
+- [ ] `PreviewsMCPApp.swift` — register `RecordCommand`
+- [ ] Test fixture `TestPreviews/AnimatedButton.swift`
+- [ ] `PreviewRecordMacOSTests.swift` — happy path + no-motion branch (with `DaemonTestLock`)
+- [ ] Verify tool appears in `ListTools` output
+- [ ] Verify `previewsmcp record --help` and `--json` output
+- [ ] Manual smoke test against `examples/`
+- [ ] **CHECKPOINT 2** — human review of macOS UX
+
+## Slice 3 — iOS `preview_record`
+
+- [ ] `SimctlRecorder.swift` — fork `xcrun simctl io recordVideo`, SIGINT finalize
+- [ ] `MovieDecoder.swift` — `AVAssetReader` → `CVPixelBuffer` → `CGImage` (conversion internal, returns `[CGImage]`)
+- [ ] `MCPServer.swift` — fill in iOS branch of `handlePreviewRecord`
+- [ ] `PreviewRecordIOSTests.swift` — happy path + no-motion (boots sim, `DaemonTestLock`)
+- [ ] Manual smoke test on iOS example project
+- [ ] No regression in `IOSPreviewSession` tests
+
+## Slice 4 — macOS session recording
+
+- [ ] `Recorder.swift` — protocol abstracting macOS / iOS session recorders
+- [ ] `RecordingState.swift` — per-session actor, `isActive`, `log`, `stop`
+- [ ] `SnapshotRecorder` session mode — live `AVAssetWriter` encoding of timer-polled `Snapshot.capture` feed (VFR, timestamps from `ContinuousClock.Instant` deltas)
+- [ ] `PixelBufferConverter.swift` — `CGImage` → `CVPixelBuffer` via `CGContext`-backed render for `AVAssetWriterInputPixelBufferAdaptor`
+- [ ] `SessionOverlay.swift` — `AVMutableVideoComposition` + `AVVideoCompositionCoreAnimationTool`
+- [ ] `MCPToolSchemas.swift` — add `previewRecordStart`, `previewRecordStop` to enum + schemas
+- [ ] `DaemonProtocol.swift` — add `RecordStartResult`, `RecordStopResult`, `ActionLogEntryDTO`
+- [ ] `MCPServer.swift` — extract switch body into `handleTool(params:)` helper
+- [ ] `MCPServer.swift` — wrap dispatch in middleware that logs to `RecordingState` when active
+- [ ] `MCPServer.swift` — `recompileCausingTools` static set
+- [ ] `MCPServer.swift` — `handlePreviewRecordStart` (macOS)
+- [ ] `MCPServer.swift` — `handlePreviewRecordStop` (macOS, including overlay composition)
+- [ ] `MCPServer.swift` — modify `handlePreviewStop` for implicit finalize
+- [ ] `RecordStartCommand.swift` — CLI daemon client, imperative (stderr only)
+- [ ] `RecordStopCommand.swift` — CLI daemon client, `--json` (emits path + action log)
+- [ ] `PreviewsMCPApp.swift` — register both commands
+- [ ] `PreviewRecordSessionMacOSTests.swift` — 3 mixed tool calls, assert action log + overlay
+- [ ] `PreviewRecordSessionMacOSTests.swift` — implicit stop test
+- [ ] Full `swift test` passes (middleware is global — no regressions)
+- [ ] Manual smoke test: record a demo, inspect .mov in QuickTime
+- [ ] **CHECKPOINT 3** — human review of session recording contract
+
+## Slice 5 — iOS session recording
+
+- [ ] `SessionSimctlRecorder.swift` — conforms to `Recorder` protocol
+- [ ] `MCPServer.swift` — iOS branch of `handlePreviewRecordStart`
+- [ ] `PreviewRecordSessionIOSTests.swift` — happy path + implicit stop (with `DaemonTestLock`)
+- [ ] Manual smoke test on iOS example project
+
+## Slice 6 — Polish
+
+- [ ] `Spritesheet.swift` — `ceil(sqrt(N))` grid, row-major, indexed cells
+- [ ] `MCPServer.swift` — wire `format: "spritesheet"` branch in `handlePreviewRecord`
+- [ ] `PreviewRecordSpritesheetTests.swift` — dimensions + decoded content
+- [ ] Update `README.md` tool list + CLI subcommands table
+- [ ] Update `AGENTS.md` — tools, CLI table, `## Recording` section, `### Structured output` list
+- [ ] `swift-format lint --strict` clean
+- [ ] `swiftlint lint --quiet` clean
+- [ ] Full `swift test` green


### PR DESCRIPTION
## Summary

- **Spec** (`SPEC.md`): Full design for 3 new MCP tools (`preview_record`, `preview_record_start`, `preview_record_stop`) targeting animation debugging and stakeholder demo recording. Went through two rounds of adversarial subagent review with prior-art citations (Playwright, Cypress, Maestro, ffmpeg scene-detect, etc.).
- **Plan** (`tasks/plan.md`, `tasks/todo.md`): 6 vertical slices with 3 human checkpoints. Updated for daemon architecture post-rebase.
- **Slice 1 — Core primitives**: Platform-agnostic algorithms in `PreviewsCore/Recording/`:
  - `FrameDiff` — SSIM on 128×128 grayscale CGImage (Wang et al. formulation, 8×8 non-overlapping windows)
  - `KeyframeSelector` — pairwise threshold scene-detect with 80ms min-gap, forced endpoints, greedy highest-diff selection
  - `ActionLog` — Sendable actor for recording session action timelines, Codable for JSON serialization

### Key design decisions in the spec
- **No ScreenCaptureKit** — reuses existing `Snapshot.capture` (`bitmapImageRepForCachingDisplay`) on a 30fps timer. No TCC permissions, no CI headaches, works headless.
- **Two tools, not one** — `preview_record` (atomic keyframes for agents) vs `preview_record_start`/`stop` (session video + action timeline for stakeholders). Different shapes, different outputs.
- **Action timeline is load-bearing** — Playwright's trace-action correlation is why it beat Cypress. Session recordings return `{path, durationMs, actions: [{tMs, tool, params, causedRecompile}]}`.
- **No gating during recording** — all tools allowed mid-recording. Recompile cuts are explained by the action timeline. Trust the timeline.
- **Touch overlay indicators** — fading circles at tap coordinates, composited via CoreGraphics (keyframes) or AVVideoCompositionCoreAnimationTool (session .mov).

## Test plan
- [x] 21 tests across 3 suites pass (`swift test --filter "FrameDiff|KeyframeSelector|ActionLog"`)
- [x] `swift build` clean — no cross-module import issues
- [x] `swift-format lint --strict` clean
- [ ] Review spec design decisions
- [ ] Review algorithm correctness (SSIM, scene-detect, min-gap)
- [ ] Approve before proceeding to Slice 2 (macOS `preview_record` end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)