### PR TITLE
Remove issue #135 Phase 4A diagnostic markers

### DIFF
--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -504,23 +504,6 @@ private func startMacOSPreview(
 }
 
 private func handlePreviewSnapshot(params: CallTool.Parameters) async throws -> CallTool.Result {
-    // TODO(#135-4B): remove these markers once the actual post-reload
-    // wedge fix lands. Instrumentation for issue #135 Phase 4A — the
-    // post-reload wedge observed in CI (PRs #133/#134 history) manifests
-    // as the daemon logging "Reloaded!" and then never responding to the
-    // next `preview_snapshot`. Stderr goes silent at that point, so we
-    // can't tell whether the handler entered at all, hung on the main
-    // actor, or wedged inside `Snapshot.capture`. These prints let
-    // the next CI failure (captured by the PR #134 post-failure dump
-    // step) localize the hang to a specific await point.
-    //
-    // Cheap (fputs + fflush, no Swift concurrency), additive (all
-    // go to the same stderr the tests already capture), and not
-    // user-visible — `DaemonClient.registerStderrLogForwarder`
-    // forwards MCP `LogMessageNotification` payloads, not raw daemon
-    // stderr. macOS snapshot handler only; iOS returns early above.
-    fputs("[snapshot] enter\n", stderr); fflush(stderr)
-
     let sessionID: String
     do { sessionID = try extractString("sessionID", from: params) } catch {
         return CallTool.Result(content: [.text(error.localizedDescription)], isError: true)
@@ -543,11 +526,9 @@ private func handlePreviewSnapshot(params: CallTool.Parameters) async throws -> 
     // macOS path. Verify existence upfront so a typo'd sessionID
     // surfaces as a clean "No session found" rather than the misleading
     // "capture failed" from `window(for:)` returning nil.
-    fputs("[snapshot] pre session-check\n", stderr); fflush(stderr)
     let isMacOSSession = await MainActor.run {
         host.allSessions[sessionID] != nil
     }
-    fputs("[snapshot] post session-check\n", stderr); fflush(stderr)
     guard isMacOSSession else {
         return CallTool.Result(
             content: [.text("No session found for \(sessionID).")],
@@ -555,50 +536,20 @@ private func handlePreviewSnapshot(params: CallTool.Parameters) async throws -> 
         )
     }
 
-    // Previously: `try await Task.sleep(for: .milliseconds(300))` with
-    // the comment "Wait briefly for SwiftUI to finish layout" (present
-    // since the initial commit, line 820b0cd). CI evidence in PR #139
-    // (run 72439165932) showed the handler wedging here under
-    // cooperative-pool starvation: the `[snapshot] post session-check`
-    // marker fired but the subsequent `[snapshot] post 300ms sleep`
-    // never did, across many snapshot cycles of `hotReloadLiteralOnly`.
-    // `Task.sleep` ultimately depends on the Swift concurrency
-    // scheduler to resume; accumulating load from rapid polling
-    // snapshots (the literal-only path doesn't have swiftc breaks to
-    // let the pool drain) left the timer's continuation unscheduled.
-    //
-    // The sleep is unnecessary in practice: `Snapshot.capture` calls
-    // `NSView.cacheDisplay(in:to:)`, which forces layout synchronously
-    // when the view is dirty. The network round-trip from client to
-    // daemon already gives the UI plenty of time to settle. All 7
-    // MacOSMCPTests pass without the sleep, including the two that
-    // verify image bytes actually change after a reload.
+    // Don't add a pre-capture `Task.sleep` here for "layout settling" —
+    // `cacheDisplay` below forces layout synchronously, and under rapid
+    // snapshot polling a cooperative sleep can starve (see issue #135).
 
     let format: Snapshot.ImageFormat = usePNG ? .png : .jpeg(quality: quality)
-    let imageData: Data
-    do {
-        imageData = try await MainActor.run {
-            fputs("[snapshot] main-actor capture enter\n", stderr); fflush(stderr)
-            guard let window = host.window(for: sessionID) else {
-                throw SnapshotError.captureFailed
-            }
-            let data = try Snapshot.capture(window: window, format: format)
-            fputs("[snapshot] main-actor capture done (\(data.count) bytes)\n", stderr)
-            fflush(stderr)
-            return data
+    let imageData: Data = try await MainActor.run {
+        guard let window = host.window(for: sessionID) else {
+            throw SnapshotError.captureFailed
         }
-    } catch {
-        // Marker fires on both the `captureFailed` and any other throw
-        // from the MainActor block so the dump shows "we exited the
-        // block one way or another" — not just the happy path.
-        fputs("[snapshot] main-actor capture threw: \(error)\n", stderr); fflush(stderr)
-        throw error
+        return try Snapshot.capture(window: window, format: format)
     }
-    fputs("[snapshot] encoding\n", stderr); fflush(stderr)
 
     let base64 = imageData.base64EncodedString()
 
-    fputs("[snapshot] returning\n", stderr); fflush(stderr)
     return CallTool.Result(content: [
         .image(data: base64, mimeType: mimeType, metadata: nil)
     ])

--- a/Sources/PreviewsMacOS/HostApp.swift
+++ b/Sources/PreviewsMacOS/HostApp.swift
@@ -212,11 +212,6 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
                             fputs("Reload failed: \(error)\n", stderr); fflush(stderr)
                         }
                     }
-                    // Phase 4A instrumentation (issue #135): marks the end
-                    // of the MainActor.run block so we can tell in the CI
-                    // stderr dump whether the wedge happens inside the
-                    // reload or in the handler that runs after it.
-                    fputs("[reload] main-actor block returned\n", stderr); fflush(stderr)
                 } catch {
                     fputs("Recompilation failed: \(error)\n", stderr)
                 }


### PR DESCRIPTION
Cleanup follow-up to PR #139. The markers (\`[snapshot] enter\`, \`[snapshot] pre session-check\`, \`[reload] main-actor block returned\`, etc.) were added on the explicit understanding — and a \`TODO(#135-4B)\` tag — that they'd be removed once Phase 4B landed. 4B landed in the same PR (#139) and issue #135 is closed, so the markers have served their purpose.

## What's removed

- 8 \`fputs(...); fflush(stderr)\` marker pairs in \`handlePreviewSnapshot\` (MCPServer.swift)
- 1 marker in \`HostApp.swift\` after the reload's \`MainActor.run\` block
- The \`do { ... } catch\` wrapper around \`MainActor.run\` in \`handlePreviewSnapshot\` that only existed to print a throw-path marker — replaced with the original direct \`try await MainActor.run { ... }\`
- ~15-line historical narrative comment on the removed 300ms \`Task.sleep\`, trimmed to a 3-line forward-facing note

## What stays

- \`fflush(stderr)\` added to pre-existing \`Reloaded!\` / \`Reload failed:\` lines — real correctness improvement (without it, libc buffering could mask those on a wedge)
- A concise comment at the site where the sleep used to be, warning future authors not to re-add a cooperative sleep (would re-introduce the #135 starvation failure mode)
- Architectural docs in \`AGENTS.md\` and the \`StallTimer\` / \`runMCPServer\` / watchdog docstrings — these describe *current* behavior, not investigation history

## Rationale

Own repo guidance on code comments says don't reference specific task/PR/CI IDs in code since they rot. The removed comments name specific PR numbers, CI run IDs, and phase labels — exactly that category.

## Test plan

- [x] \`swift build\` — clean
- [x] \`swift-format lint --strict --recursive Sources/ Tests/ examples/\` — clean
- [x] \`swift test --filter MacOSMCPTests\` — 7/7 pass in 92.9s locally
- [ ] CI

Net: 61 lines removed, 7 added. Pure code deletion / comment trim. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)