### PR TITLE
Address #159 review nits: doc tightening on session-handle surface

### DIFF
--- a/Sources/PreviewsCore/PreviewSessionHandle.swift
+++ b/Sources/PreviewsCore/PreviewSessionHandle.swift
@@ -39,6 +39,12 @@ public protocol PreviewSessionHandle: Sendable {
 
     /// Capture a screenshot. `quality >= 1.0` requests PNG output where
     /// supported; values in `[0, 1)` request JPEG at that quality.
+    ///
+    /// If a preceding `setTraits` / `switchPreview` / `reconfigure` call
+    /// changed the rendered view, call `awaitLayoutSettle()` first. On
+    /// macOS the snapshot will otherwise capture a pre-layout frame —
+    /// `cacheDisplay` forces layout synchronously but does not recover
+    /// from a fresh `loadPreview` swap on its own.
     func snapshot(quality: Double) async throws -> Data
 
     /// Wait for SwiftUI layout to settle after a fresh dylib load. macOS

--- a/Sources/PreviewsEngine/IOSPreviewHandle.swift
+++ b/Sources/PreviewsEngine/IOSPreviewHandle.swift
@@ -48,6 +48,11 @@ public actor IOSPreviewHandle: PreviewSessionHandle {
     }
 
     public func stop() async {
+        // Stop the simulator-side session first, then de-register. The
+        // ordering is safe because `IOSPreviewSession.stop()` is
+        // non-throwing — a hang would block both calls equally, but
+        // there's no path where the first succeeds and the second is
+        // skipped, so the manager can't keep a phantom entry.
         await iosSession.stop()
         await manager.removeSession(id)
     }

--- a/Sources/PreviewsEngine/SessionRouter.swift
+++ b/Sources/PreviewsEngine/SessionRouter.swift
@@ -12,6 +12,14 @@ import PreviewsMacOS
 /// and the `IOSSessionManager` lookup is a single actor hop, while the
 /// macOS lookup hops to MainActor. Order matters only for performance —
 /// session IDs are UUIDs and never collide across backends.
+///
+/// Both backends are wrapped in adapter actors (`IOSPreviewHandle`,
+/// `MacOSPreviewHandle`) rather than letting `IOSPreviewSession` conform
+/// to `PreviewSessionHandle` directly. This keeps the session types in
+/// `PreviewsIOS` / `PreviewsMacOS` free of `PreviewSessionHandle`
+/// knowledge and lets the iOS adapter own the manager-de-register hook
+/// in `stop()`, symmetric with the way macOS's `host.closePreview` does
+/// teardown and bookkeeping in one call.
 public actor SessionRouter {
     private let host: PreviewHost
     private let iosManager: IOSSessionManager


### PR DESCRIPTION
## Summary

Three small comment additions from the post-merge code review of #159 (Important + 2 Suggestions, all in the doc/comment category):

- Cross-reference \`awaitLayoutSettle()\` from \`snapshot(quality:)\`'s doc on \`PreviewSessionHandle\`. The settle requirement was previously only mentioned on the trait-mutating methods, so a reader looking at \`snapshot\` had no way to discover it.
- Justify \`IOSPreviewHandle.stop()\`'s "stop session, then de-register" ordering — safe because \`IOSPreviewSession.stop()\` is non-throwing.
- Note in \`SessionRouter\`'s header why both backends are wrapped in adapter actors (the original plan suggested conforming \`IOSPreviewSession\` directly; the implementation chose adapter symmetry instead).

No behavior change. Doc-only diff.

## Test plan

- [x] \`swift build\` clean
- [x] \`swift-format lint --strict\` clean on changed files
- [x] No source changes that affect runtime; existing test coverage from #159 stands

🤖 Generated with [Claude Code](https://claude.com/claude-code)