### PR TITLE
Detect stale stdio MCP server with preview_build_info tool (#147)

### DIFF
--- a/.claude/skills/integration-test/SKILL.md
+++ b/.claude/skills/integration-test/SKILL.md
@@ -2,7 +2,7 @@
 name: integration-test
 description: Run integration tests against example projects in the examples/ directory. Use when the user wants to validate PreviewsMCP's build system support, rendering, interaction, or hot-reload end-to-end.
 argument-hint: [example-name]
-allowed-tools: Bash, Read, Glob, Grep, preview_start, preview_snapshot, preview_configure, preview_switch, preview_elements, preview_touch, preview_stop, preview_list, simulator_list
+allowed-tools: Bash, Read, Glob, Grep, preview_start, preview_snapshot, preview_configure, preview_switch, preview_elements, preview_touch, preview_stop, preview_list, preview_build_info, simulator_list
 ---
 
 Run integration tests for PreviewsMCP example projects.
@@ -11,11 +11,25 @@ Run integration tests for PreviewsMCP example projects.
 
 - `$ARGUMENTS` — optional example name (e.g., `spm`). If omitted, run all examples.
 
+## Important: two server processes
+
+PreviewsMCP runs as two separate processes with independent state:
+- **Stdio MCP server** — spawned by Claude Code at session start via `.mcp.json`. This is what `mcp__previewsmcp__*` tool calls reach.
+- **UDS daemon** — auto-spawned by every `previewsmcp` CLI subcommand. Persists across CLI invocations.
+
+`swift build` overwrites the on-disk binary, but **resident processes keep running the old code** until they restart. Without an explicit check this skill could exercise a stale binary and report green against unchanged code. Steps 0 and 2 below guard against that.
+
 ## Steps
+
+0. **Reset daemon state.** Run `previewsmcp kill-daemon`, then `previewsmcp status`. If `status` exits 0 (a daemon is still alive), abort the skill — a residual UDS daemon is potentially stale and is load-bearing for Step 7's `preview_list` calls on non-SPM examples.
 
 1. **Discover examples.** List directories under `examples/` in the repo root. If `$ARGUMENTS` is provided, filter to that example only. If the specified example doesn't exist, report the error and list available examples.
 
-2. **Build PreviewsMCP.** Run `swift build` from the repo root. If the build fails, stop and report the error.
+2. **Build PreviewsMCP and verify the stdio server is fresh.** Run `swift build` from the repo root. If the build fails, stop and report the error. Then call `preview_build_info` (MCP tool). If the response has `stale: true`, abort with this message:
+
+   > Stdio MCP server's on-disk binary was rebuilt at `<binaryMtime>` but the running process started at `<processStartTime>`. Type `/exit` and relaunch Claude Code so it respawns the MCP server from the new binary, then re-run this skill.
+
+   If `stale: false`, proceed.
 
 3. **For each example**, read its `README.md` and follow the "Integration Test Prompt" section. The README contains the exact steps to execute, including which MCP tools to call and what to verify.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,22 @@ Key files:
 
 `PreviewsMCPApp.swift` routes commands: only `serve` runs `NSApplication`; everything else uses `dispatchMain()` + async `Task`.
 
+### Stdio server vs UDS daemon
+
+`previewsmcp serve` runs in two modes that are **separate processes with separate session state**:
+
+- **Stdio** (default) — spawned by MCP clients via `.mcp.json` (Claude Code, Cursor). Self-contained: own `PreviewHost`, `IOSSessionManager`, `ConfigCache`. Resident for the lifetime of the MCP host process.
+- **UDS daemon** (`--daemon`) — auto-spawned by every CLI subcommand at `~/.previewsmcp/serve.sock`. Persists across CLI invocations.
+
+A session created via MCP tools lives in the stdio process and is **not** visible to `previewsmcp list` / `snapshot --session-id …` (which talk to the daemon). And vice versa.
+
+When validating code changes, both halves can go stale — `swift build` overwrites the binary, but resident processes keep running the old code:
+
+- Refresh stdio: `/exit` and relaunch Claude Code (or call `preview_build_info` to detect staleness — `stale: true` means the on-disk binary has been rebuilt since the running process started).
+- Refresh daemon: `previewsmcp kill-daemon` (auto-respawns on next CLI invocation; #142's version-mismatch handshake also restarts it transparently).
+
+The stdio server has no equivalent of #142's handshake — there's no peer to handshake with — so the staleness must be detected client-side.
+
 ### CLI subcommands
 
 | Command | Purpose | Daemon? |
@@ -121,7 +137,7 @@ CLI commands follow a stdout-for-data, stderr-for-side-effects convention:
 Binary: `.build/debug/previewsmcp serve`
 Config: `/.mcp.json` (in parent directory)
 
-Tools: `preview_list`, `preview_start`, `preview_configure`, `preview_switch`, `preview_variants`, `preview_snapshot`, `preview_elements`, `preview_touch`, `preview_stop`, `simulator_list`, `session_list`
+Tools: `preview_list`, `preview_start`, `preview_configure`, `preview_switch`, `preview_variants`, `preview_snapshot`, `preview_elements`, `preview_touch`, `preview_stop`, `simulator_list`, `session_list`, `preview_build_info`
 
 All tool handlers that return non-trivial data emit a `structuredContent` payload (Codable DTOs from `DaemonProtocol.swift`) alongside the human-readable text content blocks. Agents that consume `structuredContent` can skip parsing prose.
 

--- a/Sources/PreviewsCLI/DaemonProtocol.swift
+++ b/Sources/PreviewsCLI/DaemonProtocol.swift
@@ -121,6 +121,28 @@ enum DaemonProtocol {
         let sessions: [SessionDTO]
     }
 
+    /// Result of `preview_build_info`. Lets clients detect a "swift build
+    /// happened, but the running MCP server wasn't restarted" situation —
+    /// the integration-test skill aborts on `stale: true` rather than
+    /// silently exercising stale code. See issue #147.
+    ///
+    /// Timestamps are ISO 8601 strings so the JSON is human-inspectable
+    /// without timezone ambiguity.
+    struct BuildInfoResult: Codable, Sendable, Equatable {
+        /// Absolute path of the running binary on disk.
+        let binaryPath: String
+        /// `stat`-reported mtime of `binaryPath` at handler call time.
+        let binaryMtime: String
+        /// Wall-clock instant the running process started, captured in
+        /// `PreviewsMCPApp.main`.
+        let processStartTime: String
+        /// `binaryMtime > processStartTime`. True iff the on-disk binary
+        /// has been replaced since this process started — i.e., the
+        /// running code is stale relative to whatever a fresh spawn
+        /// would execute.
+        let stale: Bool
+    }
+
     // Elements doesn't get a Codable DTO — the accessibility tree is
     // arbitrary nested JSON from WDA. The daemon encodes it directly
     // into a `Value.object(["sessionID": ..., "elements": <tree>])`

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -1335,6 +1335,10 @@ private func handlePreviewBuildInfo() -> CallTool.Result {
             structuredContent: payload
         )
     } catch {
+        // Reachable only if BuildInfoResult ever stops being Codable —
+        // a programmer error worth surfacing in serve.log rather than
+        // silently degrading to text-only.
+        Log.error("preview_build_info: structured encoding failed: \(error)")
         return CallTool.Result(content: [.text(text)])
     }
 }

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import MCP
 import PreviewsCore
