### PR TITLE
Add `previewsmcp logs` subcommand and promote Debugging section

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Other levers:
 
 - `previewsmcp status --json` — confirm the daemon is still alive (`running` / `transitional` / `stopped`) while a command is blocked.
 - `previewsmcp kill-daemon` followed by re-running the command — gives a clean daemon and a fresh `serve.log` worth of context.
-- `PREVIEWSMCP_SOCKET_DIR=/tmp/previewsmcp-debug previewsmcp …` — relocates the socket, PID, and log files so you can isolate a debug run from an existing daemon.
+- `PREVIEWSMCP_SOCKET_DIR=/tmp/previewsmcp-debug previewsmcp …` — relocates the socket, PID, and log files so you can isolate a debug run from an existing daemon. Export the variable (or prefix both invocations) so `previewsmcp logs` targets the same isolated dir rather than falling back to the default `~/.previewsmcp/serve.log`.
 - Subprocess failures (`xcodebuild`, `swiftc`, `codesign`) surface their captured stderr in the error returned to the CLI; a hang, however, won't — so if the last phase logged is a build phase and the command isn't progressing, check for a live `xcodebuild` or `swiftc` process with `ps -ef | grep -E 'xcodebuild|swiftc'`.
 
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Commands that target a session resolve it automatically: `--session <uuid>` > `-
 previewsmcp list MyView.swift                       # enumerate #Preview blocks
 previewsmcp simulators                              # list available iOS simulators
 previewsmcp status                                  # daemon alive?
+previewsmcp logs -f                                 # stream the daemon log (see Debugging)
 previewsmcp kill-daemon                             # stop the daemon process
 ```
 
@@ -184,5 +185,27 @@ The CLI uses an auto-started background daemon that manages preview sessions. On
 - `previewsmcp status` — check if the daemon is running and its PID.
 - `previewsmcp kill-daemon` — stop the daemon and clean up the socket.
 - Sessions persist across CLI invocations. `run --detach` starts one, `stop` closes it, and `configure` / `switch` / `snapshot` / `elements` / `touch` operate on it.
+
+
+## Debugging
+
+When a command appears stuck — most commonly `run` during an iOS host build — there are two places to look:
+
+1. **The CLI's own stderr.** The daemon streams progress messages for each build phase (`detecting project`, `compiling host app`, `booting simulator`, …) back to the CLI as MCP log notifications, which the CLI forwards to stderr. Whichever phase was printed last is where it's stuck.
+2. **The daemon log.** Daemon stderr is redirected to `~/.previewsmcp/serve.log` on spawn, so startup failures and anything the daemon logs outside an active RPC land in this file. Stream it in a second terminal:
+
+   ```bash
+   previewsmcp logs -f                       # follow new lines
+   previewsmcp logs -n 200                   # snapshot the last 200 lines
+   # or read the file directly:
+   tail -F ~/.previewsmcp/serve.log
+   ```
+
+Other levers:
+
+- `previewsmcp status --json` — confirm the daemon is still alive (`running` / `transitional` / `stopped`) while a command is blocked.
+- `previewsmcp kill-daemon` followed by re-running the command — gives a clean daemon and a fresh `serve.log` worth of context.
+- `PREVIEWSMCP_SOCKET_DIR=/tmp/previewsmcp-debug previewsmcp …` — relocates the socket, PID, and log files so you can isolate a debug run from an existing daemon.
+- Subprocess failures (`xcodebuild`, `swiftc`, `codesign`) surface their captured stderr in the error returned to the CLI; a hang, however, won't — so if the last phase logged is a build phase and the command isn't progressing, check for a live `xcodebuild` or `swiftc` process with `ps -ef | grep -E 'xcodebuild|swiftc'`.
 
 

