### PR TITLE
Extract LiteralRegionClassifier from ThunkGenerator

### DIFF
--- a/Sources/PreviewsCore/LiteralRegionClassifier.swift
+++ b/Sources/PreviewsCore/LiteralRegionClassifier.swift
@@ -1,0 +1,120 @@
+import SwiftSyntax
+
+/// Classifies a SwiftSyntax node as living in a SwiftUI- or UIKit-evaluated
+/// region (#160).
+///
+/// The literal-only fast path mutates `DesignTimeStore.shared.values` and
+/// relies on `@Observable` to drive a re-render — that's only sound for
+/// SwiftUI-evaluated reads. UIKit code captures the store value once at
+/// construction (`label.text = store.string("#X")`) and never observes
+/// mutation, so a literal edit inside UIKit code silently no-ops on the
+/// fast path. We taint such literals as `.uiKit` so `LiteralDiffer.diff`
+/// can downgrade `.literalOnly` to `.structural` and force a full reload.
+///
+/// Lives in its own file (separate from `ThunkGenerator`/`LiteralCollector`)
+/// because eligibility-checking ("should this literal be thunked at all?")
+/// and region classification ("what fast-path policy applies if it is?")
+/// are different concerns and were sharing a 320-line host. Public seam is
+/// `classify(_:)` so future tests / callers can reach it directly.
+enum LiteralRegionClassifier {
+
+    /// Classify the syntactic region a node lives in. Walks parent nodes
+    /// looking for an enclosing UIKit-typed scope: a function/var with a
+    /// UIKit return type, a class extending `UIView`/`UIViewController`,
+    /// a type conforming to `UIViewRepresentable`/`UIViewControllerRepresentable`,
+    /// or an extension on a UIKit type. Otherwise returns `.swiftUI`.
+    ///
+    /// This is a syntactic heuristic. False negatives exist (e.g.
+    /// `func make() -> SomeAlias` where `SomeAlias = UIView`) — they
+    /// degrade to pre-#160 behavior, no worse than status quo. False
+    /// positives (claiming UIKit when it's actually SwiftUI) cost only an
+    /// extra reload.
+    static func classify(_ node: some SyntaxProtocol) -> LiteralRegion {
+        var current: Syntax? = Syntax(node)
+        while let parent = current?.parent {
+            if let funcDecl = parent.as(FunctionDeclSyntax.self) {
+                if let returnClause = funcDecl.signature.returnClause,
+                    typeNameMentionsUIKit(returnClause.type)
+                {
+                    return .uiKit
+                }
+            }
+            if let varDecl = parent.as(VariableDeclSyntax.self) {
+                for binding in varDecl.bindings {
+                    if let typeAnnotation = binding.typeAnnotation,
+                        typeNameMentionsUIKit(typeAnnotation.type)
+                    {
+                        return .uiKit
+                    }
+                }
+            }
+            if let classDecl = parent.as(ClassDeclSyntax.self),
+                inheritanceMentionsUIKit(classDecl.inheritanceClause)
+            {
+                return .uiKit
+            }
+            if let structDecl = parent.as(StructDeclSyntax.self),
+                inheritanceMentionsUIKit(structDecl.inheritanceClause)
+            {
+                return .uiKit
+            }
+            if let extensionDecl = parent.as(ExtensionDeclSyntax.self) {
+                if typeNameMentionsUIKit(extensionDecl.extendedType)
+                    || inheritanceMentionsUIKit(extensionDecl.inheritanceClause)
+                {
+                    return .uiKit
+                }
+            }
+            current = parent
+        }
+        return .swiftUI
+    }
+
+    /// Match the type's textual representation against known UIKit class names.
+    /// Catches: `UIView`, `UIViewController`, `UIKit.UIView`, common subclasses
+    /// (`UILabel`, `UIButton`, `UIScrollView`, etc.), and `UIViewRepresentable.UIViewType`
+    /// associated-type returns.
+    ///
+    /// Uses word-boundary matching so identifiers that merely *embed* `UIView`
+    /// (e.g. `MyUIViewSubclass`, `UIViewable`) don't get false-positive tainted.
+    /// False positives cost only an extra reload, but precision is cheap here.
+    private static func typeNameMentionsUIKit(_ type: TypeSyntax) -> Bool {
+        let text = type.trimmedDescription
+        // \bUIView(Controller)?\b matches `UIView` and `UIViewController` as whole
+        // identifiers, including when wrapped (`[UIView]`, `UIView?`, `UIKit.UIView`).
+        if text.range(of: #"\bUIView(Controller)?\b"#, options: .regularExpression) != nil {
+            return true
+        }
+        // Common UIKit class names that don't fit the UIView* prefix.
+        let uikitClasses: Set<String> = [
+            "UILabel", "UIButton", "UIImageView", "UIScrollView", "UITableView",
+            "UICollectionView", "UIStackView", "UISwitch", "UISlider", "UIStepper",
+            "UISegmentedControl", "UIPageControl", "UIProgressView", "UIActivityIndicatorView",
+            "UITextField", "UITextView", "UIControl", "UIWindow",
+            "UINavigationController", "UITabBarController", "UISplitViewController",
+            "UIPageViewController", "UIAlertController", "UISearchController",
+            "UITableViewCell", "UICollectionViewCell",
+        ]
+        // Strip module prefix and generic args for the contains check.
+        let bare = text.split(separator: ".").last.map(String.init) ?? text
+        let baseName =
+            bare.split(whereSeparator: { "<>?! ".contains($0) }).first.map(String.init) ?? bare
+        return uikitClasses.contains(baseName)
+    }
+
+    /// Treat any inherited type that names a UIKit class or one of the SwiftUI<->UIKit
+    /// representable protocols as marking the enclosing scope as UIKit-evaluated.
+    private static func inheritanceMentionsUIKit(_ clause: InheritanceClauseSyntax?) -> Bool {
+        guard let clause else { return false }
+        for entry in clause.inheritedTypes {
+            let text = entry.type.trimmedDescription
+            if text.contains("UIViewRepresentable") || text.contains("UIViewControllerRepresentable") {
+                return true
+            }
+            if typeNameMentionsUIKit(entry.type) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/Sources/PreviewsCore/ThunkGenerator.swift
+++ b/Sources/PreviewsCore/ThunkGenerator.swift
@@ -86,7 +86,7 @@ final class LiteralCollector: SyntaxVisitor {
                 value: .string(text),
                 utf8Start: node.position.utf8Offset,
                 utf8End: node.endPosition.utf8Offset,
-                region: regionFor(node)
+                region: LiteralRegionClassifier.classify(node)
             ))
         return .skipChildren
     }
@@ -119,7 +119,7 @@ final class LiteralCollector: SyntaxVisitor {
                     value: .integer(-intValue),
                     utf8Start: prefix.position.utf8Offset,
                     utf8End: prefix.endPosition.utf8Offset,
-                    region: regionFor(node)
+                    region: LiteralRegionClassifier.classify(node)
                 ))
         } else {
             rawEntries.append(
@@ -127,7 +127,7 @@ final class LiteralCollector: SyntaxVisitor {
                     value: .integer(intValue),
                     utf8Start: node.position.utf8Offset,
                     utf8End: node.endPosition.utf8Offset,
-                    region: regionFor(node)
+                    region: LiteralRegionClassifier.classify(node)
                 ))
         }
         return .skipChildren
