### PR TITLE
Split DaemonClient.swift along its six concerns

### DIFF
--- a/Sources/PreviewsCLI/DaemonClient.swift
+++ b/Sources/PreviewsCLI/DaemonClient.swift
@@ -11,6 +11,18 @@ import PreviewsCore
 ///
 /// ADB-style UX: users don't think about daemon management during normal
 /// command flow — first CLI invocation transparently starts it.
+///
+/// The implementation is split across three files:
+///
+///   • This file (`DaemonClient.swift`) — public entries (`connect`,
+///     `withDaemonClient`), `openClient` initialize handshake,
+///     daemon spawn + socket-readiness poll.
+///   • `DaemonRestart.swift` — version-mismatch detection and the
+///     restart-lock-protected kill+respawn path.
+///   • `DaemonClientChannel.swift` — notification-handler wiring
+///     (stderr log forwarder, stall-timer bumpers).
+///
+/// All three live as extensions on this `enum DaemonClient` namespace.
 enum DaemonClient {
 
     /// Connect to the daemon, auto-starting it if necessary, and return a
@@ -86,7 +98,7 @@ enum DaemonClient {
         // binary that no longer matches ours (e.g., `brew upgrade`
         // moved the binary without touching the running daemon).
         // Drop this connection, take the restart lock, kill the
-        // stale daemon, respawn, and reconnect. See issue #142.
+        // stale daemon, respawn, and reconnect. See `DaemonRestart`.
         await client.disconnect()
         return try await restartDaemonAndReconnect(
             staleVersion: serverVersion,
@@ -99,12 +111,13 @@ enum DaemonClient {
 
     /// Open one MCP connection to the running daemon and return the
     /// initialize response alongside the live client. Factored out of
-    /// `connect(...)` so the version-mismatch recovery path can reuse
-    /// the same setup (including `configure`) against the respawned
-    /// daemon. `configure` runs once per invocation; callers register
+    /// `connect(...)` so the version-mismatch recovery path
+    /// (`restartDaemonAndReconnect`) can reuse the same setup
+    /// (including `configure`) against the respawned daemon.
+    /// `configure` runs once per invocation; callers register
     /// notification handlers there rather than on the returned client
     /// to avoid dropping early notifications.
-    private static func openClient(
+    static func openClient(
         clientName: String,
         configure: ((Client) async -> Void)?
     ) async throws -> (Client, Initialize.Result) {
@@ -117,158 +130,6 @@ enum DaemonClient {
         await configure?(client)
         let initResult = try await client.connect(transport: transport)
         return (client, initResult)
-    }
-
-    /// Kill the stale daemon and bring up a fresh one matching the
-    /// current CLI binary. Serialized across concurrent CLIs via
-    /// `flock` on `DaemonPaths.restartLock` so two upgraded CLIs
-    /// don't stampede (both SIGTERM, both spawn, one wins the socket
-    /// and the other's respawn collides with `ServeCommand`'s
-    /// "already running" guard). After acquiring the lock we re-probe
-    /// — a sibling CLI may have already fixed the mismatch, in which
-    /// case our initial handshake is stale and we should just use
-    /// the sibling's fresh daemon. See issue #142.
-    private static func restartDaemonAndReconnect(
-        staleVersion: String,
-        currentVersion: String,
-        clientName: String,
-        startTimeout: TimeInterval,
-        configure: ((Client) async -> Void)?
-    ) async throws -> Client {
-        let lockFd = try await acquireRestartLock()
-        defer {
-            _ = flock(lockFd, LOCK_UN)
-            close(lockFd)
-        }
-
-        // A sibling CLI may have restarted the daemon between our
-        // mismatch detection and our lock acquisition, making our
-        // cached server version stale. Always re-probe under the
-        // lock — one extra initialize round-trip, cheap, avoids
-        // killing a freshly-spawned daemon. Drop the probe client
-        // if it still mismatches; the kill+respawn below needs the
-        // socket free of our own connection.
-        let (probeClient, probeInit) = try await openClient(
-            clientName: clientName, configure: configure)
-        if versionsMatch(currentVersion, probeInit.serverInfo.version) {
-            return probeClient
-        }
-        await probeClient.disconnect()
-
-        fputs(
-            "previewsmcp: daemon was \(staleVersion), CLI is \(currentVersion) — restarting\n",
-            stderr
-        )
-
-        if let pid = DaemonLifecycle.readPID() {
-            try killDaemonAndWait(pid: pid, timeout: 5.0)
-        }
-
-        let reason =
-            "prev=\(staleVersion),now=\(currentVersion),"
-            + "by=pid\(ProcessInfo.processInfo.processIdentifier)"
-        try spawnDaemon(restartReason: reason)
-        try await waitForSocket(timeout: startTimeout)
-
-        let (client, initResult) = try await openClient(
-            clientName: clientName, configure: configure)
-        if !versionsMatch(currentVersion, initResult.serverInfo.version) {
-            await client.disconnect()
-            throw DaemonClientError.versionStillMismatched(
-                reported: initResult.serverInfo.version)
-        }
-        return client
-    }
-
-    /// SIGTERM the given pid and poll until it's gone, or throw on
-    /// timeout. Swallows ESRCH — the daemon may have exited on its
-    /// own between our read and our signal.
-    private static func killDaemonAndWait(pid: Int32, timeout: TimeInterval) throws {
-        if kill(pid, SIGTERM) != 0 && errno != ESRCH {
-            throw DaemonClientError.couldNotSignalDaemon(pid: pid, errno: errno)
-        }
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if !DaemonLifecycle.isProcessAlive(pid) { return }
-            Thread.sleep(forTimeInterval: 0.1)
-        }
-        throw DaemonClientError.restartTimedOut(pid: pid)
-    }
-
-    /// Acquire the cross-process restart lock. Blocking `flock` runs
-    /// on a dispatch-global thread so it doesn't starve Swift's
-    /// cooperative pool — same pattern as `DaemonTestLock.run` (see
-    /// its comment for context on the starvation we saw before).
-    ///
-    /// `O_CLOEXEC` is load-bearing: during the respawn we `Process`-
-    /// spawn a daemon, which inherits all of our open fds by default.
-    /// Without CLOEXEC, the daemon grandchild holds a dup of the
-    /// flock fd, so closing our end in `defer` does NOT release the
-    /// kernel-level flock — flocks only drop when *every* dup of the
-    /// fd is closed. The next CLI then blocks on `flock(LOCK_EX)`
-    /// until the daemon dies. CI saw a 50s stall here before this
-    /// flag was added. See issue #142.
-    private static func acquireRestartLock() async throws -> Int32 {
-        let path = DaemonPaths.restartLock.path
-        return try await withCheckedThrowingContinuation {
-            (cont: CheckedContinuation<Int32, Error>) in
-            DispatchQueue.global(qos: .userInitiated).async {
-                try? DaemonPaths.ensureDirectory()
-                let fd = open(path, O_CREAT | O_RDWR | O_CLOEXEC, 0o644)
-                guard fd >= 0 else {
-                    cont.resume(throwing: DaemonClientError.lockFailed(errno: errno))
-                    return
-                }
-                if flock(fd, LOCK_EX) != 0 {
-                    let err = errno
-                    close(fd)
-                    cont.resume(throwing: DaemonClientError.lockFailed(errno: err))
-                    return
-                }
-                cont.resume(returning: fd)
-            }
-        }
-    }
-
-    /// Decide whether two `serverInfo.version` strings are compatible
-    /// enough to skip a daemon restart.
-    ///
-    /// Rules:
-    ///   • Both have the git-describe suffix `-<N>-g<SHA>` (both are
-    ///     dev builds) — strict equality. Different SHAs can carry
-    ///     different protocol-affecting changes, and the whole
-    ///     purpose of the handshake is to catch those during
-    ///     development iteration.
-    ///   • Otherwise — strip the suffix from whichever side has it
-    ///     and compare. So `0.12.0` (release) matches `0.12.0-5-gabc`
-    ///     (dev build atop that release) without a pointless restart.
-    ///
-    /// Pre-release tags like `-rc.1` are preserved and compare as
-    /// distinct — the regex only matches the numeric-distance-plus-
-    /// SHA pattern git-describe produces. See issue #142.
-    private static func versionsMatch(_ a: String, _ b: String) -> Bool {
-        let aHasSuffix = gitDescribeRange(in: a) != nil
-        let bHasSuffix = gitDescribeRange(in: b) != nil
-        if aHasSuffix && bHasSuffix {
-            return a == b
-        }
-        return baseVersion(a) == baseVersion(b)
-    }
-
-    /// Strip the git-describe suffix `-<N>-g<SHA>`, if present.
-    private static func baseVersion(_ version: String) -> String {
-        guard let range = gitDescribeRange(in: version) else { return version }
-        return String(version[..<range.lowerBound])
-    }
-
-    /// Match `-<N>-g<SHA>$` where SHA is at least 4 hex chars (git's
-    /// minimum short-sha length). Narrow on purpose so hand-crafted
-    /// strings like `0.12.0-1-gz` don't accidentally match.
-    private static func gitDescribeRange(in version: String) -> Range<String.Index>? {
-        version.range(
-            of: "-[0-9]+-g[0-9a-f]{4,}$",
-            options: .regularExpression
-        )
     }
 
     /// Connect, register the default stderr log-forwarder, run `body`, and
@@ -350,40 +211,6 @@ enum DaemonClient {
         }
     }
 
-    /// Register the MCP LogMessageNotification → stderr bridge that every
-    /// CLI command shares. Daemon-side progress messages and warnings
-    /// are surfaced as MCP notifications; without this bridge they'd be
-    /// silently dropped on the client.
-    ///
-    /// Silently drops `logger == "heartbeat"` — those are the daemon's
-    /// unconditional 2s liveness pings (see `runMCPServer` in
-    /// `MCPServer.swift`). They're consumed by the stall timer (see
-    /// `registerStallBumpers`) but aren't intended for humans reading
-    /// the CLI's stderr.
-    private static func registerStderrLogForwarder(on client: Client) async {
-        await client.onNotification(LogMessageNotification.self) { message in
-            if message.params.logger == "heartbeat" { return }
-            if case .string(let text) = message.params.data {
-                Log.info(text)
-            }
-        }
-    }
-
-    /// Register handlers that bump `timer` on every incoming MCP
-    /// notification. Log messages and progress notifications both count
-    /// as "the server is alive and talking to us." Registered in
-    /// `withDaemonClient`'s configure closure so handlers are live
-    /// before the initialize handshake — early notifications shouldn't
-    /// be dropped.
-    private static func registerStallBumpers(on client: Client, timer: StallTimer) async {
-        await client.onNotification(LogMessageNotification.self) { _ in
-            await timer.bump()
-        }
-        await client.onNotification(ProgressNotification.self) { _ in
-            await timer.bump()
-        }
-    }
-
     /// Spawn the daemon as an independent child process. We don't wait for it —
     /// the daemon keeps running after this function returns and after the
     /// parent CLI exits.
@@ -391,7 +218,7 @@ enum DaemonClient {
     /// `restartReason` is propagated via `_PREVIEWSMCP_DAEMON_RESTART_REASON`
     /// so the new daemon logs a diagnostic breadcrumb to `serve.log` on
     /// startup. Only set when this spawn is a version-mismatch recovery.
-    private static func spawnDaemon(restartReason: String? = nil) throws {
+    static func spawnDaemon(restartReason: String? = nil) throws {
         // `_NSGetExecutablePath` returns the kernel's record of the binary
         // we're executing, set at exec() time. Authoritative regardless of
         // CWD, PATH resolution, or what the caller put in argv[0].
@@ -458,7 +285,7 @@ enum DaemonClient {
     }
 
     /// Poll the socket until it accepts connections or we give up.
-    private static func waitForSocket(timeout: TimeInterval) async throws {
+    static func waitForSocket(timeout: TimeInterval) async throws {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if DaemonProbe.canConnect() { return }

--- a/Sources/PreviewsCLI/DaemonClientChannel.swift
+++ b/Sources/PreviewsCLI/DaemonClientChannel.swift
@@ -1,0 +1,55 @@
+import MCP
+import PreviewsCore
+
+/// Notification-handler wiring for `DaemonClient`. Both helpers run
+/// inside `withDaemonClient`'s `configure` closure so they're
+/// registered BEFORE the MCP initialize handshake — without that
+/// ordering, notifications emitted during the handshake (rare but
+/// possible) get dropped on the floor.
+///
+/// Subtleties documented inline (and in `AGENTS.md:240-241`):
+///   • `registerStallBumpers` listens for both log and progress
+///     notifications. The daemon emits `logger: "heartbeat"` log
+///     notifications every 2s (see `runMCPServer`); without subscribing
+///     to `.debug`-level logs in `withDaemonClient`, those heartbeats
+///     are filtered before they reach the bumper and the stall timer
+///     trips immediately.
+///   • `registerStderrLogForwarder` filters out the heartbeat logger
+///     so humans reading the CLI's stderr don't see "alive alive
+///     alive" spam.
+extension DaemonClient {
+
+    /// Register the MCP LogMessageNotification → stderr bridge that every
+    /// CLI command shares. Daemon-side progress messages and warnings
+    /// are surfaced as MCP notifications; without this bridge they'd be
+    /// silently dropped on the client.
+    ///
+    /// Silently drops `logger == "heartbeat"` — those are the daemon's
+    /// unconditional 2s liveness pings (see `runMCPServer` in
+    /// `MCPServer.swift`). They're consumed by the stall timer (see
+    /// `registerStallBumpers`) but aren't intended for humans reading
+    /// the CLI's stderr.
+    static func registerStderrLogForwarder(on client: Client) async {
+        await client.onNotification(LogMessageNotification.self) { message in
+            if message.params.logger == "heartbeat" { return }
+            if case .string(let text) = message.params.data {
+                Log.info(text)
+            }
+        }
+    }
+
+    /// Register handlers that bump `timer` on every incoming MCP
+    /// notification. Log messages and progress notifications both count
+    /// as "the server is alive and talking to us." Registered in
+    /// `withDaemonClient`'s configure closure so handlers are live
+    /// before the initialize handshake — early notifications shouldn't
+    /// be dropped.
+    static func registerStallBumpers(on client: Client, timer: StallTimer) async {
+        await client.onNotification(LogMessageNotification.self) { _ in
+            await timer.bump()
+        }
+        await client.onNotification(ProgressNotification.self) { _ in
+            await timer.bump()
+        }
+    }
+}

--- a/Sources/PreviewsCLI/DaemonClientChannel.swift
+++ b/Sources/PreviewsCLI/DaemonClientChannel.swift
@@ -1,8 +1,11 @@
 import MCP
 import PreviewsCore
 
-/// Notification-handler wiring for `DaemonClient`. Both helpers run
-/// inside `withDaemonClient`'s `configure` closure so they're
+/// Notification-handler wiring for `DaemonClient`. One of three files
+/// extending the `DaemonClient` namespace — see `DaemonClient.swift`
+/// for the file-layout overview.
+///
+/// Both helpers run inside `withDaemonClient`'s `configure` closure so they're
 /// registered BEFORE the MCP initialize handshake — without that
 /// ordering, notifications emitted during the handshake (rare but
 /// possible) get dropped on the floor.

--- a/Sources/PreviewsCLI/DaemonRestart.swift
+++ b/Sources/PreviewsCLI/DaemonRestart.swift
@@ -2,7 +2,9 @@ import Darwin
 import Foundation
 import MCP
 
-/// Version-mismatch handshake recovery for `DaemonClient`.
+/// Version-mismatch handshake recovery for `DaemonClient`. One of
+/// three files extending the `DaemonClient` namespace — see
+/// `DaemonClient.swift` for the file-layout overview.
 ///
 /// When a CLI binary connects to a daemon that was spawned by a prior
 /// (now-stale) binary — e.g., `brew upgrade` moved `previewsmcp`

--- a/Sources/PreviewsCLI/DaemonRestart.swift
+++ b/Sources/PreviewsCLI/DaemonRestart.swift
@@ -1,0 +1,179 @@
+import Darwin
+import Foundation
+import MCP
+
+/// Version-mismatch handshake recovery for `DaemonClient`.
+///
+/// When a CLI binary connects to a daemon that was spawned by a prior
+/// (now-stale) binary — e.g., `brew upgrade` moved `previewsmcp`
+/// without touching the running daemon — the MCP `serverInfo.version`
+/// in the initialize response won't match the CLI's compile-time
+/// version. The connect path in `DaemonClient.connect(...)` detects
+/// this, drops the connection, and routes here.
+///
+/// Implementation:
+///   1. Acquire a cross-process `flock` on `DaemonPaths.restartLock`
+///      so concurrent CLIs serialize their restart attempts (see #142
+///      and `acquireRestartLock` for the `O_CLOEXEC` rationale).
+///   2. Re-probe under the lock — a sibling CLI may have already
+///      restarted the daemon, in which case we use the fresh one.
+///   3. SIGTERM the stale pid and wait for it to exit.
+///   4. Spawn a fresh daemon and reconnect; surface a clear error if
+///      the new daemon STILL reports a mismatched version (typically
+///      a leaked `_PREVIEWSMCP_TEST_DAEMON_VERSION` in the user's env).
+///
+/// Version comparison rules: see `versionsMatch`.
+extension DaemonClient {
+
+    /// Kill the stale daemon and bring up a fresh one matching the
+    /// current CLI binary. Serialized across concurrent CLIs via
+    /// `flock` on `DaemonPaths.restartLock` so two upgraded CLIs
+    /// don't stampede (both SIGTERM, both spawn, one wins the socket
+    /// and the other's respawn collides with `ServeCommand`'s
+    /// "already running" guard). After acquiring the lock we re-probe
+    /// — a sibling CLI may have already fixed the mismatch, in which
+    /// case our initial handshake is stale and we should just use
+    /// the sibling's fresh daemon. See issue #142.
+    static func restartDaemonAndReconnect(
+        staleVersion: String,
+        currentVersion: String,
+        clientName: String,
+        startTimeout: TimeInterval,
+        configure: ((Client) async -> Void)?
+    ) async throws -> Client {
+        let lockFd = try await acquireRestartLock()
+        defer {
+            _ = flock(lockFd, LOCK_UN)
+            close(lockFd)
+        }
+
+        // A sibling CLI may have restarted the daemon between our
+        // mismatch detection and our lock acquisition, making our
+        // cached server version stale. Always re-probe under the
+        // lock — one extra initialize round-trip, cheap, avoids
+        // killing a freshly-spawned daemon. Drop the probe client
+        // if it still mismatches; the kill+respawn below needs the
+        // socket free of our own connection.
+        let (probeClient, probeInit) = try await openClient(
+            clientName: clientName, configure: configure)
+        if versionsMatch(currentVersion, probeInit.serverInfo.version) {
+            return probeClient
+        }
+        await probeClient.disconnect()
+
+        fputs(
+            "previewsmcp: daemon was \(staleVersion), CLI is \(currentVersion) — restarting\n",
+            stderr
+        )
+
+        if let pid = DaemonLifecycle.readPID() {
+            try killDaemonAndWait(pid: pid, timeout: 5.0)
+        }
+
+        let reason =
+            "prev=\(staleVersion),now=\(currentVersion),"
+            + "by=pid\(ProcessInfo.processInfo.processIdentifier)"
+        try spawnDaemon(restartReason: reason)
+        try await waitForSocket(timeout: startTimeout)
+
+        let (client, initResult) = try await openClient(
+            clientName: clientName, configure: configure)
+        if !versionsMatch(currentVersion, initResult.serverInfo.version) {
+            await client.disconnect()
+            throw DaemonClientError.versionStillMismatched(
+                reported: initResult.serverInfo.version)
+        }
+        return client
+    }
+
+    /// SIGTERM the given pid and poll until it's gone, or throw on
+    /// timeout. Swallows ESRCH — the daemon may have exited on its
+    /// own between our read and our signal.
+    static func killDaemonAndWait(pid: Int32, timeout: TimeInterval) throws {
+        if kill(pid, SIGTERM) != 0 && errno != ESRCH {
+            throw DaemonClientError.couldNotSignalDaemon(pid: pid, errno: errno)
+        }
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if !DaemonLifecycle.isProcessAlive(pid) { return }
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        throw DaemonClientError.restartTimedOut(pid: pid)
+    }
+
+    /// Acquire the cross-process restart lock. Blocking `flock` runs
+    /// on a dispatch-global thread so it doesn't starve Swift's
+    /// cooperative pool — same pattern as `DaemonTestLock.run` (see
+    /// its comment for context on the starvation we saw before).
+    ///
+    /// `O_CLOEXEC` is load-bearing: during the respawn we `Process`-
+    /// spawn a daemon, which inherits all of our open fds by default.
+    /// Without CLOEXEC, the daemon grandchild holds a dup of the
+    /// flock fd, so closing our end in `defer` does NOT release the
+    /// kernel-level flock — flocks only drop when *every* dup of the
+    /// fd is closed. The next CLI then blocks on `flock(LOCK_EX)`
+    /// until the daemon dies. CI saw a 50s stall here before this
+    /// flag was added. See issue #142.
+    static func acquireRestartLock() async throws -> Int32 {
+        let path = DaemonPaths.restartLock.path
+        return try await withCheckedThrowingContinuation {
+            (cont: CheckedContinuation<Int32, Error>) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                try? DaemonPaths.ensureDirectory()
+                let fd = open(path, O_CREAT | O_RDWR | O_CLOEXEC, 0o644)
+                guard fd >= 0 else {
+                    cont.resume(throwing: DaemonClientError.lockFailed(errno: errno))
+                    return
+                }
+                if flock(fd, LOCK_EX) != 0 {
+                    let err = errno
+                    close(fd)
+                    cont.resume(throwing: DaemonClientError.lockFailed(errno: err))
+                    return
+                }
+                cont.resume(returning: fd)
+            }
+        }
+    }
+
+    /// Decide whether two `serverInfo.version` strings are compatible
+    /// enough to skip a daemon restart.
+    ///
+    /// Rules:
+    ///   • Both have the git-describe suffix `-<N>-g<SHA>` (both are
+    ///     dev builds) — strict equality. Different SHAs can carry
+    ///     different protocol-affecting changes, and the whole
+    ///     purpose of the handshake is to catch those during
+    ///     development iteration.
+    ///   • Otherwise — strip the suffix from whichever side has it
+    ///     and compare. So `0.12.0` (release) matches `0.12.0-5-gabc`
+    ///     (dev build atop that release) without a pointless restart.
+    ///
+    /// Pre-release tags like `-rc.1` are preserved and compare as
+    /// distinct — the regex only matches the numeric-distance-plus-
+    /// SHA pattern git-describe produces. See issue #142.
+    static func versionsMatch(_ a: String, _ b: String) -> Bool {
+        let aHasSuffix = gitDescribeRange(in: a) != nil
+        let bHasSuffix = gitDescribeRange(in: b) != nil
+        if aHasSuffix && bHasSuffix {
+            return a == b
+        }
+        return baseVersion(a) == baseVersion(b)
+    }
+
+    /// Strip the git-describe suffix `-<N>-g<SHA>`, if present.
+    static func baseVersion(_ version: String) -> String {
+        guard let range = gitDescribeRange(in: version) else { return version }
+        return String(version[..<range.lowerBound])
+    }
+
+    /// Match `-<N>-g<SHA>$` where SHA is at least 4 hex chars (git's
+    /// minimum short-sha length). Narrow on purpose so hand-crafted
+    /// strings like `0.12.0-1-gz` don't accidentally match.
+    static func gitDescribeRange(in version: String) -> Range<String.Index>? {
+        version.range(
+            of: "-[0-9]+-g[0-9a-f]{4,}$",
+            options: .regularExpression
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Step #8 of the architectural-refactor roadmap (and the last item from the plan that was on the active list). \`DaemonClient.swift\` was 501 lines covering six grown-organically concerns: auto-spawn, version handshake, restart-lock acquisition, stderr log forwarding, \`StallTimer\` wiring, and socket-readiness polling. The seams already existed in section comments — this PR moves them to discrete files via \`extension DaemonClient\`.

### After

| File | Lines | Owns |
|---|---|---|
| \`DaemonClient.swift\` | 328 | Public surface (\`connect\`, \`withDaemonClient\`), \`openClient\` handshake, daemon spawn + socket-readiness poll, \`DaemonClientError\` |
| \`DaemonRestart.swift\` (new) | 179 | Version-mismatch detection, restart-lock acquisition, kill-and-wait, git-describe version parsing |
| \`DaemonClientChannel.swift\` (new) | 55 | Notification-handler wiring (stderr log forwarder, stall-timer bumpers) |

The header docstring on \`DaemonClient\` describes the file layout so future maintainers don't have to grep for which file owns what.

### Visibility change

\`private static func\` → \`static func\` (default internal) at the extension boundary. Necessary because Swift's \`private\` is file-scoped and the extension blocks live in different files. PreviewsCLI is the executable target, so \`internal\` is effectively private from any external observer.

### Behavior preserved

No behavior change. \`AGENTS.md:240-241\` documents subtleties (timer seed, debug logging level) that all live in \`withDaemonClient\` — preserved verbatim.

## Test plan

- [x] \`swift build\` clean
- [x] \`swift-format format --in-place --recursive\` + \`swift-format lint --strict\` clean
- [x] \`swift test --filter VersionHandshakeTests\` — the version-mismatch path (\`_PREVIEWSMCP_TEST_DAEMON_VERSION\` env override + restart) still triggers a clean restart through \`restartDaemonAndReconnect\`
- [x] \`swift test --filter MacOSMCPTests\` — 7 tests pass including hot-reload, heartbeat, and the \`withTimeout\` pthread-timer regression guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)