--- a/Sources/PreviewsCLI/LogsCommand.swift
+++ b/Sources/PreviewsCLI/LogsCommand.swift
@@ -70,7 +70,16 @@ struct LogsCommand: ParsableCommand {
         //   - `kill -INT <parent-pid>` from a script or supervisor: the
         //     signal arrives only at the parent. Without forwarding,
         //     tail would outlive us and be reparented to launchd.
-        // The sources run on a background queue because waitUntilExit
+        //
+        // There is a narrow race between process.run() above and the
+        // first signal() call below where the parent still has default
+        // SIGINT/SIGTERM disposition. It's benign: in the tty case the
+        // pgroup delivery kills both parent and child at once (same
+        // observable result); in the direct-kill case the window is a
+        // handful of instructions wide, no worse than the equivalent
+        // gap in RunCommand.blockUntilSignal.
+        //
+        // Sources run on a background queue because waitUntilExit
         // blocks the calling thread (main for sync ParsableCommand).
         let signalQueue = DispatchQueue.global(qos: .userInitiated)
         var signalSources: [DispatchSourceSignal] = []
@@ -82,6 +91,11 @@ struct LogsCommand: ParsableCommand {
             signalSources.append(src)
         }
         defer {
+            // LogsCommand is a CLI leaf — no earlier code on this path
+            // installs a SIGINT/SIGTERM handler — so restoring SIG_DFL
+            // rather than the prior disposition is safe. If a future
+            // pre-run hook at the app layer installs one, revisit this
+            // and RunCommand.blockUntilSignal together.
             for src in signalSources { src.cancel() }
             signal(SIGINT, SIG_DFL)
             signal(SIGTERM, SIG_DFL)

--- a/Sources/PreviewsCLI/LogsCommand.swift
+++ b/Sources/PreviewsCLI/LogsCommand.swift
@@ -1,0 +1,96 @@
+import ArgumentParser
+import Foundation
+
+struct LogsCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "logs",
+        abstract: "Print the daemon log for debugging (~/.previewsmcp/serve.log)",
+        discussion: """
+            Prints the last N lines of the daemon log and exits. Pass
+            --follow to stream new lines as they're appended — useful for
+            diagnosing a stuck command (e.g., an iOS host build) from a
+            second terminal.
+
+            Log path: ~/.previewsmcp/serve.log, or $PREVIEWSMCP_SOCKET_DIR/serve.log
+            when that variable is set.
+            """
+    )
+
+    @Flag(
+        name: [.short, .long],
+        help: "Stream new lines as they're appended (Ctrl-C to stop)"
+    )
+    var follow: Bool = false
+
+    @Option(
+        name: [.customShort("n"), .long],
+        help: "Number of lines to print from the end of the log"
+    )
+    var lines: Int = 100
+
+    func run() throws {
+        // Create the log file (and parent dir) if absent so `tail` has
+        // something to open. Mirrors the daemon's own fallback at
+        // DaemonClient.swift:122-125 — running `logs` before the daemon
+        // has ever started should succeed quietly, not error.
+        try DaemonPaths.ensureDirectory()
+        let logPath = DaemonPaths.logFile.path
+        if !FileManager.default.fileExists(atPath: logPath) {
+            FileManager.default.createFile(atPath: logPath, contents: nil)
+        }
+
+        let process = Process()
+        // Hardcoded /usr/bin/tail matches repo convention (DaemonClient.swift:109)
+        // and avoids picking up a trojaned `tail` on PATH. BSD tail's -F
+        // follows by name and reopens on rotation/truncation.
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/tail")
+        process.arguments =
+            ["-n", String(lines)] + (follow ? ["-F", logPath] : [logPath])
+
+        // Stream output directly to the CLI's own stdio rather than
+        // capturing via a Pipe. Ctrl-C in the terminal is delivered to
+        // the foreground process group, which on Darwin the child
+        // inherits from Process.run() — so SIGINT reaches `tail` on its
+        // own, no setpgid required.
+        process.standardInput = FileHandle.standardInput
+        process.standardOutput = FileHandle.standardOutput
+        process.standardError = FileHandle.standardError
+
+        try process.run()
+        let childPID = process.processIdentifier
+
+        // After run() the child is exec'd with its own (default) signal
+        // dispositions, so adjusting the parent's from here on doesn't
+        // affect it. Suppress the default terminate-on-signal behavior
+        // in the parent and forward SIGINT/SIGTERM to the child. Two
+        // scenarios to cover:
+        //   - Ctrl-C in a terminal: the tty sends SIGINT to the whole
+        //     foreground process group, so tail already receives it on
+        //     its own. The forward is a redundant, idempotent poke.
+        //   - `kill -INT <parent-pid>` from a script or supervisor: the
+        //     signal arrives only at the parent. Without forwarding,
+        //     tail would outlive us and be reparented to launchd.
+        // The sources run on a background queue because waitUntilExit
+        // blocks the calling thread (main for sync ParsableCommand).
+        let signalQueue = DispatchQueue.global(qos: .userInitiated)
+        var signalSources: [DispatchSourceSignal] = []
+        for sig in [SIGINT, SIGTERM] {
+            signal(sig, SIG_IGN)
+            let src = DispatchSource.makeSignalSource(signal: sig, queue: signalQueue)
+            src.setEventHandler { kill(childPID, sig) }
+            src.resume()
+            signalSources.append(src)
+        }
+        defer {
+            for src in signalSources { src.cancel() }
+            signal(SIGINT, SIG_DFL)
+            signal(SIGTERM, SIG_DFL)
+        }
+
+        process.waitUntilExit()
+
+        if process.terminationStatus != 0 {
+            throw ExitCode(process.terminationStatus)
+        }
+    }
+}

