### PR TITLE
Forward SPM -package-name to dylib recompile

### DIFF
--- a/Sources/PreviewsCore/SPMBuildSystem.swift
+++ b/Sources/PreviewsCore/SPMBuildSystem.swift
@@ -552,11 +552,15 @@ public actor SPMBuildSystem: BuildSystem {
         let packageFlag = "\"-package-name\",\""
 
         for rawLine in contents.split(separator: "\n", omittingEmptySubsequences: true) {
-            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
             guard line.hasPrefix("args: ["), line.contains(moduleNeedle) else { continue }
-            guard let flagRange = line.range(of: packageFlag) else { return nil }
+            // Fall through (not bail) when the matched line lacks -package-name:
+            // SPM may emit more than one compile command per module (e.g. a
+            // wrapper plus the real args line), and only the args line carries
+            // the flag.
+            guard let flagRange = line.range(of: packageFlag) else { continue }
             let tail = line[flagRange.upperBound...]
-            guard let endQuote = tail.firstIndex(of: "\"") else { return nil }
+            guard let endQuote = tail.firstIndex(of: "\"") else { continue }
             return String(tail[..<endQuote])
         }
         return nil

--- a/Sources/PreviewsCore/SPMBuildSystem.swift
+++ b/Sources/PreviewsCore/SPMBuildSystem.swift
@@ -248,6 +248,20 @@ public actor SPMBuildSystem: BuildSystem {
             flags += ["-I", includeDir.path]
         }
 
+        // Forward SPM's -package-name so package-access symbols from sibling
+        // targets in the same package stay visible when the dylib recompiles.
+        // The identity cannot be derived from Package.swift's `name:` — for
+        // path packages SPM uses the directory basename lowercased — so we
+        // read the exact value out of the LLBuild manifest that `swift build`
+        // just wrote. Deriving the manifest path from `binPath` also covers
+        // users who relocate `.build` via --scratch-path / SWIFTPM_BUILD_DIR.
+        if let manifestPath = Self.manifestPath(forBinPath: binPath),
+            let packageName = Self.readPackageName(
+                fromManifestAt: manifestPath, forTarget: targetName)
+        {
+            flags += ["-package-name", packageName]
+        }
+
         // 8. Collect Tier 2 data: other source files in the target
         var otherSourceFiles = try collectSourceFiles(
             targetName: targetName,
@@ -504,6 +518,48 @@ public actor SPMBuildSystem: BuildSystem {
             files.append(url)
         }
         return files
+    }
+
+    // MARK: - Private: Package Name (from build manifest)
+
+    /// Locate SPM's LLBuild manifest given the build's bin path.
+    /// Bin path is `<scratch>/<triple>/<config>/`; the manifest lives at
+    /// `<scratch>/<config>.yaml`.
+    static func manifestPath(forBinPath binPath: URL) -> URL? {
+        let config = binPath.lastPathComponent
+        guard !config.isEmpty else { return nil }
+        let scratchDir = binPath.deletingLastPathComponent().deletingLastPathComponent()
+        return scratchDir.appendingPathComponent("\(config).yaml")
+    }
+
+    /// Read the `-package-name` value SPM passed to swiftc for a given target
+    /// out of the LLBuild manifest. Returns nil when the file is missing, the
+    /// target's compile command can't be found, or the target has no
+    /// `-package-name` flag (older toolchains).
+    ///
+    /// The manifest encodes each compile command on a single line like
+    ///     args: [..., "-module-name","ToDo", ..., "-package-name","spm"]
+    /// so we scan line-by-line for the one that matches our target and pull
+    /// the adjacent package-name out. Anchoring the module-name match with
+    /// surrounding quotes/commas is what keeps `ToDo` from colliding with
+    /// `ToDoExtras`.
+    static func readPackageName(fromManifestAt url: URL, forTarget target: String) -> String? {
+        guard let data = try? Data(contentsOf: url),
+            let contents = String(data: data, encoding: .utf8)
+        else { return nil }
+
+        let moduleNeedle = "\"-module-name\",\"\(target)\""
+        let packageFlag = "\"-package-name\",\""
+
+        for rawLine in contents.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard line.hasPrefix("args: ["), line.contains(moduleNeedle) else { continue }
+            guard let flagRange = line.range(of: packageFlag) else { return nil }
+            let tail = line[flagRange.upperBound...]
+            guard let endQuote = tail.firstIndex(of: "\"") else { return nil }
+            return String(tail[..<endQuote])
+        }
+        return nil
     }
 
     private static func resolvedArPath() async throws -> String {

--- a/Tests/PreviewsCoreTests/BuildSystemTests.swift
+++ b/Tests/PreviewsCoreTests/BuildSystemTests.swift
@@ -1080,4 +1080,106 @@ struct BuildSystemTests {
         let found = XcodeBuildSystem.collectGeneratedSources(derivedFileDir: tmpDir)
         #expect(found.isEmpty)
     }
+
+    // MARK: - SPMBuildSystem.readPackageName
+
+    /// Minimal LLBuild manifest fixture covering the three cases the parser
+    /// must handle: target with -package-name, target without it, and two
+    /// targets sharing a common prefix (ToDo / ToDoExtras) that must not
+    /// collide with each other.
+    private static let fixtureManifest = """
+        client:
+          name: basic
+        commands:
+          "<ToDo-debug.module>":
+            tool: swift-compiler
+            module-name: ToDo
+            description: "Compiling Swift Module 'ToDo' (5 sources)"
+            args: ["/path/swiftc","-module-name","ToDo","-emit-module","-Onone","-package-name","spm"]
+
+          "<ToDoExtras-debug.module>":
+            tool: swift-compiler
+            module-name: ToDoExtras
+            description: "Compiling Swift Module 'ToDoExtras' (1 sources)"
+            args: ["/path/swiftc","-module-name","ToDoExtras","-emit-module","-Onone","-package-name","spm"]
+
+          "<LegacyTarget-debug.module>":
+            tool: swift-compiler
+            module-name: LegacyTarget
+            description: "Compiling Swift Module 'LegacyTarget' (1 sources)"
+            args: ["/path/swiftc","-module-name","LegacyTarget","-emit-module","-Onone"]
+        """
+
+    private func writeManifest(_ contents: String) throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-manifest-\(UUID().uuidString).yaml")
+        try contents.write(to: tmp, atomically: true, encoding: .utf8)
+        return tmp
+    }
+
+    @Test("readPackageName extracts -package-name for matching target")
+    func readPackageNameFindsTarget() throws {
+        let manifest = try writeManifest(Self.fixtureManifest)
+        defer { try? FileManager.default.removeItem(at: manifest) }
+
+        let name = SPMBuildSystem.readPackageName(
+            fromManifestAt: manifest, forTarget: "ToDo")
+        #expect(name == "spm")
+    }
+
+    @Test("readPackageName distinguishes targets with shared prefix")
+    func readPackageNameAvoidsPrefixCollision() throws {
+        // ToDoExtras starts with "ToDo"; a naive substring match would
+        // return ToDoExtras's args when asked about ToDo (or vice versa).
+        // Anchoring the match with surrounding quotes/commas prevents this.
+        let manifest = try writeManifest(Self.fixtureManifest)
+        defer { try? FileManager.default.removeItem(at: manifest) }
+
+        let todo = SPMBuildSystem.readPackageName(
+            fromManifestAt: manifest, forTarget: "ToDo")
+        let todoExtras = SPMBuildSystem.readPackageName(
+            fromManifestAt: manifest, forTarget: "ToDoExtras")
+        #expect(todo == "spm")
+        #expect(todoExtras == "spm")
+    }
+
+    @Test("readPackageName returns nil when target has no -package-name flag")
+    func readPackageNameNilWhenFlagAbsent() throws {
+        let manifest = try writeManifest(Self.fixtureManifest)
+        defer { try? FileManager.default.removeItem(at: manifest) }
+
+        let name = SPMBuildSystem.readPackageName(
+            fromManifestAt: manifest, forTarget: "LegacyTarget")
+        #expect(name == nil)
+    }
+
+    @Test("readPackageName returns nil when target is not in the manifest")
+    func readPackageNameNilForUnknownTarget() throws {
+        let manifest = try writeManifest(Self.fixtureManifest)
+        defer { try? FileManager.default.removeItem(at: manifest) }
+
+        let name = SPMBuildSystem.readPackageName(
+            fromManifestAt: manifest, forTarget: "DoesNotExist")
+        #expect(name == nil)
+    }
+
+    @Test("readPackageName returns nil when manifest file is missing")
+    func readPackageNameNilForMissingFile() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-missing-\(UUID().uuidString).yaml")
+        let name = SPMBuildSystem.readPackageName(
+            fromManifestAt: missing, forTarget: "ToDo")
+        #expect(name == nil)
+    }
+
+    @Test("manifestPath derives <scratch>/<config>.yaml from bin path")
+    func manifestPathFromBinPath() {
+        let bin = URL(fileURLWithPath: "/tmp/pkg/.build/arm64-apple-macosx/debug")
+        let manifest = SPMBuildSystem.manifestPath(forBinPath: bin)
+        #expect(manifest?.path == "/tmp/pkg/.build/debug.yaml")
+
+        let releaseBin = URL(fileURLWithPath: "/tmp/pkg/.build/arm64-apple-macosx/release")
+        let releaseManifest = SPMBuildSystem.manifestPath(forBinPath: releaseBin)
+        #expect(releaseManifest?.path == "/tmp/pkg/.build/release.yaml")
+    }
 }

