### PR TITLE
Phase 4 (#135): instrumentation + remove starving 300ms Task.sleep

### DIFF
--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -555,8 +555,24 @@ private func handlePreviewSnapshot(params: CallTool.Parameters) async throws -> 
         )
     }
 
-    try await Task.sleep(for: .milliseconds(300))
-    fputs("[snapshot] post 300ms sleep\n", stderr); fflush(stderr)
+    // Previously: `try await Task.sleep(for: .milliseconds(300))` with
+    // the comment "Wait briefly for SwiftUI to finish layout" (present
+    // since the initial commit, line 820b0cd). CI evidence in PR #139
+    // (run 72439165932) showed the handler wedging here under
+    // cooperative-pool starvation: the `[snapshot] post session-check`
+    // marker fired but the subsequent `[snapshot] post 300ms sleep`
+    // never did, across many snapshot cycles of `hotReloadLiteralOnly`.
+    // `Task.sleep` ultimately depends on the Swift concurrency
+    // scheduler to resume; accumulating load from rapid polling
+    // snapshots (the literal-only path doesn't have swiftc breaks to
+    // let the pool drain) left the timer's continuation unscheduled.
+    //
+    // The sleep is unnecessary in practice: `Snapshot.capture` calls
+    // `NSView.cacheDisplay(in:to:)`, which forces layout synchronously
+    // when the view is dirty. The network round-trip from client to
+    // daemon already gives the UI plenty of time to settle. All 7
+    // MacOSMCPTests pass without the sleep, including the two that
+    // verify image bytes actually change after a reload.
 
     let format: Snapshot.ImageFormat = usePNG ? .png : .jpeg(quality: quality)
     let imageData: Data

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -504,18 +504,21 @@ private func startMacOSPreview(
 }
 
 private func handlePreviewSnapshot(params: CallTool.Parameters) async throws -> CallTool.Result {
-    // Instrumentation for issue #135 Phase 4A. The post-reload wedge
-    // observed in CI (PRs #133/#134 history) manifests as the daemon
-    // logging "Reloaded!" and then never responding to the next
-    // `preview_snapshot`. Stderr goes silent at that point, so we
+    // TODO(#135-4B): remove these markers once the actual post-reload
+    // wedge fix lands. Instrumentation for issue #135 Phase 4A — the
+    // post-reload wedge observed in CI (PRs #133/#134 history) manifests
+    // as the daemon logging "Reloaded!" and then never responding to the
+    // next `preview_snapshot`. Stderr goes silent at that point, so we
     // can't tell whether the handler entered at all, hung on the main
     // actor, or wedged inside `Snapshot.capture`. These prints let
     // the next CI failure (captured by the PR #134 post-failure dump
     // step) localize the hang to a specific await point.
     //
     // Cheap (fputs + fflush, no Swift concurrency), additive (all
-    // go to the same stderr the tests already capture), and easy to
-    // remove once 4B lands with the actual fix.
+    // go to the same stderr the tests already capture), and not
+    // user-visible — `DaemonClient.registerStderrLogForwarder`
+    // forwards MCP `LogMessageNotification` payloads, not raw daemon
+    // stderr. macOS snapshot handler only; iOS returns early above.
     fputs("[snapshot] enter\n", stderr); fflush(stderr)
 
     let sessionID: String
@@ -556,14 +559,24 @@ private func handlePreviewSnapshot(params: CallTool.Parameters) async throws -> 
     fputs("[snapshot] post 300ms sleep\n", stderr); fflush(stderr)
 
     let format: Snapshot.ImageFormat = usePNG ? .png : .jpeg(quality: quality)
-    let imageData: Data = try await MainActor.run {
-        fputs("[snapshot] main-actor capture enter\n", stderr); fflush(stderr)
-        guard let window = host.window(for: sessionID) else {
-            throw SnapshotError.captureFailed
+    let imageData: Data
+    do {
+        imageData = try await MainActor.run {
+            fputs("[snapshot] main-actor capture enter\n", stderr); fflush(stderr)
+            guard let window = host.window(for: sessionID) else {
+                throw SnapshotError.captureFailed
+            }
+            let data = try Snapshot.capture(window: window, format: format)
+            fputs("[snapshot] main-actor capture done (\(data.count) bytes)\n", stderr)
+            fflush(stderr)
+            return data
         }
-        let data = try Snapshot.capture(window: window, format: format)
-        fputs("[snapshot] main-actor capture done (\(data.count) bytes)\n", stderr); fflush(stderr)
-        return data
+    } catch {
+        // Marker fires on both the `captureFailed` and any other throw
+        // from the MainActor block so the dump shows "we exited the
+        // block one way or another" — not just the happy path.
+        fputs("[snapshot] main-actor capture threw: \(error)\n", stderr); fflush(stderr)
+        throw error
     }
     fputs("[snapshot] encoding\n", stderr); fflush(stderr)
 

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -504,6 +504,20 @@ private func startMacOSPreview(
 }
 
 private func handlePreviewSnapshot(params: CallTool.Parameters) async throws -> CallTool.Result {
+    // Instrumentation for issue #135 Phase 4A. The post-reload wedge
+    // observed in CI (PRs #133/#134 history) manifests as the daemon
+    // logging "Reloaded!" and then never responding to the next
+    // `preview_snapshot`. Stderr goes silent at that point, so we
+    // can't tell whether the handler entered at all, hung on the main
+    // actor, or wedged inside `Snapshot.capture`. These prints let
+    // the next CI failure (captured by the PR #134 post-failure dump
+    // step) localize the hang to a specific await point.
+    //
+    // Cheap (fputs + fflush, no Swift concurrency), additive (all
+    // go to the same stderr the tests already capture), and easy to
+    // remove once 4B lands with the actual fix.
+    fputs("[snapshot] enter\n", stderr); fflush(stderr)
+
     let sessionID: String
     do { sessionID = try extractString("sessionID", from: params) } catch {
         return CallTool.Result(content: [.text(error.localizedDescription)], isError: true)
@@ -526,9 +540,11 @@ private func handlePreviewSnapshot(params: CallTool.Parameters) async throws -> 
     // macOS path. Verify existence upfront so a typo'd sessionID
     // surfaces as a clean "No session found" rather than the misleading
     // "capture failed" from `window(for:)` returning nil.
+    fputs("[snapshot] pre session-check\n", stderr); fflush(stderr)
     let isMacOSSession = await MainActor.run {
         host.allSessions[sessionID] != nil
     }
+    fputs("[snapshot] post session-check\n", stderr); fflush(stderr)
     guard isMacOSSession else {
         return CallTool.Result(
             content: [.text("No session found for \(sessionID).")],
@@ -537,17 +553,23 @@ private func handlePreviewSnapshot(params: CallTool.Parameters) async throws -> 
     }
 
     try await Task.sleep(for: .milliseconds(300))
+    fputs("[snapshot] post 300ms sleep\n", stderr); fflush(stderr)
 
     let format: Snapshot.ImageFormat = usePNG ? .png : .jpeg(quality: quality)
     let imageData: Data = try await MainActor.run {
+        fputs("[snapshot] main-actor capture enter\n", stderr); fflush(stderr)
         guard let window = host.window(for: sessionID) else {
             throw SnapshotError.captureFailed
         }
-        return try Snapshot.capture(window: window, format: format)
+        let data = try Snapshot.capture(window: window, format: format)
+        fputs("[snapshot] main-actor capture done (\(data.count) bytes)\n", stderr); fflush(stderr)
+        return data
     }
+    fputs("[snapshot] encoding\n", stderr); fflush(stderr)
 
     let base64 = imageData.base64EncodedString()
 
+    fputs("[snapshot] returning\n", stderr); fflush(stderr)
     return CallTool.Result(content: [
         .image(data: base64, mimeType: mimeType, metadata: nil)
     ])

--- a/Sources/PreviewsMacOS/HostApp.swift
+++ b/Sources/PreviewsMacOS/HostApp.swift
@@ -207,11 +207,16 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
                             if let frame = existingFrame {
                                 self.windows[sessionID]?.setFrameOrigin(frame.origin)
                             }
-                            fputs("Reloaded!\n", stderr)
+                            fputs("Reloaded!\n", stderr); fflush(stderr)
                         } catch {
-                            fputs("Reload failed: \(error)\n", stderr)
+                            fputs("Reload failed: \(error)\n", stderr); fflush(stderr)
                         }
                     }
+                    // Phase 4A instrumentation (issue #135): marks the end
+                    // of the MainActor.run block so we can tell in the CI
+                    // stderr dump whether the wedge happens inside the
+                    // reload or in the handler that runs after it.
+                    fputs("[reload] main-actor block returned\n", stderr); fflush(stderr)
                 } catch {
                     fputs("Recompilation failed: \(error)\n", stderr)
                 }


### PR DESCRIPTION
Closes issue #135.

## Origin and plan change

Opened as Phase 4A — diagnostic-only instrumentation to localize the post-reload wedge that Phases 1-3 caught-but-didn't-fix. The first CI run on this PR (run 72439165932) caught the wedge in action and pinpointed it to **one specific line**, so Phase 4B (the actual fix) got added to this same PR rather than a follow-up.

## What the markers caught

From the CI dump, server \`61077F6F\`'s stderr after ~8 successful snapshot cycles:

\`\`\`
[snapshot] enter
[snapshot] pre session-check
[snapshot] post session-check    ← last marker before 10-minute silence
\`\`\`

The ONLY code between \`[snapshot] post session-check\` and the never-fired \`[snapshot] post 300ms sleep\` is:

\`\`\`swift
guard isMacOSSession else { ... }         // no await
try await Task.sleep(for: .milliseconds(300))  // ← wedges here
\`\`\`

\`Task.sleep\` ultimately depends on Swift's cooperative scheduler to resume. Under rapid snapshot polling (literal-only path has no swiftc breaks to drain the pool), the timer's continuation stays unscheduled — classic cooperative-pool starvation, the same class of failure PR #136 addressed for the test harness.

## The fix

Remove the 300ms sleep. It was added in the initial commit (820b0cd) with the generic comment \"Wait briefly for SwiftUI to finish layout.\" It's unnecessary: \`Snapshot.capture\` calls \`NSView.cacheDisplay(in:to:)\`, which forces layout synchronously when the view is dirty. The client→server round-trip already gives the UI plenty of time to settle.

All 7 \`MacOSMCPTests\` pass without the sleep — including both hot-reload tests, which assert image bytes actually change after the reload (would fail if capture returned stale frames).

## Diagnostic markers stay

Keeping the \`[snapshot]\` and \`[reload]\` markers in place for at least one release cycle. They fire on every snapshot call on the macOS path (test-only visibility — \`DaemonClient.registerStderrLogForwarder\` doesn't forward raw daemon stderr), and they're the only reason we found the root cause. Tagged with \`TODO(#135-4B)\` for future cleanup. Follow-up PR can remove them once we're confident no other failure mode lurks in this handler.

## Test plan

- [x] \`swift build\` — clean
- [x] \`swift-format lint --strict --recursive Sources/ Tests/ examples/\` — clean
- [x] \`swift test --filter MacOSMCPTests\` — 7/7 pass, 72.5s locally (including \`hotReloadLiteralOnly\` 4.9s and \`hotReloadStructural\` 7.2s — both assert byte-diff after reload, so the removed sleep can't be hiding a capture-too-early bug)
- [ ] CI \`build-and-test\` — the critical validation; PR #139's prior CI run hit the wedge at the exact spot the fix targets

## Related

Closes #135. Builds on all prior work:
- PR #134 — diagnostic watchdog + post-failure stderr dump infrastructure (this PR's markers travel on it)
- PR #136 — Phase 3 pthread test-harness timeout
- PR #137 — Phase 1 daemon heartbeat
- PR #138 — Phase 2 client stall detection
- PR #133 — the original logs subcommand that this whole epic unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)