--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -102,7 +102,7 @@ struct PreviewsMCPCommand: ParsableCommand {
             RunCommand.self, ListCommand.self, SnapshotCommand.self, VariantsCommand.self,
             ConfigureCommand.self, SwitchCommand.self, ElementsCommand.self,
             TouchCommand.self, SimulatorsCommand.self, StopCommand.self,
-            ServeCommand.self, StatusCommand.self, KillDaemonCommand.self,
+            ServeCommand.self, StatusCommand.self, LogsCommand.self, KillDaemonCommand.self,
         ],
         defaultSubcommand: RunCommand.self
     )

--- a/Tests/CLIIntegrationTests/LogsCommandTests.swift
+++ b/Tests/CLIIntegrationTests/LogsCommandTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+
+/// Thread-safe accumulator for a pipe's output. `readabilityHandler` runs
+/// on a background queue; writes here are synchronized so the poll loop can
+/// safely read `contents()`.
+private final class StdoutBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var text = ""
+
+    func append(_ s: String) {
+        lock.lock(); defer { lock.unlock() }
+        text.append(s)
+    }
+
+    func contents() -> String {
+        lock.lock(); defer { lock.unlock() }
+        return text
+    }
+}
+
+/// Integration tests for the `logs` subcommand — the debugging ergonomic
+/// wrapper over `tail` on `~/.previewsmcp/serve.log`.
+///
+/// Shares daemon directory state (`serve.log` lives under `$PREVIEWSMCP_SOCKET_DIR`
+/// or `~/.previewsmcp/`) with every other daemon-touching suite. Guard with
+/// `DaemonTestLock` so parallel `Run`/`Kill` suites don't rewrite the log
+/// under us.
+@Suite(.serialized)
+struct LogsCommandTests {
+
+    @Test(
+        "logs -n prints the last N lines of an existing log",
+        .timeLimit(.minutes(1))
+    )
+    func snapshotReturnsTailOfExistingLog() async throws {
+        try await DaemonTestLock.run {
+            // DaemonTestLock already ensured the directory exists and wrote
+            // a `=== TEST: ... ===` marker into serve.log. Append a known
+            // sentinel block that we can locate deterministically with -n.
+            let logURL = CLIRunner.daemonLogFile
+            let sentinel = (1...5).map { "logs-test-line-\($0)" }
+            if let handle = try? FileHandle(forWritingTo: logURL) {
+                _ = try? handle.seekToEnd()
+                try? handle.write(contentsOf: Data((sentinel.joined(separator: "\n") + "\n").utf8))
+                try? handle.close()
+            }
+
+            let result = try await CLIRunner.run("logs", arguments: ["-n", "5"])
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+
+            let lines = result.stdout.split(separator: "\n").map(String.init)
+            #expect(lines == sentinel, "expected exact sentinel tail, got: \(result.stdout)")
+        }
+    }
+
+    @Test(
+        "logs creates the log file when missing and exits 0",
+        .timeLimit(.minutes(1))
+    )
+    func snapshotCreatesLogFileWhenMissing() async throws {
+        try await DaemonTestLock.run {
+            let logURL = CLIRunner.daemonLogFile
+            try? FileManager.default.removeItem(at: logURL)
+            #expect(
+                !FileManager.default.fileExists(atPath: logURL.path),
+                "precondition: log file should be absent")
+
+            let result = try await CLIRunner.run("logs")
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+            #expect(
+                result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                "stdout should be empty when log was created fresh, got: '\(result.stdout)'")
+            #expect(
+                FileManager.default.fileExists(atPath: logURL.path),
+                "logs should have created the missing log file")
+        }
+    }
+
+    /// Follow mode is the command's only non-trivial runtime path — tail
+    /// streams, then SIGINT must propagate via the shared process group so
+    /// the CLI doesn't leave orphaned tail processes. CLIRunner.run can't
+    /// exercise this (it captures stdout end-to-end), so drive a raw
+    /// Process the way RunCommandTests does for its SIGINT test.
+    @Test(
+        "logs --follow streams new lines and exits on SIGINT",
+        .timeLimit(.minutes(1))
+    )
+    func followStreamsAndExitsOnSIGINT() async throws {
+        try await DaemonTestLock.run {
+            let logURL = CLIRunner.daemonLogFile
+            // Reset to a known state so our appended sentinel is uniquely
+            // identifiable in the stream.
+            try? Data().write(to: logURL)
+
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: CLIRunner.binaryPath)
+            proc.arguments = ["logs", "--follow", "-n", "0"]
+            // Inherit PREVIEWSMCP_SOCKET_DIR so the child targets the same
+            // isolated log as the test.
+            proc.environment = ProcessInfo.processInfo.environment
+            let stdoutPipe = Pipe()
+            proc.standardOutput = stdoutPipe
+            proc.standardError = FileHandle.nullDevice
+            try proc.run()
+
+            // Give tail a moment to open the file before we append, so the
+            // append lands as a fresh fs event rather than being read as
+            // initial content.
+            try await Task.sleep(nanoseconds: 300_000_000)
+
+            let sentinel = "logs-follow-sentinel-\(UUID().uuidString)"
+            if let handle = try? FileHandle(forWritingTo: logURL) {
+                _ = try? handle.seekToEnd()
+                try? handle.write(contentsOf: Data((sentinel + "\n").utf8))
+                try? handle.close()
+            }
+
+            let sawSentinel = try await Self.waitForStdoutMatch(
+                pipe: stdoutPipe, substring: sentinel, timeout: 10)
+            #expect(sawSentinel, "sentinel '\(sentinel)' should stream to stdout within 10s")
+            #expect(proc.isRunning, "follow mode should not exit on its own")
+
+            kill(proc.processIdentifier, SIGINT)
+            let deadline = Date().addingTimeInterval(5)
+            while proc.isRunning && Date() < deadline {
+                try await Task.sleep(nanoseconds: 50_000_000)
+            }
+            if proc.isRunning { proc.terminate() }
+            #expect(!proc.isRunning, "logs --follow should exit within 5s of SIGINT")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func waitForStdoutMatch(
+        pipe: Pipe, substring: String, timeout: TimeInterval
+    ) async throws -> Bool {
+        let buffer = StdoutBuffer()
+        let handle = pipe.fileHandleForReading
+        handle.readabilityHandler = { fh in
+            let data = fh.availableData
+            if !data.isEmpty, let text = String(data: data, encoding: .utf8) {
+                buffer.append(text)
+            }
+        }
+        defer { handle.readabilityHandler = nil }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if buffer.contents().contains(substring) { return true }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+        return false
+    }
+}

