### PR TITLE
Extract iOS host-app socket plumbing into IOSHostChannel actor

### DIFF
--- a/Sources/PreviewsIOS/IOSHostChannel.swift
+++ b/Sources/PreviewsIOS/IOSHostChannel.swift
@@ -157,37 +157,44 @@ public actor IOSHostChannel {
         }
     }
 
-    /// Send a message and await a response with the matching `id`.
-    /// Races the response against `timeout`. The continuation is
-    /// registered on the actor; both the response path
-    /// (`processIncomingData`) and the timeout path use
-    /// `removeValue(forKey:)` to ensure exactly one resumption.
     /// Send a message and await a response with the matching `id`,
-    /// returning the raw response bytes. Returns `Data` rather than a
-    /// decoded dictionary because `[String: Any]` is not `Sendable` and
-    /// crossing actor isolation would require `sending` semantics that
-    /// the response path can't provide. Callers `JSONSerialization`-decode
-    /// the returned bytes themselves.
+    /// returning the raw response bytes. Races the response against
+    /// `timeout`; both the response path (`processIncomingData`) and
+    /// the timeout path use `removeValue(forKey:)` to ensure exactly
+    /// one resumption.
+    ///
+    /// Returns `Data` rather than a decoded dictionary because
+    /// `[String: Any]` is not `Sendable` and crossing actor isolation
+    /// back to the caller would require `sending` semantics that the
+    /// response path can't provide. Callers decode the returned bytes
+    /// with `JSONSerialization` themselves.
     public func sendAndAwait(
         _ message: sending [String: Any], id: String, timeout: Duration
     ) async throws -> Data {
         // Fail eagerly if the peer has already disconnected. Without
-        // this guard, the call would register a continuation that no
+        // this guard the call would register a continuation that no
         // response can resolve and only the `timeout` would unblock it.
-        // The race is real: a test (or any caller) can call sendAndAwait
-        // after a peer FIN but before the read-loop's dispatched
+        // The race is real: a caller can hit `sendAndAwait` after a
+        // peer FIN but before the read-loop's dispatched
         // `handleDisconnect` Task has entered the actor.
         guard connectedFD >= 0 else {
             throw IOSPreviewSessionError.connectionLost
         }
 
-        send(message)
-
         return try await withCheckedThrowingContinuation { cont in
+            // Register the continuation BEFORE calling `send`. If `send`
+            // detects a write failure, it invokes `handleDisconnect`
+            // synchronously on this actor turn, which iterates
+            // `pendingDataResponses` and resumes every entry with
+            // `connectionLost`. With the registration in this order, a
+            // write-failure-induced disconnect resolves THIS continuation
+            // rather than leaving it stranded for the timeout to clean up.
             pendingDataResponses[id] = cont
+            send(message)
 
             // Timeout task: if no response arrives, fail the continuation.
-            // Uses removeValue to guarantee no double-resume with processIncomingData.
+            // Uses removeValue to guarantee no double-resume with
+            // processIncomingData / handleDisconnect.
             Task { [weak self] in
                 try? await Task.sleep(for: timeout)
                 guard let self else { return }

--- a/Sources/PreviewsIOS/IOSHostChannel.swift
+++ b/Sources/PreviewsIOS/IOSHostChannel.swift
@@ -1,0 +1,357 @@
+import Darwin
+import Foundation
+import PreviewsCore
+
+/// TCP loopback transport between `IOSPreviewSession` and the iOS host
+/// app. Owns all socket state (listen FD, connected FD, read source,
+/// pending response continuations) and the line-delimited JSON protocol
+/// used to drive reload / setTraits / fetchElements / touch from the
+/// daemon side.
+///
+/// Lifecycle:
+/// 1. `bindAndListen()` creates the server socket on an ephemeral
+///    127.0.0.1 port and returns the assigned port. Caller passes the
+///    port to the launching host app.
+/// 2. `awaitConnect(timeout:)` waits up to `timeout` for the host app
+///    to connect, then starts the read loop. After this returns,
+///    `send` / `sendAndAwait` are usable.
+/// 3. `send(_:)` and `sendAndAwait(_:id:timeout:)` push messages over
+///    the socket. `sendAndAwait` registers a continuation keyed by
+///    `id` and resolves it when a response with the matching `id`
+///    arrives, or fails on timeout. The same `removeValue(forKey:)` is
+///    used by the response and timeout paths so a continuation is
+///    resumed exactly once.
+/// 4. `close()` cancels the read source, fails any outstanding
+///    continuations with `connectionLost`, and clears all FDs. Idempotent.
+///
+/// Errors thrown match the existing `IOSPreviewSessionError` cases —
+/// callers' error handling on `IOSPreviewSession.start()` etc. is
+/// preserved.
+public actor IOSHostChannel {
+    private var listenFD: Int32 = -1
+    private var connectedFD: Int32 = -1
+    private var readSource: DispatchSourceRead?
+    private var readBuffer = Data()
+    /// Data-typed continuations for Sendable compliance across task boundaries.
+    private var pendingDataResponses: [String: CheckedContinuation<Data, Error>] = [:]
+
+    public init() {}
+
+    /// Whether the channel has an established connection to the host
+    /// app. Used by callers to early-fail with `notStarted` before
+    /// invoking transport methods.
+    public var isConnected: Bool { connectedFD >= 0 }
+
+    // MARK: - Lifecycle
+
+    /// Bind a TCP server socket to 127.0.0.1 on an ephemeral port and
+    /// start listening. Returns the assigned port.
+    public func bindAndListen() throws -> Int {
+        let serverFD = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        guard serverFD >= 0 else {
+            throw IOSPreviewSessionError.socketCreateFailed
+        }
+        var reuse: Int32 = 1
+        setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size))
+
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = 0  // ephemeral
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+
+        let bindResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                Darwin.bind(serverFD, sockPtr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            Darwin.close(serverFD)
+            throw IOSPreviewSessionError.socketCreateFailed
+        }
+        guard Darwin.listen(serverFD, 1) == 0 else {
+            Darwin.close(serverFD)
+            throw IOSPreviewSessionError.socketCreateFailed
+        }
+
+        // Read the assigned port
+        var boundAddr = sockaddr_in()
+        var boundLen = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let nameResult = withUnsafeMutablePointer(to: &boundAddr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                getsockname(serverFD, sockPtr, &boundLen)
+            }
+        }
+        guard nameResult == 0 else {
+            Darwin.close(serverFD)
+            throw IOSPreviewSessionError.socketCreateFailed
+        }
+        listenFD = serverFD
+        return Int(UInt16(bigEndian: boundAddr.sin_port))
+    }
+
+    /// Wait for the host app to connect (up to `timeout`), then start
+    /// the read loop. After this returns, `send` and `sendAndAwait`
+    /// are usable.
+    public func awaitConnect(timeout: Duration) async throws {
+        try await acceptConnection(timeout: timeout)
+        setupReadLoop()
+    }
+
+    /// Cancel the read source, fail outstanding response continuations
+    /// with `connectionLost`, and close all FDs. Idempotent.
+    public func close() {
+        // Fail any pending responses
+        for (_, continuation) in pendingDataResponses {
+            continuation.resume(throwing: IOSPreviewSessionError.connectionLost)
+        }
+        pendingDataResponses.removeAll()
+
+        // Cancel read source (its cancel handler closes connectedFD)
+        if let source = readSource {
+            source.cancel()
+            readSource = nil
+        } else if connectedFD >= 0 {
+            Darwin.close(connectedFD)
+        }
+        connectedFD = -1
+
+        if listenFD >= 0 {
+            Darwin.close(listenFD)
+            listenFD = -1
+        }
+
+        readBuffer.removeAll()
+    }
+
+    // MARK: - Send
+
+    /// Send a JSON message over the socket (fire-and-forget).
+    /// Newline-delimited. No-op if not connected.
+    /// `sending` lets callers pass a `[String: Any]` literal across the
+    /// actor boundary — the channel consumes it (serializes to bytes,
+    /// drops the dict) and the caller releases its reference.
+    public func send(_ dict: sending [String: Any]) {
+        guard connectedFD >= 0,
+            var data = try? JSONSerialization.data(withJSONObject: dict)
+        else { return }
+        data.append(0x0A)  // newline delimiter
+        let fd = connectedFD
+        var writeFailed = false
+        data.withUnsafeBytes { buf in
+            guard let base = buf.baseAddress else { return }
+            var remaining = buf.count
+            var offset = 0
+            while remaining > 0 {
+                let n = Darwin.write(fd, base + offset, remaining)
+                if n <= 0 {
+                    writeFailed = true
+                    break
+                }
+                offset += n
+                remaining -= n
+            }
+        }
+        if writeFailed {
+            handleDisconnect()
+        }
+    }
+
+    /// Send a message and await a response with the matching `id`.
+    /// Races the response against `timeout`. The continuation is
+    /// registered on the actor; both the response path
+    /// (`processIncomingData`) and the timeout path use
+    /// `removeValue(forKey:)` to ensure exactly one resumption.
+    /// Send a message and await a response with the matching `id`,
+    /// returning the raw response bytes. Returns `Data` rather than a
+    /// decoded dictionary because `[String: Any]` is not `Sendable` and
+    /// crossing actor isolation would require `sending` semantics that
+    /// the response path can't provide. Callers `JSONSerialization`-decode
+    /// the returned bytes themselves.
+    public func sendAndAwait(
+        _ message: sending [String: Any], id: String, timeout: Duration
+    ) async throws -> Data {
+        // Fail eagerly if the peer has already disconnected. Without
+        // this guard, the call would register a continuation that no
+        // response can resolve and only the `timeout` would unblock it.
+        // The race is real: a test (or any caller) can call sendAndAwait
+        // after a peer FIN but before the read-loop's dispatched
+        // `handleDisconnect` Task has entered the actor.
+        guard connectedFD >= 0 else {
+            throw IOSPreviewSessionError.connectionLost
+        }
+
+        send(message)
+
+        return try await withCheckedThrowingContinuation { cont in
+            pendingDataResponses[id] = cont
+
+            // Timeout task: if no response arrives, fail the continuation.
+            // Uses removeValue to guarantee no double-resume with processIncomingData.
+            Task { [weak self] in
+                try? await Task.sleep(for: timeout)
+                guard let self else { return }
+                if let cont = await self.removePendingResponse(forKey: id) {
+                    cont.resume(throwing: IOSPreviewSessionError.socketResponseTimeout(id))
+                }
+            }
+        }
+    }
+
+    // MARK: - Internals
+
+    /// Accept an incoming connection on the listen socket.
+    private func acceptConnection(timeout: Duration) async throws {
+        try await withThrowingTaskGroup(of: Int32.self) { group in
+            group.addTask { [listenFD] in
+                // The dispatch source is owned by the continuation closure
+                // but must also be cancellable from the task-cancellation
+                // handler when the timeout task throws. Without this path,
+                // `withCheckedThrowingContinuation` ignores cancellation
+                // and Task 1 stays suspended forever on the source — the
+                // 10s timer throws, the group waits for Task 1 to
+                // terminate, and the whole acceptConnection hangs until
+                // some upstream kills the caller (see iOS CI regression
+                // where a flaky host-app connection turned into a 20-min
+                // step timeout instead of a 10s clean failure).
+                let sourceBox = DispatchSourceBox()
+                return try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation {
+                        (cont: CheckedContinuation<Int32, Error>) in
+                        let source = DispatchSource.makeReadSource(
+                            fileDescriptor: listenFD, queue: .global())
+                        sourceBox.store(source)
+                        var resumed = false
+                        source.setEventHandler {
+                            source.cancel()
+                            guard !resumed else { return }
+                            resumed = true
+                            let clientFD = Darwin.accept(listenFD, nil, nil)
+                            if clientFD >= 0 {
+                                cont.resume(returning: clientFD)
+                            } else {
+                                cont.resume(throwing: IOSPreviewSessionError.socketAcceptFailed)
+                            }
+                        }
+                        source.setCancelHandler {
+                            guard !resumed else { return }
+                            resumed = true
+                            cont.resume(throwing: IOSPreviewSessionError.socketAcceptTimeout)
+                        }
+                        source.resume()
+                    }
+                } onCancel: {
+                    sourceBox.cancel()
+                }
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                throw IOSPreviewSessionError.socketAcceptTimeout
+            }
+            let fd = try await group.next()!
+            group.cancelAll()
+            self.connectedFD = fd
+        }
+
+        // Close listen socket after successful accept — no longer needed
+        if listenFD >= 0 {
+            Darwin.close(listenFD)
+            listenFD = -1
+        }
+    }
+
+    /// Set up a read loop on the connected socket.
+    private func setupReadLoop() {
+        let fd = connectedFD
+        let source = DispatchSource.makeReadSource(fileDescriptor: fd, queue: .global())
+        source.setEventHandler { [weak self] in
+            var buf = [UInt8](repeating: 0, count: 8192)
+            let n = Darwin.read(fd, &buf, buf.count)
+            if n > 0 {
+                let data = Data(buf[0..<n])
+                if let self {
+                    Task { await self.processIncomingData(data) }
+                }
+            } else if n == 0 {
+                // EOF — host app disconnected
+                if let self {
+                    Task { await self.handleDisconnect() }
+                }
+            } else {
+                // read() error — treat as disconnect (ECONNRESET, etc.)
+                let err = errno
+                if err != EAGAIN && err != EWOULDBLOCK {
+                    if let self {
+                        Task { await self.handleDisconnect() }
+                    }
+                }
+            }
+        }
+        source.setCancelHandler {
+            Darwin.close(fd)
+        }
+        source.resume()
+        readSource = source
+    }
+
+    /// Process incoming data from the socket (actor-isolated).
+    private func processIncomingData(_ data: Data) {
+        readBuffer.append(data)
+
+        // Split on newlines and process complete messages
+        while let newlineIndex = readBuffer.firstIndex(of: 0x0A) {
+            let lineData = Data(readBuffer[readBuffer.startIndex..<newlineIndex])
+            readBuffer = Data(readBuffer[(newlineIndex + 1)...])
+
+            // Parse just enough to extract the id for routing
+            guard let message = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                let id = message["id"] as? String
+            else {
+                continue
+            }
+
+            // Resume the waiting continuation with raw Data (Sendable-safe)
+            if let continuation = pendingDataResponses.removeValue(forKey: id) {
+                continuation.resume(returning: lineData)
+            }
+        }
+    }
+
+    /// Handle host app disconnect.
+    private func handleDisconnect() {
+        connectedFD = -1
+        for (_, continuation) in pendingDataResponses {
+            continuation.resume(throwing: IOSPreviewSessionError.connectionLost)
+        }
+        pendingDataResponses.removeAll()
+    }
+
+    /// Remove and return a pending response continuation (actor-isolated, prevents double-resume).
+    private func removePendingResponse(forKey id: String) -> CheckedContinuation<Data, Error>? {
+        pendingDataResponses.removeValue(forKey: id)
+    }
+}
+
+/// Thread-safe holder for a `DispatchSourceRead` that needs to be
+/// cancelled from outside the continuation that owns it. Used by
+/// `acceptConnection` to bridge task-cancellation into dispatch-source
+/// lifecycle — DispatchSource is not Sendable, so a plain closure
+/// capture won't compile under Swift 6 strict concurrency.
+private final class DispatchSourceBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var source: DispatchSourceRead?
+
+    func store(_ s: DispatchSourceRead) {
+        lock.lock()
+        defer { lock.unlock() }
+        source = s
+    }
+
+    func cancel() {
+        lock.lock()
+        let s = source
+        source = nil
+        lock.unlock()
+        s?.cancel()
+    }
+}

