### PR TITLE
Extract shared build-system filesystem helpers into BuildSystemSupport

### DIFF
--- a/Sources/PreviewsCore/BuildSystemSupport.swift
+++ b/Sources/PreviewsCore/BuildSystemSupport.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Shared filesystem helpers used by every build-system integration plus
+/// `SetupBuilder`. Each implementation (SPM, Xcode, Bazel, SetupBuilder)
+/// previously open-coded these scans; pulling them into one namespace gives a
+/// single definition that's easy to test and harder to drift.
+///
+/// The helpers here are intentionally narrow: they do filesystem reads and
+/// nothing else. Subprocess execution, `.swiftmodule` existence checks, and
+/// error wrapping stay in the concrete build systems because each has its own
+/// load-bearing diagnostic shape (e.g., `BazelBuildSystem.runBazel`'s
+/// multi-line error format covers a real CI flake — see comment there).
+enum BuildSystemSupport {
+    /// Names of `.framework` bundles directly under `binPath`.
+    ///
+    /// SPM copies pre-built `.framework` bundles (from `binaryTarget` /
+    /// XCFramework deps) into the bin directory; the setup builder ships its
+    /// own dylib alongside the same bundles. Both need the names to construct
+    /// `-F` / `-framework` flags. The scan is shallow on purpose — `.framework`
+    /// bundles only ever sit at the top level of `binPath`.
+    static func collectFrameworks(binPath: URL) -> [String] {
+        let fm = FileManager.default
+        guard
+            let entries = try? fm.contentsOfDirectory(
+                at: binPath,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+        else {
+            return []
+        }
+
+        var frameworks: [String] = []
+        for entry in entries {
+            let name = entry.lastPathComponent
+            guard name.hasSuffix(".framework") else { continue }
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: entry.path, isDirectory: &isDir), isDir.boolValue else {
+                continue
+            }
+            frameworks.append(String(name.dropLast(".framework".count)))
+        }
+        return frameworks
+    }
+
+    /// Standardized URLs of every `.swift` file directly inside
+    /// `derivedSourcesDir`. Caller is responsible for computing that directory
+    /// (SPM uses `<binPath>/<Target>.build/DerivedSources/`; Xcode uses
+    /// `<DERIVED_FILE_DIR>/DerivedSources/`). The scan is intentionally
+    /// non-recursive and unfiltered by filename — both build systems have
+    /// renamed their generated files across releases, so a whitelist would
+    /// silently drop new ones.
+    static func collectGeneratedSources(in derivedSourcesDir: URL) -> [URL] {
+        guard
+            let entries = try? FileManager.default.contentsOfDirectory(
+                at: derivedSourcesDir,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )
+        else {
+            return []
+        }
+        return
+            entries
+            .filter { $0.pathExtension == "swift" }
+            .map { $0.standardizedFileURL }
+    }
+
+    /// Recursively collect `.o` files under `directory`. Used by SPM (per
+    /// dependency-target archive) and the setup builder (single dylib link).
+    /// `swift build` emits Swift object files as `<Source>.swift.o`, so
+    /// matching by `pathExtension == "o"` covers both C and Swift outputs.
+    static func collectObjectFiles(in directory: URL) -> [URL] {
+        guard
+            let enumerator = FileManager.default.enumerator(
+                at: directory,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )
+        else {
+            return []
+        }
+        var files: [URL] = []
+        for case let url as URL in enumerator where url.pathExtension == "o" {
+            files.append(url)
+        }
+        return files
+    }
+}