--- a/Tests/CLIIntegrationTests/LogsCommandTests.swift
+++ b/Tests/CLIIntegrationTests/LogsCommandTests.swift
@@ -1,24 +1,6 @@
 import Foundation
 import Testing
 
-/// Thread-safe accumulator for a pipe's output. `readabilityHandler` runs
-/// on a background queue; writes here are synchronized so the poll loop can
-/// safely read `contents()`.
-private final class StdoutBuffer: @unchecked Sendable {
-    private let lock = NSLock()
-    private var text = ""
-
-    func append(_ s: String) {
-        lock.lock(); defer { lock.unlock() }
-        text.append(s)
-    }
-
-    func contents() -> String {
-        lock.lock(); defer { lock.unlock() }
-        return text
-    }
-}
-
 /// Integration tests for the `logs` subcommand — the debugging ergonomic
 /// wrapper over `tail` on `~/.previewsmcp/serve.log`.
 ///
@@ -78,10 +60,15 @@ struct LogsCommandTests {
     }
 
     /// Follow mode is the command's only non-trivial runtime path — tail
-    /// streams, then SIGINT must propagate via the shared process group so
-    /// the CLI doesn't leave orphaned tail processes. CLIRunner.run can't
-    /// exercise this (it captures stdout end-to-end), so drive a raw
-    /// Process the way RunCommandTests does for its SIGINT test.
+    /// streams, then SIGINT must propagate to the child so the CLI doesn't
+    /// leave orphaned tail processes. `CLIRunner.run` can't exercise this
+    /// (it captures stdout end-to-end), so drive a raw Process the way
+    /// RunCommandTests does for its SIGINT test.
+    ///
+    /// Uses `-n 0` so the initial-content print doesn't race with our
+    /// sentinel append; we poke the log on every poll iteration until the
+    /// stream observes the sentinel, avoiding a magic "wait for tail to
+    /// arm its watcher" sleep.
     @Test(
         "logs --follow streams new lines and exits on SIGINT",
         .timeLimit(.minutes(1))
@@ -89,8 +76,7 @@ struct LogsCommandTests {
     func followStreamsAndExitsOnSIGINT() async throws {
         try await DaemonTestLock.run {
             let logURL = CLIRunner.daemonLogFile
-            // Reset to a known state so our appended sentinel is uniquely
-            // identifiable in the stream.
+            // Reset to a known state so our sentinel is uniquely identifiable.
             try? Data().write(to: logURL)
 
             let proc = Process()
@@ -104,20 +90,19 @@ struct LogsCommandTests {
             proc.standardError = FileHandle.nullDevice
             try proc.run()
 
-            // Give tail a moment to open the file before we append, so the
-            // append lands as a fresh fs event rather than being read as
-            // initial content.
-            try await Task.sleep(nanoseconds: 300_000_000)
-
             let sentinel = "logs-follow-sentinel-\(UUID().uuidString)"
-            if let handle = try? FileHandle(forWritingTo: logURL) {
-                _ = try? handle.seekToEnd()
-                try? handle.write(contentsOf: Data((sentinel + "\n").utf8))
-                try? handle.close()
-            }
-
             let sawSentinel = try await Self.waitForStdoutMatch(
-                pipe: stdoutPipe, substring: sentinel, timeout: 10)
+                pipe: stdoutPipe, substring: sentinel, timeout: 10
+            ) {
+                // Rewrite the sentinel on every poll. One of these writes
+                // will land after tail has opened the file and armed its
+                // watcher, at which point the stream picks it up.
+                if let handle = try? FileHandle(forWritingTo: logURL) {
+                    _ = try? handle.seekToEnd()
+                    try? handle.write(contentsOf: Data((sentinel + "\n").utf8))
+                    try? handle.close()
+                }
+            }
             #expect(sawSentinel, "sentinel '\(sentinel)' should stream to stdout within 10s")
             #expect(proc.isRunning, "follow mode should not exit on its own")
 
@@ -133,10 +118,17 @@ struct LogsCommandTests {
 
     // MARK: - Helpers
 
+    /// Polls `pipe` for `substring` until the deadline. `poke` runs on each
+    /// iteration before the sleep — use it to re-trigger the event the
+    /// stream is supposed to observe, so the test doesn't depend on
+    /// subprocess-startup timing.
     private static func waitForStdoutMatch(
-        pipe: Pipe, substring: String, timeout: TimeInterval
+        pipe: Pipe,
+        substring: String,
+        timeout: TimeInterval,
+        poke: () async throws -> Void = {}
     ) async throws -> Bool {
-        let buffer = StdoutBuffer()
+        let buffer = PipeBuffer()
         let handle = pipe.fileHandleForReading
         handle.readabilityHandler = { fh in
             let data = fh.availableData
@@ -149,7 +141,8 @@ struct LogsCommandTests {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if buffer.contents().contains(substring) { return true }
-            try await Task.sleep(nanoseconds: 100_000_000)
+            try await poke()
+            try await Task.sleep(nanoseconds: 200_000_000)
         }
         return false
     }

--- a/Tests/CLIIntegrationTests/PipeBuffer.swift
+++ b/Tests/CLIIntegrationTests/PipeBuffer.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Thread-safe accumulator for a subprocess pipe's output. `Pipe`'s
+/// `readabilityHandler` closure runs on a background queue, so writes must
+/// be synchronized for the poll loop in the caller to safely read
+/// `contents()` concurrently.
+///
+/// Used by integration tests that need to assert on streaming stdout/stderr
+/// without capturing to end-of-stream (which would require the subprocess to
+/// exit first).
+final class PipeBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var text = ""
+
+    func append(_ s: String) {
+        lock.lock(); defer { lock.unlock() }
+        text.append(s)
+    }
+
+    func contents() -> String {
+        lock.lock(); defer { lock.unlock() }
+        return text
+    }
+}

--- a/Tests/CLIIntegrationTests/RunCommandTests.swift
+++ b/Tests/CLIIntegrationTests/RunCommandTests.swift
@@ -1,24 +1,6 @@
 import Foundation
 import Testing
 
-/// Thread-safe accumulator for a pipe's stderr output. The readabilityHandler
-/// closure runs on a background queue; this class synchronizes writes so the
-/// poll loop can safely read contents().
-private final class StderrBuffer: @unchecked Sendable {
-    private let lock = NSLock()
-    private var text = ""
-
-    func append(_ s: String) {
-        lock.lock(); defer { lock.unlock() }
-        text.append(s)
-    }
-
-    func contents() -> String {
-        lock.lock(); defer { lock.unlock() }
-        return text
-    }
-}
-
 /// Integration tests for the `run` subcommand after its migration to
 /// DaemonClient. Exercises the attached / detached flows end-to-end against
 /// a real daemon and real preview compilation.
@@ -253,7 +235,7 @@ struct RunCommandTests {
         pattern: Regex<Output>,
         timeout: TimeInterval
     ) async throws -> Bool {
-        let buffer = StderrBuffer()
+        let buffer = PipeBuffer()
         let handle = pipe.fileHandleForReading
         handle.readabilityHandler = { fileHandle in
             let data = fileHandle.availableData


### PR DESCRIPTION
## Summary

- New `previewsmcp logs` subcommand — prints the last N lines of `~/.previewsmcp/serve.log` (default 100), or streams new lines with `-f/--follow`. Creates the log file if absent so it works before the daemon has ever started.
- Promoted `## Debugging` to a top-level README section (previously a sub-subsection inside `### Daemon model`), leading with the new subcommand and keeping `tail -F` as the raw-file fallback.
- Added `previewsmcp logs -f` to the "Enumeration and diagnostics" command list under `## Usage` for discoverability.

## Motivation

Users have no documented diagnostic path when `run` hangs during an iOS host build. The daemon stderr has always been redirected to `~/.previewsmcp/serve.log`, and build-phase progress streams to the CLI's stderr via MCP log notifications, but none of it was surfaced in the README and there was no one-command shortcut.

## Implementation notes

`LogsCommand` shells out to `/usr/bin/tail` rather than reimplementing log-follow in Swift. `Process` is used directly (not `AsyncProcess`, which buffers) with stdio wired to the CLI's own TTY handles so tail's output streams live.

Signal handling is the only non-trivial piece: after `Process.run()`, the parent installs `DispatchSource.makeSignalSource` for SIGINT/SIGTERM on a background queue (because `waitUntilExit` blocks main) and forwards them to the `tail` child. Two scenarios covered:

- **Ctrl-C in a terminal** — the tty delivers SIGINT to the foreground process group, so `tail` receives it on its own; the forward is a redundant, idempotent poke.
- **`kill -INT <parent-pid>`** from a supervisor/script — the signal arrives only at the parent; without forwarding, `tail` would be orphaned to launchd.

Flag defaults follow `tail`/`kubectl logs`/`docker logs`/`journalctl` convention: snapshot by default, explicit `-f` to stream.

## Test plan

- [x] `swift build` — clean build
- [x] `.build/debug/previewsmcp logs --help` — expected flags present, discussion mentions the log path and `$PREVIEWSMCP_SOCKET_DIR`
- [x] `logs` with seeded log + `-n 5` — returns the last 5 lines, exit 0
- [x] `logs` when log file is missing — creates the file, exits 0, empty stdout (no banner)
- [x] `logs --follow` — streams an appended sentinel line within 10s and exits within 5s of SIGINT to the parent PID (covered by `LogsCommandTests.followStreamsAndExitsOnSIGINT`)
- [x] `PREVIEWSMCP_SOCKET_DIR` redirect honored — verified implicitly via `DaemonTestLock`-scoped tests targeting an isolated dir
- [x] `swift test --filter CLIIntegrationTests` — all 66 tests across 12 suites pass

## Out of scope (follow-ups worth filing)

- `--verbose` / `--debug` flag threading through existing commands
- Live subprocess stdout/stderr streaming during build phases (the "hang with no output" gap — when `xcodebuild` or `swiftc` is the one stuck, nothing new lands in `serve.log` until the child exits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)