### PR TITLE
Detect wrong MCP binary in integration-test skill (#154)

### DIFF
--- a/.claude/skills/integration-test/SKILL.md
+++ b/.claude/skills/integration-test/SKILL.md
@@ -25,11 +25,23 @@ PreviewsMCP runs as two separate processes with independent state:
 
 1. **Discover examples.** List directories under `examples/` in the repo root. If `$ARGUMENTS` is provided, filter to that example only. If the specified example doesn't exist, report the error and list available examples.
 
-2. **Build PreviewsMCP and verify the stdio server is fresh.** Run `swift build` from the repo root. If the build fails, stop and report the error. Then call `preview_build_info` (MCP tool). If the response has `stale: true`, abort with this message:
+2. **Build PreviewsMCP and verify the stdio server is fresh and pointed at this worktree.** Run `swift build` from the repo root. If the build fails, stop and report the error. Then call `preview_build_info` (MCP tool) and run both checks below. They cover independent failure modes — wrong binary entirely (worktree-vs-parent) vs stale binary at the right path (rebuild without restart) — and both must pass before proceeding.
+
+   **2a. Wrong-binary check.** Compute the expected binary path from the worktree the skill is running in, resolving symlinks the same way `preview_build_info` does:
+
+   ```bash
+   git_root=$(git rev-parse --show-toplevel)
+   expected=$(python3 -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' \
+              "$git_root/.build/$(uname -m)-apple-macosx/debug/previewsmcp")
+   ```
+
+   Compare `expected` against `binaryPath` from `preview_build_info`. If they differ, abort:
+
+   > MCP server is running `<binaryPath>` but you're working in `<git_root>`. Tool calls won't reflect your changes. Type `/exit`, `cd` to the worktree directory, and relaunch `claude` (avoid `/resume` — it preserves the original project root and silently keeps the wrong binary). See issue #154.
+
+   **2b. Stale-binary check.** If the response has `stale: true`, abort:
 
    > Stdio MCP server's on-disk binary was rebuilt at `<binaryMtime>` but the running process started at `<processStartTime>`. Type `/exit` and relaunch Claude Code so it respawns the MCP server from the new binary, then re-run this skill.
-
-   If `stale: false`, proceed.
 
 3. **For each example**, read its `README.md` and follow the "Integration Test Prompt" section. The README contains the exact steps to execute, including which MCP tools to call and what to verify.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ When validating code changes, both halves can go stale — `swift build` overwri
 
 The stdio server has no equivalent of #142's handshake — there's no peer to handshake with — so the staleness must be detected client-side.
 
-**Worktree footgun (#154):** when iterating in a git worktree (e.g., `.claude/worktrees/<name>/`), Claude Code may launch the stdio MCP server from the parent repo's `.build/...`, not the worktree's. `/resume` makes this sticky — it preserves the original project root regardless of where you re-launch from. `preview_build_info`'s `stale: false` won't catch this; it only knows about the binary at its own resolved path. To validate worktree-local changes via MCP tool calls, exit Claude Code, `cd` into the worktree directory, and start a fresh session (not `/resume`). The integration-test skill's Step 2 detects the mismatch automatically by comparing `binaryPath` to the worktree-derived expected path.
+**Worktrees (#154):** open Claude Code from inside the worktree directory, not via `/resume` from the main repo. `/resume` preserves the original project root, so the stdio MCP server keeps pointing at the main repo's `.build/...` binary regardless of where you re-launched. Fresh launches in each worktree resolve the relative `.mcp.json` command path correctly. The integration-test skill's Step 2 catches the mismatch automatically if you forget.
 
 ### CLI subcommands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,8 @@ When validating code changes, both halves can go stale — `swift build` overwri
 
 The stdio server has no equivalent of #142's handshake — there's no peer to handshake with — so the staleness must be detected client-side.
 
+**Worktree footgun (#154):** when iterating in a git worktree (e.g., `.claude/worktrees/<name>/`), Claude Code may launch the stdio MCP server from the parent repo's `.build/...`, not the worktree's. `/resume` makes this sticky — it preserves the original project root regardless of where you re-launch from. `preview_build_info`'s `stale: false` won't catch this; it only knows about the binary at its own resolved path. To validate worktree-local changes via MCP tool calls, exit Claude Code, `cd` into the worktree directory, and start a fresh session (not `/resume`). The integration-test skill's Step 2 detects the mismatch automatically by comparing `binaryPath` to the worktree-derived expected path.
+
 ### CLI subcommands
 
 | Command | Purpose | Daemon? |


### PR DESCRIPTION
Fixes #154.

## Summary

When iterating in a git worktree nested under the main repo (e.g., `.claude/worktrees/<name>/`), Claude Code launches the stdio MCP server from the parent repo's `.build/`, not the worktree's. `/resume` makes it sticky — it preserves the original project root regardless of relaunch CWD. The integration-test skill's `preview_build_info` staleness check (#147 / #150) happily reports green in this state: the binary at the resolved path *does* match its running process; it just isn't the binary the developer is iterating on.

Hit live during PR #153 validation — a full integration-test run reported green against a parent-repo binary that didn't have any of the PR's changes.

## Approach

Step 2 of the skill now runs two independent checks:

- **2a. Wrong-binary check.** Derive expected path from `git rev-parse --show-toplevel` of the skill's CWD, resolve symlinks the same way `preview_build_info` does, compare to its returned `binaryPath`. Mismatch aborts with a tailored relaunch message that explicitly names `/resume` as the trap.
- **2b. Stale-binary check.** Existing logic, unchanged.

Both checks must pass before proceeding. They cover independent failure modes — wrong binary entirely vs stale binary at the right path.

## Why not change `preview_build_info` itself

The MCP server has no way to know what the developer's current worktree is. Users who installed PreviewsMCP via brew / mint / a binary copy have no `<root>/.build/<arch>/debug/previewsmcp` layout to compare against — a server-side check would falsely flag every end-user install as "wrong tree." The skill is the only programmatic caller of `preview_build_info` and the right place for developer-mode context (CWD, expected build layout).

## Documentation

Adds a "worktree footgun" paragraph to AGENTS.md alongside the existing "Refresh stdio" guidance, with a pointer to the skill's automatic detection.

## Out of scope

The upstream Claude Code behavior — `${workspaceFolder}` not expanding in `.mcp.json` `command` (anthropics/claude-code#3239, #9427), and `/resume` preserving the original project root regardless of relaunch CWD. Tracked separately upstream.

## Test plan

- [x] Skill change is markdown-only — verified the rendered Step 2 reads cleanly
- [x] AGENTS.md addition reads cleanly in context
- [x] Manual: simulated the abort message wording — it correctly names /resume as the cause
- [ ] Next time `/integration-test` runs in a worktree, Step 2 will exercise the new check end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)