### PR TITLE
Make CLI integration tests diagnosable + cancellation-safe (#127)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,13 +95,26 @@ jobs:
         run: swift test --filter "PreviewsCoreTests"
 
       - name: CLI integration tests
-        timeout-minutes: 60
+        # 15m > per-test .timeLimit(.minutes(5)) so test-level timeouts fire
+        # first with a source-located Testing error instead of a bare GHA
+        # step kill. Warm-cache local wall-clock is ~3 min for 61 tests;
+        # 15m leaves substantial headroom for cold caches and one or two
+        # localized timeouts. See issue #127 for context.
+        timeout-minutes: 15
         env:
           NSUnbufferedIO: "YES"
         run: >-
           swift test --filter "CLIIntegrationTests"
           --skip "snapshotIOS"
           --skip "iosCLIWorkflow"
+
+      - name: Dump daemon log on CLI test failure
+        if: failure()
+        run: |
+          echo "--- daemon log ($PREVIEWSMCP_SOCKET_DIR/serve.log) ---"
+          cat "$PREVIEWSMCP_SOCKET_DIR/serve.log" 2>/dev/null || echo "(no log file)"
+          echo "--- socket dir listing ---"
+          ls -la "$PREVIEWSMCP_SOCKET_DIR/" 2>/dev/null || echo "(dir not found)"
 
       - name: MCP integration tests
         # 15m > per-test .timeLimit(.minutes(10)) so test-level timeouts fire first

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -1079,12 +1079,19 @@ private func handlePreviewSwitch(params: CallTool.Parameters, server: Server) as
 
     // iOS path
     if let iosSession = await iosState.getSession(sessionID) {
+        // Bounds-check before delegating. The compile path will also
+        // validate (PreviewSession.compile throws previewNotFound) but
+        // an early structured error guarantees a fast, deterministic
+        // failure regardless of any upstream transport state. See #127.
+        let previews = try PreviewParser.parse(fileAt: iosSession.sourceFile)
+        if let outOfRange = previewIndexOutOfRangeError(newIndex, count: previews.count) {
+            return outOfRange
+        }
         await progress.report(.compilingBridge, message: "Switching to preview \(newIndex)...")
         try await iosSession.switchPreview(to: newIndex)
         let activeTraits = await iosSession.currentTraits
         let traitInfo = activeTraits.isEmpty ? "" : " Traits: \(traitsSummary(activeTraits))."
 
-        let previews = try PreviewParser.parse(fileAt: iosSession.sourceFile)
         let previewList = formatPreviewList(previews: previews, activeIndex: newIndex)
         let structured = DaemonProtocol.SwitchResult(
             sessionID: sessionID,
@@ -1110,6 +1117,11 @@ private func handlePreviewSwitch(params: CallTool.Parameters, server: Server) as
         return CallTool.Result(content: [.text("No session found for \(sessionID)")], isError: true)
     }
 
+    let previews = try PreviewParser.parse(fileAt: session.sourceFile)
+    if let outOfRange = previewIndexOutOfRangeError(newIndex, count: previews.count) {
+        return outOfRange
+    }
+
     await progress.report(.compilingBridge, message: "Switching to preview \(newIndex)...")
     let compileResult = try await session.switchPreview(to: newIndex)
     try await MainActor.run {
@@ -1119,7 +1131,6 @@ private func handlePreviewSwitch(params: CallTool.Parameters, server: Server) as
     let activeTraits = await session.currentTraits
     let traitInfo = activeTraits.isEmpty ? "" : " Traits: \(traitsSummary(activeTraits))."
 
-    let previews = try PreviewParser.parse(fileAt: session.sourceFile)
     let previewList = formatPreviewList(previews: previews, activeIndex: newIndex)
     let structured = DaemonProtocol.SwitchResult(
         sessionID: sessionID,
@@ -1136,5 +1147,20 @@ private func handlePreviewSwitch(params: CallTool.Parameters, server: Server) as
             )
         ],
         structuredContent: structured
+    )
+}
+
+/// Validate `previewIndex` against the parsed preview count. Returns a
+/// structured error result if out of range, or `nil` if the index is
+/// valid. Centralized so the iOS and macOS switch paths return identical
+/// error messages — `SwitchCommandTests.switchOutOfRange` asserts on the
+/// exact "out of range" substring.
+private func previewIndexOutOfRangeError(_ newIndex: Int, count: Int) -> CallTool.Result? {
+    guard newIndex < 0 || newIndex >= count else { return nil }
+    return CallTool.Result(
+        content: [
+            .text("Preview index \(newIndex) out of range (available: 0..<\(count))")
+        ],
+        isError: true
     )
 }

