### PR TITLE
Add inline snapshot rendering for supported terminals (#125)

### DIFF
--- a/Sources/PreviewsCLI/SnapshotCommand.swift
+++ b/Sources/PreviewsCLI/SnapshotCommand.swift
@@ -357,6 +357,8 @@ struct SnapshotCommand: AsyncParsableCommand {
         throw SnapshotCommandError.noImageContent(response.content.joinedText())
     }
 
+    private static let newline = Data([0x0A])
+
     /// Try to render the snapshot inline in the terminal. Suppressed
     /// automatically when stdout is not a TTY, when `--inline never` is set,
     /// or when the terminal doesn't speak a protocol we support. Any stderr
@@ -371,9 +373,10 @@ struct SnapshotCommand: AsyncParsableCommand {
             stdoutIsTTY: isTTY
         )
         switch decision {
-        case .emit(let bytes):
+        case .emit(let bytes, let hint):
             FileHandle.standardOutput.write(bytes)
-            FileHandle.standardOutput.write(Data([0x0A]))
+            FileHandle.standardOutput.write(Self.newline)
+            if let hint { fputs(hint + "\n", stderr) }
         case .skip(let hint):
             if let hint { fputs(hint + "\n", stderr) }
         }

--- a/Sources/PreviewsCLI/SnapshotCommand.swift
+++ b/Sources/PreviewsCLI/SnapshotCommand.swift
@@ -98,6 +98,12 @@ struct SnapshotCommand: AsyncParsableCommand {
     )
     var json: Bool = false
 
+    @Option(
+        name: .long,
+        help: "Render the snapshot inline in the terminal when supported: 'auto' (default), 'always', or 'never'. Honors $PREVIEWSMCP_INLINE."
+    )
+    var inline: InlineMode = .auto
+
     mutating func run() async throws {
         // Validate traits locally so bad flags fail before hitting the daemon.
         do {
@@ -342,12 +348,35 @@ struct SnapshotCommand: AsyncParsableCommand {
                         )
                     )
                 } else {
+                    emitInlineIfPossible(imageData: data)
                     print(outputURL.path)
                 }
                 return
             }
         }
         throw SnapshotCommandError.noImageContent(response.content.joinedText())
+    }
+
+    /// Try to render the snapshot inline in the terminal. Suppressed
+    /// automatically when stdout is not a TTY, when `--inline never` is set,
+    /// or when the terminal doesn't speak a protocol we support. Any stderr
+    /// hint from the decision (e.g. tmux passthrough is off) is surfaced
+    /// here so the user knows why they didn't get an image.
+    private func emitInlineIfPossible(imageData: Data) {
+        let isTTY = isatty(FileHandle.standardOutput.fileDescriptor) != 0
+        let decision = TerminalImages.renderInline(
+            imageData: imageData,
+            mode: inline,
+            jsonOutput: false,
+            stdoutIsTTY: isTTY
+        )
+        switch decision {
+        case .emit(let bytes):
+            FileHandle.standardOutput.write(bytes)
+            FileHandle.standardOutput.write(Data([0x0A]))
+        case .skip(let hint):
+            if let hint { fputs(hint + "\n", stderr) }
+        }
     }
 
     private func format(for mimeType: String) -> String {

--- a/Sources/PreviewsCLI/TerminalImages/DownscaleCG.swift
+++ b/Sources/PreviewsCLI/TerminalImages/DownscaleCG.swift
@@ -1,0 +1,50 @@
+import Foundation
+import ImageIO
+import CoreGraphics
+import UniformTypeIdentifiers
+
+/// Produces a smaller PNG suitable for inline display when the source image
+/// exceeds `threshold` pixels on its widest side. Returns the original data
+/// unchanged when under the threshold or when the resize fails.
+///
+/// The on-disk artifact (the file the user asked for via `--output`) is
+/// written at full resolution upstream — this helper only affects the bytes
+/// we emit to the terminal.
+enum DownscaleCG {
+    static let defaultThreshold: Int = 1200
+    static let defaultTargetMaxPixel: Int = 1000
+
+    static func downscaleIfNeeded(
+        _ data: Data,
+        threshold: Int = defaultThreshold,
+        targetMaxPixel: Int = defaultTargetMaxPixel
+    ) -> Data {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+            return data
+        }
+        guard let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+              let width = props[kCGImagePropertyPixelWidth] as? Int,
+              let height = props[kCGImagePropertyPixelHeight] as? Int
+        else {
+            return data
+        }
+        guard max(width, height) > threshold else { return data }
+
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: targetMaxPixel,
+        ]
+        guard let thumb = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+            return data
+        }
+
+        let outData = NSMutableData()
+        guard let dest = CGImageDestinationCreateWithData(outData, UTType.png.identifier as CFString, 1, nil) else {
+            return data
+        }
+        CGImageDestinationAddImage(dest, thumb, nil)
+        guard CGImageDestinationFinalize(dest) else { return data }
+        return outData as Data
+    }
+}

--- a/Sources/PreviewsCLI/TerminalImages/DownscaleCG.swift
+++ b/Sources/PreviewsCLI/TerminalImages/DownscaleCG.swift
@@ -20,13 +20,13 @@ enum DownscaleCG {
         targetMaxPixel: Int = defaultTargetMaxPixel
     ) -> Data {
         guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
-            return data
+            return failSilently(data, reason: "CGImageSource creation failed")
         }
         guard let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
               let width = props[kCGImagePropertyPixelWidth] as? Int,
               let height = props[kCGImagePropertyPixelHeight] as? Int
         else {
-            return data
+            return failSilently(data, reason: "pixel dimensions unavailable")
         }
         guard max(width, height) > threshold else { return data }
 