@@ -149,7 +149,7 @@ final class LiteralCollector: SyntaxVisitor {
                     value: .float(-doubleValue),
                     utf8Start: prefix.position.utf8Offset,
                     utf8End: prefix.endPosition.utf8Offset,
-                    region: regionFor(node)
+                    region: LiteralRegionClassifier.classify(node)
                 ))
         } else {
             rawEntries.append(
@@ -157,7 +157,7 @@ final class LiteralCollector: SyntaxVisitor {
                     value: .float(doubleValue),
                     utf8Start: node.position.utf8Offset,
                     utf8End: node.endPosition.utf8Offset,
-                    region: regionFor(node)
+                    region: LiteralRegionClassifier.classify(node)
                 ))
         }
         return .skipChildren
@@ -174,7 +174,7 @@ final class LiteralCollector: SyntaxVisitor {
                 value: .boolean(value),
                 utf8Start: node.position.utf8Offset,
                 utf8End: node.endPosition.utf8Offset,
-                region: regionFor(node)
+                region: LiteralRegionClassifier.classify(node)
             ))
         return .skipChildren
     }
@@ -314,108 +314,10 @@ final class LiteralCollector: SyntaxVisitor {
         return false
     }
 
-    // MARK: - Region classification (#160)
-    //
-    // Classifies each literal as living in either a SwiftUI- or UIKit-evaluated
-    // region. The literal-only fast path mutates `DesignTimeStore.shared.values`
-    // and relies on `@Observable` to drive a re-render — that's only sound for
-    // SwiftUI-evaluated reads. UIKit code captures the store value once at
-    // construction (`label.text = store.string("#X")`) and never observes
-    // mutation, so a literal edit inside UIKit code silently no-ops on the
-    // fast path. We taint such literals as `.uiKit` so `LiteralDiffer.diff`
-    // can downgrade `.literalOnly` to `.structural` and force a full reload.
-    //
-    // This is a syntactic heuristic. False negatives exist (e.g.
-    // `func make() -> SomeAlias` where `SomeAlias = UIView`), but they
-    // degrade to today's behavior — no worse than status quo. False positives
-    // (claiming UIKit when it's actually SwiftUI) cost only an extra reload.
-    private func regionFor(_ node: some SyntaxProtocol) -> LiteralRegion {
-        var current: Syntax? = Syntax(node)
-        while let parent = current?.parent {
-            if let funcDecl = parent.as(FunctionDeclSyntax.self) {
-                if let returnClause = funcDecl.signature.returnClause,
-                    typeNameMentionsUIKit(returnClause.type)
-                {
-                    return .uiKit
-                }
-            }
-            if let varDecl = parent.as(VariableDeclSyntax.self) {
-                for binding in varDecl.bindings {
-                    if let typeAnnotation = binding.typeAnnotation,
-                        typeNameMentionsUIKit(typeAnnotation.type)
-                    {
-                        return .uiKit
-                    }
-                }
-            }
-            if let classDecl = parent.as(ClassDeclSyntax.self),
-                inheritanceMentionsUIKit(classDecl.inheritanceClause)
-            {
-                return .uiKit
-            }
-            if let structDecl = parent.as(StructDeclSyntax.self),
-                inheritanceMentionsUIKit(structDecl.inheritanceClause)
-            {
-                return .uiKit
-            }
-            if let extensionDecl = parent.as(ExtensionDeclSyntax.self) {
-                if typeNameMentionsUIKit(extensionDecl.extendedType)
-                    || inheritanceMentionsUIKit(extensionDecl.inheritanceClause)
-                {
-                    return .uiKit
-                }
-            }
-            current = parent
-        }
-        return .swiftUI
-    }
-
-    /// Match the type's textual representation against known UIKit class names.
-    /// Catches: `UIView`, `UIViewController`, `UIKit.UIView`, common subclasses
-    /// (`UILabel`, `UIButton`, `UIScrollView`, etc.), and `UIViewRepresentable.UIViewType`
-    /// associated-type returns.
-    ///
-    /// Uses word-boundary matching so identifiers that merely *embed* `UIView`
-    /// (e.g. `MyUIViewSubclass`, `UIViewable`) don't get false-positive tainted.
-    /// False positives cost only an extra reload, but precision is cheap here.
-    private func typeNameMentionsUIKit(_ type: TypeSyntax) -> Bool {
-        let text = type.trimmedDescription
-        // \bUIView(Controller)?\b matches `UIView` and `UIViewController` as whole
-        // identifiers, including when wrapped (`[UIView]`, `UIView?`, `UIKit.UIView`).
-        if text.range(of: #"\bUIView(Controller)?\b"#, options: .regularExpression) != nil {
-            return true
-        }
-        // Common UIKit class names that don't fit the UIView* prefix.
-        let uikitClasses: Set<String> = [
-            "UILabel", "UIButton", "UIImageView", "UIScrollView", "UITableView",
-            "UICollectionView", "UIStackView", "UISwitch", "UISlider", "UIStepper",
-            "UISegmentedControl", "UIPageControl", "UIProgressView", "UIActivityIndicatorView",
-            "UITextField", "UITextView", "UIControl", "UIWindow",
-            "UINavigationController", "UITabBarController", "UISplitViewController",
-            "UIPageViewController", "UIAlertController", "UISearchController",
-            "UITableViewCell", "UICollectionViewCell",
-        ]
-        // Strip module prefix and generic args for the contains check.
-        let bare = text.split(separator: ".").last.map(String.init) ?? text
-        let baseName = bare.split(whereSeparator: { "<>?! ".contains($0) }).first.map(String.init) ?? bare
-        return uikitClasses.contains(baseName)
-    }
-
-    /// Treat any inherited type that names a UIKit class or one of the SwiftUI<->UIKit
-    /// representable protocols as marking the enclosing scope as UIKit-evaluated.
-    private func inheritanceMentionsUIKit(_ clause: InheritanceClauseSyntax?) -> Bool {
-        guard let clause else { return false }
-        for entry in clause.inheritedTypes {
-            let text = entry.type.trimmedDescription
-            if text.contains("UIViewRepresentable") || text.contains("UIViewControllerRepresentable") {
-                return true
-            }
-            if typeNameMentionsUIKit(entry.type) {
-                return true
-            }
-        }
-        return false
-    }
+    // Per-literal region classification (#160) lives in
+    // `LiteralRegionClassifier.swift` — separate concern from the
+    // eligibility checks above (those decide *whether* to thunk; the
+    // classifier decides *what fast-path policy* applies if it is).
 
     private func isSimpleString(_ node: StringLiteralExprSyntax) -> Bool {
         // Reject multiline

--- a/Tests/PreviewsCoreTests/LiteralRegionClassifierTests.swift
+++ b/Tests/PreviewsCoreTests/LiteralRegionClassifierTests.swift
@@ -1,0 +1,141 @@
+import SwiftParser
+import SwiftSyntax
+import Testing
+
+@testable import PreviewsCore
+
+/// Direct unit tests for `LiteralRegionClassifier.classify(_:)`. The classifier
+/// is also exercised transitively via `ThunkGeneratorTests` (which checks the
+/// region field on collected `LiteralEntry` values) and `LiteralDifferTests`
+/// (which checks that tainted literals downgrade `.literalOnly` to `.structural`).
+/// These tests target the public seam directly so a future change can verify
+/// the classifier in isolation without reaching through the thunk pipeline.
+@Suite("LiteralRegionClassifier")
+struct LiteralRegionClassifierTests {
+
+    /// Find the first string-literal expression matching `value` in `source`
+    /// and return the classifier's verdict on it. Mirrors how
+    /// `LiteralCollector` invokes the classifier — pass the literal node, not
+    /// its parent — so the tests exercise the same call shape as production.
+    private func regionOfFirstString(_ value: String, in source: String) -> LiteralRegion? {
+        let tree = Parser.parse(source: source)
+        let finder = StringLiteralFinder(target: value, viewMode: .sourceAccurate)
+        finder.walk(tree)
+        guard let node = finder.match else { return nil }
+        return LiteralRegionClassifier.classify(node)
+    }
+
+    @Test("Literal with no UIKit-typed enclosing scope is .swiftUI")
+    func bareSwiftUIRegion() {
+        let source = """
+            import SwiftUI
+            struct V: View {
+                var body: some View { Text("Hi") }
+            }
+            """
+        #expect(regionOfFirstString("Hi", in: source) == .swiftUI)
+    }
+
+    @Test("Literal inside class extending UIView is .uiKit")
+    func uiViewSubclassRegion() {
+        let source = """
+            import UIKit
+            class MyView: UIView {
+                func setup() {
+                    let l = UILabel()
+                    l.text = "before"
+                }
+            }
+            """
+        #expect(regionOfFirstString("before", in: source) == .uiKit)
+    }
+
+    @Test("Literal inside UIViewRepresentable conformance is .uiKit")
+    func uiViewRepresentableRegion() {
+        let source = """
+            import SwiftUI
+            import UIKit
+            struct W: UIViewRepresentable {
+                func makeUIView(context: Context) -> UIView {
+                    let v = UIView()
+                    v.accessibilityLabel = "tag"
+                    return v
+                }
+                func updateUIView(_ uiView: UIView, context: Context) {}
+            }
+            """
+        #expect(regionOfFirstString("tag", in: source) == .uiKit)
+    }
+
+    @Test("Literal inside func returning UIView is .uiKit")
+    func functionReturningUIViewRegion() {
+        let source = """
+            import UIKit
+            func makeLabel() -> UILabel {
+                let l = UILabel()
+                l.text = "hi"
+                return l
+            }
+            """
+        #expect(regionOfFirstString("hi", in: source) == .uiKit)
+    }
+
+    @Test("Literal inside extension on UIView is .uiKit")
+    func uiViewExtensionRegion() {
+        let source = """
+            import UIKit
+            extension UIView {
+                func helper() {
+                    let l = UILabel()
+                    l.text = "tag"
+                }
+            }
+            """
+        #expect(regionOfFirstString("tag", in: source) == .uiKit)
+    }
+
+    @Test("Literal inside identifier merely embedding UIView is .swiftUI")
+    func wordBoundaryFalsePositiveGuard() {
+        // `MyUIViewSubclass` and `UIViewable` happen to contain "UIView" as a
+        // substring. The word-boundary check must not taint them.
+        let source = """
+            struct MyUIViewSubclass {
+                func make() -> String { "shouldFastPath" }
+            }
+            protocol UIViewable {
+                func tag() -> String
+            }
+            extension UIViewable {
+                func tag() -> String { "tagVal" }
+            }
+            """
+        #expect(regionOfFirstString("shouldFastPath", in: source) == .swiftUI)
+        #expect(regionOfFirstString("tagVal", in: source) == .swiftUI)
+    }
+}
+
+/// Walks a syntax tree to find a `StringLiteralExprSyntax` whose joined
+/// content matches `target`. Used by the classifier tests to obtain a real
+/// literal node to pass into `LiteralRegionClassifier.classify(_:)`.
+private final class StringLiteralFinder: SyntaxVisitor {
+    let target: String
+    var match: StringLiteralExprSyntax?
+
+    init(target: String, viewMode: SyntaxTreeViewMode) {
+        self.target = target
+        super.init(viewMode: viewMode)
+    }
+
+    override func visit(_ node: StringLiteralExprSyntax) -> SyntaxVisitorContinueKind {
+        guard match == nil else { return .skipChildren }
+        let text = node.segments.compactMap { segment -> String? in
+            if case .stringSegment(let s) = segment { return s.content.text }
+            return nil
+        }.joined()
+        if text == target {
+            match = node
+            return .skipChildren
+        }
+        return .visitChildren
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on top of #163. Pure refactor — no behavior change. Splits the region-classification block introduced in #163 out of `ThunkGenerator.swift` into a focused `LiteralRegionClassifier.swift`.

The two concerns that ended up sharing `LiteralCollector` answer different questions:

- **Eligibility checks** (`isInsideCodeBlock`, `isMacroArgument`, `isInsideAttribute`, …) — *should this literal be thunked at all?*
- **Region classification** (`regionFor`, `typeNameMentionsUIKit`, `inheritanceMentionsUIKit`) — *what fast-path policy applies if it is?*

Co-locating them was a happenstance of how #160 landed. SRP says they belong in separate files. Reviewer flagged this as Suggestion 3 in the #163 review and I deferred it for scope; this is the follow-up.

### What moves

| Before | After |
|---|---|
| `LiteralCollector.regionFor(_:)` (private method, ~40 lines) | `LiteralRegionClassifier.classify(_:)` (public seam) |
| `LiteralCollector.typeNameMentionsUIKit(_:)` (~30 lines) | private static on `LiteralRegionClassifier` |
| `LiteralCollector.inheritanceMentionsUIKit(_:)` (~15 lines) | private static on `LiteralRegionClassifier` |

`ThunkGenerator.swift` shrinks from ~430 lines back to ~310 — closer to its size before #160.

### Tests

Adds `LiteralRegionClassifierTests` (6 tests) that hit the new public seam directly: bare SwiftUI region, UIView subclass, UIViewRepresentable conformance, function-returning-UIView, extension-on-UIView, and a word-boundary false-positive guard for identifiers that merely embed `UIView` (e.g. `MyUIViewSubclass`, `UIViewable`).

The classifier is still exercised transitively via `ThunkGeneratorTests` and `LiteralDifferTests` (which carry the original #160 coverage). The new direct tests give finer-grained signal — a classifier regression now fails the classifier suite without needing the rest of the thunk pipeline to be wired up.

## Test plan

- [x] `swift build` clean
- [x] `swift test --filter "LiteralRegionClassifier|ThunkGenerator|LiteralDiffer|BodyKindCodeContract|BodyKindProbeEmission|BridgeGenerator"` → 112 tests pass
- [x] `swift-format lint --strict` clean
- [x] `swiftlint lint --quiet` exit 0

## Merge order

Merge after #163. GitHub's "Update branch" will rebase this onto `main` once #163 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)