### PR TITLE
Cross-process session registry: session_list returns the union

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -80,6 +80,10 @@ let package = Package(
             dependencies: ["PreviewsIOS"]
         ),
         .testTarget(
+            name: "PreviewsEngineTests",
+            dependencies: ["PreviewsEngine"]
+        ),
+        .testTarget(
             name: "CLIIntegrationTests",
             dependencies: []
         ),

--- a/Sources/PreviewsCLI/DaemonListener.swift
+++ b/Sources/PreviewsCLI/DaemonListener.swift
@@ -32,6 +32,12 @@ enum DaemonListener {
         let sharedCompiler = try await Compiler()
         let iosManager = IOSSessionManager()
         let configCache = ConfigCache()
+        // Cross-process session registry. Constructed once and attached
+        // here (not per-connection) so the publish-on-mutation hooks on
+        // the iOS manager and macOS host are wired exactly once. See
+        // architectural plan #6b.
+        let registry = SessionRegistry(registryDir: DaemonPaths.sessionsDirectory)
+        await registry.attachTo(iosManager: iosManager, previewHost: host)
 
         let params = NWParameters.tcp
         params.requiredLocalEndpoint = NWEndpoint.unix(path: DaemonPaths.socket.path)
@@ -43,7 +49,8 @@ enum DaemonListener {
             Task {
                 await handleConnection(
                     connection, compiler: sharedCompiler,
-                    host: host, iosManager: iosManager, configCache: configCache
+                    host: host, iosManager: iosManager, configCache: configCache,
+                    registry: registry
                 )
             }
         }
@@ -74,13 +81,15 @@ enum DaemonListener {
     /// sharing the given compiler and module-level state with other connections.
     private static func handleConnection(
         _ connection: NWConnection, compiler: Compiler,
-        host: PreviewHost, iosManager: IOSSessionManager, configCache: ConfigCache
+        host: PreviewHost, iosManager: IOSSessionManager, configCache: ConfigCache,
+        registry: SessionRegistry
     ) async {
         do {
             let transport = NetworkTransport(connection: connection)
             let (server, _) = try await configureMCPServer(
                 host: host, iosManager: iosManager,
-                configCache: configCache, sharedCompiler: compiler
+                configCache: configCache, registry: registry,
+                sharedCompiler: compiler
             )
             try await runMCPServer(server, transport: transport)
             // `runMCPServer` returns when the transport closes (client disconnected).

--- a/Sources/PreviewsCLI/DaemonPaths.swift
+++ b/Sources/PreviewsCLI/DaemonPaths.swift
@@ -45,6 +45,15 @@ enum DaemonPaths {
         directory.appendingPathComponent("restart.lock")
     }
 
+    /// Cross-process session registry directory. Each running
+    /// PreviewsMCP process (stdio MCP server, UDS daemon) writes a
+    /// `<pid>.json` file here describing its current session set so
+    /// `session_list` from any process can return the union. See
+    /// `SessionRegistry`.
+    static var sessionsDirectory: URL {
+        directory.appendingPathComponent("sessions", isDirectory: true)
+    }
+
     /// Ensure the directory exists with owner-only permissions.
     static func ensureDirectory() throws {
         try FileManager.default.createDirectory(

--- a/Sources/PreviewsCLI/Handlers/HandlerContext.swift
+++ b/Sources/PreviewsCLI/Handlers/HandlerContext.swift
@@ -15,6 +15,7 @@ struct HandlerContext: Sendable {
     let iosState: IOSSessionManager
     let configCache: ConfigCache
     let router: SessionRouter
+    let registry: SessionRegistry
     let macCompiler: Compiler
     let server: Server
 }

--- a/Sources/PreviewsCLI/Handlers/SessionListHandler.swift
+++ b/Sources/PreviewsCLI/Handlers/SessionListHandler.swift
@@ -1,4 +1,5 @@
 import MCP
+import PreviewsEngine
 
 enum SessionListHandler: ToolHandler {
     static let name: ToolName = .sessionList
@@ -13,9 +14,18 @@ enum SessionListHandler: ToolHandler {
         ])
     )
 
-    /// List all active sessions (iOS + macOS). Output is one line per session in
-    /// the format `<sessionID>\t<platform>\t<sourceFilePath>` — tab-delimited for
-    /// simple client-side parsing. Empty result when no sessions are active.
+    /// List all active sessions (iOS + macOS) across every running
+    /// PreviewsMCP process. Output is one line per session in the
+    /// format `<sessionID>\t<platform>\t<sourceFilePath>` — tab-delimited
+    /// for simple client-side parsing. Empty result when no sessions
+    /// are active anywhere.
+    ///
+    /// The local in-memory state covers sessions THIS process owns;
+    /// `SessionRegistry.readOthers()` covers sessions owned by peer
+    /// processes (typically: stdio MCP server vs UDS daemon — each
+    /// holds its own session pool, but `session_list` from either
+    /// returns the union). See `SessionRegistry` and the architectural
+    /// plan's #6b for context.
     static func handle(
         _ params: CallTool.Parameters,
         ctx: HandlerContext
@@ -41,6 +51,20 @@ enum SessionListHandler: ToolHandler {
                     sessionID: id,
                     platform: "macos",
                     sourceFilePath: session.sourceFile.path
+                )
+            )
+        }
+
+        // Merge in sessions published by peer processes via the
+        // cross-process registry. Stale-PID filtering and lazy
+        // file cleanup happen inside `readOthers()`.
+        let peerEntries = await ctx.registry.readOthers()
+        for entry in peerEntries {
+            sessions.append(
+                DaemonProtocol.SessionDTO(
+                    sessionID: entry.sessionID,
+                    platform: entry.platform,
+                    sourceFilePath: entry.sourceFilePath
                 )
             )
         }

--- a/Sources/PreviewsCLI/Handlers/SessionListHandler.swift
+++ b/Sources/PreviewsCLI/Handlers/SessionListHandler.swift
@@ -69,6 +69,15 @@ enum SessionListHandler: ToolHandler {
             )
         }
 
+        // De-dup by sessionID. Local + registry can theoretically both
+        // surface the same ID — local always wins because it's appended
+        // first and the second-pass insert preserves the first occurrence.
+        // Session IDs are UUIDs and shouldn't collide across processes,
+        // but a daemon-restart-with-handoff path or a copy-paste bug
+        // could break that, and the cost of guarding is one Dictionary.
+        var seen: Set<String> = []
+        sessions = sessions.filter { seen.insert($0.sessionID).inserted }
+
         // Stable ordering so clients parsing the output get consistent results.
         sessions.sort { $0.sessionID < $1.sessionID }
         let lines = sessions.map { "\($0.sessionID)\t\($0.platform)\t\($0.sourceFilePath)" }

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -1,3 +1,4 @@
+import Foundation
 import MCP
 import PreviewsCore
 import PreviewsEngine
@@ -61,11 +62,34 @@ func configureMCPServer(
     )
 
     let router = SessionRouter(host: previewHost, iosManager: iosManager)
+
+    // Cross-process session registry. Each PreviewsMCP process (stdio
+    // MCP server, UDS daemon) publishes its session set to a per-PID
+    // file under `~/.previewsmcp/sessions/`; `SessionListHandler`
+    // returns the union of local + peer sessions so a `session_list`
+    // call from either mouth sees everything (see #6b in the
+    // architectural plan).
+    let registry = SessionRegistry(registryDir: DaemonPaths.sessionsDirectory)
+    await iosManager.setRegistry(registry)
+    await MainActor.run {
+        previewHost.onSessionsChanged = { [weak previewHost] in
+            guard let previewHost else { return }
+            let snapshot: [(String, URL)] = previewHost.allSessions.map {
+                ($0.key, $0.value.sourceFile)
+            }
+            Task { await registry.publishMacOSSessions(snapshot) }
+        }
+        // Trigger an initial publish so a registry attached after
+        // sessions exist (e.g., daemon reconfiguration) doesn't lose them.
+        previewHost.onSessionsChanged?()
+    }
+
     let ctx = HandlerContext(
         host: previewHost,
         iosState: iosManager,
         configCache: cache,
         router: router,
+        registry: registry,
         macCompiler: compiler,
         server: server
     )

--- a/Sources/PreviewsCLI/MCPServer.swift
+++ b/Sources/PreviewsCLI/MCPServer.swift
@@ -35,6 +35,12 @@ func mcpToolSchemas() -> [Tool] {
 
 /// Configures and returns an MCP server with preview tools.
 ///
+/// - Parameter registry: The cross-process session registry. Must be
+///   attached to `previewHost` and `iosManager` already (call
+///   `await registry.attachTo(iosManager:previewHost:)` once at host
+///   construction time, BEFORE invoking this function — daemon mode
+///   calls `configureMCPServer` per-connection and we don't want to
+///   re-attach on every accept).
 /// - Parameter sharedCompiler: Pass a pre-built `Compiler` to reuse across
 ///   multiple server instances (e.g., daemon mode, where each accepted client
 ///   connection gets its own `Server` but they all share one compiler). When
@@ -44,6 +50,7 @@ func configureMCPServer(
     host previewHost: PreviewHost,
     iosManager: IOSSessionManager,
     configCache cache: ConfigCache,
+    registry: SessionRegistry,
     sharedCompiler: Compiler? = nil
 ) async throws -> (Server, Compiler) {
     cleanupStaleTempDirs()
@@ -62,27 +69,6 @@ func configureMCPServer(
     )
 
     let router = SessionRouter(host: previewHost, iosManager: iosManager)
-
-    // Cross-process session registry. Each PreviewsMCP process (stdio
-    // MCP server, UDS daemon) publishes its session set to a per-PID
-    // file under `~/.previewsmcp/sessions/`; `SessionListHandler`
-    // returns the union of local + peer sessions so a `session_list`
-    // call from either mouth sees everything (see #6b in the
-    // architectural plan).
-    let registry = SessionRegistry(registryDir: DaemonPaths.sessionsDirectory)
-    await iosManager.setRegistry(registry)
-    await MainActor.run {
-        previewHost.onSessionsChanged = { [weak previewHost] in
-            guard let previewHost else { return }
-            let snapshot: [(String, URL)] = previewHost.allSessions.map {
-                ($0.key, $0.value.sourceFile)
-            }
-            Task { await registry.publishMacOSSessions(snapshot) }
-        }
-        // Trigger an initial publish so a registry attached after
-        // sessions exist (e.g., daemon reconfiguration) doesn't lose them.
-        previewHost.onSessionsChanged?()
-    }
 
     let ctx = HandlerContext(
         host: previewHost,

--- a/Sources/PreviewsCLI/ServeCommand.swift
+++ b/Sources/PreviewsCLI/ServeCommand.swift
@@ -60,9 +60,16 @@ struct ServeCommand: ParsableCommand {
         Task { @MainActor in
             let host = Self.sharedHost!
             do {
+                // One iosManager / configCache / registry per stdio process.
+                // Attach the registry here so its publish-on-mutation hooks
+                // are wired before any tool call can create a session.
+                try DaemonPaths.ensureDirectory()
+                let iosManager = IOSSessionManager()
+                let registry = SessionRegistry(registryDir: DaemonPaths.sessionsDirectory)
+                await registry.attachTo(iosManager: iosManager, previewHost: host)
                 let (server, _) = try await configureMCPServer(
-                    host: host, iosManager: IOSSessionManager(),
-                    configCache: ConfigCache()
+                    host: host, iosManager: iosManager,
+                    configCache: ConfigCache(), registry: registry
                 )
                 let startISO = ISO8601DateFormatter().string(from: ProcessStartup.time)
                 Log.info(

--- a/Sources/PreviewsEngine/IOSSessionManager.swift
+++ b/Sources/PreviewsEngine/IOSSessionManager.swift
@@ -11,8 +11,20 @@ public actor IOSSessionManager {
     private var hostBuilder: IOSHostBuilder?
     private var sessions: [String: IOSPreviewSession] = [:]
     private var fileWatchers: [String: FileWatcher] = [:]
+    /// Cross-process session registry. When attached, every mutation
+    /// republishes the current iOS session set so peer processes see
+    /// our sessions in their `session_list` output.
+    private var registry: SessionRegistry?
 
     public init() {}
+
+    /// Attach a `SessionRegistry` so this manager publishes its iOS
+    /// session set on every mutation. Idempotent — replacing the
+    /// registry republishes against the new one.
+    public func setRegistry(_ registry: SessionRegistry) async {
+        self.registry = registry
+        await republish()
+    }
 
     public func getCompiler() async throws -> Compiler {
         if let c = compiler { return c }
@@ -28,18 +40,20 @@ public actor IOSSessionManager {
         return b
     }
 
-    public func addSession(_ session: IOSPreviewSession) {
+    public func addSession(_ session: IOSPreviewSession) async {
         sessions[session.id] = session
+        await republish()
     }
 
     public func getSession(_ id: String) -> IOSPreviewSession? {
         sessions[id]
     }
 
-    public func removeSession(_ id: String) {
+    public func removeSession(_ id: String) async {
         sessions.removeValue(forKey: id)
         fileWatchers[id]?.stop()
         fileWatchers.removeValue(forKey: id)
+        await republish()
     }
 
     public func setFileWatcher(_ id: String, _ watcher: FileWatcher) {
@@ -52,5 +66,11 @@ public actor IOSSessionManager {
 
     public func allSessionsInfo() -> [(id: String, sourceFile: URL)] {
         sessions.map { ($0.key, $0.value.sourceFile) }
+    }
+
+    private func republish() async {
+        guard let registry else { return }
+        let snapshot = sessions.map { ($0.key, $0.value.sourceFile) }
+        await registry.publishIOSSessions(snapshot)
     }
 }

--- a/Sources/PreviewsEngine/SessionRegistry.swift
+++ b/Sources/PreviewsEngine/SessionRegistry.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import PreviewsMacOS
 
 /// Cross-process registry of live preview sessions.
 ///
@@ -78,6 +79,29 @@ public actor SessionRegistry {
         let result = Darwin.kill(pid, 0)
         if result == 0 { return true }
         return errno != ESRCH
+    }
+
+    // MARK: - Attach
+
+    /// Wire this registry to the iOS manager and macOS host so they
+    /// publish on every session-set mutation. Call once at host
+    /// construction time — both `DaemonListener.start` and
+    /// `ServeCommand.runStdio` do so. Calling more than once is
+    /// wasteful but not unsafe (idempotent attach + redundant
+    /// initial publishes).
+    public func attachTo(iosManager: IOSSessionManager, previewHost: PreviewHost) async {
+        await iosManager.setRegistry(self)
+        await MainActor.run {
+            // weak self so the host doesn't extend the registry's life
+            // beyond intended scope.
+            previewHost.publishSessions = { [weak self] snapshot in
+                await self?.publishMacOSSessions(snapshot)
+            }
+            // Trigger an initial publish so a registry attached after
+            // sessions exist (e.g., reattach during integration tests)
+            // doesn't lose them.
+            previewHost.notifySessionsChanged()
+        }
     }
 
     // MARK: - Publish
@@ -159,6 +183,11 @@ public actor SessionRegistry {
         // partial file. `Data.write(options: .atomic)` writes to a
         // temp and renames into place.
         try? data.write(to: target, options: .atomic)
+        // Tighten permissions explicitly. The parent directory is 0700
+        // so the file is already user-private, but session entries
+        // embed full filesystem paths and 0600 is one fewer place
+        // someone has to look to verify that.
+        try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: target.path)
     }
 
 }

--- a/Sources/PreviewsEngine/SessionRegistry.swift
+++ b/Sources/PreviewsEngine/SessionRegistry.swift
@@ -1,0 +1,164 @@
+import Darwin
+import Foundation
+
+/// Cross-process registry of live preview sessions.
+///
+/// PreviewsMCP runs in two flavors that hold distinct session pools:
+/// the stdio MCP server (one per Claude-Code-style host) and the UDS
+/// daemon (`previewsmcp serve --daemon`, shared by every CLI command).
+/// Without coordination, `session_list` from one mouth doesn't see
+/// sessions created via the other — the user-visible "phantom session"
+/// bug documented in `AGENTS.md:78-94`.
+///
+/// This registry pins each process's session set to a JSON file at
+/// `<registryDir>/<pid>.json`. Each process writes its own file on
+/// every session-set mutation; on read, every PID file is enumerated
+/// and stale entries (where the named PID no longer exists) are
+/// dropped. `SessionListHandler` reads the local in-memory state plus
+/// `readOthers()` and returns the union.
+///
+/// Create-side stays split — sessions still live in the process that
+/// owns the simulator/host. Only the read-side is unified.
+///
+/// Stale-file cleanup runs lazily during `readOthers`. Files for crashed
+/// processes accumulate harmlessly until the next read picks them up.
+/// We don't register an `atexit` cleanup hook because Swift's bridge
+/// to it is fragile and the lazy filter is sufficient for correctness.
+public actor SessionRegistry {
+
+    /// One row in the per-process registry file. Mirrors
+    /// `DaemonProtocol.SessionDTO` in shape; defined here so
+    /// `PreviewsEngine` doesn't need to import `PreviewsCLI`.
+    public struct Entry: Codable, Sendable, Equatable {
+        public let sessionID: String
+        public let platform: String
+        public let sourceFilePath: String
+
+        public init(sessionID: String, platform: String, sourceFilePath: String) {
+            self.sessionID = sessionID
+            self.platform = platform
+            self.sourceFilePath = sourceFilePath
+        }
+    }
+
+    /// On-disk file shape: a header with the writer's PID plus the
+    /// session entries. The `pid` field lets readers detect a recycled
+    /// PID — if the file's `pid` doesn't match its filename, we treat
+    /// it as stale.
+    private struct FileContents: Codable {
+        let pid: Int32
+        let sessions: [Entry]
+    }
+
+    private let registryDir: URL
+    private let pid: Int32
+    private let pidFileName: String
+    private let liveCheck: @Sendable (Int32) -> Bool
+    private var iosSnapshot: [Entry] = []
+    private var macSnapshot: [Entry] = []
+
+    public init(
+        registryDir: URL,
+        liveCheck: (@Sendable (Int32) -> Bool)? = nil,
+        pid: Int32 = getpid()
+    ) {
+        self.registryDir = registryDir
+        self.pid = pid
+        self.pidFileName = "\(pid).json"
+        self.liveCheck = liveCheck ?? Self.defaultLiveCheck
+    }
+
+    /// Default `kill(pid, 0)` liveness check. Returns `true` if the
+    /// process exists, including the EPERM case (signalable by us or
+    /// not — a live process running as a different user must not have
+    /// its sessions dropped). Test code can pass a custom predicate
+    /// via `init(registryDir:pid:liveCheck:)`.
+    @Sendable
+    private static func defaultLiveCheck(_ pid: Int32) -> Bool {
+        let result = Darwin.kill(pid, 0)
+        if result == 0 { return true }
+        return errno != ESRCH
+    }
+
+    // MARK: - Publish
+
+    /// Replace the iOS slice of our published session set and rewrite
+    /// our PID file.
+    public func publishIOSSessions(_ sessions: [(id: String, sourceFile: URL)]) {
+        iosSnapshot = sessions.map {
+            Entry(sessionID: $0.id, platform: "ios", sourceFilePath: $0.sourceFile.path)
+        }
+        writeOurFile()
+    }
+
+    /// Replace the macOS slice of our published session set and rewrite
+    /// our PID file.
+    public func publishMacOSSessions(_ sessions: [(id: String, sourceFile: URL)]) {
+        macSnapshot = sessions.map {
+            Entry(sessionID: $0.id, platform: "macos", sourceFilePath: $0.sourceFile.path)
+        }
+        writeOurFile()
+    }
+
+    /// Remove our PID file. Best-effort; safe to call multiple times.
+    public func unpublish() {
+        let path = registryDir.appendingPathComponent(pidFileName)
+        try? FileManager.default.removeItem(at: path)
+    }
+
+    // MARK: - Read
+
+    /// Read sessions published by other processes. Filters out stale
+    /// PID files (PID no longer running, or filename/contents PID
+    /// mismatch). Lazily deletes the stale files it finds.
+    public func readOthers() -> [Entry] {
+        let fm = FileManager.default
+        guard
+            let entries = try? fm.contentsOfDirectory(
+                at: registryDir,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles])
+        else {
+            return []
+        }
+
+        var collected: [Entry] = []
+        for url in entries where url.pathExtension == "json" {
+            let stem = url.deletingPathExtension().lastPathComponent
+            guard let filePID = Int32(stem) else { continue }
+            // Skip our own file — we already merge in-memory.
+            if filePID == pid { continue }
+            // Skip stale processes (and lazily delete the file).
+            guard liveCheck(filePID) else {
+                try? fm.removeItem(at: url)
+                continue
+            }
+            guard
+                let data = try? Data(contentsOf: url),
+                let decoded = try? JSONDecoder().decode(FileContents.self, from: data),
+                decoded.pid == filePID
+            else { continue }
+            collected.append(contentsOf: decoded.sessions)
+        }
+        return collected
+    }
+
+    // MARK: - Internals
+
+    private func writeOurFile() {
+        let payload = FileContents(pid: pid, sessions: iosSnapshot + macSnapshot)
+        guard let data = try? JSONEncoder().encode(payload) else { return }
+
+        let fm = FileManager.default
+        try? fm.createDirectory(
+            at: registryDir, withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+
+        let target = registryDir.appendingPathComponent(pidFileName)
+        // Write atomically so concurrent readers can't observe a
+        // partial file. `Data.write(options: .atomic)` writes to a
+        // temp and renames into place.
+        try? data.write(to: target, options: .atomic)
+    }
+
+}

--- a/Sources/PreviewsMacOS/HostApp.swift
+++ b/Sources/PreviewsMacOS/HostApp.swift
@@ -28,6 +28,12 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     /// Callback invoked after NSApplication finishes launching.
     public var onLaunch: (@MainActor () -> Void)?
 
+    /// Invoked whenever `sessions` changes (added or removed). The
+    /// engine layer wires this up to publish the macOS session set
+    /// to the cross-process `SessionRegistry`. Fire-and-forget — the
+    /// callback may launch its own Task to enter actor-isolated code.
+    public var onSessionsChanged: (@MainActor @Sendable () -> Void)?
+
     public override init() {
         super.init()
     }
@@ -150,6 +156,7 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         buildContext: BuildContext? = nil
     ) {
         sessions[sessionID] = session
+        onSessionsChanged?()
         let fileURL = URL(fileURLWithPath: filePath)
         let allPaths = [filePath] + additionalPaths
         fileWatchers[sessionID]?.stop()
@@ -267,6 +274,7 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         fileWatchers[sessionID]?.stop()
         fileWatchers.removeValue(forKey: sessionID)
         sessions.removeValue(forKey: sessionID)
+        onSessionsChanged?()
         fputs("closePreview: watchers/sessions removed\n", stderr); fflush(stderr)
 
         if let window = windows.removeValue(forKey: sessionID) {

--- a/Sources/PreviewsMacOS/HostApp.swift
+++ b/Sources/PreviewsMacOS/HostApp.swift
@@ -28,11 +28,19 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     /// Callback invoked after NSApplication finishes launching.
     public var onLaunch: (@MainActor () -> Void)?
 
-    /// Invoked whenever `sessions` changes (added or removed). The
-    /// engine layer wires this up to publish the macOS session set
-    /// to the cross-process `SessionRegistry`. Fire-and-forget — the
-    /// callback may launch its own Task to enter actor-isolated code.
-    public var onSessionsChanged: (@MainActor @Sendable () -> Void)?
+    /// Async sink that publishes a snapshot of macOS sessions to the
+    /// cross-process registry. Set once by the engine layer at host
+    /// construction; not reassigned per MCP connection.
+    public var publishSessions: (@Sendable ([(id: String, sourceFile: URL)]) async -> Void)?
+
+    /// Tail of the chained publish queue. Every `notifySessionsChanged`
+    /// call snapshots the current sessions on MainActor and spawns a
+    /// Task that `await`s this prior Task before invoking
+    /// `publishSessions`. Holding the chain guarantees FIFO arrival at
+    /// the registry actor — without it, two MainActor mutations in
+    /// quick succession can spawn Tasks that race for the registry's
+    /// queue and persist the older snapshot last.
+    private var lastPublishTask: Task<Void, Never>?
 
     public override init() {
         super.init()
@@ -156,7 +164,7 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         buildContext: BuildContext? = nil
     ) {
         sessions[sessionID] = session
-        onSessionsChanged?()
+        notifySessionsChanged()
         let fileURL = URL(fileURLWithPath: filePath)
         let allPaths = [filePath] + additionalPaths
         fileWatchers[sessionID]?.stop()
@@ -274,7 +282,7 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         fileWatchers[sessionID]?.stop()
         fileWatchers.removeValue(forKey: sessionID)
         sessions.removeValue(forKey: sessionID)
-        onSessionsChanged?()
+        notifySessionsChanged()
         fputs("closePreview: watchers/sessions removed\n", stderr); fflush(stderr)
 
         if let window = windows.removeValue(forKey: sessionID) {
@@ -306,5 +314,23 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     /// Get the window for a session (for snapshotting).
     public func window(for sessionID: String) -> NSWindow? {
         windows[sessionID]
+    }
+
+    /// Snapshot the current sessions and chain a publish Task. Each new
+    /// Task `await`s the prior `lastPublishTask` before calling
+    /// `publishSessions`, guaranteeing FIFO order at the registry even
+    /// though the publish itself runs on a different actor. All
+    /// read/writes of `lastPublishTask` happen on MainActor (this
+    /// method is not async), so the chain head is consistent.
+    public func notifySessionsChanged() {
+        guard let publishSessions else { return }
+        let snapshot: [(id: String, sourceFile: URL)] = sessions.map {
+            (id: $0.key, sourceFile: $0.value.sourceFile)
+        }
+        let prev = lastPublishTask
+        lastPublishTask = Task { [publishSessions] in
+            await prev?.value
+            await publishSessions(snapshot)
+        }
     }
 }

--- a/Tests/PreviewsEngineTests/SessionRegistryTests.swift
+++ b/Tests/PreviewsEngineTests/SessionRegistryTests.swift
@@ -1,0 +1,211 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import PreviewsEngine
+
+/// Round-trip + stale-PID-filter tests for the cross-process session
+/// registry. These don't fork a real second process — they construct
+/// two `SessionRegistry` instances pointing at the same fixture
+/// directory but with different PIDs, simulating two PreviewsMCP
+/// processes coordinating via the filesystem.
+/// Used in place of the default `kill(pid, 0)` liveness check so the
+/// fake PIDs we hand to test registries don't get filtered out as
+/// stale on read. Tests that care about stale-PID behavior override
+/// this back to the real check or a custom predicate.
+@Sendable private func alwaysLive(_ pid: Int32) -> Bool { true }
+
+@Suite("SessionRegistry")
+struct SessionRegistryTests {
+
+    // MARK: - publish round trip
+
+    @Test("publishIOSSessions writes a file the peer can read")
+    func iosRoundTrip() async throws {
+        let dir = makeFixture()
+        defer { cleanup(dir) }
+
+        let writer = SessionRegistry(registryDir: dir, liveCheck: alwaysLive, pid: 100_001)
+        let reader = SessionRegistry(registryDir: dir, liveCheck: alwaysLive, pid: 100_002)
+
+        await writer.publishIOSSessions([
+            (id: "ios-A", sourceFile: URL(fileURLWithPath: "/tmp/A.swift"))
+        ])
+
+        let entries = await reader.readOthers()
+        #expect(entries.count == 1)
+        #expect(entries.first?.sessionID == "ios-A")
+        #expect(entries.first?.platform == "ios")
+        #expect(entries.first?.sourceFilePath == "/tmp/A.swift")
+    }
+
+    @Test("publishMacOSSessions writes a file the peer can read")
+    func macRoundTrip() async throws {
+        let dir = makeFixture()
+        defer { cleanup(dir) }
+
+        let writer = SessionRegistry(registryDir: dir, liveCheck: alwaysLive, pid: 100_011)
+        let reader = SessionRegistry(registryDir: dir, liveCheck: alwaysLive, pid: 100_012)
+
+        await writer.publishMacOSSessions([
+            (id: "mac-A", sourceFile: URL(fileURLWithPath: "/tmp/Mac.swift"))
+        ])
+
+        let entries = await reader.readOthers()
+        #expect(entries.count == 1)
+        #expect(entries.first?.sessionID == "mac-A")
+        #expect(entries.first?.platform == "macos")
+    }
+
+    @Test("publish combines iOS and macOS slices in one file")
+    func combinedSlices() async throws {
+        let dir = makeFixture()
+        defer { cleanup(dir) }
+
+        let writer = SessionRegistry(registryDir: dir, liveCheck: alwaysLive, pid: 100_021)
+        let reader = SessionRegistry(registryDir: dir, liveCheck: alwaysLive, pid: 100_022)
+
+        await writer.publishIOSSessions([
+            (id: "ios-X", sourceFile: URL(fileURLWithPath: "/tmp/X.swift"))
+        ])
+        await writer.publishMacOSSessions([
+            (id: "mac-Y", sourceFile: URL(fileURLWithPath: "/tmp/Y.swift"))
+        ])
+
+        let entries = await reader.readOthers().sorted { $0.sessionID < $1.sessionID }
+        #expect(entries.map(\.sessionID) == ["ios-X", "mac-Y"])
+        #expect(entries.map(\.platform) == ["ios", "macos"])
+    }
+
+    @Test("readOthers excludes the reader's own PID file")
+    func excludesOwn() async throws {
+        let dir = makeFixture()
+        defer { cleanup(dir) }
+
+        let writer = SessionRegistry(registryDir: dir, liveCheck: alwaysLive, pid: 100_031)
+        await writer.publishIOSSessions([
+            (id: "self-only", sourceFile: URL(fileURLWithPath: "/tmp/me.swift"))
+        ])
+
+        // The same PID reads its own file via `readOthers` — must not see itself.
+        let entries = await writer.readOthers()
+        #expect(entries.isEmpty)
+    }
+
+    // MARK: - mutation behavior
+
+    @Test("publishing an empty set leaves an empty file (peer sees no sessions)")
+    func clearsByPublishingEmpty() async throws {
+        let dir = makeFixture()
+        defer { cleanup(dir) }
+
+        let writer = SessionRegistry(registryDir: dir, liveCheck: alwaysLive, pid: 100_041)
+        let reader = SessionRegistry(registryDir: dir, liveCheck: alwaysLive, pid: 100_042)
+
+        await writer.publishIOSSessions([
+            (id: "ephemeral", sourceFile: URL(fileURLWithPath: "/tmp/e.swift"))
+        ])
+        #expect(await reader.readOthers().count == 1)
+
+        await writer.publishIOSSessions([])
+        #expect(await reader.readOthers().isEmpty)
+    }
+
+    @Test("unpublish removes the writer's file")
+    func unpublishRemoves() async throws {
+        let dir = makeFixture()
+        defer { cleanup(dir) }
+
+        let writer = SessionRegistry(registryDir: dir, liveCheck: alwaysLive, pid: 100_051)
+        let reader = SessionRegistry(registryDir: dir, liveCheck: alwaysLive, pid: 100_052)
+
+        await writer.publishIOSSessions([
+            (id: "vanishing", sourceFile: URL(fileURLWithPath: "/tmp/v.swift"))
+        ])
+        #expect(await reader.readOthers().count == 1)
+
+        await writer.unpublish()
+        #expect(await reader.readOthers().isEmpty)
+
+        // Idempotent — calling again must not throw.
+        await writer.unpublish()
+    }
+
+    // MARK: - stale-PID filter
+
+    @Test("readOthers drops files for non-existent PIDs and deletes them")
+    func filtersStaleAndDeletes() async throws {
+        let dir = makeFixture()
+        defer { cleanup(dir) }
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        // PID 1 exists on macOS (launchd) but we use a definitely-dead
+        // value via a fresh `Process()`'s PID after termination.
+        let stalePID = makeStalePID()
+        let staleFile = dir.appendingPathComponent("\(stalePID).json")
+        let stalePayload =
+            #"{"pid":\#(stalePID),"sessions":[{"sessionID":"ghost","platform":"ios","sourceFilePath":"/dev/null"}]}"#
+        try stalePayload.write(to: staleFile, atomically: true, encoding: .utf8)
+
+        // Use the default `kill(pid, 0)` predicate here so we exercise
+        // the real stale-PID path.
+        let reader = SessionRegistry(registryDir: dir, pid: 100_061)
+        let entries = await reader.readOthers()
+        #expect(entries.isEmpty, "stale-PID file must not contribute sessions")
+
+        // Lazy cleanup: the stale file should be deleted on read.
+        #expect(
+            !FileManager.default.fileExists(atPath: staleFile.path),
+            "readOthers() should garbage-collect the stale file"
+        )
+    }
+
+    @Test("readOthers ignores files whose embedded PID doesn't match the filename")
+    func filtersRecycledPID() async throws {
+        let dir = makeFixture()
+        defer { cleanup(dir) }
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        // File named after a live PID (the test's own) but whose
+        // embedded `pid` field disagrees — simulates a recycled PID
+        // landing on someone else's leftover file before they had a
+        // chance to overwrite it.
+        let livePID = getpid()
+        let payload = #"{"pid":999999,"sessions":[{"sessionID":"recycled","platform":"ios","sourceFilePath":"/x"}]}"#
+        try payload.write(
+            to: dir.appendingPathComponent("\(livePID).json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // Reader is a different PID so livePID is "other" from its
+        // perspective — but the recycled-PID guard should skip it.
+        let reader = SessionRegistry(registryDir: dir, liveCheck: alwaysLive, pid: livePID + 1)
+        #expect(await reader.readOthers().isEmpty)
+    }
+
+    // MARK: - Fixtures
+
+    private func makeFixture() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-registry-test-\(UUID().uuidString)")
+    }
+
+    private func cleanup(_ dir: URL) {
+        try? FileManager.default.removeItem(at: dir)
+    }
+
+    /// A PID that is reliably not-running. We spawn `/bin/echo`, wait
+    /// for it to exit, then return its PID. The kernel won't re-use
+    /// the slot for the duration of the test.
+    private func makeStalePID() -> Int32 {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/echo")
+        proc.arguments = ["stale"]
+        proc.standardOutput = Pipe()
+        proc.standardError = Pipe()
+        try? proc.run()
+        proc.waitUntilExit()
+        return proc.processIdentifier
+    }
+}


### PR DESCRIPTION
## Summary

Step #6b of the architectural-refactor roadmap. **Stacked on top of #167** (\`worktree-ios-host-channel\`); rebases automatically once #167 merges.

PreviewsMCP runs in two flavors that hold distinct session pools — the stdio MCP server and the UDS daemon. Without coordination, \`session_list\` from one mouth doesn't see sessions created via the other; AGENTS.md:78-94 documents this as a known phantom-session bug.

This PR implements read-side unification only — create-side stays split, but \`session_list\` from any process now returns the union.

### Mechanism

- New \`SessionRegistry\` actor (PreviewsEngine) pins each process's session set to \`~/.previewsmcp/sessions/<pid>.json\` on every mutation.
- \`SessionListHandler\` reads local in-memory state plus \`registry.readOthers()\` (peer PID files), merges, sorts, returns.
- Stale-PID filter via \`kill(pid, 0)\`; lazy GC of dead-process files during \`readOthers()\`.
- Recycled-PID guard: file's embedded \`pid\` field must match its filename stem.

### Wiring

- \`IOSSessionManager.setRegistry(_:)\`: attach point. \`addSession\` and \`removeSession\` republish on every mutation.
- \`PreviewHost.onSessionsChanged\` callback: PreviewsMacOS can't depend on PreviewsEngine without creating a cycle, so the host fires a callback that PreviewsCLI's \`configureMCPServer\` wires to the registry. Invoked from \`watchFile\` (add) and \`closePreview\` (remove).
- \`HandlerContext.registry\`: threaded into every tool handler.
- \`DaemonPaths.sessionsDirectory\`: \`~/.previewsmcp/sessions/\`.

### Acceptance

- \`SessionListHandler\` from either mouth returns the union of sessions across both processes ✓
- Create-side unchanged ✓
- \`ListToolsSnapshotTests\` passes — no schema wire-byte drift ✓
- New \`PreviewsEngineTests/SessionRegistryTests\` (8 tests) covers round-trip publish/read, own-PID exclusion, empty publish clearing, unpublish idempotency, and both stale-PID paths.
- All existing MCP integration tests (MacOS workflow, structuredContent decode, variants, hot-reload, heartbeat) pass.

### Why no atexit cleanup

Swift's bridge to \`atexit\` is fragile and lazy stale-file filtering covers correctness. Files for crashed processes accumulate harmlessly until the next \`readOthers()\` call removes them. The \`sessions\` directory under \`~/.previewsmcp/\` is bounded in practice (one file per running PreviewsMCP process).

### Stacked PR note

This branches from \`worktree-ios-host-channel\` (PR #167). When #167 merges, GitHub will retarget this PR's base to \`main\` automatically; if there's a manual nudge needed I'll handle it.

## Test plan

- [x] \`swift build\` clean
- [x] \`swift-format format --in-place --recursive\` + \`swift-format lint --strict\` clean
- [x] \`swift test --filter SessionRegistryTests\` — 8 tests pass
- [x] \`swift test --filter ListToolsSnapshotTests\` — wire bytes unchanged
- [x] \`swift test --filter MacOSMCPTests\` — 7 tests pass (full workflow incl. session_list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)