@@ -36,15 +36,25 @@ enum DownscaleCG {
             kCGImageSourceThumbnailMaxPixelSize: targetMaxPixel,
         ]
         guard let thumb = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
-            return data
+            return failSilently(data, reason: "CGImageSourceCreateThumbnailAtIndex returned nil")
         }
 
         let outData = NSMutableData()
         guard let dest = CGImageDestinationCreateWithData(outData, UTType.png.identifier as CFString, 1, nil) else {
-            return data
+            return failSilently(data, reason: "CGImageDestination creation failed")
         }
         CGImageDestinationAddImage(dest, thumb, nil)
-        guard CGImageDestinationFinalize(dest) else { return data }
+        guard CGImageDestinationFinalize(dest) else {
+            return failSilently(data, reason: "CGImageDestinationFinalize returned false")
+        }
         return outData as Data
+    }
+
+    private static func failSilently(_ original: Data, reason: String) -> Data {
+        fputs(
+            "note: inline downscale failed (\(reason)); emitting full-resolution image\n",
+            stderr
+        )
+        return original
     }
 }

--- a/Sources/PreviewsCLI/TerminalImages/Environment.swift
+++ b/Sources/PreviewsCLI/TerminalImages/Environment.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Readonly view of the environment variables the terminal-image code needs.
+/// Abstracted into a protocol so tests can drive capability detection with
+/// deterministic input rather than mutating the real process environment.
+protocol TerminalEnvironment: Sendable {
+    var term: String? { get }
+    var termProgram: String? { get }
+    var lcTerminal: String? { get }
+    var kittyWindowID: String? { get }
+    var tmux: String? { get }
+    var previewsmcpInline: String? { get }
+}
+
+struct ProcessTerminalEnvironment: TerminalEnvironment {
+    private var env: [String: String] { ProcessInfo.processInfo.environment }
+    var term: String? { env["TERM"] }
+    var termProgram: String? { env["TERM_PROGRAM"] }
+    var lcTerminal: String? { env["LC_TERMINAL"] }
+    var kittyWindowID: String? { env["KITTY_WINDOW_ID"] }
+    var tmux: String? { env["TMUX"] }
+    var previewsmcpInline: String? { env["PREVIEWSMCP_INLINE"] }
+}
+
+struct MockTerminalEnvironment: TerminalEnvironment {
+    var term: String?
+    var termProgram: String?
+    var lcTerminal: String?
+    var kittyWindowID: String?
+    var tmux: String?
+    var previewsmcpInline: String?
+}

--- a/Sources/PreviewsCLI/TerminalImages/Environment.swift
+++ b/Sources/PreviewsCLI/TerminalImages/Environment.swift
@@ -21,12 +21,3 @@ struct ProcessTerminalEnvironment: TerminalEnvironment {
     var tmux: String? { env["TMUX"] }
     var previewsmcpInline: String? { env["PREVIEWSMCP_INLINE"] }
 }
-
-struct MockTerminalEnvironment: TerminalEnvironment {
-    var term: String?
-    var termProgram: String?
-    var lcTerminal: String?
-    var kittyWindowID: String?
-    var tmux: String?
-    var previewsmcpInline: String?
-}

--- a/Sources/PreviewsCLI/TerminalImages/ITerm2Encoder.swift
+++ b/Sources/PreviewsCLI/TerminalImages/ITerm2Encoder.swift
@@ -11,11 +11,10 @@ enum ITerm2Encoder {
     static func encode(imageData: Data) -> Data {
         let base64 = imageData.base64EncodedString()
         let header = "\u{1B}]1337;File=inline=1;size=\(imageData.count):"
-        let terminator = "\u{07}"
         var out = Data()
-        out.append(header.data(using: .utf8)!)
-        out.append(base64.data(using: .utf8)!)
-        out.append(terminator.data(using: .utf8)!)
+        out.append(Data(header.utf8))
+        out.append(Data(base64.utf8))
+        out.append(0x07)
         return out
     }
 }

--- a/Sources/PreviewsCLI/TerminalImages/ITerm2Encoder.swift
+++ b/Sources/PreviewsCLI/TerminalImages/ITerm2Encoder.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Emits the iTerm2 inline-image escape:
+///
+///     ESC ] 1337 ; File = inline=1 ; size=N : <base64> BEL
+///
+/// The payload's width/height are left to the terminal (`width=auto;height=auto`
+/// is implicit when omitted). `size=N` is the raw-byte length (not base64 size);
+/// iTerm2's docs recommend including it so the terminal can preallocate.
+enum ITerm2Encoder {
+    static func encode(imageData: Data) -> Data {
+        let base64 = imageData.base64EncodedString()
+        let header = "\u{1B}]1337;File=inline=1;size=\(imageData.count):"
+        let terminator = "\u{07}"
+        var out = Data()
+        out.append(header.data(using: .utf8)!)
+        out.append(base64.data(using: .utf8)!)
+        out.append(terminator.data(using: .utf8)!)
+        return out
+    }
+}