--- a/Sources/PreviewsIOS/IOSPreviewSession.swift
+++ b/Sources/PreviewsIOS/IOSPreviewSession.swift
@@ -383,28 +383,44 @@ public actor IOSPreviewSession {
     private func acceptConnection(timeout: Duration) async throws {
         try await withThrowingTaskGroup(of: Int32.self) { group in
             group.addTask { [listenFD] in
-                try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Int32, Error>) in
-                    let source = DispatchSource.makeReadSource(
-                        fileDescriptor: listenFD, queue: .global())
-                    var resumed = false
-                    source.setEventHandler {
-                        source.cancel()
-                        guard !resumed else { return }
-                        resumed = true
-                        let clientFD = Darwin.accept(listenFD, nil, nil)
-                        if clientFD >= 0 {
-                            cont.resume(returning: clientFD)
-                        } else {
-                            cont.resume(throwing: IOSPreviewSessionError.socketAcceptFailed)
+                // The dispatch source is owned by the continuation closure
+                // but must also be cancellable from the task-cancellation
+                // handler when the timeout task throws. Without this path,
+                // `withCheckedThrowingContinuation` ignores cancellation
+                // and Task 1 stays suspended forever on the source — the
+                // 10s timer throws, the group waits for Task 1 to
+                // terminate, and the whole acceptConnection hangs until
+                // some upstream kills the caller (see iOS CI regression
+                // where a flaky host-app connection turned into a 20-min
+                // step timeout instead of a 10s clean failure).
+                let sourceBox = DispatchSourceBox()
+                return try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation {
+                        (cont: CheckedContinuation<Int32, Error>) in
+                        let source = DispatchSource.makeReadSource(
+                            fileDescriptor: listenFD, queue: .global())
+                        sourceBox.store(source)
+                        var resumed = false
+                        source.setEventHandler {
+                            source.cancel()
+                            guard !resumed else { return }
+                            resumed = true
+                            let clientFD = Darwin.accept(listenFD, nil, nil)
+                            if clientFD >= 0 {
+                                cont.resume(returning: clientFD)
+                            } else {
+                                cont.resume(throwing: IOSPreviewSessionError.socketAcceptFailed)
+                            }
                         }
+                        source.setCancelHandler {
+                            guard !resumed else { return }
+                            resumed = true
+                            cont.resume(throwing: IOSPreviewSessionError.socketAcceptTimeout)
+                        }
+                        source.resume()
                     }
-                    source.setCancelHandler {
-                        // Clean up on timeout: cancel fires when task group cancels this task
-                        guard !resumed else { return }
-                        resumed = true
-                        cont.resume(throwing: IOSPreviewSessionError.socketAcceptTimeout)
-                    }
-                    source.resume()
+                } onCancel: {
+                    sourceBox.cancel()
                 }
             }
             group.addTask {
@@ -608,4 +624,28 @@ public enum IOSPreviewSessionError: Error, LocalizedError, CustomStringConvertib
     }
 
     public var errorDescription: String? { description }
+}
+
+/// Thread-safe holder for a `DispatchSourceRead` that needs to be
+/// cancelled from outside the continuation that owns it. Used by
+/// `acceptConnection` to bridge task-cancellation into dispatch-source
+/// lifecycle — DispatchSource is not Sendable, so a plain closure
+/// capture won't compile under Swift 6 strict concurrency.
+private final class DispatchSourceBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var source: DispatchSourceRead?
+
+    func store(_ s: DispatchSourceRead) {
+        lock.lock()
+        defer { lock.unlock() }
+        source = s
+    }
+
+    func cancel() {
+        lock.lock()
+        let s = source
+        source = nil
+        lock.unlock()
+        s?.cancel()
+    }
 }

--- a/Tests/CLIIntegrationTests/CLIRunner.swift
+++ b/Tests/CLIIntegrationTests/CLIRunner.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import os
 
 /// Result of running the CLI binary.
 struct CLIResult: Sendable {
@@ -27,28 +28,76 @@ enum CLIRunner {
     static let xcworkspaceExampleRoot: URL = repoRoot.appendingPathComponent("examples/xcworkspace")
     static let bazelExampleRoot: URL = repoRoot.appendingPathComponent("examples/bazel")
 
+    /// Mirrors `Sources/PreviewsCLI/DaemonPaths.swift`. The daemon writes its
+    /// stderr to this file when launched detached. We can't import PreviewsCLI
+    /// from this test target, so the resolution logic is duplicated here.
+    static var daemonLogFile: URL {
+        let dir: URL
+        if let override = ProcessInfo.processInfo.environment["PREVIEWSMCP_SOCKET_DIR"] {
+            dir = URL(fileURLWithPath: override, isDirectory: true)
+        } else {
+            dir = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".previewsmcp", isDirectory: true)
+        }
+        return dir.appendingPathComponent("serve.log")
+    }
+
     // MARK: - Process runner
 
+    /// Per-subcommand timeout for `previewsmcp <subcommand>` invocations. Used
+    /// when the caller doesn't pass an explicit `timeout`. Tuned so that a
+    /// hung subprocess fails the individual call rather than the whole test
+    /// suite — see issue #127.
+    private static func defaultTimeout(for subcommand: String) -> Duration {
+        switch subcommand {
+        case "start", "run":
+            // Cold first-build on Bazel/SPM examples can exceed 60s.
+            .seconds(240)
+        case "kill-daemon":
+            .seconds(10)
+        default:
+            .seconds(60)
+        }
+    }
+
     /// Run `previewsmcp` with the given subcommand and arguments.
+    ///
+    /// Hangs are bounded by `timeout` (default = `defaultTimeout(for:)`).
+    /// On timeout the subprocess is SIGTERM'd then SIGKILL'd after a 2s
+    /// grace; the captured stderr and the daemon's `serve.log` are dumped
+    /// via `Issue.record` and the call throws `CLIRunnerError.timedOut`.
+    /// The runner is cancellation-safe: if the parent task is cancelled
+    /// (e.g., by `.timeLimit` firing), the subprocess is killed too so
+    /// the daemon doesn't stay busy serving an abandoned client.
     static func run(
         _ subcommand: String,
         arguments: [String] = [],
-        workingDirectory: URL? = nil
+        workingDirectory: URL? = nil,
+        timeout: Duration? = nil
     ) async throws -> CLIResult {
         try #require(
             FileManager.default.fileExists(atPath: binaryPath),
             "previewsmcp binary not found at \(binaryPath). Run 'swift build' first."
         )
+        let effective = timeout ?? defaultTimeout(for: subcommand)
         return try await runProcess(
             binaryPath,
             arguments: [subcommand] + arguments,
-            workingDirectory: workingDirectory
+            workingDirectory: workingDirectory,
+            label: subcommand,
+            timeout: effective
         )
     }
 
     /// Check if a command-line tool is available on PATH.
     static func toolAvailable(_ name: String) async -> Bool {
-        let result = try? await runProcess("/usr/bin/which", arguments: [name])
+        let result = try? await runProcess(
+            "/usr/bin/which",
+            arguments: [name],
+            workingDirectory: nil,
+            label: "which",
+            timeout: .seconds(10)
+        )
         return result?.exitCode == 0
     }
 
@@ -93,67 +142,239 @@ enum CLIRunner {
         return dir
     }
 
-    /// Run an arbitrary external process (not the CLI binary).
+    /// Run an arbitrary external process (not the CLI binary). External
+    /// tools (xcodegen, simctl, etc.) get a generous 5-minute default
+    /// timeout; override per-call if needed.
     static func runExternal(
         _ executable: String,
         arguments: [String] = [],
-        workingDirectory: URL? = nil
+        workingDirectory: URL? = nil,
+        timeout: Duration = .seconds(300)
     ) async throws -> CLIResult {
-        try await runProcess(executable, arguments: arguments, workingDirectory: workingDirectory)
+        try await runProcess(
+            executable,
+            arguments: arguments,
+            workingDirectory: workingDirectory,
+            label: "external:\((executable as NSString).lastPathComponent)",
+            timeout: timeout
+        )
     }
 
     // MARK: - Private process helper
 
+    /// Cancellation- and timeout-safe subprocess runner.
+    ///
+    /// State machine guards the continuation against double-resume and
+    /// guarantees the subprocess is signalled exactly once on the
+    /// terminal path (normal exit, timeout, cancellation, or
+    /// `process.run()` throw). See issue #127 for context — the prior
+    /// implementation used `withCheckedThrowingContinuation` with no
+    /// cancellation handler, which left subprocesses running after
+    /// `.timeLimit` fired and wedged subsequent tests.
     private static func runProcess(
         _ executable: String,
-        arguments: [String] = [],
-        workingDirectory: URL? = nil
+        arguments: [String],
+        workingDirectory: URL?,
+        label: String,
+        timeout: Duration
     ) async throws -> CLIResult {
-        try await withCheckedThrowingContinuation { continuation in
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: executable)
-            process.arguments = arguments
-            if let wd = workingDirectory {
-                process.currentDirectoryURL = wd
+        // Per-call stderr capture file. Mirrors MCPTestServer's pattern
+        // (PR #126): a plain file handle avoids both the CFRunLoop
+        // retention bug of Pipe+readabilityHandler and the
+        // shared-stderr NSApplication-startup hang of inheriting
+        // FileHandle.standardError.
+        let stderrLogPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cli-runner-stderr-\(UUID().uuidString).log")
+        FileManager.default.createFile(atPath: stderrLogPath.path, contents: nil)
+        defer { try? FileManager.default.removeItem(at: stderrLogPath) }
+        guard let stderrHandle = FileHandle(forWritingAtPath: stderrLogPath.path) else {
+            throw CLIRunnerError.cannotCreateStderrLog(stderrLogPath.path)
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        if let wd = workingDirectory {
+            process.currentDirectoryURL = wd
+        }
+        process.standardError = stderrHandle
+
+        let stdoutPipe = Pipe()
+        process.standardOutput = stdoutPipe
+
+        // Read stdout on a background thread to avoid pipe-full deadlocks.
+        let stdoutBox = LockedData()
+        let stdoutGroup = DispatchGroup()
+        stdoutGroup.enter()
+        DispatchQueue.global().async {
+            stdoutBox.append(stdoutPipe.fileHandleForReading.readDataToEndOfFile())
+            stdoutGroup.leave()
+        }
+
+        let state = OSAllocatedUnfairLock<RunState>(initialState: .notStarted)
+        let stderrPath = stderrLogPath
+        let runLabel = label
+        let runTimeout = timeout
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<CLIResult, Error>) in
+
+                // Schedule the timeout. Cancelled when the process exits
+                // normally or when run() throws so it can't fire late.
+                let timeoutTask = Task<Void, Never> {
+                    try? await Task.sleep(for: runTimeout)
+                    if Task.isCancelled { return }
+
+                    let pid = state.withLock { s -> pid_t? in
+                        switch s {
+                        case .running(let p):
+                            s = .resumed
+                            return p
+                        case .notStarted, .resumed:
+                            return nil
+                        }
+                    }
+                    guard let pid else { return }
+
+                    Foundation.kill(pid, SIGTERM)
+                    DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
+                        Foundation.kill(pid, SIGKILL)
+                    }
+
+                    let stderrText = Self.readFile(stderrPath)
+                    let serveLogText = Self.readFile(daemonLogFile)
+                    Issue.record(
+                        """
+                        CLI subprocess timed out after \(runTimeout) (label: \(runLabel)).
+
+                        --- subprocess stderr ---
+                        \(stderrText.isEmpty ? "(empty)" : stderrText)
+
+                        --- daemon serve.log (\(daemonLogFile.path)) ---
+                        \(serveLogText.isEmpty ? "(empty or missing)" : serveLogText)
+                        """
+                    )
+                    continuation.resume(
+                        throwing: CLIRunnerError.timedOut(
+                            label: runLabel, duration: runTimeout))
+                }
+
+                process.terminationHandler = { proc in
+                    let shouldResume = state.withLock { s -> Bool in
+                        switch s {
+                        case .running:
+                            s = .resumed
+                            return true
+                        case .notStarted, .resumed:
+                            return false
+                        }
+                    }
+                    guard shouldResume else { return }
+
+                    timeoutTask.cancel()
+                    stdoutGroup.wait()
+                    let stdout = (String(data: stdoutBox.value, encoding: .utf8) ?? "")
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    let stderr = Self.readFile(stderrPath)
+                    continuation.resume(
+                        returning: CLIResult(
+                            stdout: stdout, stderr: stderr,
+                            exitCode: proc.terminationStatus))
+                }
+
+                do {
+                    try process.run()
+                    let pid = process.processIdentifier
+                    let raced = state.withLock { s -> Bool in
+                        switch s {
+                        case .notStarted:
+                            s = .running(pid)
+                            return false
+                        case .running, .resumed:
+                            // Cancellation handler ran between Process()
+                            // init and run() and tagged us as resumed —
+                            // kill the process we just started.
+                            return true
+                        }
+                    }
+                    if raced {
+                        Foundation.kill(pid, SIGTERM)
+                        DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
+                            Foundation.kill(pid, SIGKILL)
+                        }
+                        timeoutTask.cancel()
+                        continuation.resume(throwing: CancellationError())
+                    }
+                } catch {
+                    let shouldResume = state.withLock { s -> Bool in
+                        switch s {
+                        case .notStarted:
+                            s = .resumed
+                            return true
+                        case .running, .resumed:
+                            return false
+                        }
+                    }
+                    if shouldResume {
+                        timeoutTask.cancel()
+                        continuation.resume(throwing: error)
+                    }
+                }
             }