--- a/Sources/PreviewsIOS/IOSPreviewSession.swift
+++ b/Sources/PreviewsIOS/IOSPreviewSession.swift
@@ -27,13 +27,10 @@ public actor IOSPreviewSession {
     private let setupDylibPath: URL?
     public var currentTraits: PreviewTraits { traits }
 
-    // TCP socket state
-    private var listenFD: Int32 = -1
-    private var connectedFD: Int32 = -1
-    private var readSource: DispatchSourceRead?
-    private var readBuffer = Data()
-    // Data-typed continuations for Sendable compliance across task boundaries
-    private var pendingDataResponses: [String: CheckedContinuation<Data, Error>] = [:]
+    /// Transport to the iOS host app. Owns all socket state — bind,
+    /// accept, line-delimited JSON send/receive, lifecycle. Constructed
+    /// per-session and torn down by `stop()`.
+    private let channel = IOSHostChannel()
 
     public static let hostBundleID = "com.previewsmcp.host"
 
@@ -108,47 +105,7 @@ public actor IOSPreviewSession {
         stage("host app ready")
 
         // 4. Create TCP server on loopback, bind to ephemeral port
-        let serverFD = Darwin.socket(AF_INET, SOCK_STREAM, 0)
-        guard serverFD >= 0 else {
-            throw IOSPreviewSessionError.socketCreateFailed
-        }
-        var reuse: Int32 = 1
-        setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size))
-
-        var addr = sockaddr_in()
-        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
-        addr.sin_family = sa_family_t(AF_INET)
-        addr.sin_port = 0  // ephemeral
-        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
-
-        let bindResult = withUnsafePointer(to: &addr) { ptr in
-            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
-                Darwin.bind(serverFD, sockPtr, socklen_t(MemoryLayout<sockaddr_in>.size))
-            }
-        }
-        guard bindResult == 0 else {
-            Darwin.close(serverFD)
-            throw IOSPreviewSessionError.socketCreateFailed
-        }
-        guard Darwin.listen(serverFD, 1) == 0 else {
-            Darwin.close(serverFD)
-            throw IOSPreviewSessionError.socketCreateFailed
-        }
-
-        // Read the assigned port
-        var boundAddr = sockaddr_in()
-        var boundLen = socklen_t(MemoryLayout<sockaddr_in>.size)
-        let nameResult = withUnsafeMutablePointer(to: &boundAddr) { ptr in
-            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
-                getsockname(serverFD, sockPtr, &boundLen)
-            }
-        }
-        guard nameResult == 0 else {
-            Darwin.close(serverFD)
-            throw IOSPreviewSessionError.socketCreateFailed
-        }
-        let port = Int(UInt16(bigEndian: boundAddr.sin_port))
-        listenFD = serverFD
+        let port = try await channel.bindAndListen()
 
         // 5. Boot + install + launch with retry. The whole sequence is
         // retried because PR #141 CI has shown the iOS simulator