--- a/Sources/PreviewsCLI/TerminalImages/TerminalCapability.swift
+++ b/Sources/PreviewsCLI/TerminalImages/TerminalCapability.swift
@@ -66,6 +66,18 @@ struct CapabilityDecision: Sendable, Equatable {
 }
 
 enum TerminalCapabilityDetector {
+    /// Surfaced on stderr when a user is inside tmux with a supported outer
+    /// terminal but `allow-passthrough` is off, so they know why their image
+    /// didn't render and how to fix it.
+    static let tmuxPassthroughOffHint =
+        "note: running inside tmux; enable with `tmux set -g allow-passthrough on`"
+
+    /// Surfaced when `--inline always` forces output on a terminal we can't
+    /// classify as supporting iTerm2 protocol — the bytes will show as
+    /// garbage on Terminal.app or Alacritty, but at least the user knows why.
+    static let forcedOnUnsupportedHint =
+        "note: emitting inline image on an unrecognized terminal because --inline always"
+
     static func detect(
         env: TerminalEnvironment,
         tmuxProbe: TmuxProbe = ProcessTmuxProbe()
@@ -89,7 +101,7 @@ enum TerminalCapabilityDetector {
             return CapabilityDecision(
                 capability: .unsupported,
                 needsTmuxWrap: false,
-                hint: "note: running inside tmux; enable with `tmux set -g allow-passthrough on`"
+                hint: tmuxPassthroughOffHint
             )
         case .unknown:
             return CapabilityDecision(capability: .unsupported, needsTmuxWrap: false, hint: nil)

--- a/Sources/PreviewsCLI/TerminalImages/TerminalCapability.swift
+++ b/Sources/PreviewsCLI/TerminalImages/TerminalCapability.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+enum TerminalCapability: Sendable, Equatable {
+    /// Outer terminal speaks the iTerm2 inline-image protocol (OSC 1337).
+    /// Covers iTerm2, WezTerm, and Ghostty — all of which accept the same
+    /// encoding.
+    case iTerm2
+    /// Terminal is known but v1 has no encoder for it. Treat as unsupported
+    /// at the render call site; kept as its own case so future protocol
+    /// support slots in without changing detection rules.
+    case kittyOnly
+    /// No inline-image support detected.
+    case unsupported
+
+    var supportsInlineV1: Bool { self == .iTerm2 }
+}
+
+enum TmuxPassthroughState: Sendable, Equatable {
+    case on
+    case off
+    case unknown
+}
+
+/// Seam for the `tmux show-options` call used during capability detection.
+protocol TmuxProbe: Sendable {
+    func allowPassthrough() -> TmuxPassthroughState
+}
+
+/// Shells out to `tmux show-options -gv allow-passthrough`. Accepts both
+/// `on` and `all` (tmux ≥ 3.3) as enabled; anything else is `off`.
+/// Returns `.unknown` if the command fails — callers then treat it
+/// conservatively as "do not emit".
+struct ProcessTmuxProbe: TmuxProbe {
+    func allowPassthrough() -> TmuxPassthroughState {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["tmux", "show-options", "-gv", "allow-passthrough"]
+        let out = Pipe()
+        process.standardOutput = out
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return .unknown
+        }
+        guard process.terminationStatus == 0 else { return .unknown }
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        let value = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? ""
+        switch value {
+        case "on", "all": return .on
+        case "off", "": return .off
+        default: return .unknown
+        }
+    }
+}
+
+struct CapabilityDecision: Sendable, Equatable {
+    let capability: TerminalCapability
+    let needsTmuxWrap: Bool
+    /// Non-nil when we intentionally suppressed inline output but want to
+    /// explain why on stderr (e.g. tmux passthrough is off).
+    let hint: String?
+}
+
+enum TerminalCapabilityDetector {
+    static func detect(
+        env: TerminalEnvironment,
+        tmuxProbe: TmuxProbe = ProcessTmuxProbe()
+    ) -> CapabilityDecision {
+        let outer = classifyOuterTerminal(env: env)
+
+        guard env.tmux != nil else {
+            return CapabilityDecision(capability: outer, needsTmuxWrap: false, hint: nil)
+        }
+
+        // Inside tmux. If the outer terminal can't render, wrapping won't
+        // help — skip the probe entirely.
+        guard outer.supportsInlineV1 else {
+            return CapabilityDecision(capability: .unsupported, needsTmuxWrap: false, hint: nil)
+        }
+
+        switch tmuxProbe.allowPassthrough() {
+        case .on:
+            return CapabilityDecision(capability: outer, needsTmuxWrap: true, hint: nil)
+        case .off:
+            return CapabilityDecision(
+                capability: .unsupported,
+                needsTmuxWrap: false,
+                hint: "note: running inside tmux; enable with `tmux set -g allow-passthrough on`"
+            )
+        case .unknown:
+            return CapabilityDecision(capability: .unsupported, needsTmuxWrap: false, hint: nil)
+        }
+    }
+
+    private static func classifyOuterTerminal(env: TerminalEnvironment) -> TerminalCapability {
+        // iTerm2 protocol is accepted by iTerm.app, WezTerm, and Ghostty.
+        if env.termProgram == "iTerm.app"
+            || env.termProgram == "WezTerm"
+            || env.termProgram == "ghostty"
+            || env.lcTerminal == "iTerm2"
+        {
+            return .iTerm2
+        }
+        if env.term == "xterm-kitty" || env.kittyWindowID != nil {
+            return .kittyOnly
+        }
+        return .unsupported
+    }
+}

--- a/Sources/PreviewsCLI/TerminalImages/TerminalImages.swift
+++ b/Sources/PreviewsCLI/TerminalImages/TerminalImages.swift
@@ -7,9 +7,10 @@ enum InlineMode: String, Sendable, Equatable, CaseIterable, ExpressibleByArgumen
 
 enum InlineDecision: Sendable, Equatable {
     /// Emit these bytes to stdout (already protocol-framed and, if needed,
-    /// tmux-wrapped). Caller is responsible for adding a trailing newline
-    /// before printing the path.
-    case emit(Data)
+    /// tmux-wrapped). `hint` is an optional stderr warning — used when the
+    /// user forced `--inline always` on a terminal we can't classify, so
+    /// the output doesn't feel like a silent failure.
+    case emit(Data, hint: String?)
     /// Skip inline output. `hint` is a short stderr message to surface, if any.
     case skip(hint: String?)
 }
@@ -41,8 +42,16 @@ enum TerminalImages {
 
         let decision = TerminalCapabilityDetector.detect(env: env, tmuxProbe: tmuxProbe)
 
-        if decision.capability.supportsInlineV1 || effectiveMode == .always {
-            return .emit(encode(imageData, wrap: decision.needsTmuxWrap))
+        if decision.capability.supportsInlineV1 {
+            return .emit(encode(imageData, wrap: decision.needsTmuxWrap), hint: nil)
+        }
+        if effectiveMode == .always {
+            // User forced it on an unknown terminal — emit iTerm2 bytes but
+            // surface a hint so garbled output doesn't look like a bug.
+            return .emit(
+                encode(imageData, wrap: decision.needsTmuxWrap),
+                hint: TerminalCapabilityDetector.forcedOnUnsupportedHint
+            )
         }
         return .skip(hint: decision.hint)
     }

--- a/Sources/PreviewsCLI/TerminalImages/TerminalImages.swift
+++ b/Sources/PreviewsCLI/TerminalImages/TerminalImages.swift
@@ -1,0 +1,68 @@
+import ArgumentParser
+import Foundation
+
+enum InlineMode: String, Sendable, Equatable, CaseIterable, ExpressibleByArgument {
+    case auto, always, never
+}
+
+enum InlineDecision: Sendable, Equatable {
+    /// Emit these bytes to stdout (already protocol-framed and, if needed,
+    /// tmux-wrapped). Caller is responsible for adding a trailing newline
+    /// before printing the path.
+    case emit(Data)
+    /// Skip inline output. `hint` is a short stderr message to surface, if any.
+    case skip(hint: String?)
+}
+
+/// Pure decision+encoding function with no I/O. The caller injects whether
+/// stdout is a TTY and the environment — keeps the unit tests deterministic
+/// and runnable without a real terminal.
+enum TerminalImages {
+    static func renderInline(
+        imageData: Data,
+        mode: InlineMode,
+        jsonOutput: Bool,
+        stdoutIsTTY: Bool,
+        env: TerminalEnvironment = ProcessTerminalEnvironment(),
+        tmuxProbe: TmuxProbe = ProcessTmuxProbe()
+    ) -> InlineDecision {
+        if jsonOutput { return .skip(hint: nil) }
+
+        let effectiveMode = resolveMode(mode: mode, env: env)
+
+        switch effectiveMode {
+        case .never:
+            return .skip(hint: nil)
+        case .auto where !stdoutIsTTY:
+            return .skip(hint: nil)
+        case .auto, .always:
+            break
+        }
+
+        let decision = TerminalCapabilityDetector.detect(env: env, tmuxProbe: tmuxProbe)
+
+        if decision.capability.supportsInlineV1 || effectiveMode == .always {
+            return .emit(encode(imageData, wrap: decision.needsTmuxWrap))
+        }
+        return .skip(hint: decision.hint)
+    }
+
+    private static func encode(_ imageData: Data, wrap: Bool) -> Data {
+        let downscaled = DownscaleCG.downscaleIfNeeded(imageData)
+        let encoded = ITerm2Encoder.encode(imageData: downscaled)
+        return wrap ? TmuxPassthrough.wrap(encoded) : encoded
+    }
+
+    /// `PREVIEWSMCP_INLINE` lets users pin the mode without touching the
+    /// flag every invocation. The flag still wins when set to a non-default
+    /// value — only `auto` defers to the env var.
+    private static func resolveMode(mode: InlineMode, env: TerminalEnvironment) -> InlineMode {
+        guard mode == .auto else { return mode }
+        switch env.previewsmcpInline?.lowercased() {
+        case "0", "false", "never": return .never
+        case "1", "true", "always": return .always
+        case "auto", "", nil: return .auto
+        default: return .auto
+        }
+    }
+}

--- a/Sources/PreviewsCLI/TerminalImages/TmuxPassthrough.swift
+++ b/Sources/PreviewsCLI/TerminalImages/TmuxPassthrough.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Wraps an escape sequence so that tmux with `allow-passthrough on`
+/// forwards it to the outer terminal.
+///
+/// Format: `ESC P tmux ; <inner-with-ESC-doubled> ESC \`
+/// Every `0x1B` inside the inner payload is duplicated; tmux strips the
+/// duplicate on the way out.
+enum TmuxPassthrough {
+    static func wrap(_ inner: Data) -> Data {
+        var out = Data()
+        out.append(contentsOf: [0x1B, 0x50])       // ESC P
+        out.append(contentsOf: Array("tmux;".utf8))
+        for byte in inner {
+            if byte == 0x1B {
+                out.append(0x1B)
+                out.append(0x1B)
+            } else {
+                out.append(byte)
+            }
+        }
+        out.append(contentsOf: [0x1B, 0x5C])       // ESC \
+        return out
+    }
+}

--- a/Tests/PreviewsCLITests/TerminalImagesTests.swift
+++ b/Tests/PreviewsCLITests/TerminalImagesTests.swift
@@ -3,6 +3,16 @@ import Testing
 
 @testable import PreviewsCLI
 
+/// Deterministic test environment — avoids touching the real process env.
+struct MockTerminalEnvironment: TerminalEnvironment {
+    var term: String?
+    var termProgram: String?
+    var lcTerminal: String?
+    var kittyWindowID: String?
+    var tmux: String?
+    var previewsmcpInline: String?
+}
+
 /// Test double for `tmux show-options` — avoids spawning a real tmux process
 /// so capability tests run deterministically in any environment (CI, local,
 /// in/out of tmux).
@@ -108,7 +118,7 @@ struct TerminalCapabilityDetectorTests {
         let decision = TerminalCapabilityDetector.detect(env: env, tmuxProbe: StubTmuxProbe(state: .off))
         #expect(decision.capability == .unsupported)
         #expect(decision.needsTmuxWrap == false)
-        #expect(decision.hint?.contains("allow-passthrough") == true)
+        #expect(decision.hint == TerminalCapabilityDetector.tmuxPassthroughOffHint)
     }
 
     @Test("tmux + supported outer + probe unknown → unsupported, no hint")
@@ -177,7 +187,7 @@ struct TerminalImagesRenderInlineTests {
             env: MockTerminalEnvironment(termProgram: "iTerm.app"),
             tmuxProbe: StubTmuxProbe(state: .unknown)
         )
-        guard case .emit(let bytes) = d else { Issue.record("expected .emit"); return }
+        guard case .emit(let bytes, _) = d else { Issue.record("expected .emit"); return }
         let s = String(data: bytes, encoding: .utf8) ?? ""
         #expect(s.hasPrefix("\u{1B}]1337;"))
         #expect(!s.hasPrefix("\u{1B}Ptmux;"))
@@ -191,7 +201,7 @@ struct TerminalImagesRenderInlineTests {
             env: MockTerminalEnvironment(termProgram: "iTerm.app", tmux: "/tmp/tmux/default"),
             tmuxProbe: StubTmuxProbe(state: .on)
         )
-        guard case .emit(let bytes) = d else { Issue.record("expected .emit"); return }
+        guard case .emit(let bytes, _) = d else { Issue.record("expected .emit"); return }
         let s = String(data: bytes, encoding: .utf8) ?? ""
         #expect(s.hasPrefix("\u{1B}Ptmux;"))
         #expect(s.hasSuffix("\u{1B}\\"))
@@ -205,11 +215,10 @@ struct TerminalImagesRenderInlineTests {
             env: MockTerminalEnvironment(termProgram: "iTerm.app", tmux: "/tmp/tmux/default"),
             tmuxProbe: StubTmuxProbe(state: .off)
         )
-        guard case .skip(let hint) = d else { Issue.record("expected .skip"); return }
-        #expect(hint?.contains("allow-passthrough") == true)
+        #expect(d == .skip(hint: TerminalCapabilityDetector.tmuxPassthroughOffHint))
     }
 
-    @Test("always overrides unsupported terminal and emits")
+    @Test("always overrides unsupported terminal and emits with stderr hint")
     func alwaysOverridesUnsupported() {
         let d = TerminalImages.renderInline(
             imageData: pixel, mode: .always, jsonOutput: false,
@@ -217,8 +226,9 @@ struct TerminalImagesRenderInlineTests {
             env: MockTerminalEnvironment(term: "xterm-256color"),
             tmuxProbe: StubTmuxProbe(state: .unknown)
         )
-        guard case .emit(let bytes) = d else { Issue.record("expected .emit"); return }
+        guard case .emit(let bytes, let hint) = d else { Issue.record("expected .emit"); return }
         #expect(!bytes.isEmpty)
+        #expect(hint == TerminalCapabilityDetector.forcedOnUnsupportedHint)
     }
 
     @Test("always overrides non-TTY stdout and emits")
@@ -252,6 +262,31 @@ struct TerminalImagesRenderInlineTests {
             tmuxProbe: StubTmuxProbe(state: .unknown)
         )
         guard case .emit = d else { Issue.record("expected .emit"); return }
+    }
+
+    @Test(
+        "PREVIEWSMCP_INLINE string variants resolved correctly under mode=auto",
+        arguments: [
+            ("0", false), ("false", false), ("never", false),
+            ("1", true), ("true", true), ("always", true),
+            ("auto", true), ("", true), ("garbage", true),
+        ] as [(String, Bool)]
+    )
+    func envVarVariants(raw: String, shouldEmit: Bool) {
+        let env = MockTerminalEnvironment(
+            termProgram: "iTerm.app",
+            previewsmcpInline: raw
+        )
+        let d = TerminalImages.renderInline(
+            imageData: pixel, mode: .auto, jsonOutput: false,
+            stdoutIsTTY: true,
+            env: env,
+            tmuxProbe: StubTmuxProbe(state: .unknown)
+        )
+        switch d {
+        case .emit: #expect(shouldEmit, "expected skip for PREVIEWSMCP_INLINE=\(raw)")
+        case .skip: #expect(!shouldEmit, "expected emit for PREVIEWSMCP_INLINE=\(raw)")
+        }
     }
 
     @Test("explicit --inline never wins over PREVIEWSMCP_INLINE=1")

--- a/Tests/PreviewsCLITests/TerminalImagesTests.swift
+++ b/Tests/PreviewsCLITests/TerminalImagesTests.swift
@@ -1,0 +1,267 @@
+import Foundation
+import Testing
+
+@testable import PreviewsCLI
+
+/// Test double for `tmux show-options` — avoids spawning a real tmux process
+/// so capability tests run deterministically in any environment (CI, local,
+/// in/out of tmux).
+struct StubTmuxProbe: TmuxProbe {
+    let state: TmuxPassthroughState
+    func allowPassthrough() -> TmuxPassthroughState { state }
+}
+
+@Suite("ITerm2Encoder")
+struct ITerm2EncoderTests {
+    @Test("encodes a fixed 4-byte payload to the documented OSC 1337 framing")
+    func goldenBytes() {
+        let input = Data([0x00, 0x01, 0x02, 0x03])
+        let output = ITerm2Encoder.encode(imageData: input)
+        let expected = "\u{1B}]1337;File=inline=1;size=4:AAECAw==\u{07}"
+        #expect(String(data: output, encoding: .utf8) == expected)
+    }
+
+    @Test("size header matches raw byte length, not base64 length")
+    func sizeIsRawByteCount() {
+        // 5 bytes encode to 8 base64 chars — size must report 5.
+        let input = Data([0xDE, 0xAD, 0xBE, 0xEF, 0x42])
+        let output = ITerm2Encoder.encode(imageData: input)
+        let s = String(data: output, encoding: .utf8) ?? ""
+        #expect(s.contains(";size=5:"))
+        #expect(!s.contains(";size=8:"))
+    }
+}
+
+@Suite("TmuxPassthrough")
+struct TmuxPassthroughTests {
+    @Test("wraps with ESC P tmux ; … ESC \\")
+    func framesWithDCS() {
+        let inner = Data([0x41, 0x42])   // "AB", no ESC inside
+        let wrapped = TmuxPassthrough.wrap(inner)
+        let expected = Data([0x1B, 0x50])          // ESC P
+            + Data("tmux;".utf8)
+            + Data([0x41, 0x42])
+            + Data([0x1B, 0x5C])                   // ESC \
+        #expect(wrapped == expected)
+    }
+
+    @Test("doubles every inner ESC (0x1B → 0x1B 0x1B)")
+    func doublesEscapes() {
+        let inner = Data([0x1B, 0x41, 0x1B])
+        let wrapped = TmuxPassthrough.wrap(inner)
+        let expected = Data([0x1B, 0x50])
+            + Data("tmux;".utf8)
+            + Data([0x1B, 0x1B, 0x41, 0x1B, 0x1B])
+            + Data([0x1B, 0x5C])
+        #expect(wrapped == expected)
+    }
+
+    @Test("wrapping an iTerm2 payload produces a tmux-ready double-ESC prefix")
+    func wrapIntegratesWithITerm2Encoder() {
+        let image = Data([0x00, 0x01, 0x02, 0x03])
+        let inner = ITerm2Encoder.encode(imageData: image)
+        let wrapped = TmuxPassthrough.wrap(inner)
+        // The only ESC in the iTerm2 payload is the leading one — it must
+        // appear doubled in the wrapped output.
+        let s = String(data: wrapped, encoding: .utf8) ?? ""
+        #expect(s.hasPrefix("\u{1B}Ptmux;\u{1B}\u{1B}]1337;"))
+        #expect(s.hasSuffix("\u{07}\u{1B}\\"))
+    }
+}
+
+@Suite("TerminalCapabilityDetector")
+struct TerminalCapabilityDetectorTests {
+    @Test(
+        "outer terminal classification",
+        arguments: [
+            (MockTerminalEnvironment(termProgram: "iTerm.app"), TerminalCapability.iTerm2),
+            (MockTerminalEnvironment(termProgram: "WezTerm"), .iTerm2),
+            (MockTerminalEnvironment(termProgram: "ghostty"), .iTerm2),
+            (MockTerminalEnvironment(lcTerminal: "iTerm2"), .iTerm2),
+            (MockTerminalEnvironment(term: "xterm-kitty"), .kittyOnly),
+            (MockTerminalEnvironment(kittyWindowID: "1"), .kittyOnly),
+            (MockTerminalEnvironment(term: "xterm-256color"), .unsupported),
+            (MockTerminalEnvironment(), .unsupported),
+        ] as [(MockTerminalEnvironment, TerminalCapability)]
+    )
+    func classifiesOuterTerminal(env: MockTerminalEnvironment, expected: TerminalCapability) {
+        let decision = TerminalCapabilityDetector.detect(
+            env: env, tmuxProbe: StubTmuxProbe(state: .unknown)
+        )
+        #expect(decision.capability == expected)
+        #expect(decision.needsTmuxWrap == false)
+        #expect(decision.hint == nil)
+    }
+
+    @Test("tmux + supported outer + passthrough on → needsTmuxWrap")
+    func tmuxOnWraps() {
+        let env = MockTerminalEnvironment(termProgram: "iTerm.app", tmux: "/tmp/tmux-500/default,1234,0")
+        let decision = TerminalCapabilityDetector.detect(env: env, tmuxProbe: StubTmuxProbe(state: .on))
+        #expect(decision.capability == .iTerm2)
+        #expect(decision.needsTmuxWrap == true)
+        #expect(decision.hint == nil)
+    }
+
+    @Test("tmux + supported outer + passthrough off → unsupported + hint")
+    func tmuxOffEmitsHint() {
+        let env = MockTerminalEnvironment(termProgram: "iTerm.app", tmux: "/tmp/tmux-500/default,1234,0")
+        let decision = TerminalCapabilityDetector.detect(env: env, tmuxProbe: StubTmuxProbe(state: .off))
+        #expect(decision.capability == .unsupported)
+        #expect(decision.needsTmuxWrap == false)
+        #expect(decision.hint?.contains("allow-passthrough") == true)
+    }
+
+    @Test("tmux + supported outer + probe unknown → unsupported, no hint")
+    func tmuxUnknownIsQuiet() {
+        let env = MockTerminalEnvironment(termProgram: "iTerm.app", tmux: "/tmp/tmux-500/default,1234,0")
+        let decision = TerminalCapabilityDetector.detect(env: env, tmuxProbe: StubTmuxProbe(state: .unknown))
+        #expect(decision.capability == .unsupported)
+        #expect(decision.hint == nil)
+    }
+
+    @Test("tmux + unsupported outer → do not probe, stay unsupported, no hint")
+    func tmuxWithUnsupportedOuterSkipsProbe() {
+        let env = MockTerminalEnvironment(term: "xterm-256color", tmux: "/tmp/tmux/default")
+        // If this test accidentally calls through, the probe returns .on — which
+        // *would* flip the decision if detection didn't short-circuit. Using a
+        // probe that would cause the wrong answer is the trap we're guarding.
+        let decision = TerminalCapabilityDetector.detect(env: env, tmuxProbe: StubTmuxProbe(state: .on))
+        #expect(decision.capability == .unsupported)
+        #expect(decision.needsTmuxWrap == false)
+        #expect(decision.hint == nil)
+    }
+}
+
+@Suite("TerminalImages.renderInline")
+struct TerminalImagesRenderInlineTests {
+    private let pixel = Data([0x01, 0x02, 0x03])
+
+    @Test("--json always skips")
+    func jsonSkips() {
+        let d = TerminalImages.renderInline(
+            imageData: pixel, mode: .auto, jsonOutput: true,
+            stdoutIsTTY: true,
+            env: MockTerminalEnvironment(termProgram: "iTerm.app"),
+            tmuxProbe: StubTmuxProbe(state: .unknown)
+        )
+        #expect(d == .skip(hint: nil))
+    }
+
+    @Test("--inline never skips, even on TTY + supported terminal")
+    func neverSkips() {
+        let d = TerminalImages.renderInline(
+            imageData: pixel, mode: .never, jsonOutput: false,
+            stdoutIsTTY: true,
+            env: MockTerminalEnvironment(termProgram: "iTerm.app"),
+            tmuxProbe: StubTmuxProbe(state: .unknown)
+        )
+        #expect(d == .skip(hint: nil))
+    }
+
+    @Test("auto + non-TTY skips (piped output)")
+    func autoPipedSkips() {
+        let d = TerminalImages.renderInline(
+            imageData: pixel, mode: .auto, jsonOutput: false,
+            stdoutIsTTY: false,
+            env: MockTerminalEnvironment(termProgram: "iTerm.app"),
+            tmuxProbe: StubTmuxProbe(state: .unknown)
+        )
+        #expect(d == .skip(hint: nil))
+    }
+
+    @Test("auto + TTY + iTerm2 emits unwrapped OSC 1337")
+    func autoTTYSupported() {
+        let d = TerminalImages.renderInline(
+            imageData: pixel, mode: .auto, jsonOutput: false,
+            stdoutIsTTY: true,
+            env: MockTerminalEnvironment(termProgram: "iTerm.app"),
+            tmuxProbe: StubTmuxProbe(state: .unknown)
+        )
+        guard case .emit(let bytes) = d else { Issue.record("expected .emit"); return }
+        let s = String(data: bytes, encoding: .utf8) ?? ""
+        #expect(s.hasPrefix("\u{1B}]1337;"))
+        #expect(!s.hasPrefix("\u{1B}Ptmux;"))
+    }
+
+    @Test("auto + TTY + tmux + passthrough on emits wrapped bytes")
+    func autoTmuxOnWraps() {
+        let d = TerminalImages.renderInline(
+            imageData: pixel, mode: .auto, jsonOutput: false,
+            stdoutIsTTY: true,
+            env: MockTerminalEnvironment(termProgram: "iTerm.app", tmux: "/tmp/tmux/default"),
+            tmuxProbe: StubTmuxProbe(state: .on)
+        )
+        guard case .emit(let bytes) = d else { Issue.record("expected .emit"); return }
+        let s = String(data: bytes, encoding: .utf8) ?? ""
+        #expect(s.hasPrefix("\u{1B}Ptmux;"))
+        #expect(s.hasSuffix("\u{1B}\\"))
+    }
+
+    @Test("auto + TTY + tmux + passthrough off skips with hint")
+    func autoTmuxOffSkipsWithHint() {
+        let d = TerminalImages.renderInline(
+            imageData: pixel, mode: .auto, jsonOutput: false,
+            stdoutIsTTY: true,
+            env: MockTerminalEnvironment(termProgram: "iTerm.app", tmux: "/tmp/tmux/default"),
+            tmuxProbe: StubTmuxProbe(state: .off)
+        )
+        guard case .skip(let hint) = d else { Issue.record("expected .skip"); return }
+        #expect(hint?.contains("allow-passthrough") == true)
+    }
+
+    @Test("always overrides unsupported terminal and emits")
+    func alwaysOverridesUnsupported() {
+        let d = TerminalImages.renderInline(
+            imageData: pixel, mode: .always, jsonOutput: false,
+            stdoutIsTTY: true,
+            env: MockTerminalEnvironment(term: "xterm-256color"),
+            tmuxProbe: StubTmuxProbe(state: .unknown)
+        )
+        guard case .emit(let bytes) = d else { Issue.record("expected .emit"); return }
+        #expect(!bytes.isEmpty)
+    }
+
+    @Test("always overrides non-TTY stdout and emits")
+    func alwaysOverridesPiped() {
+        let d = TerminalImages.renderInline(
+            imageData: pixel, mode: .always, jsonOutput: false,
+            stdoutIsTTY: false,
+            env: MockTerminalEnvironment(termProgram: "iTerm.app"),
+            tmuxProbe: StubTmuxProbe(state: .unknown)
+        )
+        guard case .emit = d else { Issue.record("expected .emit"); return }
+    }
+
+    @Test("PREVIEWSMCP_INLINE=0 + mode=auto → skip")
+    func envVarNeverOverridesAuto() {
+        let d = TerminalImages.renderInline(
+            imageData: pixel, mode: .auto, jsonOutput: false,
+            stdoutIsTTY: true,
+            env: MockTerminalEnvironment(termProgram: "iTerm.app", previewsmcpInline: "0"),
+            tmuxProbe: StubTmuxProbe(state: .unknown)
+        )
+        #expect(d == .skip(hint: nil))
+    }
+
+    @Test("PREVIEWSMCP_INLINE=1 + mode=auto + non-TTY → emit (env forced always)")
+    func envVarAlwaysBeatsNonTTY() {
+        let d = TerminalImages.renderInline(
+            imageData: pixel, mode: .auto, jsonOutput: false,
+            stdoutIsTTY: false,
+            env: MockTerminalEnvironment(termProgram: "iTerm.app", previewsmcpInline: "1"),
+            tmuxProbe: StubTmuxProbe(state: .unknown)
+        )
+        guard case .emit = d else { Issue.record("expected .emit"); return }
+    }
+
+    @Test("explicit --inline never wins over PREVIEWSMCP_INLINE=1")
+    func flagBeatsEnv() {
+        let d = TerminalImages.renderInline(
+            imageData: pixel, mode: .never, jsonOutput: false,
+            stdoutIsTTY: true,
+            env: MockTerminalEnvironment(termProgram: "iTerm.app", previewsmcpInline: "1"),
+            tmuxProbe: StubTmuxProbe(state: .unknown)
+        )
+        #expect(d == .skip(hint: nil))
+    }
+}

--- a/scripts/test-inline-image.sh
+++ b/scripts/test-inline-image.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Manual smoke test for issue #125 inline snapshot rendering.
+#
+# Emits an iTerm2 OSC 1337 inline-image escape (DCS-wrapped if running
+# inside tmux) for a PNG. Uses Sources/PreviewsIOS/AppIcon.png by default.
+#
+# If you see the icon rendered in your terminal, your setup supports
+# inline rendering and `previewsmcp snapshot` will render inline too.
+# If you see base64 garbage or nothing, your terminal doesn't support
+# the protocol — `previewsmcp snapshot` will fall back to path-only.
+#
+# Usage:
+#   scripts/test-inline-image.sh [path-to-png]
+#
+# tmux caveat:
+#   Inside tmux this script emits the DCS passthrough envelope, but tmux
+#   still discards it unless `allow-passthrough` is on. Enable with:
+#     tmux set -g allow-passthrough on
+#   and re-run. Revert with `tmux set -g allow-passthrough off` when done.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+IMG="${1:-${REPO_ROOT}/Sources/PreviewsIOS/AppIcon.png}"
+
+if [[ ! -f "$IMG" ]]; then
+    echo "error: image not found: $IMG" >&2
+    exit 1
+fi
+
+SIZE=$(wc -c < "$IMG" | tr -d ' ')
+B64=$(base64 < "$IMG" | tr -d '\n')
+
+if [[ -n "${TMUX:-}" ]]; then
+    PT=$(tmux show-options -gv allow-passthrough 2>/dev/null || echo "unknown")
+    if [[ "$PT" != "on" && "$PT" != "all" ]]; then
+        echo "note: inside tmux with allow-passthrough=${PT}; enable with:" >&2
+        echo "        tmux set -g allow-passthrough on" >&2
+    fi
+    printf '\033Ptmux;\033\033]1337;File=inline=1;size=%s:%s\007\033\\' "$SIZE" "$B64"
+else
+    printf '\033]1337;File=inline=1;size=%s:%s\007' "$SIZE" "$B64"
+fi
+printf '\n'


### PR DESCRIPTION
Closes #125.

## Summary

- `preview snapshot` now renders the PNG inline in the terminal via iTerm2's OSC 1337 protocol when stdout is a TTY and the terminal is iTerm2, WezTerm, or Ghostty. The on-disk file behavior is unchanged.
- New `--inline {auto,always,never}` (default `auto`); honors `PREVIEWSMCP_INLINE`.
- tmux-aware: when `$TMUX` is set, probes `allow-passthrough` and either DCS-wraps the escape (if on) or prints a one-line stderr hint (if off).
- Large images (>1200px on widest side) are downscaled to 1000px via CoreGraphics for display only — the file at `--output` stays full-resolution.

## Behavior matrix

| stdout | mode | outer | tmux state | result |
|---|---|---|---|---|
| TTY | auto | iTerm2/WezTerm/Ghostty | no tmux | image + path |
| TTY | auto | supported | passthrough on | wrapped image + path |
| TTY | auto | supported | passthrough off | path + stderr hint |
| TTY | auto | Terminal.app | — | path only |
| pipe | auto | any | any | path only |
| any | `--json` | any | any | JSON only (unchanged) |
| any | `never` | any | any | path only |
| any | `always` | any | any | image + path (may garble on unsupported) |

## Test plan

- [x] 28 unit tests in `Tests/PreviewsCLITests/TerminalImagesTests.swift` — all pass. Covers: golden-byte iTerm2 encoding, golden-byte tmux DCS wrap with ESC-doubling, 8-case capability classification, tmux passthrough state transitions, full decision matrix (mode × TTY × capability × env-var overrides × json).
- [x] `swift build` clean.
- [ ] Manual: in local iTerm2 (no SSH/tmux): `previewsmcp snapshot Foo.swift` — expect image inline, path below.
- [ ] Manual: same, piped to `cat` — expect path only, no escape bytes.
- [ ] Manual: same, with `--json` — expect JSON only.
- [ ] Manual: same, with `--inline never` — expect path only.
- [ ] Manual: in tmux with `allow-passthrough on`, local iTerm2 — expect image inline.
- [ ] Manual: in tmux with `allow-passthrough off`, local iTerm2 — expect path + stderr hint, no garbage.
- [ ] Manual: Terminal.app — expect path only (unsupported fallback).
- [ ] Manual: preview at 2400px wide — expect inline renders downscaled; file on disk at full res.

## Notes for reviewer

- Decision logic is a pure function with injected `TerminalEnvironment`, `TmuxProbe`, and `stdoutIsTTY` flag — unit tests run without a real terminal. The one real I/O point (`ProcessTmuxProbe`) is swapped out in tests via `StubTmuxProbe`.
- Kitty graphics protocol and Sixel deliberately deferred; rationale in the [plan comment](https://github.com/obj-p/PreviewsMCP/issues/125#issuecomment-4300099041). Will file a follow-up for Kitty once v1 is stable.
- tmux DCS wrapping was in scope per the [plan amendment](https://github.com/obj-p/PreviewsMCP/issues/125#issuecomment-4300112954) — without it the feature is broken for tmux users even when they've enabled passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)