-
-            let stdoutPipe = Pipe()
-            let stderrPipe = Pipe()
-            process.standardOutput = stdoutPipe
-            process.standardError = stderrPipe
-
-            // Read pipes on background threads to avoid deadlock with large output.
-            let stdoutBox = LockedData()
-            let stderrBox = LockedData()
-            let group = DispatchGroup()
-
-            group.enter()
-            DispatchQueue.global().async {
-                stdoutBox.append(stdoutPipe.fileHandleForReading.readDataToEndOfFile())
-                group.leave()
+        } onCancel: {
+            // Synchronous handler. Signal the subprocess if it's running;
+            // do NOT resume the continuation here — terminationHandler
+            // will fire after SIGKILL and resume with the killed exit
+            // status. The caller's next `try await` then surfaces the
+            // CancellationError on its own.
+            let pid = state.withLock { s -> pid_t? in
+                switch s {
+                case .running(let p):
+                    return p
+                case .notStarted:
+                    // Race: cancellation before run() completed. Mark
+                    // resumed so the run() path knows to resume with
+                    // CancellationError and kill whatever pid it just
+                    // started.
+                    s = .resumed
+                    return nil
+                case .resumed:
+                    return nil
+                }
             }
-
-            group.enter()
-            DispatchQueue.global().async {
-                stderrBox.append(stderrPipe.fileHandleForReading.readDataToEndOfFile())
-                group.leave()
+            guard let pid else { return }
+            Foundation.kill(pid, SIGTERM)
+            DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
+                Foundation.kill(pid, SIGKILL)
             }
+        }
+    }
 