--- a/Tests/PreviewsCoreTests/PreviewSessionBuildContextTests.swift
+++ b/Tests/PreviewsCoreTests/PreviewSessionBuildContextTests.swift
@@ -94,6 +94,21 @@ struct PreviewSessionBuildContextTests {
             flags.contains("-rpath"),
             "SPMBuildSystem should add -rpath for framework dlopen; flags were: \(flags)"
         )
+        // Package-access: SPM passes `-package-name <identity>` to every
+        // swiftc invocation in the package. The dylib recompile must carry
+        // the same flag for `package`-scoped symbols to remain visible
+        // across module boundaries. For `examples/spm/` SPM derives the
+        // identity as "spm" (lowercased directory basename).
+        #expect(
+            flags.contains("-package-name"),
+            "SPMBuildSystem should forward -package-name from .build/debug.yaml; flags were: \(flags)"
+        )
+        if let idx = flags.firstIndex(of: "-package-name") {
+            #expect(
+                idx + 1 < flags.count && flags[idx + 1] == "spm",
+                "Expected -package-name spm; flags were: \(flags)"
+            )
+        }
     }
 
     @Test("Tier 2 compile: dylib + populated literals + DesignTimeStore symbols")

--- a/examples/spm/Sources/ToDo/Summary.swift
+++ b/examples/spm/Sources/ToDo/Summary.swift
@@ -5,13 +5,24 @@ import ToDoExtras
 /// ToDo target means compiling any Tier 2 dylib for this package requires
 /// linking `libToDoExtras.a`, which in turn requires SPMBuildSystem to add
 /// `-L <binPath>` to the compiler flags.