@@ -125,6 +126,8 @@ func configureMCPServer(
             return try await handleSimulatorList()
         case .sessionList:
             return await handleSessionList()
+        case .previewBuildInfo:
+            return handlePreviewBuildInfo()
         }
     }
 
@@ -1248,4 +1251,90 @@ private func previewIndexOutOfRangeError(_ newIndex: Int, count: Int) -> CallToo
         ],
         isError: true
     )
+}
+
+// MARK: - preview_build_info
+
+/// Resolve the running executable's absolute path via `_NSGetExecutablePath`.
+/// Authoritative on Darwin — independent of `argv[0]`, which can be relative
+/// or rewritten by the caller. Issue #100 covers migrating the daemon spawn
+/// path to this primitive; this handler uses it locally without changing
+/// that surface.
+private func resolveRunningBinaryPath() -> String? {
+    var size: UInt32 = 0
+    _ = _NSGetExecutablePath(nil, &size)
+    var buf = [UInt8](repeating: 0, count: Int(size))
+    let result = buf.withUnsafeMutableBufferPointer { ptr -> Int32 in
+        ptr.baseAddress!.withMemoryRebound(to: CChar.self, capacity: Int(size)) {
+            _NSGetExecutablePath($0, &size)
+        }
+    }
+    guard result == 0 else { return nil }
+    // Drop trailing NUL.
+    if let nulIndex = buf.firstIndex(of: 0) {
+        buf.removeSubrange(nulIndex..<buf.endIndex)
+    }
+    let raw = String(decoding: buf, as: UTF8.self)
+    // Resolve `..` and symlinks so the mtime stat matches what the build
+    // system actually wrote — `swift build` may produce an argv[0] like
+    // `/.../.build/arm64-apple-macosx/debug/previewsmcp` and a logical
+    // symlink alias at `.build/debug/previewsmcp`. The skill stats the
+    // alias; the handler should report the resolved target.
+    return URL(fileURLWithPath: raw).resolvingSymlinksInPath().path
+}
+
+/// Stat `path` and return its mtime, or nil if the file is unreachable.
+private func mtime(at path: String) -> Date? {
+    guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+        let date = attrs[.modificationDate] as? Date
+    else { return nil }
+    return date
+}
+
+/// Build the `preview_build_info` response. Synchronous: no I/O beyond a
+/// single stat, no daemon state read.
+private func handlePreviewBuildInfo() -> CallTool.Result {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+    let processStartISO = formatter.string(from: ProcessStartup.time)
+
+    guard let binaryPath = resolveRunningBinaryPath() else {
+        return CallTool.Result(
+            content: [.text("preview_build_info: could not resolve running binary path")],
+            isError: true
+        )
+    }
+
+    guard let binaryMtimeDate = mtime(at: binaryPath) else {
+        return CallTool.Result(
+            content: [.text("preview_build_info: could not stat \(binaryPath)")],
+            isError: true
+        )
+    }
+    let binaryMtimeISO = formatter.string(from: binaryMtimeDate)
+    let stale = binaryMtimeDate > ProcessStartup.time
+
+    let payload = DaemonProtocol.BuildInfoResult(
+        binaryPath: binaryPath,
+        binaryMtime: binaryMtimeISO,
+        processStartTime: processStartISO,
+        stale: stale
+    )
+
+    let staleHint =
+        stale
+        ? " STALE — on-disk binary was rebuilt after this server started; restart the MCP host to pick up the new binary."
+        : ""
+    let text =
+        "binary=\(binaryPath) mtime=\(binaryMtimeISO) processStart=\(processStartISO) stale=\(stale).\(staleHint)"
+
+    do {
+        return try CallTool.Result(
+            content: [.text(text)],
+            structuredContent: payload
+        )
+    } catch {
+        return CallTool.Result(content: [.text(text)])
+    }
 }

