### PR TITLE
Cleanup: shared verifySwiftModule + distinct decode-failed iOS error

### DIFF
--- a/Sources/PreviewsCore/BazelBuildSystem.swift
+++ b/Sources/PreviewsCore/BazelBuildSystem.swift
@@ -212,10 +212,8 @@ public actor BazelBuildSystem: BuildSystem {
         let moduleDir = bazelBin.appendingPathComponent(
             target.replacingOccurrences(of: "//", with: "")
                 .split(separator: ":").first.map(String.init) ?? "")
-        let swiftmodule = moduleDir.appendingPathComponent("\(moduleName).swiftmodule")
-
-        guard FileManager.default.fileExists(atPath: swiftmodule.path) else {
-            throw BuildSystemError.missingArtifacts(
+        try BuildSystemSupport.verifySwiftModule(named: moduleName, in: moduleDir) {
+            BuildSystemError.missingArtifacts(
                 "Expected \(moduleName).swiftmodule in bazel-bin output for \(target)")
         }
 

--- a/Sources/PreviewsCore/BuildSystemSupport.swift
+++ b/Sources/PreviewsCore/BuildSystemSupport.swift
@@ -66,6 +66,30 @@ enum BuildSystemSupport {
             .map { $0.standardizedFileURL }
     }
 
+    /// Verify that `<modulesDir>/<moduleName>.swiftmodule` exists; if
+    /// missing, throw the error returned by `onMissing()`. SPM,
+    /// SetupBuilder, and Bazel all do this exact "build path →
+    /// fileExists → throw" check after their own build subprocess
+    /// finishes, with different concrete error types
+    /// (`BuildSystemError.missingArtifacts` vs
+    /// `SetupBuilderError.moduleNotFound`). The closure pattern lets
+    /// each caller throw its own type without forcing a single error
+    /// shape on all of them.
+    ///
+    /// Xcode's "verify build outputs" check is structurally different
+    /// (it looks at `BUILT_PRODUCTS_DIR`, not a specific module file)
+    /// and is intentionally NOT routed through this helper.
+    static func verifySwiftModule(
+        named moduleName: String,
+        in modulesDir: URL,
+        onMissing makeError: () -> Error
+    ) throws {
+        let swiftmodule = modulesDir.appendingPathComponent("\(moduleName).swiftmodule")
+        guard FileManager.default.fileExists(atPath: swiftmodule.path) else {
+            throw makeError()
+        }
+    }
+
     /// Recursively collect `.o` files under `directory`. Used by SPM (per
     /// dependency-target archive) and the setup builder (single dylib link).
     /// `swift build` emits Swift object files as `<Source>.swift.o`, so

--- a/Sources/PreviewsCore/SPMBuildSystem.swift
+++ b/Sources/PreviewsCore/SPMBuildSystem.swift
@@ -190,9 +190,8 @@ public actor SPMBuildSystem: BuildSystem {
 
         // 5. Verify the module exists
         let modulesDir = binPath.appendingPathComponent("Modules")
-        let swiftmodule = modulesDir.appendingPathComponent("\(targetName).swiftmodule")
-        guard FileManager.default.fileExists(atPath: swiftmodule.path) else {
-            throw BuildSystemError.missingArtifacts(
+        try BuildSystemSupport.verifySwiftModule(named: targetName, in: modulesDir) {
+            BuildSystemError.missingArtifacts(
                 "Expected \(targetName).swiftmodule at \(modulesDir.path)"
             )
         }

--- a/Sources/PreviewsCore/SetupBuilder.swift
+++ b/Sources/PreviewsCore/SetupBuilder.swift
@@ -85,14 +85,8 @@ public enum SetupBuilder {
         let binPath = URL(fileURLWithPath: binPathResult.stdout)
         let modulesDir = binPath.appendingPathComponent("Modules")
 
-        guard
-            FileManager.default.fileExists(
-                atPath: modulesDir.appendingPathComponent("\(config.moduleName).swiftmodule").path
-            )
-        else {
-            throw SetupBuilderError.moduleNotFound(
-                config.moduleName, searchPath: modulesDir.path
-            )
+        try BuildSystemSupport.verifySwiftModule(named: config.moduleName, in: modulesDir) {
+            SetupBuilderError.moduleNotFound(config.moduleName, searchPath: modulesDir.path)
         }
 
         // Link .o files into a dynamic library so all preview dylibs share the same statics.

--- a/Sources/PreviewsIOS/IOSPreviewSession.swift
+++ b/Sources/PreviewsIOS/IOSPreviewSession.swift
@@ -344,7 +344,7 @@ public actor IOSPreviewSession {
         guard let response = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any],
             let tree = response["tree"] as? [String: Any]
         else {
-            throw IOSPreviewSessionError.socketResponseTimeout("elementsResponse")
+            throw IOSPreviewSessionError.responseDecodeFailed(operation: "elements")
         }
 
         // Apply server-side filtering if needed
@@ -409,6 +409,10 @@ public enum IOSPreviewSessionError: Error, LocalizedError, CustomStringConvertib
     case socketAcceptTimeout
     case socketResponseTimeout(String)
     case connectionLost
+    /// JSON parse or shape mismatch on a host-app response. Distinct
+    /// from `socketResponseTimeout` so callers and operators can tell
+    /// "host app didn't respond" from "host app responded with garbage."
+    case responseDecodeFailed(operation: String)
 
     public var description: String {
         switch self {
@@ -418,6 +422,8 @@ public enum IOSPreviewSessionError: Error, LocalizedError, CustomStringConvertib
         case .socketAcceptTimeout: return "Timed out waiting for host app to connect"
         case .socketResponseTimeout(let id): return "Timed out waiting for response (id: \(id))"
         case .connectionLost: return "Connection to host app lost"
+        case .responseDecodeFailed(let operation):
+            return "Failed to decode host app response (operation: \(operation))"
         }
     }
 


### PR DESCRIPTION
## Summary

Two ergonomics polish items left over from prior code-review passes, bundled into one PR.

### 1. \`BuildSystemSupport.verifySwiftModule(named:in:onMissing:)\`

SPM, SetupBuilder, and Bazel each open-coded the same "build module path → \`fileExists\` → throw" check after their build subprocess finished, with three different concrete error types (\`BuildSystemError.missingArtifacts\` for SPM and Bazel, \`SetupBuilderError.moduleNotFound\` for SetupBuilder). Pull the shape into a single helper that takes a \`() -> Error\` factory so each caller keeps its own error type without forcing a single shape on all of them.

Xcode's "verify build outputs" check is intentionally NOT routed through this helper — it looks at \`BUILT_PRODUCTS_DIR\` (a directory existence check), not a specific \`.swiftmodule\` file. Different shape, kept separate.

### 2. \`IOSPreviewSessionError.responseDecodeFailed(operation:)\`

\`IOSPreviewSession.fetchElements\` previously threw \`socketResponseTimeout("elementsResponse")\` when the host app responded with malformed JSON or a response missing the expected \`tree\` key. The error name read as "the host app didn't respond in time" when the actual issue was "the host app responded with garbage."

Add a dedicated \`responseDecodeFailed(operation:)\` case so operators can triage the two scenarios distinctly. The original timeout case stays — it's still the right thing for actual timeouts in \`IOSHostChannel.sendAndAwait\`.

## Test plan

- [x] \`swift build\` clean
- [x] \`swift-format format --in-place --recursive\` + \`swift-format lint --strict\` clean
- [x] \`swift test --filter "BuildSystem|Bazel|Xcode|SetupBuilder|SetupCache|IOSPreviewSession"\` — 103 tests across 6 suites pass (including iOS end-to-end with simulator boot/install/launch/screenshot)

## Diff stat

\`\`\`
 Sources/PreviewsCore/BazelBuildSystem.swift   |  6 ++----
 Sources/PreviewsCore/BuildSystemSupport.swift | 24 ++++++++++++++++++++++++
 Sources/PreviewsCore/SPMBuildSystem.swift     |  5 ++---
 Sources/PreviewsCore/SetupBuilder.swift       | 10 ++--------
 Sources/PreviewsIOS/IOSPreviewSession.swift   |  8 +++++++-
 5 files changed, 37 insertions(+), 16 deletions(-)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)