### PR TITLE
Make BazelBuildSystem error message complete on opaque exits

### DIFF
--- a/Sources/PreviewsCore/BazelBuildSystem.swift
+++ b/Sources/PreviewsCore/BazelBuildSystem.swift
@@ -307,6 +307,15 @@ public actor BazelBuildSystem: BuildSystem {
     }
 
     /// Run a bazel command via `/usr/bin/env`, check exit code, and return stdout.
+    ///
+    /// On nonzero exit, the thrown `BuildSystemError.buildFailed` carries the
+    /// full command line, both captured streams (or `(empty)` placeholders),
+    /// and the pwd. The previous shape — `output.stderr.isEmpty ? output.stdout
+    /// : output.stderr` — discarded one stream and yielded a blank diagnostic
+    /// when both streams were empty (CI run 25243519727 surfaced exactly this:
+    /// bazel exited 7 with no captured output, leaving the test failure
+    /// message as just "Project build failed (exit code 7):" with nothing
+    /// after the colon).
     @discardableResult
     private func runBazel(
         _ arguments: [String], discardStderr: Bool = false
@@ -315,8 +324,19 @@ public actor BazelBuildSystem: BuildSystem {
             "/usr/bin/env", arguments: arguments,
             workingDirectory: projectRoot, discardStderr: discardStderr)
         guard output.exitCode == 0 else {
+            let cmd = arguments.joined(separator: " ")
+            let stderrSection = output.stderr.isEmpty ? "(empty)" : output.stderr
+            let stdoutSection = output.stdout.isEmpty ? "(empty)" : output.stdout
+            let diagnostic = """
+                command: \(cmd)
+                cwd: \(projectRoot.path)
+                stderr:
+                \(stderrSection)
+                stdout:
+                \(stdoutSection)
+                """
             throw BuildSystemError.buildFailed(
-                stderr: output.stderr.isEmpty ? output.stdout : output.stderr,
+                stderr: diagnostic,
                 exitCode: output.exitCode
             )
         }


### PR DESCRIPTION
## Summary

CI run [25243519727](https://github.com/obj-p/PreviewsMCP/actions/runs/25243519727) surfaced a `snapshotBazel` failure where bazel exited 7 with **both stderr and stdout empty**. The pre-existing error formatter in `runBazel`:

```swift
stderr: output.stderr.isEmpty ? output.stdout : output.stderr,
```

discarded one stream by design and yielded an empty diagnostic when both were empty. The test failure looked like:

```
Project build failed (exit code 7):

```

— with nothing after the colon, leaving no way to tell whether the failure was a corrupt bazel binary, a concurrent workspace lock, an analysis failure with output redirected, or something else.

The rerun of the same SHA passed, so this particular instance was transient. But silent-flake conditions in Bazel (server crashes, remote-cache evictions mid-fetch, partial bazelisk downloads, fd exhaustion) are common enough that we'll see it again. When we do, the test failure should point at the offending command, not at the absence of one.

## Change

The thrown `BuildSystemError.buildFailed` now carries:
- the bazel command and arguments that failed
- the working directory (`projectRoot`)
- the captured stderr (or `(empty)` if truly silent)
- the captured stdout (or `(empty)` if truly silent)

No behavior change on the happy path. No public-API change to `BuildSystemError.buildFailed` — the diagnostic is composed into the existing `stderr:` field.

## Why not also try to fix the underlying flake?

Without an actual reproduction we'd be speculating (version mismatch? concurrent jobs? remote cache state?). The diagnostic improvement is the load-bearing fix: the next occurrence will be self-describing instead of opaque, and we can address the actual root cause then. Adding speculative defensive layers (retry-on-fail, isolated `--output_user_root`) without evidence risks masking legitimate build failures.

## Test plan

- [x] `swift build` clean
- [x] `swift test --filter SnapshotCommandTests/snapshotBazel` passes (4.8s) — happy path unaffected
- [ ] CI green