### PR TITLE
Use _NSGetExecutablePath for daemon self-path resolution (#100)

### DIFF
--- a/Sources/PreviewsCLI/DaemonClient.swift
+++ b/Sources/PreviewsCLI/DaemonClient.swift
@@ -40,8 +40,9 @@ enum DaemonClient {
         configure: ((Client) async -> Void)? = nil
     ) async throws -> Client {
         // When no daemon is running we spawn one ourselves. By
-        // construction its binary matches argv[0], so the MCP
-        // `serverInfo.version` must equal our own compile-time
+        // construction its binary is the one we're currently running
+        // (resolved authoritatively via `_NSGetExecutablePath`), so the
+        // MCP `serverInfo.version` must equal our own compile-time
         // version — no handshake check needed on this branch.
         let weJustSpawned = !DaemonProbe.canConnect()
         if weJustSpawned {
@@ -372,14 +373,17 @@ enum DaemonClient {
     /// so the new daemon logs a diagnostic breadcrumb to `serve.log` on
     /// startup. Only set when this spawn is a version-mismatch recovery.
     private static func spawnDaemon(restartReason: String? = nil) throws {
-        let selfPath = ProcessInfo.processInfo.arguments[0]
-        let binaryURL = URL(fileURLWithPath: selfPath).standardizedFileURL
+        // `_NSGetExecutablePath` returns the kernel's record of the binary
+        // we're executing, set at exec() time. Authoritative regardless of
+        // CWD, PATH resolution, or what the caller put in argv[0].
+        guard let selfPath = resolveRunningBinaryPath() else {
+            throw DaemonClientError.binaryNotFound(path: "<unknown>")
+        }
+        let binaryURL = URL(fileURLWithPath: selfPath)
 
-        // Best-effort sanity check so a missing binary surfaces as a clear
-        // error instead of Process.run()'s generic POSIX failure. This is
-        // not a security boundary — a spoofed argv[0] pointing at some
-        // other real executable would still pass this check. See #100 for
-        // authoritative self-path resolution via _NSGetExecutablePath.
+        // Defense in depth: the binary could have been moved or deleted
+        // between resolution and Process.run(). Surface a clear error
+        // instead of Process.run()'s generic POSIX failure.
         guard FileManager.default.isExecutableFile(atPath: binaryURL.path) else {
             throw DaemonClientError.binaryNotFound(path: binaryURL.path)
         }
@@ -419,11 +423,11 @@ enum DaemonClient {
         env["_PREVIEWSMCP_DAEMON_RESTART_REASON"] = restartReason
         proc.environment = env
 
-        // Log the binary path on a restart spawn so a user diagnosing
-        // a respawn loop can see whether argv[0] still points at the
-        // stale binary (see issue #100). No-op for normal startup
-        // spawns — the daemon's own "daemon ready (pid ...)" line is
-        // enough for those.
+        // Log the resolved binary path on a restart spawn so a user
+        // diagnosing a respawn loop can see whether the running binary
+        // is still the stale one. No-op for normal startup spawns —
+        // the daemon's own "daemon ready (pid ...)" line is enough
+        // for those.
         if restartReason != nil {
             fputs(
                 "previewsmcp: respawning daemon from \(binaryURL.path)\n",

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -1255,34 +1255,6 @@ private func previewIndexOutOfRangeError(_ newIndex: Int, count: Int) -> CallToo
 
 // MARK: - preview_build_info
 
-/// Resolve the running executable's absolute path via `_NSGetExecutablePath`.
-/// Authoritative on Darwin — independent of `argv[0]`, which can be relative
-/// or rewritten by the caller. Issue #100 covers migrating the daemon spawn
-/// path to this primitive; this handler uses it locally without changing
-/// that surface.
-private func resolveRunningBinaryPath() -> String? {
-    var size: UInt32 = 0
-    _ = _NSGetExecutablePath(nil, &size)
-    var buf = [UInt8](repeating: 0, count: Int(size))
-    let result = buf.withUnsafeMutableBufferPointer { ptr -> Int32 in
-        ptr.baseAddress!.withMemoryRebound(to: CChar.self, capacity: Int(size)) {
-            _NSGetExecutablePath($0, &size)
-        }
-    }
-    guard result == 0 else { return nil }
-    // Drop trailing NUL.
-    if let nulIndex = buf.firstIndex(of: 0) {
-        buf.removeSubrange(nulIndex..<buf.endIndex)
-    }
-    let raw = String(decoding: buf, as: UTF8.self)
-    // Resolve `..` and symlinks so the mtime stat matches what the build
-    // system actually wrote — `swift build` may produce an argv[0] like
-    // `/.../.build/arm64-apple-macosx/debug/previewsmcp` and a logical
-    // symlink alias at `.build/debug/previewsmcp`. The skill stats the
-    // alias; the handler should report the resolved target.
-    return URL(fileURLWithPath: raw).resolvingSymlinksInPath().path
-}
-
 /// Stat `path` and return its mtime, or nil if the file is unreachable.
 private func mtime(at path: String) -> Date? {
     guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),

--- a/Sources/PreviewsCLI/SelfPath.swift
+++ b/Sources/PreviewsCLI/SelfPath.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Resolve the running executable's absolute path via `_NSGetExecutablePath`.
+/// Authoritative on Darwin — independent of `argv[0]`, which can be relative
+/// (`./previewsmcp`), bare when PATH-resolved, or rewritten by the caller via
+/// `execve`. The kernel records the real on-disk path at exec time and this
+/// call reads it back; no CWD coupling, no caller spoofing.
+///
+/// Symlinks are resolved so callers comparing against build-system output
+/// (e.g., stat-ing `.build/debug/previewsmcp`) see the canonical target —
+/// `swift build` produces a logical alias under `.build/debug/` that points
+/// at the real binary under `.build/<arch>/debug/`.
+///
+/// Returns nil only if `_NSGetExecutablePath` itself fails — should not occur
+/// on a healthy process.
+func resolveRunningBinaryPath() -> String? {
+    var size: UInt32 = 0
+    _ = _NSGetExecutablePath(nil, &size)
+    var buf = [UInt8](repeating: 0, count: Int(size))
+    let result = buf.withUnsafeMutableBufferPointer { ptr -> Int32 in
+        ptr.baseAddress!.withMemoryRebound(to: CChar.self, capacity: Int(size)) {
+            _NSGetExecutablePath($0, &size)
+        }
+    }
+    guard result == 0 else { return nil }
+    if let nulIndex = buf.firstIndex(of: 0) {
+        buf.removeSubrange(nulIndex..<buf.endIndex)
+    }
+    let raw = String(decoding: buf, as: UTF8.self)
+    return URL(fileURLWithPath: raw).resolvingSymlinksInPath().path
+}

--- a/Tests/PreviewsCLITests/SelfPathTests.swift
+++ b/Tests/PreviewsCLITests/SelfPathTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+
+@testable import PreviewsCLI
+
+/// Unit tests for `resolveRunningBinaryPath`. The fix for issue #100 swapped
+/// the daemon-spawn self-path lookup from `argv[0]` to `_NSGetExecutablePath`.
+/// The chdir test below is the load-bearing one — it pins the property argv[0]
+/// lacked (CWD-independence). The whole suite is `.serialized` because the
+/// chdir test mutates process-global state.
+@Suite("SelfPath", .serialized)
+struct SelfPathTests {
+
+    @Test("returns an absolute, executable path")
+    func returnsAbsoluteExecutable() throws {
+        let path = try #require(resolveRunningBinaryPath())
+        #expect(path.hasPrefix("/"), "expected absolute path, got \(path)")
+        #expect(
+            FileManager.default.isExecutableFile(atPath: path),
+            "expected executable at \(path)")
+    }
+
+    @Test("returns the same value across calls")
+    func deterministic() throws {
+        let first = try #require(resolveRunningBinaryPath())
+        let second = try #require(resolveRunningBinaryPath())
+        #expect(first == second)
+    }
+
+    @Test("invariant under chdir — the property argv[0] lacks")
+    func invariantUnderChdir() throws {
+        let original = FileManager.default.currentDirectoryPath
+        defer { _ = FileManager.default.changeCurrentDirectoryPath(original) }
+
+        let before = try #require(resolveRunningBinaryPath())
+        #expect(FileManager.default.changeCurrentDirectoryPath("/tmp"))
+        let after = try #require(resolveRunningBinaryPath())
+        #expect(before == after)
+    }
+}


### PR DESCRIPTION
Fixes #100.

## Summary

`DaemonClient.spawnDaemon` resolved the binary to launch via `ProcessInfo.processInfo.arguments[0]`. argv[0] is unreliable in three ways:

1. **Relative paths.** `./previewsmcp` lands as `argv[0] = "./previewsmcp"`. `URL(fileURLWithPath:).standardizedFileURL` resolves it against the *current* working directory — fine today since the CLI doesn't chdir, but a tripwire for any future code that does.
2. **PATH-resolved invocations.** When the shell finds the binary via PATH, argv[0] is the bare name `previewsmcp`. Resolution against CWD silently fails.
3. **Caller-controlled.** `execve` lets the parent set argv[0] to anything — wrapper scripts, launchers, misbehaving init systems. Not a security boundary, but adds weird-environment failures.

The version-mismatch respawn logic from #142 makes this load-bearing — every transparent daemon respawn re-runs `spawnDaemon`, so a fragile self-path shows up as a respawn loop or a spurious `binaryNotFound` against a CLI that's actually on disk. The existing code at `DaemonClient.swift:380-385` already had a comment pointing at #100 acknowledging this.

`MCPServer.swift` already had a working `_NSGetExecutablePath`-backed helper for `preview_build_info` (added in #150), file-private, with a section comment that explicitly named #100 as the issue to migrate the daemon path to it. This change extracts that helper into module-internal `Sources/PreviewsCLI/SelfPath.swift` and points both call sites at it. The kernel records the executing binary's path at `execve` time; this primitive reads it back regardless of CWD or argv[0].

Stale comments in `DaemonClient.swift` referencing argv[0] (lines 43-45 and 422-426) updated to reflect the new authoritative resolution.

## Test plan

`Tests/PreviewsCLITests/SelfPathTests.swift` covers the property argv[0] lacked:

- [x] `returns an absolute, executable path` — proves no relative-path output
- [x] `returns the same value across calls` — determinism
- [x] `invariant under chdir — the property argv[0] lacks` — captures path, chdir to /tmp, calls again, asserts equal

The suite is `@Suite(.serialized)` because the chdir test mutates process-global state.

- [x] `swift build` clean
- [x] `swift test --filter SelfPath` — 3/3 pass
- [x] Full `swift test` — pre-existing flakes confirmed unrelated by re-running each in isolation: StallTimer, AsyncProcess, IOSCLIWorkflowTests, IOSMCPTests all pass clean. Same flakes have hit other recent PRs (see #126, #136, #141).

🤖 Generated with [Claude Code](https://claude.com/claude-code)