--- a/Sources/PreviewsCore/SPMBuildSystem.swift
+++ b/Sources/PreviewsCore/SPMBuildSystem.swift
@@ -212,7 +212,7 @@ public actor SPMBuildSystem: BuildSystem {
         //     dependencies) directly into binPath. These aren't covered by the
         //     .build/-directory scan above — they need -F (framework search path)
         //     and -framework flags instead of -L/-l.
-        let frameworkNames = collectFrameworks(binPath: binPath)
+        let frameworkNames = BuildSystemSupport.collectFrameworks(binPath: binPath)
 
         // 7. Build compiler flags
         //    -I <Modules>   resolves dependency .swiftmodule files at compile time
@@ -301,19 +301,7 @@ public actor SPMBuildSystem: BuildSystem {
             binPath
             .appendingPathComponent("\(targetName).build")
             .appendingPathComponent("DerivedSources")
-        guard
-            let entries = try? FileManager.default.contentsOfDirectory(
-                at: derivedDir,
-                includingPropertiesForKeys: nil,
-                options: [.skipsHiddenFiles]
-            )
-        else {
-            return []
-        }
-        return
-            entries
-            .filter { $0.pathExtension == "swift" }
-            .map { $0.standardizedFileURL }
+        return BuildSystemSupport.collectGeneratedSources(in: derivedDir)
     }
 
     // MARK: - Private: Package Description
@@ -484,7 +472,7 @@ public actor SPMBuildSystem: BuildSystem {
             }
 
             // Collect .o files produced for this target.
-            let objectFiles = collectObjectFiles(in: entry)
+            let objectFiles = BuildSystemSupport.collectObjectFiles(in: entry)
             guard !objectFiles.isEmpty else { continue }
 
             // Write to a unique temp file and atomically swap into place so a
@@ -514,53 +502,6 @@ public actor SPMBuildSystem: BuildSystem {
         }
 
         return libs
-    }
-
-    /// Collect `.framework` bundles in binPath (binary XCFramework dependencies).
-    /// Returns the framework names (e.g. ["Lottie"]) for use with `-framework`.
-    private func collectFrameworks(binPath: URL) -> [String] {
-        let fm = FileManager.default
-        guard
-            let entries = try? fm.contentsOfDirectory(
-                at: binPath,
-                includingPropertiesForKeys: [.isDirectoryKey],
-                options: [.skipsHiddenFiles]
-            )
-        else {
-            return []
-        }
-
-        var frameworks: [String] = []
-        for entry in entries {
-            let name = entry.lastPathComponent
-            guard name.hasSuffix(".framework") else { continue }
-            var isDir: ObjCBool = false
-            guard fm.fileExists(atPath: entry.path, isDirectory: &isDir), isDir.boolValue else {
-                continue
-            }
-            let frameworkName = String(name.dropLast(".framework".count))
-            frameworks.append(frameworkName)
-        }
-        return frameworks
-    }
-
-    /// Recursively collect `.o` files under a target's build directory, including
-    /// files named `Foo.swift.o` that swift build emits for Swift sources.
-    private func collectObjectFiles(in directory: URL) -> [URL] {
-        guard
-            let enumerator = FileManager.default.enumerator(
-                at: directory,
-                includingPropertiesForKeys: nil,
-                options: [.skipsHiddenFiles]
-            )
-        else {
-            return []
-        }
-        var files: [URL] = []
-        for case let url as URL in enumerator where url.pathExtension == "o" {
-            files.append(url)
-        }
-        return files
     }
 
     // MARK: - Private: Package Name (from build manifest)

--- a/Sources/PreviewsCore/SetupBuilder.swift
+++ b/Sources/PreviewsCore/SetupBuilder.swift
@@ -111,7 +111,7 @@ public enum SetupBuilder {
             "-Xlinker", "-rpath", "-Xlinker", binPath.path,
         ]
 
-        let frameworkNames = collectFrameworks(binPath: binPath)
+        let frameworkNames = BuildSystemSupport.collectFrameworks(binPath: binPath)
         if !frameworkNames.isEmpty {
             flags += ["-F", binPath.path]
             for fw in frameworkNames {
@@ -159,7 +159,7 @@ public enum SetupBuilder {
                 else { continue }
                 let targetName = String(name.dropLast(".build".count))
                 if targetName.hasPrefix("_") { continue }
-                allObjectFiles.append(contentsOf: collectObjectFiles(in: entry))
+                allObjectFiles.append(contentsOf: BuildSystemSupport.collectObjectFiles(in: entry))
             }
         }
 
@@ -204,7 +204,7 @@ public enum SetupBuilder {
         }
         args += ["-sdk", sdkPath]
 
-        let frameworks = collectFrameworks(binPath: binPath)
+        let frameworks = BuildSystemSupport.collectFrameworks(binPath: binPath)
         if !frameworks.isEmpty {
             args += ["-F", binPath.path]
             for fw in frameworks {
@@ -270,19 +270,6 @@ public enum SetupBuilder {
         }
     }
 
-    private static func collectObjectFiles(in directory: URL) -> [URL] {
-        guard
-            let enumerator = FileManager.default.enumerator(
-                at: directory, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]
-            )
-        else { return [] }
-        var files: [URL] = []
-        for case let url as URL in enumerator where url.pathExtension == "o" {
-            files.append(url)
-        }
-        return files
-    }
-
     private static func resolveSwiftc() async throws -> String {
         let result = try await runAsync(
             "/usr/bin/xcrun", arguments: ["--find", "swiftc"], discardStderr: true
@@ -329,26 +316,6 @@ public enum SetupBuilder {
             )
         }
         return result.stdout
-    }
-
-    private static func collectFrameworks(binPath: URL) -> [String] {
-        guard
-            let entries = try? FileManager.default.contentsOfDirectory(
-                at: binPath,
-                includingPropertiesForKeys: [.isDirectoryKey],
-                options: [.skipsHiddenFiles]
-            )
-        else { return [] }
-
-        return entries.compactMap { entry in
-            let name = entry.lastPathComponent
-            guard name.hasSuffix(".framework") else { return nil }
-            var isDir: ObjCBool = false
-            guard FileManager.default.fileExists(atPath: entry.path, isDirectory: &isDir),
-                isDir.boolValue
-            else { return nil }
-            return String(name.dropLast(".framework".count))
-        }
     }
 
 }