--- a/Sources/PreviewsCLI/MCPToolSchemas.swift
+++ b/Sources/PreviewsCLI/MCPToolSchemas.swift
@@ -13,6 +13,7 @@ enum ToolName: String {
     case previewVariants = "preview_variants"
     case simulatorList = "simulator_list"
     case sessionList = "session_list"
+    case previewBuildInfo = "preview_build_info"
 }
 
 /// All MCP tool schemas exposed by the daemon. Separated from handler
@@ -347,6 +348,15 @@ func mcpToolSchemas() -> [Tool] {
             name: ToolName.sessionList.rawValue,
             description:
                 "List all active preview sessions in the daemon, with their source file paths and platforms. Used by CLI commands to resolve --file to --session, and for diagnostic tooling.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([:]),
+            ])
+        ),
+        Tool(
+            name: ToolName.previewBuildInfo.rawValue,
+            description:
+                "Report the running server's binary path, mtime, and process start time. Returns stale=true when the on-disk binary has been replaced since the running process started — i.e., a swift build happened but the resident MCP server wasn't restarted. Used by the integration-test skill to detect stale-binary footguns before validating behavior.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([:]),

--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -8,9 +8,25 @@ enum CLIPlatform: String, ExpressibleByArgument, CaseIterable {
     case ios
 }
 
+/// Wall-clock instant the process began. Captured at app entry (the first
+/// line of `PreviewsMCPApp.main`) so the `preview_build_info` MCP tool can
+/// compare against the on-disk binary's mtime to detect "swift build
+/// happened but the running process wasn't restarted." Must be initialized
+/// here, not lazily inside an MCP handler — the daemon can spend seconds
+/// listening before the first request arrives, and during that window
+/// `swift build` could overwrite the binary, falsely reporting fresh.
+/// See issue #147.
+enum ProcessStartup {
+    static let time = Date()
+}
+
 @main
 struct PreviewsMCPApp {
     static func main() {
+        // Touch ProcessStartup.time at the earliest possible point so its
+        // lazy-init resolves to the actual app-birth instant.
+        _ = ProcessStartup.time
+
         // Force unbuffered stderr. When previewsmcp runs as a subprocess
         // with stderr redirected to a file (e.g., MCPTestServer captures,
         // or the daemon's ~/.previewsmcp/serve.log), libc stdio switches

--- a/Sources/PreviewsCLI/ServeCommand.swift
+++ b/Sources/PreviewsCLI/ServeCommand.swift
@@ -101,7 +101,10 @@ struct ServeCommand: ParsableCommand {
                 let host = Self.sharedHost!
                 _ = try await DaemonListener.start(host: host)
                 try DaemonLifecycle.register()
-                Log.info("daemon ready (pid \(ProcessInfo.processInfo.processIdentifier))")
+                let startISO = ISO8601DateFormatter().string(from: ProcessStartup.time)
+                Log.info(
+                    "daemon ready (pid \(ProcessInfo.processInfo.processIdentifier), started \(startISO))"
+                )
                 // One-line breadcrumb so `serve.log` records when the
                 // daemon was (re)spawned because of a version-mismatch
                 // restart. Diagnoses repeated restart loops in bug

--- a/Sources/PreviewsCLI/ServeCommand.swift
+++ b/Sources/PreviewsCLI/ServeCommand.swift
@@ -63,7 +63,10 @@ struct ServeCommand: ParsableCommand {
                     host: host, iosManager: IOSSessionManager(),
                     configCache: ConfigCache()
                 )
-                Log.info("MCP server starting on stdio...")
+                let startISO = ISO8601DateFormatter().string(from: ProcessStartup.time)
+                Log.info(
+                    "MCP server starting on stdio (pid \(ProcessInfo.processInfo.processIdentifier), started \(startISO))..."
+                )
                 let transport = StdioTransport()
                 try await runMCPServer(server, transport: transport)
             } catch {

--- a/Tests/MCPIntegrationTests/BuildInfoTests.swift
+++ b/Tests/MCPIntegrationTests/BuildInfoTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import MCP
+import Testing
+
+@testable import PreviewsCLI
+
+/// Coverage for `preview_build_info` and the staleness primitive it
+/// surfaces. The integration-test skill aborts when `stale: true`, so the
+/// load-bearing OS behavior — that `stat` on the binary path advances after
+/// `swift build` (atomic-rename or in-place rewrite) while the running
+/// process keeps its own start time — is exactly what these tests lock in.
+/// See issue #147.
+@Suite("preview_build_info", .serialized)
+struct BuildInfoTests {
+
+    /// Fresh server, untouched binary. Round-trip the structured payload
+    /// and confirm shape: every field present, `stale: false`, mtime
+    /// strictly less than (or equal to) processStartTime.
+    @Test("returns structured payload with stale=false on a fresh server")
+    func freshServerNotStale() async throws {
+        let server = try await MCPTestServer.start()
+        defer { server.stop() }
+
+        let result = try await server.callToolResult(name: "preview_build_info")
+        let info = try MCPTestServer.decodeStructured(
+            DaemonProtocol.BuildInfoResult.self, from: result
+        )
+
+        #expect(info.binaryPath.hasSuffix("/previewsmcp"), "binaryPath = \(info.binaryPath)")
+        #expect(!info.binaryMtime.isEmpty)
+        #expect(!info.processStartTime.isEmpty)
+        #expect(info.stale == false, "fresh server should not be stale: \(info)")
+
+        // mtime <= processStartTime is the freshness invariant. We don't
+        // assert strict <, because the build-and-spawn sequence under
+        // test-suite parallelism can land within the same wall-clock
+        // millisecond.
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let mtime = try #require(formatter.date(from: info.binaryMtime))
+        let started = try #require(formatter.date(from: info.processStartTime))
+        #expect(mtime <= started, "mtime \(mtime) should be <= processStart \(started)")
+    }
+
+    /// Force the on-disk binary's mtime to a strictly-future timestamp via
+    /// `utimensat` and re-call. The handler must report `stale: true` and
+    /// `binaryMtime > <pre-mutation mtime>` strictly. This is the OS
+    /// behavior the integration-test skill's abort path depends on — if a
+    /// future linker/sandbox change ever decoupled the path-stat from the
+    /// post-rebuild file, this test surfaces it instead of the tool
+    /// silently lying.
+    @Test("reports stale=true after binary mtime is advanced post-spawn")
+    func mtimeAdvanceMakesServerStale() async throws {
+        let server = try await MCPTestServer.start()
+        defer { server.stop() }
+
+        // Capture pre-mutation values from a fresh call.
+        let before = try MCPTestServer.decodeStructured(
+            DaemonProtocol.BuildInfoResult.self,
+            from: try await server.callToolResult(name: "preview_build_info")
+        )
+        #expect(before.stale == false)
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let preMtime = try #require(formatter.date(from: before.binaryMtime))
+        let processStart = try #require(formatter.date(from: before.processStartTime))
+
+        // Set the binary's mtime to a strictly-future timestamp. Future
+        // means "after processStartTime" — that's the staleness primitive.
+        let futureDate = processStart.addingTimeInterval(60)
+        try setMtime(at: before.binaryPath, to: futureDate)
+
+        let after = try MCPTestServer.decodeStructured(
+            DaemonProtocol.BuildInfoResult.self,
+            from: try await server.callToolResult(name: "preview_build_info")
+        )
+
+        let postMtime = try #require(formatter.date(from: after.binaryMtime))
+        #expect(after.stale == true, "after mtime advance should be stale: \(after)")
+        #expect(postMtime > preMtime, "mtime should advance: \(preMtime) -> \(postMtime)")
+        #expect(
+            postMtime > processStart,
+            "post mtime \(postMtime) should exceed processStart \(processStart)"
+        )
+
+        // Restore the original mtime so subsequent test runs (and the
+        // user's local `swift build` cache invalidation) aren't perturbed.
+        // Best-effort: errors here are benign — the next `swift build`
+        // will reset the mtime regardless.
+        try? setMtime(at: before.binaryPath, to: preMtime)
+    }
+
+    /// Wrapper around `utimensat(2)` that sets both atime and mtime to
+    /// `date`. We use the libc primitive (rather than `touch -t`) for
+    /// sub-second precision and to keep the test free of shell timing
+    /// quirks across macOS versions.
+    private func setMtime(at path: String, to date: Date) throws {
+        let seconds = time_t(date.timeIntervalSince1970)
+        let nanoseconds = Int(
+            (date.timeIntervalSince1970 - TimeInterval(seconds)) * 1_000_000_000
+        )
+        var times = (
+            timespec(tv_sec: seconds, tv_nsec: nanoseconds),  // atime
+            timespec(tv_sec: seconds, tv_nsec: nanoseconds)  // mtime
+        )
+        let result = withUnsafePointer(to: &times) { ptr -> Int32 in
+            ptr.withMemoryRebound(to: timespec.self, capacity: 2) { ts in
+                utimensat(AT_FDCWD, path, ts, 0)
+            }
+        }
+        if result != 0 {
+            let err = String(cString: strerror(errno))
+            throw BuildInfoTestError.utimensatFailed(path: path, message: err)
+        }
+    }
+
+    private enum BuildInfoTestError: Error, CustomStringConvertible {
+        case utimensatFailed(path: String, message: String)
+
+        var description: String {
+            switch self {
+            case .utimensatFailed(let path, let message):
+                return "utimensat(\(path)) failed: \(message)"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new MCP tool `preview_build_info` that reports the running server's binary path, on-disk mtime, and process start time, along with `stale = binaryMtime > processStartTime`.
- Updates the `integration-test` skill: Step 0 hard-resets the UDS daemon (kill-daemon + status verify), and Step 2 calls `preview_build_info` after `swift build` and aborts with a restart-Claude-Code instruction when `stale: true`.
- Documents the split-brain (stdio server vs UDS daemon — separate processes, separate session state) in `AGENTS.md`.

## Why

The integration-test skill called `mcp__previewsmcp__*` tools to validate behavior, but those calls hit the stdio MCP server Claude Code spawned at session start — not the freshly-built `.build/debug/previewsmcp`. `swift build` overwrites the binary while the resident process keeps running the old code, so a contributor could edit code, run the skill, see green, and ship a regression. The build step never exercised the change.

Mtime/start-time comparison was chosen over baking `--dirty` into `GeneratedVersion`: `Plugins/GenerateVersion/GenerateVersion.swift` pins `inputFiles: [gitHeadURL]`, so the plugin only re-runs when HEAD moves. Uncommitted edits don't move HEAD; the dirty bit would have been a placebo. Mtime sidesteps that and is a strict superset (catches same-SHA rebuilds too).

## What changed

- `Sources/PreviewsCLI/MCPToolSchemas.swift` — new `previewBuildInfo` tool case + schema (no params).
- `Sources/PreviewsCLI/MCPServer.swift` — dispatch + handler that resolves the binary via `_NSGetExecutablePath`, stats mtime, compares to `ProcessStartup.time`.
- `Sources/PreviewsCLI/PreviewsMCPApp.swift` — `enum ProcessStartup { static let time = Date() }` referenced at app entry to force lazy-init at app birth.
- `Sources/PreviewsCLI/ServeCommand.swift` — daemon boot log includes ISO8601 start time so `stale=true` reports correlate to actual restart events.
- `Sources/PreviewsCLI/DaemonProtocol.swift` — new `BuildInfoResult` DTO.
- `.claude/skills/integration-test/SKILL.md` — Step 0 hardening, Step 2 staleness gate, two-process model preface.
- `AGENTS.md` — new "Stdio server vs UDS daemon" subsection.
- `Tests/MCPIntegrationTests/BuildInfoTests.swift` — fresh-server roundtrip + deterministic mtime-mutation lock-in (uses `utimensat` for sub-second precision).

## Out of scope

- Unifying the stdio server and UDS daemon into one backend. The durable answer (have stdio forward to the daemon) is a substantial refactor; tracked as #147's stretch goal #4 for follow-up.
- Migrating the daemon spawn path to `_NSGetExecutablePath` (#100). The handler uses it locally; the spawn path is unchanged.
- Per-build random nonce for absolute build identity — diminishing returns once mtime is in play.

## Test plan

- [x] `swift build` clean.
- [x] `BuildInfoTests` (2 tests): fresh-server `stale=false`; post-`utimensat` `stale=true` and `binaryMtime > preMtime` strictly.
- [x] `MacOSMCPTests` (7 tests) — verified existing MCP surface is unaffected.
- [x] `VersionHandshakeTests` (3 tests) — verified the daemon respawn handshake is unaffected.
- [x] Manual smoke: stdio JSON-RPC `tools/call preview_build_info` returns the structured payload with valid ISO8601 timestamps and `stale: false`.
- [ ] Run the integration-test skill end-to-end after this lands to confirm Step 0 + Step 2 fire as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)