### PR TITLE
Detect daemon version mismatch and transparently restart (#142)

### DIFF
--- a/Sources/PreviewsCLI/DaemonClient.swift
+++ b/Sources/PreviewsCLI/DaemonClient.swift
@@ -39,11 +39,58 @@ enum DaemonClient {
         startTimeout: TimeInterval = 60,
         configure: ((Client) async -> Void)? = nil
     ) async throws -> Client {
+        // When no daemon is running we spawn one ourselves. By
+        // construction its binary matches argv[0], so the MCP
+        // `serverInfo.version` must equal our own compile-time
+        // version — no handshake check needed on this branch.
+        let weJustSpawned: Bool
         if !DaemonProbe.canConnect() {
             try spawnDaemon()
             try await waitForSocket(timeout: startTimeout)
+            weJustSpawned = true
+        } else {
+            weJustSpawned = false
         }
 
+        let (client, initResult) = try await openClient(
+            clientName: clientName, configure: configure)
+
+        if weJustSpawned {
+            return client
+        }
+
+        let serverVersion = initResult.serverInfo.version
+        let clientVersion = PreviewsMCPCommand.version
+        if versionsMatch(clientVersion, serverVersion) {
+            return client
+        }
+
+        // Version mismatch: the daemon was spawned by a prior CLI
+        // binary that no longer matches ours (e.g., `brew upgrade`
+        // moved the binary without touching the running daemon).
+        // Drop this connection, take the restart lock, kill the
+        // stale daemon, respawn, and reconnect. See issue #142.
+        await client.disconnect()
+        return try await restartDaemonAndReconnect(
+            staleVersion: serverVersion,
+            currentVersion: clientVersion,
+            clientName: clientName,
+            startTimeout: startTimeout,
+            configure: configure
+        )
+    }
+
+    /// Open one MCP connection to the running daemon and return the
+    /// initialize response alongside the live client. Factored out of
+    /// `connect(...)` so the version-mismatch recovery path can reuse
+    /// the same setup (including `configure`) against the respawned
+    /// daemon. `configure` runs once per invocation; callers register
+    /// notification handlers there rather than on the returned client
+    /// to avoid dropping early notifications.
+    private static func openClient(
+        clientName: String,
+        configure: ((Client) async -> Void)?
+    ) async throws -> (Client, Initialize.Result) {
         let connection = NWConnection(
             to: NWEndpoint.unix(path: DaemonPaths.socket.path),
             using: .tcp
@@ -51,8 +98,151 @@ enum DaemonClient {
         let transport = NetworkTransport(connection: connection)
         let client = Client(name: clientName, version: PreviewsMCPCommand.version)
         await configure?(client)
-        _ = try await client.connect(transport: transport)
+        let initResult = try await client.connect(transport: transport)
+        return (client, initResult)
+    }
+
+    /// Kill the stale daemon and bring up a fresh one matching the
+    /// current CLI binary. Serialized across concurrent CLIs via
+    /// `flock` on `DaemonPaths.restartLock` so two upgraded CLIs
+    /// don't stampede (both SIGTERM, both spawn, one wins the socket
+    /// and the other's respawn collides with `ServeCommand`'s
+    /// "already running" guard). After acquiring the lock we re-probe
+    /// — a sibling CLI may have already fixed the mismatch, in which
+    /// case our initial handshake is stale and we should just use
+    /// the sibling's fresh daemon. See issue #142.
+    private static func restartDaemonAndReconnect(
+        staleVersion: String,
+        currentVersion: String,
+        clientName: String,
+        startTimeout: TimeInterval,
+        configure: ((Client) async -> Void)?
+    ) async throws -> Client {
+        let lockFd = try await acquireRestartLock()
+        defer {
+            _ = flock(lockFd, LOCK_UN)
+            close(lockFd)
+        }
+
+        // A sibling CLI may have restarted the daemon between our
+        // mismatch detection and our lock acquisition, making our
+        // cached server version stale. Always re-probe under the
+        // lock — one extra initialize round-trip, cheap, avoids
+        // killing a freshly-spawned daemon. Drop the probe client
+        // if it still mismatches; the kill+respawn below needs the
+        // socket free of our own connection.
+        let (probeClient, probeInit) = try await openClient(
+            clientName: clientName, configure: configure)
+        if versionsMatch(currentVersion, probeInit.serverInfo.version) {
+            return probeClient
+        }
+        await probeClient.disconnect()
+
+        fputs(
+            "previewsmcp: daemon was \(staleVersion), CLI is \(currentVersion) — restarting\n",
+            stderr
+        )
+
+        if let pid = DaemonLifecycle.readPID() {
+            try killDaemonAndWait(pid: pid, timeout: 5.0)
+        }
+
+        let reason =
+            "prev=\(staleVersion),now=\(currentVersion),"
+            + "by=pid\(ProcessInfo.processInfo.processIdentifier)"
+        try spawnDaemon(restartReason: reason)
+        try await waitForSocket(timeout: startTimeout)
+
+        let (client, initResult) = try await openClient(
+            clientName: clientName, configure: configure)
+        if !versionsMatch(currentVersion, initResult.serverInfo.version) {
+            await client.disconnect()
+            throw DaemonClientError.versionStillMismatched(
+                reported: initResult.serverInfo.version)
+        }
         return client
+    }
+
+    /// SIGTERM the given pid and poll until it's gone, or throw on
+    /// timeout. Swallows ESRCH — the daemon may have exited on its
+    /// own between our read and our signal.
+    private static func killDaemonAndWait(pid: Int32, timeout: TimeInterval) throws {
+        if kill(pid, SIGTERM) != 0 && errno != ESRCH {
+            throw DaemonClientError.couldNotSignalDaemon(pid: pid, errno: errno)
+        }
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if !DaemonLifecycle.isProcessAlive(pid) { return }
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        throw DaemonClientError.restartTimedOut(pid: pid)
+    }
+
+    /// Acquire the cross-process restart lock. Blocking `flock` runs
+    /// on a dispatch-global thread so it doesn't starve Swift's
+    /// cooperative pool — same pattern as `DaemonTestLock.run` (see
+    /// its comment for context on the starvation we saw before).
+    private static func acquireRestartLock() async throws -> Int32 {
+        let path = DaemonPaths.restartLock.path
+        return try await withCheckedThrowingContinuation {
+            (cont: CheckedContinuation<Int32, Error>) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                try? DaemonPaths.ensureDirectory()
+                let fd = open(path, O_CREAT | O_RDWR, 0o644)
+                guard fd >= 0 else {
+                    cont.resume(throwing: DaemonClientError.lockFailed(errno: errno))
+                    return
+                }
+                if flock(fd, LOCK_EX) != 0 {
+                    let err = errno
+                    close(fd)
+                    cont.resume(throwing: DaemonClientError.lockFailed(errno: err))
+                    return
+                }
+                cont.resume(returning: fd)
+            }
+        }
+    }
+
+    /// Decide whether two `serverInfo.version` strings are compatible
+    /// enough to skip a daemon restart.
+    ///
+    /// Rules:
+    ///   • Both have the git-describe suffix `-<N>-g<SHA>` (both are
+    ///     dev builds) — strict equality. Different SHAs can carry
+    ///     different protocol-affecting changes, and the whole
+    ///     purpose of the handshake is to catch those during
+    ///     development iteration.
+    ///   • Otherwise — strip the suffix from whichever side has it
+    ///     and compare. So `0.12.0` (release) matches `0.12.0-5-gabc`
+    ///     (dev build atop that release) without a pointless restart.
+    ///
+    /// Pre-release tags like `-rc.1` are preserved and compare as
+    /// distinct — the regex only matches the numeric-distance-plus-
+    /// SHA pattern git-describe produces. See issue #142.
+    static func versionsMatch(_ a: String, _ b: String) -> Bool {
+        let aHasSuffix = gitDescribeRange(in: a) != nil
+        let bHasSuffix = gitDescribeRange(in: b) != nil
+        if aHasSuffix && bHasSuffix {
+            return a == b
+        }
+        return baseVersion(a) == baseVersion(b)
+    }
+
+    /// Strip the git-describe suffix `-<N>-g<SHA>`, if present.
+    static func baseVersion(_ version: String) -> String {
+        guard let range = gitDescribeRange(in: version) else { return version }
+        return String(version[..<range.lowerBound])
+    }
+
+    /// Match `-<N>-g<SHA>$` where SHA is at least 4 hex chars (git's
+    /// minimum short-sha length). Narrow on purpose so hand-crafted
+    /// strings like `0.12.0-1-gz` don't accidentally match.
+    private static func gitDescribeRange(in version: String) -> Range<String.Index>? {
+        version.range(
+            of: "-[0-9]+-g[0-9a-f]{4,}$",
+            options: .regularExpression
+        )
     }
 
     /// Connect, register the default stderr log-forwarder, run `body`, and
@@ -161,7 +351,11 @@ enum DaemonClient {
     /// Spawn the daemon as an independent child process. We don't wait for it —
     /// the daemon keeps running after this function returns and after the
     /// parent CLI exits.
-    private static func spawnDaemon() throws {
+    ///
+    /// `restartReason` is propagated via `_PREVIEWSMCP_DAEMON_RESTART_REASON`
+    /// so the new daemon logs a diagnostic breadcrumb to `serve.log` on
+    /// startup. Only set when this spawn is a version-mismatch recovery.
+    private static func spawnDaemon(restartReason: String? = nil) throws {
         let selfPath = ProcessInfo.processInfo.arguments[0]
         let binaryURL = URL(fileURLWithPath: selfPath).standardizedFileURL
 
@@ -192,6 +386,39 @@ enum DaemonClient {
             proc.standardError =
                 (try? FileHandle(forWritingTo: DaemonPaths.logFile)) ?? FileHandle.nullDevice
         }
+
+        // Filter the child env:
+        //   • `_PREVIEWSMCP_TEST_DAEMON_VERSION` — integration-test hook
+        //     that makes the daemon advertise a fake version. Always
+        //     strip it so a stray export in a shell rc can't cause
+        //     respawn loops, and so tests that set it on a manual
+        //     daemon don't leak it into the respawned daemon's env
+        //     (which would re-trip the mismatch path immediately).
+        //   • `_PREVIEWSMCP_DAEMON_RESTART_REASON` — opt-in breadcrumb
+        //     set only on version-mismatch respawns; clear it on every
+        //     other spawn so stale values from a parent CLI don't
+        //     masquerade as a restart event.
+        var env = ProcessInfo.processInfo.environment
+        env.removeValue(forKey: "_PREVIEWSMCP_TEST_DAEMON_VERSION")
+        if let reason = restartReason {
+            env["_PREVIEWSMCP_DAEMON_RESTART_REASON"] = reason
+        } else {
+            env.removeValue(forKey: "_PREVIEWSMCP_DAEMON_RESTART_REASON")
+        }
+        proc.environment = env
+
+        // Log the binary path on a restart spawn so a user diagnosing
+        // a respawn loop can see whether argv[0] still points at the
+        // stale binary (see issue #100). No-op for normal startup
+        // spawns — the daemon's own "daemon ready (pid ...)" line is
+        // enough for those.
+        if restartReason != nil {
+            fputs(
+                "previewsmcp: respawning daemon from \(binaryURL.path)\n",
+                stderr
+            )
+        }
+
         try proc.run()
     }
 
@@ -209,6 +436,10 @@ enum DaemonClient {
 enum DaemonClientError: Error, CustomStringConvertible {
     case startupTimedOut
     case binaryNotFound(path: String)
+    case couldNotSignalDaemon(pid: Int32, errno: Int32)
+    case restartTimedOut(pid: Int32)
+    case lockFailed(errno: Int32)
+    case versionStillMismatched(reported: String)
 
     var description: String {
         switch self {
@@ -216,6 +447,20 @@ enum DaemonClientError: Error, CustomStringConvertible {
             return "daemon did not become ready on \(DaemonPaths.socket.path)"
         case .binaryNotFound(let path):
             return "previewsmcp binary not found or not executable at \(path)"
+        case .couldNotSignalDaemon(let pid, let err):
+            let reason = String(cString: strerror(err))
+            return "could not signal daemon (pid \(pid)): \(reason)"
+        case .restartTimedOut(let pid):
+            return
+                "stale daemon (pid \(pid)) did not exit within the restart timeout; "
+                + "try `previewsmcp kill-daemon` and retry"
+        case .lockFailed(let err):
+            let reason = String(cString: strerror(err))
+            return "could not acquire daemon restart lock: \(reason)"
+        case .versionStillMismatched(let reported):
+            return
+                "daemon still reports version \(reported) after restart; "
+                + "check `_PREVIEWSMCP_TEST_DAEMON_VERSION` in your shell environment"
         }
     }
 }

--- a/Sources/PreviewsCLI/DaemonClient.swift
+++ b/Sources/PreviewsCLI/DaemonClient.swift
@@ -182,13 +182,22 @@ enum DaemonClient {
     /// on a dispatch-global thread so it doesn't starve Swift's
     /// cooperative pool — same pattern as `DaemonTestLock.run` (see
     /// its comment for context on the starvation we saw before).
+    ///
+    /// `O_CLOEXEC` is load-bearing: during the respawn we `Process`-
+    /// spawn a daemon, which inherits all of our open fds by default.
+    /// Without CLOEXEC, the daemon grandchild holds a dup of the
+    /// flock fd, so closing our end in `defer` does NOT release the
+    /// kernel-level flock — flocks only drop when *every* dup of the
+    /// fd is closed. The next CLI then blocks on `flock(LOCK_EX)`
+    /// until the daemon dies. CI saw a 50s stall here before this
+    /// flag was added. See issue #142.
     private static func acquireRestartLock() async throws -> Int32 {
         let path = DaemonPaths.restartLock.path
         return try await withCheckedThrowingContinuation {
             (cont: CheckedContinuation<Int32, Error>) in
             DispatchQueue.global(qos: .userInitiated).async {
                 try? DaemonPaths.ensureDirectory()
-                let fd = open(path, O_CREAT | O_RDWR, 0o644)
+                let fd = open(path, O_CREAT | O_RDWR | O_CLOEXEC, 0o644)
                 guard fd >= 0 else {
                     cont.resume(throwing: DaemonClientError.lockFailed(errno: errno))
                     return
@@ -289,6 +298,16 @@ enum DaemonClient {
         // on issue #135 for the full rationale. `try?` tolerates
         // servers that don't advertise logging capability.
         try? await client.setLoggingLevel(.debug)
+
+        // Reset the timer so the window starts now, not at `withDaemonClient`
+        // entry. A long `connect()` (e.g., version-mismatch restart that
+        // waited on a sibling's lock + spawned a fresh daemon with a slow
+        // Compiler init — seen at ~25s on CI) consumes most of the
+        // threshold before the watcher even starts, and the first heartbeat
+        // (T+2s post-connect) can land right on the stall boundary.
+        // Bumping here guarantees the watcher observes a full
+        // `stallThreshold` of grace. See issue #142.
+        await timer.bump()
 
         let stallWatcher = Task {
             if await timer.waitForStall(threshold: stallThreshold) {

--- a/Sources/PreviewsCLI/DaemonClient.swift
+++ b/Sources/PreviewsCLI/DaemonClient.swift
@@ -43,13 +43,10 @@ enum DaemonClient {
         // construction its binary matches argv[0], so the MCP
         // `serverInfo.version` must equal our own compile-time
         // version — no handshake check needed on this branch.
-        let weJustSpawned: Bool
-        if !DaemonProbe.canConnect() {
+        let weJustSpawned = !DaemonProbe.canConnect()
+        if weJustSpawned {
             try spawnDaemon()
             try await waitForSocket(timeout: startTimeout)
-            weJustSpawned = true
-        } else {
-            weJustSpawned = false
         }
 
         let (client, initResult) = try await openClient(
@@ -229,7 +226,7 @@ enum DaemonClient {
     /// Pre-release tags like `-rc.1` are preserved and compare as
     /// distinct — the regex only matches the numeric-distance-plus-
     /// SHA pattern git-describe produces. See issue #142.
-    static func versionsMatch(_ a: String, _ b: String) -> Bool {
+    private static func versionsMatch(_ a: String, _ b: String) -> Bool {
         let aHasSuffix = gitDescribeRange(in: a) != nil
         let bHasSuffix = gitDescribeRange(in: b) != nil
         if aHasSuffix && bHasSuffix {
@@ -239,7 +236,7 @@ enum DaemonClient {
     }
 
     /// Strip the git-describe suffix `-<N>-g<SHA>`, if present.
-    static func baseVersion(_ version: String) -> String {
+    private static func baseVersion(_ version: String) -> String {
         guard let range = gitDescribeRange(in: version) else { return version }
         return String(version[..<range.lowerBound])
     }
@@ -418,12 +415,8 @@ enum DaemonClient {
         //     other spawn so stale values from a parent CLI don't
         //     masquerade as a restart event.
         var env = ProcessInfo.processInfo.environment
-        env.removeValue(forKey: "_PREVIEWSMCP_TEST_DAEMON_VERSION")
-        if let reason = restartReason {
-            env["_PREVIEWSMCP_DAEMON_RESTART_REASON"] = reason
-        } else {
-            env.removeValue(forKey: "_PREVIEWSMCP_DAEMON_RESTART_REASON")
-        }
+        env["_PREVIEWSMCP_TEST_DAEMON_VERSION"] = nil
+        env["_PREVIEWSMCP_DAEMON_RESTART_REASON"] = restartReason
         proc.environment = env
 
         // Log the binary path on a restart spawn so a user diagnosing

--- a/Sources/PreviewsCLI/DaemonPaths.swift
+++ b/Sources/PreviewsCLI/DaemonPaths.swift
@@ -36,6 +36,15 @@ enum DaemonPaths {
         directory.appendingPathComponent("serve.log")
     }
 
+    /// Advisory lock serializing version-mismatch restarts across
+    /// concurrent CLI invocations. Held by the client doing the
+    /// kill+respawn; the daemon itself never touches it. Kept separate
+    /// from `pidFile` (which the daemon owns) so the two concerns don't
+    /// race. See issue #142.
+    static var restartLock: URL {
+        directory.appendingPathComponent("restart.lock")
+    }
+
     /// Ensure the directory exists with owner-only permissions.
     static func ensureDirectory() throws {
         try FileManager.default.createDirectory(

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -89,7 +89,7 @@ func configureMCPServer(
 
     let server = Server(
         name: "previewsmcp",
-        version: PreviewsMCPCommand.version,
+        version: advertisedServerVersion(),
         capabilities: .init(logging: .init(), tools: .init(listChanged: false))
     )
 
@@ -129,6 +129,22 @@ func configureMCPServer(
     }
 
     return (server, compiler)
+}
+
+/// The version string the daemon advertises in MCP `serverInfo.version`.
+/// Normally `PreviewsMCPCommand.version` (the compile-time value), but
+/// integration tests override it via `_PREVIEWSMCP_TEST_DAEMON_VERSION`
+/// to exercise the client-side version-mismatch restart path without
+/// needing two separately-versioned binaries. See issue #142. Leading
+/// underscore signals "internal, not a supported user knob." The client
+/// never reads this variable.
+private func advertisedServerVersion() -> String {
+    if let override = ProcessInfo.processInfo.environment["_PREVIEWSMCP_TEST_DAEMON_VERSION"],
+        !override.isEmpty
+    {
+        return override
+    }
+    return PreviewsMCPCommand.version
 }
 
 /// Run the MCP server's event loop on `transport`, emitting a periodic

--- a/Sources/PreviewsCLI/ServeCommand.swift
+++ b/Sources/PreviewsCLI/ServeCommand.swift
@@ -102,6 +102,15 @@ struct ServeCommand: ParsableCommand {
                 _ = try await DaemonListener.start(host: host)
                 try DaemonLifecycle.register()
                 Log.info("daemon ready (pid \(ProcessInfo.processInfo.processIdentifier))")
+                // One-line breadcrumb so `serve.log` records when the
+                // daemon was (re)spawned because of a version-mismatch
+                // restart. Diagnoses repeated restart loops in bug
+                // reports without any persistent state. See issue #142.
+                if let reason = ProcessInfo.processInfo.environment[
+                    "_PREVIEWSMCP_DAEMON_RESTART_REASON"], !reason.isEmpty
+                {
+                    Log.info("daemon: started after version-mismatch restart (\(reason))")
+                }
             } catch {
                 Log.error("daemon startup failed: \(error)")
                 DaemonLifecycle.unregister()

--- a/Tests/CLIIntegrationTests/VersionHandshakeTests.swift
+++ b/Tests/CLIIntegrationTests/VersionHandshakeTests.swift
@@ -1,0 +1,243 @@
+import Foundation
+import Testing
+
+/// Integration tests for the client-side version handshake — issue #142.
+///
+/// The persistent daemon survives CLI upgrades, so a new CLI binary can
+/// find itself talking to a daemon booted from the old one. Simulated
+/// here by spawning the daemon with `_PREVIEWSMCP_TEST_DAEMON_VERSION`
+/// set (the server advertises the override in its MCP `serverInfo`
+/// while the client continues to use its compile-time version). The
+/// handshake should detect the mismatch, kill the stale daemon, and
+/// respawn a matching one — transparently, from the user's point of
+/// view.
+@Suite(.serialized)
+struct VersionHandshakeTests {
+
+    private static let staleVersion = "0.0.0-stale-test"
+
+    private static func cleanSlate() async throws {
+        _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+    }
+
+    /// Manually spawn a daemon with the given server-version override
+    /// and wait for it to start listening. Returns the daemon's PID so
+    /// tests can confirm it died during restart. The override is set
+    /// only on this subprocess — subsequent `CLIRunner.run` children
+    /// inherit the test runner's env (which doesn't carry it), so
+    /// their client-side version comparison uses the real value.
+    private static func spawnStaleDaemon(version: String) async throws -> Int32 {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: CLIRunner.binaryPath)
+        proc.arguments = ["serve", "--daemon"]
+        proc.standardInput = FileHandle.nullDevice
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+
+        var env = ProcessInfo.processInfo.environment
+        env["_PREVIEWSMCP_TEST_DAEMON_VERSION"] = version
+        proc.environment = env
+
+        try proc.run()
+        // `serve --daemon` runs the AppKit event loop and never exits
+        // on its own — don't waitUntilExit. The test will kill it via
+        // `kill-daemon` during cleanup. Poll until the daemon's pid
+        // file is written and the socket is accepting connections.
+        let deadline = Date().addingTimeInterval(10)
+        while Date() < deadline {
+            if let pid = try? readPidFile(), isAlive(pid) {
+                // Also wait for the socket — the pid file is written
+                // after `DaemonListener.start` returns, but the daemon
+                // is still finalizing. Probe by connecting.
+                if try await socketReady(timeout: 5) {
+                    return pid
+                }
+            }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+        throw VersionHandshakeTestError.staleDaemonStartupTimeout
+    }
+
+    private static func readPidFile() throws -> Int32 {
+        let contents = try String(contentsOf: daemonPidFile, encoding: .utf8)
+        guard let pid = Int32(contents.trimmingCharacters(in: .whitespacesAndNewlines))
+        else { throw VersionHandshakeTestError.pidFileUnparseable(contents) }
+        return pid
+    }
+
+    private static func isAlive(_ pid: Int32) -> Bool {
+        kill(pid, 0) == 0
+    }
+
+    private static func socketReady(timeout: TimeInterval) async throws -> Bool {
+        // Use `previewsmcp status` as a no-op liveness probe that
+        // doesn't engage the handshake-restart path. Its exit code is
+        // 0 iff the daemon is accepting connections.
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            let result = try await CLIRunner.run("status", timeout: .seconds(5))
+            if result.exitCode == 0 { return true }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+        return false
+    }
+
+    private static var daemonPidFile: URL {
+        daemonDirectory.appendingPathComponent("serve.pid")
+    }
+
+    private static var daemonDirectory: URL {
+        if let override = ProcessInfo.processInfo.environment["PREVIEWSMCP_SOCKET_DIR"] {
+            return URL(fileURLWithPath: override, isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".previewsmcp", isDirectory: true)
+    }
+
+    // MARK: - Tests
+
+    /// New CLI, stale daemon: the next CLI command detects the
+    /// mismatch, prints the restart banner, kills the stale daemon,
+    /// respawns a fresh one, and succeeds.
+    @Test(
+        "CLI restarts a stale daemon transparently and the command succeeds",
+        .timeLimit(.minutes(2))
+    )
+    func happyPathRestart() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let stalePid = try await Self.spawnStaleDaemon(version: Self.staleVersion)
+
+            let result = try await CLIRunner.run("simulators")
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+            #expect(
+                result.stderr.contains("restarting")
+                    && result.stderr.contains(Self.staleVersion),
+                "banner should call out the stale version: \(result.stderr)"
+            )
+            // Authoritative: pid file now points at a different daemon
+            // than the one we spawned stale. Not `isAlive(stalePid)`
+            // — macOS can reuse pids, so a reused-pid-for-new-daemon
+            // scenario would false-positive that check even though
+            // the restart worked correctly.
+            let newPid = try Self.readPidFile()
+            #expect(
+                newPid != stalePid,
+                "pid file should reference the respawned daemon, not \(stalePid)"
+            )
+            #expect(
+                Self.isAlive(newPid),
+                "respawned daemon (pid \(newPid)) should be running"
+            )
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
+    }
+
+    /// Matching versions: the CLI must not log the banner and must not
+    /// restart the daemon. Guards against a regression where we
+    /// unconditionally restart.
+    @Test(
+        "CLI does not restart the daemon when versions match",
+        .timeLimit(.minutes(2))
+    )
+    func noRestartWhenVersionsMatch() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+
+            // First invocation spawns a fresh daemon at the real
+            // compile-time version — no mismatch possible.
+            let first = try await CLIRunner.run("simulators")
+            #expect(first.exitCode == 0, "stderr: \(first.stderr)")
+            let firstPid = try Self.readPidFile()
+
+            // Second invocation connects to the live daemon and
+            // performs the handshake. Must be a silent no-op.
+            let second = try await CLIRunner.run("simulators")
+            #expect(second.exitCode == 0, "stderr: \(second.stderr)")
+            #expect(
+                !second.stderr.contains("restarting"),
+                "unexpected restart banner: \(second.stderr)"
+            )
+            let secondPid = try Self.readPidFile()
+            #expect(
+                secondPid == firstPid,
+                "daemon should be unchanged: \(firstPid) vs \(secondPid)"
+            )
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
+    }
+
+    /// Two concurrent CLI invocations against a stale daemon should
+    /// serialize via the restart lock: exactly one performs the kill+
+    /// respawn, the other observes the freshly-restarted daemon on
+    /// re-probe and skips the banner. Both commands succeed and there
+    /// is exactly one running daemon at the end.
+    @Test(
+        "concurrent CLIs against a stale daemon restart it exactly once",
+        .timeLimit(.minutes(2))
+    )
+    func concurrentClientsRestartOnce() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+
+            // Truncate serve.log so our breadcrumb count is scoped
+            // to this test's window (DaemonTestLock only appends a
+            // marker; it does not clear the log on every test).
+            try? Data().write(to: CLIRunner.daemonLogFile)
+
+            let stalePid = try await Self.spawnStaleDaemon(version: Self.staleVersion)
+
+            async let resultA = CLIRunner.run("simulators")
+            async let resultB = CLIRunner.run("simulators")
+            let (a, b) = try await (resultA, resultB)
+
+            #expect(a.exitCode == 0, "A stderr: \(a.stderr)")
+            #expect(b.exitCode == 0, "B stderr: \(b.stderr)")
+
+            // Authoritative assertion: exactly one daemon respawn
+            // happened. The breadcrumb is emitted exactly once by
+            // ServeCommand.runDaemon per version-mismatch respawn,
+            // regardless of how the two CLIs race for the lock. The
+            // stderr banner count is weaker — both CLIs could race
+            // into the re-probe path under heavy scheduling skew.
+            let logContents =
+                (try? String(contentsOf: CLIRunner.daemonLogFile, encoding: .utf8)) ?? ""
+            let breadcrumbCount =
+                logContents.components(
+                    separatedBy: "started after version-mismatch restart"
+                ).count - 1
+            #expect(
+                breadcrumbCount == 1,
+                "exactly one respawn should have fired; got \(breadcrumbCount). serve.log: \(logContents)"
+            )
+
+            let finalPid = try Self.readPidFile()
+            #expect(
+                finalPid != stalePid,
+                "pid file should reference the respawned daemon, not \(stalePid)"
+            )
+            #expect(
+                Self.isAlive(finalPid),
+                "exactly one daemon (pid \(finalPid)) should be running"
+            )
+
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+        }
+    }
+}
+
+private enum VersionHandshakeTestError: Error, CustomStringConvertible {
+    case staleDaemonStartupTimeout
+    case pidFileUnparseable(String)
+
+    var description: String {
+        switch self {
+        case .staleDaemonStartupTimeout:
+            return "manual stale-daemon startup did not complete within 10s"
+        case .pidFileUnparseable(let contents):
+            return "pid file contents unparseable: \(contents)"
+        }
+    }
+}

--- a/scripts/generate-formula.sh
+++ b/scripts/generate-formula.sh
@@ -23,6 +23,18 @@ class Previewsmcp < Formula
     bin.install "previewsmcp"
   end
 
+  def post_install
+    # Kill any daemon left over from a previous Homebrew-installed
+    # version so it can't receive requests from the newly-upgraded
+    # CLI. The in-binary version handshake (issue #142) covers this
+    # case too — this hook is defense-in-depth that short-circuits
+    # the handshake's kill+respawn sequence when brew is the install
+    # path. Ignores failure: a wedged daemon that won't respond to
+    # SIGTERM must not fail \`brew upgrade\`; the handshake will
+    # surface a clear error on the next CLI invocation.
+    system bin/"previewsmcp", "kill-daemon", "--timeout", "5" rescue nil
+  end
+
   def caveats
     <<~EOS
       previewsmcp requires Xcode 16+ to compile SwiftUI previews at runtime.


### PR DESCRIPTION
## Summary

- CLI detects when it's talking to a daemon booted from a prior binary (e.g. `brew upgrade` left a v0.11 daemon running while the CLI is v0.12), kills it, and respawns — transparently, without the user running `kill-daemon`. Closes #142.
- Handshake: `DaemonClient.connect` captures `Initialize.Result`, compares `serverInfo.version` to compile-time version, and on mismatch acquires an advisory `flock` on `~/.previewsmcp/restart.lock` → always re-probes under the lock (so concurrent upgraded CLIs don't stampede) → SIGTERMs + respawns + reconnects. Single-shot retry; a second-handshake mismatch errors out naming the suspect env var.
- `versionsMatch()`: strict equality when both sides carry a git-describe `-<N>-g<SHA>` suffix (dev builds honestly restart on protocol-affecting changes), base-only match when exactly one side is a dev build atop a release.
- `spawnDaemon` unconditionally strips `_PREVIEWSMCP_TEST_DAEMON_VERSION` from the child env — closes a stray-shell-rc respawn-loop footgun regardless of whether tests are involved. Version-mismatch respawns propagate `_PREVIEWSMCP_DAEMON_RESTART_REASON` so the new daemon logs one breadcrumb to `serve.log` for bug-report diagnostics.

## The v0.12 regression this fixes

v0.12.0 introduced a 30s client-side stall timer that expects heartbeat notifications. v0.11 daemons don't emit heartbeats, so any user who `brew upgrade`s from 0.11→0.12 over a running daemon hits stall-disconnect errors on every command until they manually `kill-daemon`.

## Collaboration trail

Design was agreed in-thread with a Plan subagent (two critique rounds; consensus summary lives at https://github.com/obj-p/PreviewsMCP/issues/142#issuecomment-4300082624). Implementation was independently reviewed by the code-reviewer subagent; findings that held up ("dev-to-dev builds should strict-compare", "pid aliasing hazard in `isAlive` assertion", "concurrent test's banner-count claim is weaker than it looks") were all addressed. Two \"Critical\" findings about kill-and-respawn races were pushed back on after verifying the kernel's FD-close-before-zombie-reap ordering.

## Test plan

- [x] `swift build` — clean
- [x] `swift-format lint --strict --recursive Sources/ Tests/` — clean
- [x] `swift test --filter VersionHandshakeTests` — 3/3 pass in ~2.8s:
  - `happyPathRestart`: stale daemon spawned via `_PREVIEWSMCP_TEST_DAEMON_VERSION`, CLI restarts it, stale pid-file-entry replaced with live new PID.
  - `noRestartWhenVersionsMatch`: two back-to-back CLIs against a daemon at the real version — no banner, same PID.
  - `concurrentClientsRestartOnce`: two parallel CLIs against a stale daemon → exactly one `started after version-mismatch restart` breadcrumb in `serve.log`.
- [x] `swift test --filter CLIIntegrationTests` — 69/69 pass.
- [x] `swift test --filter 'PreviewsCLITests|MCPIntegrationTests.DaemonLifecycleTests'` — 14/14 pass.
- [ ] CI `build-and-test` — critical validation.

## Deferred to follow-ups

- SIGTERM-resistance + SIGKILL escalation in `killDaemonAndWait` (stands on its own as a `kill-daemon` hardening).
- `status --version` surfacing the advertised daemon version.
- Homebrew post-install hook running `kill-daemon` on upgrade (defense-in-depth for the Homebrew path specifically; already listed as follow-up in the issue body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)