--- a/Sources/PreviewsCore/XcodeBuildSystem.swift
+++ b/Sources/PreviewsCore/XcodeBuildSystem.swift
@@ -290,19 +290,7 @@ public actor XcodeBuildSystem: BuildSystem {
     /// whitelist — Xcode's generator set changes across releases.
     nonisolated static func collectGeneratedSources(derivedFileDir: URL) -> [URL] {
         let derivedSources = derivedFileDir.appendingPathComponent("DerivedSources")
-        guard
-            let entries = try? FileManager.default.contentsOfDirectory(
-                at: derivedSources,
-                includingPropertiesForKeys: nil,
-                options: [.skipsHiddenFiles]
-            )
-        else {
-            return []
-        }
-        return
-            entries
-            .filter { $0.pathExtension == "swift" }
-            .map { $0.standardizedFileURL }
+        return BuildSystemSupport.collectGeneratedSources(in: derivedSources)
     }
 
     /// Apply `rewriteResourceBundle` to every source file when the build

--- a/Tests/PreviewsCoreTests/BuildSystemSupportTests.swift
+++ b/Tests/PreviewsCoreTests/BuildSystemSupportTests.swift
@@ -1,0 +1,188 @@
+import Foundation
+import Testing
+
+@testable import PreviewsCore
+
+/// Direct fixture tests for `BuildSystemSupport`. The shared filesystem
+/// helpers are now load-bearing for SPM and SetupBuilder linking; without
+/// these tests, a regression in scan logic silently breaks linking with
+/// no failing test (the only existing coverage was via the `SPM` /
+/// `Xcode` shims for `collectGeneratedSources`).
+@Suite("BuildSystemSupport")
+struct BuildSystemSupportTests {
+
+    // MARK: - collectFrameworks
+
+    @Test("collectFrameworks returns names of .framework bundles in binPath")
+    func frameworks_findsBundles() throws {
+        let tmp = makeFixture()
+        defer { cleanup(tmp) }
+
+        try makeFrameworkBundle(named: "Lottie", in: tmp)
+        try makeFrameworkBundle(named: "FirebaseAnalytics", in: tmp)
+
+        let names = BuildSystemSupport.collectFrameworks(binPath: tmp).sorted()
+        #expect(names == ["FirebaseAnalytics", "Lottie"])
+    }
+
+    @Test("collectFrameworks ignores plain files with .framework suffix")
+    func frameworks_ignoresFiles() throws {
+        let tmp = makeFixture()
+        defer { cleanup(tmp) }
+
+        try makeFrameworkBundle(named: "Real", in: tmp)
+        // A regular file named like a framework — must not be reported.
+        try "not a bundle".write(
+            to: tmp.appendingPathComponent("Fake.framework"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        #expect(BuildSystemSupport.collectFrameworks(binPath: tmp) == ["Real"])
+    }
+
+    @Test("collectFrameworks ignores entries without .framework suffix")
+    func frameworks_filtersBySuffix() throws {
+        let tmp = makeFixture()
+        defer { cleanup(tmp) }
+
+        try makeFrameworkBundle(named: "Real", in: tmp)
+        try FileManager.default.createDirectory(
+            at: tmp.appendingPathComponent("NotAFramework"),
+            withIntermediateDirectories: false
+        )
+
+        #expect(BuildSystemSupport.collectFrameworks(binPath: tmp) == ["Real"])
+    }
+
+    @Test("collectFrameworks returns empty for a nonexistent directory")
+    func frameworks_missingDirectoryReturnsEmpty() {
+        let bogus = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-bogus-\(UUID().uuidString)")
+        #expect(BuildSystemSupport.collectFrameworks(binPath: bogus).isEmpty)
+    }
+
+    // MARK: - collectGeneratedSources
+
+    @Test("collectGeneratedSources returns .swift files in the directory")
+    func generated_findsSwiftFiles() throws {
+        let tmp = makeFixture()
+        defer { cleanup(tmp) }
+
+        try "// a".write(
+            to: tmp.appendingPathComponent("a.swift"), atomically: true, encoding: .utf8)
+        try "// b".write(
+            to: tmp.appendingPathComponent("b.swift"), atomically: true, encoding: .utf8)
+
+        let found = BuildSystemSupport.collectGeneratedSources(in: tmp)
+            .map(\.lastPathComponent)
+            .sorted()
+        #expect(found == ["a.swift", "b.swift"])
+    }
+
+    @Test("collectGeneratedSources filters non-.swift files")
+    func generated_filtersByExtension() throws {
+        let tmp = makeFixture()
+        defer { cleanup(tmp) }
+
+        try "// keep".write(
+            to: tmp.appendingPathComponent("keep.swift"), atomically: true, encoding: .utf8)
+        try "// header".write(
+            to: tmp.appendingPathComponent("ignore.h"), atomically: true, encoding: .utf8)
+        try "// no ext".write(
+            to: tmp.appendingPathComponent("README"), atomically: true, encoding: .utf8)
+
+        #expect(
+            BuildSystemSupport.collectGeneratedSources(in: tmp)
+                .map(\.lastPathComponent) == ["keep.swift"]
+        )
+    }
+
+    @Test("collectGeneratedSources is non-recursive")
+    func generated_nonRecursive() throws {
+        let tmp = makeFixture()
+        defer { cleanup(tmp) }
+        let nested = tmp.appendingPathComponent("nested")
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+
+        try "// shallow".write(
+            to: tmp.appendingPathComponent("shallow.swift"), atomically: true, encoding: .utf8)
+        try "// deep".write(
+            to: nested.appendingPathComponent("deep.swift"), atomically: true, encoding: .utf8)
+
+        let found = BuildSystemSupport.collectGeneratedSources(in: tmp)
+            .map(\.lastPathComponent)
+        #expect(found == ["shallow.swift"])
+    }
+
+    @Test("collectGeneratedSources returns empty for a nonexistent directory")
+    func generated_missingDirectoryReturnsEmpty() {
+        let bogus = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-bogus-\(UUID().uuidString)")
+        #expect(BuildSystemSupport.collectGeneratedSources(in: bogus).isEmpty)
+    }
+
+    // MARK: - collectObjectFiles
+
+    @Test("collectObjectFiles returns .o files recursively")
+    func objects_recursive() throws {
+        let tmp = makeFixture()
+        defer { cleanup(tmp) }
+        let sub = tmp.appendingPathComponent("Foo.build")
+        let subSub = sub.appendingPathComponent("nested")
+        try FileManager.default.createDirectory(at: subSub, withIntermediateDirectories: true)
+
+        try Data().write(to: tmp.appendingPathComponent("top.o"))
+        try Data().write(to: sub.appendingPathComponent("mid.o"))
+        try Data().write(to: subSub.appendingPathComponent("deep.swift.o"))
+
+        let found = BuildSystemSupport.collectObjectFiles(in: tmp)
+            .map(\.lastPathComponent)
+            .sorted()
+        #expect(found == ["deep.swift.o", "mid.o", "top.o"])
+    }
+
+    @Test("collectObjectFiles filters non-.o files")
+    func objects_filtersByExtension() throws {
+        let tmp = makeFixture()
+        defer { cleanup(tmp) }
+
+        try Data().write(to: tmp.appendingPathComponent("keep.o"))
+        try "src".write(
+            to: tmp.appendingPathComponent("source.swift"), atomically: true, encoding: .utf8)
+        try Data().write(to: tmp.appendingPathComponent("static.a"))
+
+        #expect(
+            BuildSystemSupport.collectObjectFiles(in: tmp)
+                .map(\.lastPathComponent) == ["keep.o"]
+        )
+    }
+
+    @Test("collectObjectFiles returns empty for a nonexistent directory")
+    func objects_missingDirectoryReturnsEmpty() {
+        let bogus = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-bogus-\(UUID().uuidString)")
+        #expect(BuildSystemSupport.collectObjectFiles(in: bogus).isEmpty)
+    }
+
+    // MARK: - Fixture helpers
+
+    private func makeFixture() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-bsupport-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    /// Build a minimal `<name>.framework` directory bundle in `parent`.
+    /// `collectFrameworks` checks `.isDirectory` on the entry, so an empty
+    /// directory is sufficient; we don't need an Info.plist or binary.
+    private func makeFrameworkBundle(named name: String, in parent: URL) throws {
+        let bundle = parent.appendingPathComponent("\(name).framework")
+        try FileManager.default.createDirectory(at: bundle, withIntermediateDirectories: true)
+    }
+}


### PR DESCRIPTION
## Summary

Step #4 of the architectural-refactor roadmap. Three build-system implementations (\`SPMBuildSystem\`, \`XcodeBuildSystem\`, \`BazelBuildSystem\`) and \`SetupBuilder\` previously open-coded the same filesystem scans for frameworks, generated sources, and object files. Pull them into one \`BuildSystemSupport\` namespace so each helper has a single definition.

### What was extracted

New \`Sources/PreviewsCore/BuildSystemSupport.swift\` (89 lines, file-level \`enum\`):

- \`collectFrameworks(binPath:)\` — shallow scan for \`.framework\` bundles. Used by \`SPMBuildSystem\` and \`SetupBuilder\` (twice).
- \`collectGeneratedSources(in:)\` — non-recursive \`.swift\` scan in a \`DerivedSources\` directory. Used by \`SPMBuildSystem\` and \`XcodeBuildSystem\` (each via a thin path-computing shim that preserves the public test surface).
- \`collectObjectFiles(in:)\` — recursive \`.o\` walk. Used by \`SPMBuildSystem\` and \`SetupBuilder\`.

### What was considered and left

- \`runBuildSubprocess\` — each system's error diagnostic shape diverges meaningfully. \`BazelBuildSystem.runBazel\`'s multi-line "command/cwd/stdout/stderr" diagnostic is load-bearing per its inline comment (covers a real CI flake from run 25243519727). SPM and Xcode use the shorter \`output.stderr.isEmpty ? output.stdout : output.stderr\` shape. Merging would force one shape on all three and either lose the Bazel diagnostic or impose its verbosity on the others.
- \`verifySwiftModule\` — each is a 1-2 line \`FileManager.fileExists\` check throwing a different error type (\`BuildSystemError.missingArtifacts\`, \`SetupBuilderError.moduleNotFound\`, plus Xcode's settings-based \`BUILT_PRODUCTS_DIR\` check that doesn't even target a \`.swiftmodule\`). Generalizing yields no real shrinkage.
- \`BazelBuildSystem\` doesn't consume any of the shared helpers — its phases use \`bazel query\` / \`bazel cquery\` rather than filesystem scans. That's the "even if it's only 2 of 4" caveat the plan flagged.
- No template-method \`BuildSystemPhases\` protocol — wouldn't have shortened anything. The plan explicitly said "only if it actually shortens."
- \`SPMBuildSystem.shouldSkipDependencyTarget\` and the SPM archive-then-link logic untouched per the "leave alone" list.

### Acceptance criterion

The plan's acceptance: "\`runBuildSubprocess\`, \`collectFrameworks\`, \`verifySwiftModule\`, and \`collectGeneratedSources\` are each defined exactly once in \`BuildSystemSupport.swift\` and referenced from all three build systems plus \`SetupBuilder\` (verified by grep, not by line-count heuristic)."

Reality: only the three filesystem helpers (\`collectFrameworks\`, \`collectGeneratedSources\`, \`collectObjectFiles\`) genuinely benefit from sharing. The other two (\`runBuildSubprocess\`, \`verifySwiftModule\`) have load-bearing per-system specialization — merging them would regress diagnostic quality. Bazel uses zero of the shared helpers because its phases are filesystem-free. The grep verification: \`grep -n "static func collect\\(Frameworks\\|GeneratedSources\\|ObjectFiles\\)" Sources/PreviewsCore/\` shows each helper defined exactly once in \`BuildSystemSupport.swift\`.

### Sanity-check items

1. \`SPMBuildSystem.collectGeneratedSources(binPath:targetName:)\` and \`XcodeBuildSystem.collectGeneratedSources(derivedFileDir:)\` are kept as thin static shims that delegate to \`BuildSystemSupport.collectGeneratedSources(in:)\`. Tests reference the old signatures, so the shims preserve the public surface rather than forcing a test migration. The dual surface (shim + base helper) feels right; let me know if you'd prefer to drop the shims and migrate tests to the base helper directly.
2. \`BuildSystemSupport\` is module-internal. If a future test target needs to call into it directly, visibility would need to change.

## Test plan

- [x] \`swift build\` clean
- [x] \`swift test --filter BuildSystem\` — 69/69 pass
- [x] \`swift test --filter Bazel\` — 8/8 pass
- [x] \`swift test --filter Xcode\` — 9/9 pass
- [x] \`swift test --filter SetupBuilder\` — 3/3 pass
- [x] \`swift test --filter SetupCache\` — 17/17 pass
- [x] \`swift-format format --in-place --recursive Sources/\` + \`swift-format lint --strict\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)