+///
+/// `PackageScopedLabel` is `package`-scoped in `ToDoExtras`, so the dylib
+/// recompile must be invoked with `-package-name spm` for this file to
+/// compile — it's the regression guard for the SPMBuildSystem fix that
+/// forwards the package identity from `.build/debug.yaml`.
 struct Summary: View {
     let items: [Item]
 
     var body: some View {
         let completed = items.filter(\.isComplete).count
-        Text(ProgressFormatter.summary(completed: completed, total: items.count))
-            .font(.headline)
+        let remaining = items.count - completed
+        VStack(alignment: .leading) {
+            Text(ProgressFormatter.summary(completed: completed, total: items.count))
+                .font(.headline)
+            Text(PackageScopedLabel.remaining(remaining))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
     }
 }
 

--- a/examples/spm/Sources/ToDoExtras/Formatter.swift
+++ b/examples/spm/Sources/ToDoExtras/Formatter.swift
@@ -10,3 +10,13 @@ public enum ProgressFormatter {
         return "\(completed)/\(total) (\(percent)%)"
     }
 }
+
+/// Package-scoped helper exercised from `ToDo`. `package` access requires the
+/// consumer to be compiled with the same `-package-name` as this module —
+/// without that flag on the dylib recompile, the preview build fails with
+/// "cannot find 'PackageScopedLabel' in scope".
+package enum PackageScopedLabel {
+    package static func remaining(_ count: Int) -> String {
+        count == 1 ? "1 item remaining" : "\(count) items remaining"
+    }
+}


### PR DESCRIPTION
## Summary
- Fix dylib recompile failing with `cannot find 'X' in scope` when the previewed file references `package`-scoped symbols from a sibling target — SPM passes `-package-name <identity>` to every target it builds, but `SPMBuildSystem` wasn't forwarding it to the raw swiftc invocation.
- Read the identity out of SPM's own LLBuild manifest (`.build/<config>.yaml`) rather than recomputing it (SPM uses the lowercased directory basename for path packages, not `Package.swift`'s `name:`).
- Derive the manifest path from `binPath` so `--scratch-path` / `SWIFTPM_BUILD_DIR` users are covered.

## Regression guard
`examples/spm/Sources/ToDoExtras/Formatter.swift` now exposes `package enum PackageScopedLabel`, referenced from `Summary.swift` in the `ToDo` target. The existing `tier2Compile` end-to-end test fails with the exact error from the bug report when the fix is disabled; passes with it in place.

## Test plan
- [x] `swift build`
- [x] `swift test --filter BuildSystem` (59 tests, incl. 6 new for `readPackageName` / `manifestPath`)
- [x] `swift test --filter PreviewSessionBuildContextTests` (5 tests, incl. updated `spmLinksDependencyTargets` asserting `-package-name spm`)
- [x] Sanity-check: temporarily disabled the fix and confirmed `tier2Compile` fails with `cannot find 'PackageScopedLabel' in scope` — the exact symptom from the bug report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)