### PR TITLE
Drive trait schema enums from PreviewTraits canonical lists

### DIFF
--- a/Sources/PreviewsCLI/Handlers/PreviewConfigureHandler.swift
+++ b/Sources/PreviewsCLI/Handlers/PreviewConfigureHandler.swift
@@ -17,41 +17,26 @@ enum PreviewConfigureHandler: ToolHandler {
                     "type": .string("string"),
                     "description": .string("Session ID from preview_start"),
                 ]),
-                "colorScheme": .object([
-                    "type": .string("string"),
-                    "enum": .array([.string("light"), .string("dark")]),
-                    "description": .string("Color scheme override"),
-                ]),
-                "dynamicTypeSize": .object([
-                    "type": .string("string"),
-                    "enum": .array([
-                        .string("xSmall"), .string("small"), .string("medium"),
-                        .string("large"),
-                        .string("xLarge"), .string("xxLarge"), .string("xxxLarge"),
-                        .string("accessibility1"), .string("accessibility2"),
-                        .string("accessibility3"),
-                        .string("accessibility4"), .string("accessibility5"),
-                    ]),
-                    "description": .string("Dynamic Type size override"),
-                ]),
-                "locale": .object([
-                    "type": .string("string"),
-                    "description": .string(
+                "colorScheme": traitProperty(
+                    enumValues: PreviewTraits.validColorSchemes,
+                    description: "Color scheme override"
+                ),
+                "dynamicTypeSize": traitProperty(
+                    enumValues: PreviewTraits.validDynamicTypeSizes,
+                    description: "Dynamic Type size override"
+                ),
+                "locale": traitProperty(
+                    description:
                         "BCP 47 locale identifier (e.g., 'en', 'ar', 'ja-JP'). Pass empty string to clear."
-                    ),
-                ]),
-                "layoutDirection": .object([
-                    "type": .string("string"),
-                    "description": .string(
+                ),
+                "layoutDirection": traitProperty(
+                    description:
                         "Layout direction: 'leftToRight' or 'rightToLeft'. Pass empty string to clear."
-                    ),
-                ]),
-                "legibilityWeight": .object([
-                    "type": .string("string"),
-                    "description": .string(
+                ),
+                "legibilityWeight": traitProperty(
+                    description:
                         "Legibility weight: 'regular' or 'bold'. Pass empty string to clear."
-                    ),
-                ]),
+                ),
             ]),
             "required": .array([.string("sessionID")]),
         ])

--- a/Sources/PreviewsCLI/Handlers/PreviewStartHandler.swift
+++ b/Sources/PreviewsCLI/Handlers/PreviewStartHandler.swift
@@ -62,46 +62,25 @@ enum PreviewStartHandler: ToolHandler {
                         "Xcode scheme name (only used for .xcodeproj / .xcworkspace projects). Required when the project contains more than one scheme and none of them match the source file's directory."
                     ),
                 ]),
-                "colorScheme": .object([
-                    "type": .string("string"),
-                    "enum": .array([.string("light"), .string("dark")]),
-                    "description": .string("Color scheme override: 'light' or 'dark'"),
-                ]),
-                "dynamicTypeSize": .object([
-                    "type": .string("string"),
-                    "enum": .array([
-                        .string("xSmall"), .string("small"), .string("medium"),
-                        .string("large"),
-                        .string("xLarge"), .string("xxLarge"), .string("xxxLarge"),
-                        .string("accessibility1"), .string("accessibility2"),
-                        .string("accessibility3"),
-                        .string("accessibility4"), .string("accessibility5"),
-                    ]),
-                    "description": .string(
-                        "Dynamic Type size (e.g., 'large', 'accessibility3')"),
-                ]),
-                "locale": .object([
-                    "type": .string("string"),
-                    "description": .string(
-                        "BCP 47 locale identifier (e.g., 'en', 'ar', 'ja-JP')"),
-                ]),
-                "layoutDirection": .object([
-                    "type": .string("string"),
-                    "enum": .array([
-                        .string("leftToRight"), .string("rightToLeft"),
-                    ]),
-                    "description": .string(
-                        "Layout direction: 'leftToRight' or 'rightToLeft'"),
-                ]),
-                "legibilityWeight": .object([
-                    "type": .string("string"),
-                    "enum": .array([
-                        .string("regular"), .string("bold"),
-                    ]),
-                    "description": .string(
-                        "Legibility weight: 'regular' or 'bold' (Bold Text accessibility)"
-                    ),
-                ]),
+                "colorScheme": traitProperty(
+                    enumValues: PreviewTraits.validColorSchemes,
+                    description: "Color scheme override: 'light' or 'dark'"
+                ),
+                "dynamicTypeSize": traitProperty(
+                    enumValues: PreviewTraits.validDynamicTypeSizes,
+                    description: "Dynamic Type size (e.g., 'large', 'accessibility3')"
+                ),
+                "locale": traitProperty(
+                    description: "BCP 47 locale identifier (e.g., 'en', 'ar', 'ja-JP')"
+                ),
+                "layoutDirection": traitProperty(
+                    enumValues: PreviewTraits.validLayoutDirections,
+                    description: "Layout direction: 'leftToRight' or 'rightToLeft'"
+                ),
+                "legibilityWeight": traitProperty(
+                    enumValues: PreviewTraits.validLegibilityWeights,
+                    description: "Legibility weight: 'regular' or 'bold' (Bold Text accessibility)"
+                ),
             ]),
             "required": .array([.string("filePath")]),
         ])