@@ -231,36 +188,16 @@ public actor IOSPreviewSession {
         // 6. Accept connection from host app (up to 10 seconds)
         stage("launched pid=\(pid); awaiting socket connection")
         await progress?.report(.connectingToApp, message: "Waiting for host app connection...")
-        try await acceptConnection(timeout: .seconds(10))
-        setupReadLoop()
+        try await channel.awaitConnect(timeout: .seconds(10))
         stage("connected; start complete")
 
         return pid
     }
 
-    /// Close the socket connection and clean up resources.
-    public func stop() {
-        // Fail any pending responses
-        for (_, continuation) in pendingDataResponses {
-            continuation.resume(throwing: IOSPreviewSessionError.connectionLost)
-        }
-        pendingDataResponses.removeAll()
-
-        // Cancel read source (its cancel handler closes connectedFD)
-        if let source = readSource {
-            source.cancel()
-            readSource = nil
-        } else if connectedFD >= 0 {
-            Darwin.close(connectedFD)
-        }
-        connectedFD = -1
-
-        if listenFD >= 0 {
-            Darwin.close(listenFD)
-            listenFD = -1
-        }
-
-        readBuffer.removeAll()
+    /// Close the socket connection and clean up resources. Idempotent —
+    /// `IOSHostChannel.close()` is safe to call when nothing was opened.
+    public func stop() async {
+        await channel.close()
     }
 
     // MARK: - Communication
@@ -268,7 +205,7 @@ public actor IOSPreviewSession {
     /// Recompile the preview and signal the host app to reload via socket.
     /// Waits for reloadAck to ensure SwiftUI environment has propagated.
     public func reload() async throws {
-        guard connectedFD >= 0 else {
+        guard await channel.isConnected else {
             throw IOSPreviewSessionError.notStarted
         }
 
@@ -287,7 +224,7 @@ public actor IOSPreviewSession {
         let compileResult = try await previewSession.compile()
 
         let requestID = UUID().uuidString
-        _ = try await sendAndAwait(
+        _ = try await channel.sendAndAwait(
             ["type": "reload", "id": requestID, "dylibPath": compileResult.dylibPath.path],
             id: requestID,
             timeout: .seconds(5)
@@ -298,7 +235,7 @@ public actor IOSPreviewSession {
     /// falls back to full recompile if structural changes are detected.
     @discardableResult
     public func handleSourceChange() async throws -> Bool {
-        guard connectedFD >= 0 else {
+        guard await channel.isConnected else {
             throw IOSPreviewSessionError.notStarted
         }
 
@@ -327,7 +264,7 @@ public actor IOSPreviewSession {
                 }
                 return entry
             }
-            sendMessage(["type": "literals", "changes": json])
+            await channel.send(["type": "literals", "changes": json])
             return true
         }
 
@@ -369,7 +306,7 @@ public actor IOSPreviewSession {
 
     /// Send a tap at the given point coordinates (in device points).
     public func sendTap(x: Double, y: Double) async throws {
-        sendMessage(["type": "touch", "action": "tap", "x": x, "y": y])
+        await channel.send(["type": "touch", "action": "tap", "x": x, "y": y])
         try await Task.sleep(for: .milliseconds(250))
     }
 
@@ -380,7 +317,7 @@ public actor IOSPreviewSession {
         duration: Double = 0.3,
         steps: Int = 10
     ) async throws {
-        sendMessage([
+        await channel.send([
             "type": "touch",
             "action": "swipe",
             "fromX": fromX, "fromY": fromY,
@@ -393,18 +330,20 @@ public actor IOSPreviewSession {
     /// Fetch the accessibility tree from the running preview.
     /// - Parameter filter: Filter mode: "all" (default), "interactable", or "labeled"
     public func fetchElements(filter: String = "all") async throws -> String {
-        guard connectedFD >= 0 else {
+        guard await channel.isConnected else {
             throw IOSPreviewSessionError.notStarted
         }
 
         let requestID = UUID().uuidString
-        let response = try await sendAndAwait(
+        let responseData = try await channel.sendAndAwait(
             ["type": "elements", "id": requestID, "filter": filter],
             id: requestID,
             timeout: .seconds(3)
         )
 
-        guard let tree = response["tree"] as? [String: Any] else {
+        guard let response = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any],
+            let tree = response["tree"] as? [String: Any]
+        else {
             throw IOSPreviewSessionError.socketResponseTimeout("elementsResponse")
         }
 
@@ -423,195 +362,6 @@ public actor IOSPreviewSession {
     /// Capture a screenshot of the simulator.
     public func screenshot(jpegQuality: Double = 0.85) async throws -> Data {
         return try await simulatorManager.screenshotData(udid: deviceUDID, jpegQuality: jpegQuality)
-    }
-
-    // MARK: - Socket internals
-
-    /// Accept an incoming connection on the listen socket.
-    private func acceptConnection(timeout: Duration) async throws {
-        try await withThrowingTaskGroup(of: Int32.self) { group in
-            group.addTask { [listenFD] in
-                // The dispatch source is owned by the continuation closure
-                // but must also be cancellable from the task-cancellation
-                // handler when the timeout task throws. Without this path,
-                // `withCheckedThrowingContinuation` ignores cancellation
-                // and Task 1 stays suspended forever on the source — the
-                // 10s timer throws, the group waits for Task 1 to
-                // terminate, and the whole acceptConnection hangs until
-                // some upstream kills the caller (see iOS CI regression
-                // where a flaky host-app connection turned into a 20-min
-                // step timeout instead of a 10s clean failure).
-                let sourceBox = DispatchSourceBox()
-                return try await withTaskCancellationHandler {
-                    try await withCheckedThrowingContinuation {
-                        (cont: CheckedContinuation<Int32, Error>) in
-                        let source = DispatchSource.makeReadSource(
-                            fileDescriptor: listenFD, queue: .global())
-                        sourceBox.store(source)
-                        var resumed = false
-                        source.setEventHandler {
-                            source.cancel()
-                            guard !resumed else { return }
-                            resumed = true
-                            let clientFD = Darwin.accept(listenFD, nil, nil)
-                            if clientFD >= 0 {
-                                cont.resume(returning: clientFD)
-                            } else {
-                                cont.resume(throwing: IOSPreviewSessionError.socketAcceptFailed)
-                            }
-                        }
-                        source.setCancelHandler {
-                            guard !resumed else { return }
-                            resumed = true
-                            cont.resume(throwing: IOSPreviewSessionError.socketAcceptTimeout)
-                        }
-                        source.resume()
-                    }
-                } onCancel: {
-                    sourceBox.cancel()
-                }
-            }
-            group.addTask {
-                try await Task.sleep(for: timeout)
-                throw IOSPreviewSessionError.socketAcceptTimeout
-            }
-            let fd = try await group.next()!
-            group.cancelAll()
-            self.connectedFD = fd
-        }
-
-        // Close listen socket after successful accept — no longer needed
-        if listenFD >= 0 {
-            Darwin.close(listenFD)
-            listenFD = -1
-        }
-    }
-
-    /// Set up a read loop on the connected socket.
-    private func setupReadLoop() {
-        let fd = connectedFD
-        let source = DispatchSource.makeReadSource(fileDescriptor: fd, queue: .global())
-        source.setEventHandler { [weak self] in
-            var buf = [UInt8](repeating: 0, count: 8192)
-            let n = Darwin.read(fd, &buf, buf.count)
-            if n > 0 {
-                let data = Data(buf[0..<n])
-                if let self {
-                    Task { await self.processIncomingData(data) }
-                }
-            } else if n == 0 {
-                // EOF — host app disconnected
-                if let self {
-                    Task { await self.handleDisconnect() }
-                }
-            } else {
-                // read() error — treat as disconnect (ECONNRESET, etc.)
-                let err = errno
-                if err != EAGAIN && err != EWOULDBLOCK {
-                    if let self {
-                        Task { await self.handleDisconnect() }
-                    }
-                }
-            }
-        }
-        source.setCancelHandler {
-            Darwin.close(fd)
-        }
-        source.resume()
-        readSource = source
-    }
-
-    /// Process incoming data from the socket (actor-isolated).
-    private func processIncomingData(_ data: Data) {
-        readBuffer.append(data)
-
-        // Split on newlines and process complete messages
-        while let newlineIndex = readBuffer.firstIndex(of: 0x0A) {
-            let lineData = Data(readBuffer[readBuffer.startIndex..<newlineIndex])
-            readBuffer = Data(readBuffer[(newlineIndex + 1)...])
-
-            // Parse just enough to extract the id for routing
-            guard let message = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
-                let id = message["id"] as? String
-            else {
-                continue
-            }
-
-            // Resume the waiting continuation with raw Data (Sendable-safe)
-            if let continuation = pendingDataResponses.removeValue(forKey: id) {
-                continuation.resume(returning: lineData)
-            }
-        }
-    }
-
-    /// Handle host app disconnect.
-    private func handleDisconnect() {
-        connectedFD = -1
-        for (_, continuation) in pendingDataResponses {
-            continuation.resume(throwing: IOSPreviewSessionError.connectionLost)
-        }
-        pendingDataResponses.removeAll()
-    }
-
-    /// Send a JSON message over the socket (fire-and-forget).
-    private func sendMessage(_ dict: [String: Any]) {
-        guard connectedFD >= 0,
-            var data = try? JSONSerialization.data(withJSONObject: dict)
-        else { return }
-        data.append(0x0A)  // newline delimiter
-        let fd = connectedFD
-        var writeFailed = false
-        data.withUnsafeBytes { buf in
-            guard let base = buf.baseAddress else { return }
-            var remaining = buf.count
-            var offset = 0
-            while remaining > 0 {
-                let n = Darwin.write(fd, base + offset, remaining)
-                if n <= 0 {
-                    writeFailed = true
-                    break
-                }
-                offset += n
-                remaining -= n
-            }
-        }
-        if writeFailed {
-            handleDisconnect()
-        }
-    }
-
-    /// Send a message and await a response with the matching id.
-    /// Races the response against a timeout. The continuation is registered on the actor,
-    /// and both the response path (processIncomingData) and the timeout path use
-    /// removeValue(forKey:) to ensure exactly one resumption.
-    private func sendAndAwait(
-        _ message: [String: Any], id: String, timeout: Duration
-    ) async throws -> [String: Any] {
-        sendMessage(message)
-
-        let responseData: Data = try await withCheckedThrowingContinuation { cont in
-            pendingDataResponses[id] = cont
-
-            // Timeout task: if no response arrives, fail the continuation.
-            // Uses removeValue to guarantee no double-resume with processIncomingData.
-            Task { [weak self] in
-                try? await Task.sleep(for: timeout)
-                guard let self else { return }
-                if let cont = await self.removePendingResponse(forKey: id) {
-                    cont.resume(throwing: IOSPreviewSessionError.socketResponseTimeout(id))
-                }
-            }
-        }
-
-        guard let dict = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
-            throw IOSPreviewSessionError.socketResponseTimeout(id)
-        }
-        return dict
-    }
-
-    /// Remove and return a pending response continuation (actor-isolated, prevents double-resume).
-    private func removePendingResponse(forKey id: String) -> CheckedContinuation<Data, Error>? {
-        pendingDataResponses.removeValue(forKey: id)
     }
 
     // MARK: - Accessibility tree filtering
@@ -672,28 +422,4 @@ public enum IOSPreviewSessionError: Error, LocalizedError, CustomStringConvertib
     }
 
     public var errorDescription: String? { description }
-}
-
-/// Thread-safe holder for a `DispatchSourceRead` that needs to be
-/// cancelled from outside the continuation that owns it. Used by
-/// `acceptConnection` to bridge task-cancellation into dispatch-source
-/// lifecycle — DispatchSource is not Sendable, so a plain closure
-/// capture won't compile under Swift 6 strict concurrency.
-private final class DispatchSourceBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var source: DispatchSourceRead?
-
-    func store(_ s: DispatchSourceRead) {
-        lock.lock()
-        defer { lock.unlock() }
-        source = s
-    }
-
-    func cancel() {
-        lock.lock()
-        let s = source
-        source = nil
-        lock.unlock()
-        s?.cancel()
-    }
 }

--- a/Tests/PreviewsIOSTests/IOSHostChannelTests.swift
+++ b/Tests/PreviewsIOSTests/IOSHostChannelTests.swift
@@ -73,7 +73,9 @@ struct IOSHostChannelTests {
                 timeout: .seconds(10)
             )
         }
-        try await Task.sleep(for: .milliseconds(50))
+        // 200ms is more than enough on local but adds CI cushion — a busy
+        // GHA agent can take >50ms to schedule the actor entry.
+        try await Task.sleep(for: .milliseconds(200))
 
         let start = Date()
         Darwin.close(clientFD)

--- a/Tests/PreviewsIOSTests/IOSHostChannelTests.swift
+++ b/Tests/PreviewsIOSTests/IOSHostChannelTests.swift
@@ -1,0 +1,160 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import PreviewsIOS
+
+/// Race-tests for the iOS host-app socket channel. The most error-prone
+/// piece of the original `IOSPreviewSession` socket layer was the
+/// accept/disconnect cleanup: a peer that connects and immediately
+/// closes can leave `pendingDataResponses` continuations dangling, leak
+/// the `DispatchSourceRead`, or double-resume a continuation. These
+/// tests exercise that path without spinning up a real iOS simulator.
+@Suite("IOSHostChannel")
+struct IOSHostChannelTests {
+
+    @Test("sendAndAwait after peer disconnect fails fast with connectionLost")
+    func disconnectBeforeSendFailsFast() async throws {
+        let channel = IOSHostChannel()
+        defer { Task { await channel.close() } }
+
+        let port = try await channel.bindAndListen()
+        async let connect: Void = channel.awaitConnect(timeout: .seconds(5))
+        let clientFD = try connectClient(port: port)
+        try await connect
+
+        Darwin.close(clientFD)
+
+        // Wait up to 1s for the read loop to observe EOF.
+        let deadline = Date().addingTimeInterval(1.0)
+        while Date() < deadline, await channel.isConnected {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(!(await channel.isConnected), "channel should observe disconnect within 1s")
+
+        // The early-check in `sendAndAwait` must catch the disconnected
+        // state and fail without registering a continuation that only
+        // the timeout could resolve.
+        let start = Date()
+        do {
+            _ = try await channel.sendAndAwait(
+                ["type": "ping", "id": "x"],
+                id: "x",
+                timeout: .seconds(5)
+            )
+            Issue.record("expected sendAndAwait to throw connectionLost")
+        } catch IOSPreviewSessionError.connectionLost {
+            // expected
+        } catch {
+            Issue.record("expected connectionLost, got \(error)")
+        }
+        let elapsed = Date().timeIntervalSince(start)
+        #expect(elapsed < 1.0, "disconnect-before-send should fail in well under the 5s timeout")
+    }
+
+    @Test("pending sendAndAwait fails with connectionLost when peer disconnects mid-flight")
+    func pendingFailsOnDisconnect() async throws {
+        let channel = IOSHostChannel()
+        defer { Task { await channel.close() } }
+
+        let port = try await channel.bindAndListen()
+        async let connect: Void = channel.awaitConnect(timeout: .seconds(5))
+        let clientFD = try connectClient(port: port)
+        try await connect
+
+        // Issue sendAndAwait in a background task with a long timeout.
+        // Give the channel a moment to register the continuation, then
+        // disconnect. The pending continuation must be resumed with
+        // `connectionLost` via `handleDisconnect` — NOT via the timeout.
+        let pending = Task {
+            try await channel.sendAndAwait(
+                ["type": "ping", "id": "x"],
+                id: "x",
+                timeout: .seconds(10)
+            )
+        }
+        try await Task.sleep(for: .milliseconds(50))
+
+        let start = Date()
+        Darwin.close(clientFD)
+
+        do {
+            _ = try await pending.value
+            Issue.record("expected pending sendAndAwait to throw connectionLost")
+        } catch IOSPreviewSessionError.connectionLost {
+            // expected
+        } catch {
+            Issue.record("expected connectionLost, got \(error)")
+        }
+        let elapsed = Date().timeIntervalSince(start)
+        #expect(elapsed < 2.0, "pending continuation should be failed by disconnect well before the 10s timeout")
+    }
+
+    @Test("close() is idempotent after a successful connect")
+    func closeIsIdempotent() async throws {
+        let channel = IOSHostChannel()
+        let port = try await channel.bindAndListen()
+        async let connect: Void = channel.awaitConnect(timeout: .seconds(5))
+        let clientFD = try connectClient(port: port)
+        try await connect
+
+        Darwin.close(clientFD)
+
+        // Two close() calls in succession must not crash, double-cancel
+        // the read source, or double-close any FD.
+        await channel.close()
+        await channel.close()
+
+        let isConnected = await channel.isConnected
+        #expect(!isConnected)
+    }
+
+    @Test("close() before any connect succeeds")
+    func closeBeforeConnect() async throws {
+        let channel = IOSHostChannel()
+        _ = try await channel.bindAndListen()
+        await channel.close()
+        // Second close() with everything already torn down must be a no-op.
+        await channel.close()
+
+        let isConnected = await channel.isConnected
+        #expect(!isConnected)
+    }
+
+    @Test("close() before bindAndListen is a no-op")
+    func closeWithoutBind() async {
+        let channel = IOSHostChannel()
+        await channel.close()
+        let isConnected = await channel.isConnected
+        #expect(!isConnected)
+    }
+
+    // MARK: - Helpers
+
+    /// Connect a TCP client socket to 127.0.0.1:port. Returns the
+    /// client-side FD so the test can simulate a disconnect by closing
+    /// it. Caller owns the FD.
+    private func connectClient(port: Int) throws -> Int32 {
+        let fd = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw IOSPreviewSessionError.socketCreateFailed
+        }
+
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = UInt16(port).bigEndian
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+
+        let result = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                Darwin.connect(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard result == 0 else {
+            Darwin.close(fd)
+            throw IOSPreviewSessionError.socketAcceptFailed
+        }
+        return fd
+    }
+}


### PR DESCRIPTION
## Summary

Step #3 of the architectural-refactor roadmap. \`IOSPreviewSession.swift\` previously mixed four concerns: orchestration, raw BSD socket plumbing, JSON request/response routing, and SwiftUI-domain operations. Pull the socket layer into a dedicated \`IOSHostChannel\` actor so the session is pure orchestration.

### Changes

- New \`Sources/PreviewsIOS/IOSHostChannel.swift\` (347 lines) — public actor owning \`listenFD\` / \`connectedFD\` / \`readSource\` / \`readBuffer\` / \`pendingDataResponses\`. Exposes \`bindAndListen() -> Int\`, \`awaitConnect(timeout:)\`, \`send(_:)\`, \`sendAndAwait(_:id:timeout:) -> Data\`, \`close()\`, \`isConnected\`.
- \`Sources/PreviewsIOS/IOSPreviewSession.swift\`: 699 → 426 lines (-273). Holds a single \`private let channel = IOSHostChannel()\` instead of five socket-state properties. No longer imports \`Darwin\` for socket APIs (acceptance criterion met). \`stop()\` becomes \`async\` — the only caller, \`IOSPreviewHandle.stop()\`, already awaits it.
- New \`Tests/PreviewsIOSTests/IOSHostChannelTests.swift\` (5 tests, all use real loopback socket pairs).

### API shape changes for the channel

- \`send(_:)\` takes \`sending [String: Any]\` so callers can pass dict literals across actor isolation without Swift 6 Sendable errors. The channel consumes the dict (serializes, drops the reference).
- \`sendAndAwait(_:id:timeout:)\` returns raw \`Data\` (was \`[String: Any]\`) for the same reason. \`IOSPreviewSession.fetchElements\` decodes the bytes itself.
- New upfront \`connectedFD >= 0\` check in \`sendAndAwait\` fails fast with \`connectionLost\` when the peer has already disconnected — without it, the call registers a continuation only the timeout can resolve. The race is real: \`handleDisconnect\` runs on a dispatched \`Task\` and may not have entered the actor yet when a caller hits \`sendAndAwait\`.

### Race-test coverage

The plan flagged the accept/disconnect cleanup at the original \`IOSPreviewSession.swift:428-522\` as the most error-prone bit of the move. New tests exercise it with no simulator dependency:

- \`sendAndAwait after peer disconnect fails fast with connectionLost\` — early-check path, asserts < 1s elapsed (well under 5s timeout).
- \`pending sendAndAwait fails with connectionLost when peer disconnects mid-flight\` — \`handleDisconnect\` resumes-with-error path, asserts < 2s elapsed (well under 10s timeout).
- \`close() is idempotent after a successful connect\` — second \`close()\` must not double-cancel the read source or double-close any FD.
- \`close() before any connect succeeds\` — close() with everything torn down.
- \`close() before bindAndListen is a no-op\`.

### Optional follow-up

The plan flagged porting \`IOSHostChannel\` from BSD sockets to \`NWConnection\` so the project has one networking abstraction (\`DaemonClient\` already uses NWConnection). Out of scope for this PR — revisit if any host-app protocol changes warrant it.

## Test plan

- [x] \`swift build\` clean
- [x] \`swift-format format --in-place\` + \`swift-format lint --strict\` clean
- [x] \`swift test --filter IOSHostChannelTests\` — 5 race tests pass (21ms / 51ms timings reflect actual disconnect-observation latency)
- [x] \`swift test --filter PreviewsIOSTests\` — 14 tests including E2E (compile/boot/install/launch/screenshot)
- [x] \`swift test --filter IOSMCPTests\` — 2 tests including full iOS workflow (touch, swipe, elements, switch)
- [x] \`swift test --filter MacOSMCPTests\` — 7 tests, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)