-            process.terminationHandler = { proc in
-                group.wait()
-                let stdout = (String(data: stdoutBox.value, encoding: .utf8) ?? "")
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                let stderr = String(data: stderrBox.value, encoding: .utf8) ?? ""
-                continuation.resume(
-                    returning: CLIResult(
-                        stdout: stdout, stderr: stderr, exitCode: proc.terminationStatus))
-            }
+    private static func readFile(_ url: URL) -> String {
+        (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+    }
+}
 
-            do {
-                try process.run()
-            } catch {
-                continuation.resume(throwing: error)
-            }
+/// Subprocess lifecycle states for `runProcess`. The state machine ensures
+/// the continuation is resumed exactly once across the four terminal paths
+/// (normal exit, timeout, cancellation, run() throw).
+private enum RunState: Sendable {
+    case notStarted
+    case running(pid_t)
+    case resumed
+}
+
+enum CLIRunnerError: Error, LocalizedError {
+    case timedOut(label: String, duration: Duration)
+    case cannotCreateStderrLog(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .timedOut(let label, let duration):
+            "CLI invocation '\(label)' timed out after \(duration)"
+        case .cannotCreateStderrLog(let path):
+            "Could not open stderr log for writing at \(path)"
         }
     }
 }

--- a/Tests/CLIIntegrationTests/CLIRunner.swift
+++ b/Tests/CLIIntegrationTests/CLIRunner.swift
@@ -50,8 +50,13 @@ enum CLIRunner {
     /// suite — see issue #127.
     private static func defaultTimeout(for subcommand: String) -> Duration {
         switch subcommand {
-        case "start", "run":
-            // Cold first-build on Bazel/SPM examples can exceed 60s.
+        case "start", "run", "snapshot", "variants":
+            // Commands that can trigger compile + (iOS) simulator boot +
+            // host-app build + render in a single invocation. Cold iOS
+            // snapshot observed at ~200s (compile + build host app + boot
+            // + install + launch + capture). Cold Bazel/SPM first-build
+            // can exceed 60s even on macOS. 240s covers both with
+            // headroom.
             .seconds(240)
         case "kill-daemon":
             .seconds(10)

--- a/Tests/CLIIntegrationTests/CLIRunner.swift
+++ b/Tests/CLIIntegrationTests/CLIRunner.swift
@@ -52,12 +52,13 @@ enum CLIRunner {
         switch subcommand {
         case "start", "run", "snapshot", "variants":
             // Commands that can trigger compile + (iOS) simulator boot +
-            // host-app build + render in a single invocation. Cold iOS
-            // snapshot observed at ~200s (compile + build host app + boot
-            // + install + launch + capture). Cold Bazel/SPM first-build
-            // can exceed 60s even on macOS. 240s covers both with
-            // headroom.
-            .seconds(240)
+            // host-app build + render in a single invocation. Last-known-
+            // green iosCLIWorkflow took 274s total for run + touch×2 +
+            // elements×2 + variants + stop — meaning the `run` step alone
+            // consumed ~200-230s on that particular CI runner. 360s gives
+            // ~50% headroom over the observed time. Cold Bazel/SPM
+            // first-build can exceed 60s even on macOS, also covered.
+            .seconds(360)
         case "kill-daemon":
             .seconds(10)
         default:

--- a/Tests/CLIIntegrationTests/ConfigureCommandTests.swift
+++ b/Tests/CLIIntegrationTests/ConfigureCommandTests.swift
@@ -65,7 +65,7 @@ struct ConfigureCommandTests {
     /// before and after and asserting the PNG output differs.
     @Test(
         "configure dark mode changes the rendered snapshot",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func configureChangesRenderedOutput() async throws {
         try await DaemonTestLock.run {
@@ -132,7 +132,7 @@ struct ConfigureCommandTests {
     /// set to unset (rather than the old no-op "empty is ignored" bug).
     @Test(
         "configure --color-scheme empty-string clears the trait",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func configureClearsTrait() async throws {
         try await DaemonTestLock.run {
@@ -182,7 +182,7 @@ struct ConfigureCommandTests {
     /// and that the daemon identifies the session in its response.
     @Test(
         "configure --session targets a specific session by UUID",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func configureExplicitSession() async throws {
         try await DaemonTestLock.run {

--- a/Tests/CLIIntegrationTests/DaemonTestLock.swift
+++ b/Tests/CLIIntegrationTests/DaemonTestLock.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Cross-suite serialization for daemon-touching integration tests.
 ///
@@ -10,6 +11,25 @@ import Foundation
 /// completion handlers from firing.
 enum DaemonTestLock {
 
+    /// Set true the first time any test acquires the lock in this process.
+    /// Used to truncate `serve.log` exactly once per `swift test` run so
+    /// CI failure dumps stay scoped to the failing run rather than
+    /// accumulating across local re-runs. Truncation happens *inside*
+    /// the lock to prevent races with other suites running in parallel.
+    private static let didTruncateLog = OSAllocatedUnfairLock<Bool>(initialState: false)
+
+    private static var daemonDirectory: URL {
+        if let override = ProcessInfo.processInfo.environment["PREVIEWSMCP_SOCKET_DIR"] {
+            return URL(fileURLWithPath: override, isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".previewsmcp", isDirectory: true)
+    }
+
+    private static var serveLogPath: URL {
+        daemonDirectory.appendingPathComponent("serve.log")
+    }
+
     private static var lockPath: String {
         let dir =
             ProcessInfo.processInfo.environment["PREVIEWSMCP_SOCKET_DIR"]
@@ -17,7 +37,16 @@ enum DaemonTestLock {
         return (dir as NSString).appendingPathComponent("previewsmcp-daemon-test.lock")
     }
 
-    static func run<T: Sendable>(body: @Sendable () async throws -> T) async throws -> T {
+    /// Run `body` while holding the cross-suite daemon lock.
+    ///
+    /// The `context` (typically `#function`) is written into the daemon's
+    /// `serve.log` as a per-test marker so the CI failure dump is greppable
+    /// to the failing test's window. Pass a stable, human-readable identifier
+    /// — `"\(Self.self).\(#function)"` is a good default.
+    static func run<T: Sendable>(
+        _ context: String = #function,
+        body: @Sendable () async throws -> T
+    ) async throws -> T {
         // Acquire the lock on a non-cooperative thread so we don't
         // block the Swift concurrency thread pool.
         let path = lockPath
@@ -56,6 +85,11 @@ enum DaemonTestLock {
             }
         }
 
+        // Inside the lock: prep serve.log so the diagnostic dump on
+        // failure has clean, greppable context. Both ops are best-effort
+        // — they must never fail the test.
+        prepareServeLog(testContext: context)
+
         let result: Swift.Result<T, Error>
         do {
             result = .success(try await body())
@@ -66,5 +100,40 @@ enum DaemonTestLock {
         _ = flock(fd, LOCK_UN)
         close(fd)
         return try result.get()
+    }
+
+    /// Truncate `serve.log` on the first call in this process; always append
+    /// a `=== TEST: <ctx> @ <iso8601> ===` marker so the dump can be sliced
+    /// to a single test's window.
+    private static func prepareServeLog(testContext: String) {
+        let logURL = serveLogPath
+        let fm = FileManager.default
+
+        // Make sure the parent directory exists; the daemon may not have
+        // started yet on the very first test.
+        try? fm.createDirectory(
+            at: logURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+
+        let shouldTruncate = didTruncateLog.withLock { flag -> Bool in
+            if flag { return false }
+            flag = true
+            return true
+        }
+        if shouldTruncate, fm.fileExists(atPath: logURL.path) {
+            try? Data().write(to: logURL)
+        }
+
+        let marker = "=== TEST: \(testContext) @ \(ISO8601DateFormatter().string(from: Date())) ===\n"
+        guard let data = marker.data(using: .utf8) else { return }
+        if fm.fileExists(atPath: logURL.path) {
+            if let handle = try? FileHandle(forWritingTo: logURL) {
+                _ = try? handle.seekToEnd()
+                try? handle.write(contentsOf: data)
+                try? handle.close()
+            }
+        } else {
+            fm.createFile(atPath: logURL.path, contents: data)
+        }
     }
 }

--- a/Tests/CLIIntegrationTests/ElementsCommandTests.swift
+++ b/Tests/CLIIntegrationTests/ElementsCommandTests.swift
@@ -31,7 +31,7 @@ struct ElementsCommandTests {
     /// cleanly.
     @Test(
         "elements against a macOS session surfaces an iOS-only error",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func elementsRejectsMacOSSession() async throws {
         try await DaemonTestLock.run {

--- a/Tests/CLIIntegrationTests/IOSCLIWorkflowTests.swift
+++ b/Tests/CLIIntegrationTests/IOSCLIWorkflowTests.swift
@@ -18,7 +18,7 @@ struct IOSCLIWorkflowTests {
 
     @Test(
         "iOS CLI workflow: touch, elements, variants, stop",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(10))
     )
     func iosCLIWorkflow() async throws {
         try await DaemonTestLock.run {

--- a/Tests/CLIIntegrationTests/RunCommandTests.swift
+++ b/Tests/CLIIntegrationTests/RunCommandTests.swift
@@ -50,7 +50,7 @@ struct RunCommandTests {
 
     @Test(
         "run --detach starts daemon, prints session UUID, exits",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func detachStartsSessionAndExits() async throws {
         try await DaemonTestLock.run {
@@ -95,7 +95,7 @@ struct RunCommandTests {
     /// that never called preview_start would pass that weaker check.
     @Test(
         "run (attached) creates a live session then exits on SIGINT",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func attachedBlocksUntilSignal() async throws {
         try await DaemonTestLock.run {
@@ -145,7 +145,7 @@ struct RunCommandTests {
     /// the client. That's expected; the *daemon* surviving is what we test.
     @Test(
         "daemon survives SIGHUP to the run client",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func daemonSurvivesClientSIGHUP() async throws {
         try await DaemonTestLock.run {
@@ -192,7 +192,7 @@ struct RunCommandTests {
 
     @Test(
         "run --detach reuses an already-running daemon",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func detachReusesDaemon() async throws {
         try await DaemonTestLock.run {

--- a/Tests/CLIIntegrationTests/SimulatorsCommandTests.swift
+++ b/Tests/CLIIntegrationTests/SimulatorsCommandTests.swift
@@ -18,7 +18,7 @@ struct SimulatorsCommandTests {
     /// sentinel. This also implicitly verifies daemon auto-start.
     @Test(
         "simulators succeeds with either device lines or the no-devices sentinel",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func simulatorsAlwaysProducesOutput() async throws {
         try await DaemonTestLock.run {
@@ -64,7 +64,7 @@ struct SimulatorsCommandTests {
 
     @Test(
         "simulators --json emits valid JSON with expected fields",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func simulatorsJSON() async throws {
         try await DaemonTestLock.run {

--- a/Tests/CLIIntegrationTests/SnapshotCommandTests.swift
+++ b/Tests/CLIIntegrationTests/SnapshotCommandTests.swift
@@ -4,11 +4,20 @@ import Testing
 @Suite("CLI snapshot command", .serialized)
 struct SnapshotCommandTests {
 
+    /// Kill any leftover daemon so each test starts from a known state.
+    /// Parity with `SwitchCommandTests.cleanSlate` — without this, a
+    /// prior test that left the daemon in a wedged session state can
+    /// corrupt subsequent snapshot tests (see issue #127 cascade).
+    private static func cleanSlate() async throws {
+        _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+    }
+
     // MARK: - macOS snapshot tests (SPM example)
 
-    @Test("Basic macOS snapshot produces valid PNG", .timeLimit(.minutes(20)))
+    @Test("Basic macOS snapshot produces valid PNG", .timeLimit(.minutes(5)))
     func basicMacOSSnapshot() async throws {
         try await DaemonTestLock.run {
+            try await Self.cleanSlate()
             let tempDir = try CLIRunner.makeTempDir()
             defer { try? FileManager.default.removeItem(at: tempDir) }
 
@@ -29,9 +38,10 @@ struct SnapshotCommandTests {
         }
     }
 
-    @Test("Snapshot with --preview 1 produces different image", .timeLimit(.minutes(20)))
+    @Test("Snapshot with --preview 1 produces different image", .timeLimit(.minutes(5)))
     func snapshotPreviewIndex1() async throws {
         try await DaemonTestLock.run {
+            try await Self.cleanSlate()
             let tempDir = try CLIRunner.makeTempDir()
             defer { try? FileManager.default.removeItem(at: tempDir) }
 
@@ -67,9 +77,10 @@ struct SnapshotCommandTests {
         }
     }
 
-    @Test("Snapshot with --color-scheme dark produces different image", .timeLimit(.minutes(20)))
+    @Test("Snapshot with --color-scheme dark produces different image", .timeLimit(.minutes(5)))
     func snapshotDarkMode() async throws {
         try await DaemonTestLock.run {
+            try await Self.cleanSlate()
             let tempDir = try CLIRunner.makeTempDir()
             defer { try? FileManager.default.removeItem(at: tempDir) }
 
@@ -104,10 +115,11 @@ struct SnapshotCommandTests {
 
     @Test(
         "Snapshot with --dynamic-type-size accessibility3 produces image",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func snapshotDynamicTypeSize() async throws {
         try await DaemonTestLock.run {
+            try await Self.cleanSlate()
             let tempDir = try CLIRunner.makeTempDir()
             defer { try? FileManager.default.removeItem(at: tempDir) }
 
@@ -128,9 +140,10 @@ struct SnapshotCommandTests {
         }
     }
 
-    @Test("Snapshot with JPEG output produces valid JPEG", .timeLimit(.minutes(20)))
+    @Test("Snapshot with JPEG output produces valid JPEG", .timeLimit(.minutes(5)))
     func snapshotJPEGOutput() async throws {
         try await DaemonTestLock.run {
+            try await Self.cleanSlate()
             let tempDir = try CLIRunner.makeTempDir()
             defer { try? FileManager.default.removeItem(at: tempDir) }
 
@@ -149,9 +162,10 @@ struct SnapshotCommandTests {
         }
     }
 
-    @Test("Snapshot of PreviewProvider file produces valid PNG", .timeLimit(.minutes(20)))
+    @Test("Snapshot of PreviewProvider file produces valid PNG", .timeLimit(.minutes(5)))
     func snapshotPreviewProvider() async throws {
         try await DaemonTestLock.run {
+            try await Self.cleanSlate()
             let tempDir = try CLIRunner.makeTempDir()
             defer { try? FileManager.default.removeItem(at: tempDir) }
 
@@ -172,9 +186,10 @@ struct SnapshotCommandTests {
 
     // MARK: - Error cases
 
-    @Test("Snapshot with invalid --preview 99 returns non-zero exit", .timeLimit(.minutes(20)))
+    @Test("Snapshot with invalid --preview 99 returns non-zero exit", .timeLimit(.minutes(5)))
     func snapshotInvalidPreviewIndex() async throws {
         try await DaemonTestLock.run {
+            try await Self.cleanSlate()
             let tempDir = try CLIRunner.makeTempDir()
             defer { try? FileManager.default.removeItem(at: tempDir) }
 
@@ -197,6 +212,7 @@ struct SnapshotCommandTests {
     @Test("Snapshot with invalid --dynamic-type-size returns non-zero exit")
     func snapshotInvalidDynamicTypeSize() async throws {
         try await DaemonTestLock.run {
+            try await Self.cleanSlate()
             let tempDir = try CLIRunner.makeTempDir()
             defer { try? FileManager.default.removeItem(at: tempDir) }
 
@@ -218,6 +234,7 @@ struct SnapshotCommandTests {
     @Test("Snapshot of nonexistent file returns non-zero exit")
     func snapshotNonexistentFile() async throws {
         try await DaemonTestLock.run {
+            try await Self.cleanSlate()
             let tempDir = try CLIRunner.makeTempDir()
             defer { try? FileManager.default.removeItem(at: tempDir) }
 
@@ -235,9 +252,10 @@ struct SnapshotCommandTests {
 
     // MARK: - Build system tests (gated)
 
-    @Test("Snapshot of xcodeproj example with --project", .timeLimit(.minutes(20)))
+    @Test("Snapshot of xcodeproj example with --project", .timeLimit(.minutes(5)))
     func snapshotXcodeproj() async throws {
         try await DaemonTestLock.run {
+            try await Self.cleanSlate()
             guard await CLIRunner.toolAvailable("mint") else {
                 print("Mint not available — skipping xcodeproj snapshot test")
                 return
@@ -271,9 +289,10 @@ struct SnapshotCommandTests {
         }
     }
 
-    @Test("Snapshot of xcworkspace example with --project", .timeLimit(.minutes(20)))
+    @Test("Snapshot of xcworkspace example with --project", .timeLimit(.minutes(5)))
     func snapshotXcworkspace() async throws {
         try await DaemonTestLock.run {
+            try await Self.cleanSlate()
             guard await CLIRunner.toolAvailable("mint") else {
                 print("Mint not available — skipping xcworkspace snapshot test")
                 return
@@ -306,9 +325,10 @@ struct SnapshotCommandTests {
         }
     }
 
-    @Test("Snapshot of Bazel example with --project", .timeLimit(.minutes(20)))
+    @Test("Snapshot of Bazel example with --project", .timeLimit(.minutes(5)))
     func snapshotBazel() async throws {
         try await DaemonTestLock.run {
+            try await Self.cleanSlate()
             var hasBazel = await CLIRunner.toolAvailable("bazelisk")
             if !hasBazel { hasBazel = await CLIRunner.toolAvailable("bazel") }
             guard hasBazel else {
@@ -336,9 +356,10 @@ struct SnapshotCommandTests {
 
     // MARK: - iOS snapshot (gated)
 
-    @Test("Snapshot with --platform ios produces valid image", .timeLimit(.minutes(20)))
+    @Test("Snapshot with --platform ios produces valid image", .timeLimit(.minutes(10)))
     func snapshotIOS() async throws {
         try await DaemonTestLock.run {
+            try await Self.cleanSlate()
             let simResult = try await CLIRunner.runExternal(
                 "/usr/bin/xcrun",
                 arguments: ["simctl", "list", "devices", "available"]
@@ -374,10 +395,11 @@ struct SnapshotCommandTests {
     /// whereas an ephemeral cold-start takes several seconds.
     @Test(
         "Snapshot reuses an already-running session instead of ephemeral",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func snapshotReusesLiveSession() async throws {
         try await DaemonTestLock.run {
+            try await Self.cleanSlate()
             let tempDir = try CLIRunner.makeTempDir()
             defer { try? FileManager.default.removeItem(at: tempDir) }
 

--- a/Tests/CLIIntegrationTests/StopCommandTests.swift
+++ b/Tests/CLIIntegrationTests/StopCommandTests.swift
@@ -80,7 +80,7 @@ struct StopCommandTests {
     /// daemon reports it closed and that no sessions remain.
     @Test(
         "stop closes the sole running session",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func stopSoleSession() async throws {
         try await DaemonTestLock.run {
@@ -152,7 +152,7 @@ struct StopCommandTests {
     /// confirming a subsequent `stop` sees nothing left.
     @Test(
         "stop --all closes every active session",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func stopAllClosesEverything() async throws {
         try await DaemonTestLock.run {
@@ -203,7 +203,7 @@ struct StopCommandTests {
     /// daemon accepts the UUID and references it in its response.
     @Test(
         "stop --session targets a specific session by UUID",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func stopExplicitSession() async throws {
         try await DaemonTestLock.run {

--- a/Tests/CLIIntegrationTests/SwitchCommandTests.swift
+++ b/Tests/CLIIntegrationTests/SwitchCommandTests.swift
@@ -35,7 +35,7 @@ struct SwitchCommandTests {
     /// the empty state.
     @Test(
         "switch changes the active preview in a live session",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func switchChangesActivePreview() async throws {
         try await DaemonTestLock.run {
@@ -99,7 +99,7 @@ struct SwitchCommandTests {
     /// error message cleanly.
     @Test(
         "switch with out-of-range index reports an error",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func switchOutOfRange() async throws {
         try await DaemonTestLock.run {
@@ -121,6 +121,15 @@ struct SwitchCommandTests {
             // ToDoView only has 2 previews (indices 0 and 1).
             let result = try await CLIRunner.run("switch", arguments: ["99"])
             #expect(result.exitCode != 0)
+            // Assert on the exact daemon-side bounds-check message. If this
+            // substring stops appearing (e.g., validation moves earlier or
+            // an upstream hang prevents the check from being reached), the
+            // test fails loud rather than silently passing on any non-zero
+            // exit. See issue #127 for context.
+            #expect(
+                result.stderr.contains("out of range (available: 0..<2)"),
+                "expected daemon out-of-range error, got: \(result.stderr)"
+            )
 
             _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
         }

--- a/Tests/CLIIntegrationTests/TouchCommandTests.swift
+++ b/Tests/CLIIntegrationTests/TouchCommandTests.swift
@@ -86,7 +86,7 @@ struct TouchCommandTests {
     /// macOS session it should surface the iOS-only error.
     @Test(
         "touch against a macOS session surfaces an iOS-only error",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func touchRejectsMacOSSession() async throws {
         try await DaemonTestLock.run {

--- a/Tests/CLIIntegrationTests/VariantsCommandTests.swift
+++ b/Tests/CLIIntegrationTests/VariantsCommandTests.swift
@@ -10,7 +10,7 @@ struct VariantsCommandTests {
 
     // MARK: - Happy paths
 
-    @Test("Captures multiple presets to distinct files", .timeLimit(.minutes(20)))
+    @Test("Captures multiple presets to distinct files", .timeLimit(.minutes(5)))
     func capturesMultiplePresets() async throws {
         try await DaemonTestLock.run {
             try await Self.cleanSlate()
@@ -53,7 +53,7 @@ struct VariantsCommandTests {
         }
     }
 
-    @Test("JSON variant uses custom label as filename", .timeLimit(.minutes(20)))
+    @Test("JSON variant uses custom label as filename", .timeLimit(.minutes(5)))
     func jsonVariantUsesCustomLabel() async throws {
         try await DaemonTestLock.run {
             try await Self.cleanSlate()
@@ -85,7 +85,7 @@ struct VariantsCommandTests {
         }
     }
 
-    @Test("PNG format produces valid PNG files", .timeLimit(.minutes(20)))
+    @Test("PNG format produces valid PNG files", .timeLimit(.minutes(5)))
     func pngFormat() async throws {
         try await DaemonTestLock.run {
             try await Self.cleanSlate()
@@ -125,7 +125,7 @@ struct VariantsCommandTests {
     /// --all reports it).
     @Test(
         "variants reuses an already-running session",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func variantsReusesLiveSession() async throws {
         try await DaemonTestLock.run {
@@ -179,7 +179,7 @@ struct VariantsCommandTests {
     /// "ERROR_STATE" still captures successfully.
     @Test(
         "Label containing 'ERROR' is not mis-bucketed as failure",
-        .timeLimit(.minutes(20))
+        .timeLimit(.minutes(5))
     )
     func labelContainingErrorStillCapturesSuccessfully() async throws {
         try await DaemonTestLock.run {


### PR DESCRIPTION
Closes #127.

## Problem

Issue #127 tracked two CLI integration test flakes that escalated into a **6-test cascade** on PR #124's rerun:
1. `SnapshotCommandTests.snapshotDarkMode` — light & dark snapshots returned identical bytes (37288 == 37288).
2. `SwitchCommandTests.switchOutOfRange` — `switch 99` hit the 20-min `.timeLimit` instead of failing fast.
3. Six subsequent tests cascaded and each hit their own 20-min limit, killing CI's 60-min step timeout.

**Root cause of the cascade:** `CLIRunner.runProcess` used `withCheckedThrowingContinuation` with no cancellation handler. When `.timeLimit` fired, the test `Task` was cancelled and `DaemonTestLock` released the lock — but the subprocess kept running and the daemon stayed busy serving it. The next test acquired the released lock, tried to talk to the still-busy daemon, and hung.

## What this PR does

Diagnostics-first, cancellation-safety, source-located failures. Mirrors PR #126's playbook (which fixed the analogous issue for MCP integration tests) and lands a small daemon-side belt for the switch bounds bug. The underlying color-scheme bug (Stage B) and the upstream switch hang are deliberately unfixed — they need a diagnostic-rich reproduction to investigate without speculation. The infra here makes that possible.

### `CLIRunner` (`Tests/CLIIntegrationTests/CLIRunner.swift`)
- Per-subcommand timeout table: 60s default, `start`/`run` 240s (cold Bazel/SPM compile), `kill-daemon` 10s. Override per call via the new `timeout:` parameter.
- `runProcess` wrapped in `withTaskCancellationHandler`. State machine (`OSAllocatedUnfairLock<RunState>`) guards the continuation against double-resume across the four terminal paths (normal exit, timeout, cancellation, `run()` throw). On cancellation/timeout: SIGTERM, then SIGKILL after 2s grace.
- Stderr captured to a per-call temp file (mirrors `MCPTestServer`'s pattern from PR #126).
- On timeout: subprocess stderr **and** the daemon's `serve.log` are dumped via `Issue.record`.

### `DaemonTestLock` (`Tests/CLIIntegrationTests/DaemonTestLock.swift`)
- Optional `context: String` parameter (defaults to `#function`) is written into `serve.log` as a `=== TEST: <ctx> @ <iso8601> ===` marker so CI dumps are greppable.
- `serve.log` truncated once per process (a `didTruncateLog` flag) so a failure dump shows just the failing run, not accumulated history. Truncation runs **inside** the lock so concurrent suites can't race.

### `SnapshotCommandTests`
- Added `cleanSlate()` (`kill-daemon --timeout 2`) parity with `SwitchCommandTests`. Without it, a wedged daemon from a prior test silently corrupts subsequent snapshots.

### `MCPServer.handlePreviewSwitch` (`Sources/PreviewsCLI/MCPServer.swift`)
- Daemon-side bounds check on `previewIndex` in **both** iOS and macOS paths before delegating to `switchPreview`. Returns `isError: true` with the exact substring `"out of range (available: 0..<N)"`. The compile path already validated, but the observed `switch 99` hang was upstream of `switchPreview` entirely — this belt guarantees a fast structured failure regardless. `SwitchCommandTests.switchOutOfRange` now asserts on the exact substring so a regression that bypasses this check fails loud rather than silently passing.

### CI (`.github/workflows/ci.yml`)
- New `Dump daemon log on CLI test failure` step in the `build-and-test` job (mirror of the iOS job's existing block).
- CLI step timeout cut from 60m → 15m. Per-test `.timeLimit` cut from 20m → 5m (10m for the two iOS-simulator tests). Warm-cache local wall-clock is ~3 min for 61 tests; slowest individual test 33s, slowest body ~8s. The new bounds preserve cold-cache headroom while ensuring that on a hang the per-test `.timeLimit` fires first with a source-located Testing error.

## Test plan

- [x] `swift test --filter CLIIntegrationTests --skip snapshotIOS --skip iosCLIWorkflow` → 61/61 green in 174s
- [x] `swift test --filter PreviewsCoreTests` → 204/204 green
- [x] `swift build` clean
- [x] `swift-format lint --strict` clean on touched files
- [x] Negative path: `CLIRunner.run("serve", timeout: .seconds(3))` fails at exactly 3.007s with the diagnostic dump (`Issue.record`) and `daemon: received SIGTERM, shutting down` in the log — confirms the full timeout + kill chain end-to-end
- [ ] CI confirms green run + the new daemon-log dump step works
- [ ] Re-run CI ≥ 3× consecutively before merge

## Follow-ups (not in this PR)

- **Stage B**: investigate the color-scheme flake once a CI run produces a diagnostic-rich repro (candidates documented in the plan: dylib state leak across ephemeral sessions, headless `NSHostingView` not honoring `.preferredColorScheme` at capture time, or `BridgeGenerator` not emitting different source for light vs dark).
- The upstream cause of the `switch 99` hang is also still open — the daemon-side bounds check fast-fails it, but if it ever manifests via another route (variants, configure, etc.), A1's diagnostics will surface it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)