--- a/Sources/PreviewsCLI/Handlers/TraitPropertySchema.swift
+++ b/Sources/PreviewsCLI/Handlers/TraitPropertySchema.swift
@@ -1,0 +1,21 @@
+import MCP
+import PreviewsCore
+
+/// JSON-Schema property fragment for a single trait input. Used by
+/// `preview_start` and `preview_configure` to expose trait overrides
+/// with a consistent shape — `type: string`, optional `enum` constraint,
+/// per-handler description.
+///
+/// The `enum` arrays read from `PreviewTraits.valid*` so the canonical
+/// list of accepted values lives in one place. Handlers spell out their
+/// own descriptions (e.g., `preview_configure` adds "Pass empty string
+/// to clear" hints that `preview_start` doesn't need) — only the value
+/// list is shared.
+func traitProperty(enumValues: [String]? = nil, description: String) -> Value {
+    var members: [(String, Value)] = [("type", .string("string"))]
+    if let enumValues {
+        members.append(("enum", .array(enumValues.map { .string($0) })))
+    }
+    members.append(("description", .string(description)))
+    return .object(Dictionary(uniqueKeysWithValues: members))
+}

--- a/Sources/PreviewsCLI/Handlers/TraitPropertySchema.swift
+++ b/Sources/PreviewsCLI/Handlers/TraitPropertySchema.swift
@@ -12,10 +12,15 @@ import PreviewsCore
 /// to clear" hints that `preview_start` doesn't need) — only the value
 /// list is shared.
 func traitProperty(enumValues: [String]? = nil, description: String) -> Value {
-    var members: [(String, Value)] = [("type", .string("string"))]
+    // Key insertion order doesn't matter — `JSONEncoder.outputFormatting`
+    // includes `.sortedKeys`, so the wire bytes alphabetize regardless
+    // of how we build the dictionary here.
+    var members: [String: Value] = [
+        "type": .string("string"),
+        "description": .string(description),
+    ]
     if let enumValues {
-        members.append(("enum", .array(enumValues.map { .string($0) })))
+        members["enum"] = .array(enumValues.map { .string($0) })
     }
-    members.append(("description", .string(description)))
-    return .object(Dictionary(uniqueKeysWithValues: members))
+    return .object(members)
 }

--- a/Sources/PreviewsCore/PreviewTraits.swift
+++ b/Sources/PreviewsCore/PreviewTraits.swift
@@ -63,18 +63,26 @@ public struct PreviewTraits: Sendable, Equatable {
         )
     }
 
-    public static let validColorSchemes: Set<String> = ["light", "dark"]
+    /// Canonical trait value lists, ordered so MCP tool schemas exposing
+    /// them as `enum` constraints get a stable, meaningful presentation
+    /// order (size order for `dynamicTypeSize`, light-then-dark, etc.).
+    /// Order is wire-relevant: `Tests/PreviewsCLITests/list_tools_snapshot.json`
+    /// pins the JSON-encoded order.
+    ///
+    /// `.contains` membership is O(n) on arrays, but n is tiny (≤12).
 
-    public static let validDynamicTypeSizes: Set<String> = [
+    public static let validColorSchemes: [String] = ["light", "dark"]
+
+    public static let validDynamicTypeSizes: [String] = [
         "xSmall", "small", "medium", "large",
         "xLarge", "xxLarge", "xxxLarge",
         "accessibility1", "accessibility2", "accessibility3",
         "accessibility4", "accessibility5",
     ]
 
-    public static let validLayoutDirections: Set<String> = ["leftToRight", "rightToLeft"]
+    public static let validLayoutDirections: [String] = ["leftToRight", "rightToLeft"]
 
-    public static let validLegibilityWeights: Set<String> = ["regular", "bold"]
+    public static let validLegibilityWeights: [String] = ["regular", "bold"]
 
     /// Normalize empty strings to nil (used for trait clearing).
     private static func normalize(_ value: String?) -> String? {
@@ -137,7 +145,7 @@ public struct PreviewTraits: Sendable, Equatable {
 
     /// All recognized preset names (color schemes + dynamic type sizes + layout/legibility).
     public static var allPresetNames: Set<String> {
-        validColorSchemes.union(validDynamicTypeSizes).union(["rtl", "ltr", "boldText"])
+        Set(validColorSchemes).union(validDynamicTypeSizes).union(["rtl", "ltr", "boldText"])
     }
 
     /// A trait variant resolved from a user-supplied string (preset name or JSON object).

--- a/Sources/PreviewsCore/PreviewTraits.swift
+++ b/Sources/PreviewsCore/PreviewTraits.swift
@@ -63,13 +63,12 @@ public struct PreviewTraits: Sendable, Equatable {
         )
     }
 
-    /// Canonical trait value lists, ordered so MCP tool schemas exposing
-    /// them as `enum` constraints get a stable, meaningful presentation
-    /// order (size order for `dynamicTypeSize`, light-then-dark, etc.).
-    /// Order is wire-relevant: `Tests/PreviewsCLITests/list_tools_snapshot.json`
-    /// pins the JSON-encoded order.
-    ///
-    /// `.contains` membership is O(n) on arrays, but n is tiny (≤12).
+    /// Canonical trait value lists. Stored as ordered arrays — not Sets —
+    /// because the wire shape matters: MCP tool schemas expose these as
+    /// JSON `enum` arrays in declaration order, and
+    /// `Tests/PreviewsCLITests/list_tools_snapshot.json` pins the
+    /// resulting bytes. `.contains` membership against these arrays is
+    /// O(n), but n is tiny (≤12) — acceptable for the validation paths.
 
     public static let validColorSchemes: [String] = ["light", "dark"]
 

--- a/Tests/PreviewsCLITests/TraitSchemaTests.swift
+++ b/Tests/PreviewsCLITests/TraitSchemaTests.swift
@@ -1,0 +1,75 @@
+import MCP
+import PreviewsCore
+import Testing
+
+@testable import PreviewsCLI
+
+/// Pin the contract that `preview_start` and `preview_configure` schemas
+/// derive their trait `enum` constraints from `PreviewTraits.valid*`
+/// arrays — the canonical source of truth.
+///
+/// Catches the realistic regression: a future contributor adds a new
+/// dynamic type size (or color scheme, or layout direction) to
+/// `PreviewTraits` but forgets to update one of the schemas. The
+/// canonical array would have N+1 entries, the schema would have N, and
+/// these tests would fail with a clear "schema drifted from canonical"
+/// signal.
+///
+/// Does not catch a contributor copy-pasting the literals inline with
+/// matching values — that's a source-level concern beyond runtime tests.
+/// The `ListToolsSnapshotTests` byte-snapshot will at least catch any
+/// VALUE drift.
+@Suite("Trait schema canonical-reference")
+struct TraitSchemaTests {
+
+    @Test("preview_start enum constraints match PreviewTraits canonical lists")
+    func previewStartReferencesCanonical() {
+        let props = traitProperties(in: PreviewStartHandler.schema)
+        #expect(enumValues(of: props["colorScheme"]) == PreviewTraits.validColorSchemes)
+        #expect(enumValues(of: props["dynamicTypeSize"]) == PreviewTraits.validDynamicTypeSizes)
+        #expect(enumValues(of: props["layoutDirection"]) == PreviewTraits.validLayoutDirections)
+        #expect(enumValues(of: props["legibilityWeight"]) == PreviewTraits.validLegibilityWeights)
+    }
+
+    @Test("preview_configure enum constraints match PreviewTraits canonical lists")
+    func previewConfigureReferencesCanonical() {
+        let props = traitProperties(in: PreviewConfigureHandler.schema)
+        #expect(enumValues(of: props["colorScheme"]) == PreviewTraits.validColorSchemes)
+        #expect(enumValues(of: props["dynamicTypeSize"]) == PreviewTraits.validDynamicTypeSizes)
+        // Note: preview_configure doesn't enforce enums on layoutDirection
+        // or legibilityWeight (it accepts empty-string-as-clear), so those
+        // properties have no `enum` field. That's intentional asymmetry,
+        // not drift.
+    }
+
+    @Test("both handlers agree on shared trait values")
+    func handlersAgreeOnSharedValues() {
+        let startProps = traitProperties(in: PreviewStartHandler.schema)
+        let configureProps = traitProperties(in: PreviewConfigureHandler.schema)
+        #expect(enumValues(of: startProps["colorScheme"]) == enumValues(of: configureProps["colorScheme"]))
+        #expect(
+            enumValues(of: startProps["dynamicTypeSize"])
+                == enumValues(of: configureProps["dynamicTypeSize"])
+        )
+    }
+}
+
+/// Extract the `properties` object from a tool's `inputSchema`.
+private func traitProperties(in tool: Tool) -> [String: Value] {
+    guard case .object(let schema) = tool.inputSchema,
+        case .object(let props) = schema["properties"]
+    else { return [:] }
+    return props
+}
+
+/// Pull the `enum` array out of a property schema as `[String]`, or `nil`
+/// if the property has no `enum` constraint.
+private func enumValues(of property: Value?) -> [String]? {
+    guard case .object(let body) = property,
+        case .array(let values) = body["enum"]
+    else { return nil }
+    return values.compactMap {
+        if case .string(let s) = $0 { return s }
+        return nil
+    }
+}


### PR DESCRIPTION
## Summary

Step #5 of the architectural-refactor roadmap. The previous shape duplicated the 12-string \`dynamicTypeSize\` enum verbatim across \`previewStart\` and \`previewConfigure\` schemas — adding a new value meant editing \`PreviewTraits\` plus both schemas, with no test catching a forgotten edit.

After the refactor, both schemas reference \`PreviewTraits.validColorSchemes\` / \`validDynamicTypeSizes\` / \`validLayoutDirections\` / \`validLegibilityWeights\` directly. Adding a new value touches one place (\`PreviewTraits\`) and both schemas pick it up automatically.

### Changes

- \`PreviewTraits.swift\`: convert the four \`valid*\` constants from \`Set<String>\` to ordered \`[String]\`. Order matters because the schema enum arrays are wire-relevant (the \`ListToolsSnapshotTests\` byte-snapshot pins array order in JSON). Internal callers (\`.contains\` for validation, \`.union\` in \`allPresetNames\`) all work on arrays or are wrapped with \`Set(...)\`.
- New \`Handlers/TraitPropertySchema.swift\` with a small \`traitProperty(enumValues:description:)\` helper that builds the consistent \`{type, enum, description}\` Value shape. Descriptions stay per-handler since \`previewStart\` and \`previewConfigure\` legitimately say different things ("override" suffix vs "Pass empty string to clear" suffix).
- \`PreviewStartHandler.swift\` and \`PreviewConfigureHandler.swift\`: trait property literals replaced with \`traitProperty(enumValues: PreviewTraits.validX, description: ...)\` calls.

### Acceptance gate

- \`ListToolsSnapshotTests\` passes — the JSON-encoded \`ListTools\` response is byte-identical pre/post (the \`Tests/PreviewsCLITests/list_tools_snapshot.json\` fixture from #162 didn't change).
- New \`TraitSchemaTests\` asserts both handlers' enum constraints match the canonical \`PreviewTraits\` arrays. Catches the realistic regression: adding a value to \`PreviewTraits\` but forgetting to pick it up in a schema.

### What's NOT changed

- Trait extraction in \`parseTraits\` (in \`MCPServerSupport.swift\`) still names the 5 trait fields explicitly. \`PreviewTraits.validated\` takes 5 named parameters; refactoring that requires a deeper PreviewsCore API change. Out of scope.
- Asymmetric \`enum\` enforcement: \`previewConfigure\` deliberately doesn't enforce \`enum\` on \`layoutDirection\` / \`legibilityWeight\` (it accepts empty-string-as-clear). Preserved.

## Test plan

- [x] \`swift build\` clean
- [x] \`swift-format format --in-place --recursive Sources/ Tests/PreviewsCLITests/\` clean
- [x] \`swift test --filter ListToolsSnapshotTests\` — wire bytes match
- [x] \`swift test --filter TraitSchemaTests\` — 3 new tests pass
- [x] \`swift test --filter MacOSMCPTests\` — 7 tests pass (including \`structuredContent payloads decode for each migrated tool\` and the variants test)
- [x] \`swift test --filter PreviewsCoreTests\` — 246 tests pass (including \`BridgeGeneratorTraitsTests.validColorSchemes\` and \`validDynamicTypeSizes\` which compare against the now-Array constants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)