### PR TITLE
Compile preview dylib with -wmo -num-threads N

### DIFF
--- a/Sources/PreviewsCore/Compiler.swift
+++ b/Sources/PreviewsCore/Compiler.swift
@@ -124,7 +124,15 @@ public actor Compiler {
 
         try source.write(to: sourceFile, atomically: true, encoding: .utf8)
 
-        // Build argument list
+        // Build argument list.
+        //
+        // `-wmo -num-threads N` is the "fast debug build" recipe: one frontend
+        // invocation type-checks the whole module once (cheaper than batched
+        // mode's per-batch re-typechecking on import-heavy code), then
+        // codegen parallelizes across N threads. `-num-threads` alone is a
+        // no-op without `-wmo`. Onone keeps cross-file inlining off so this
+        // doesn't slow down link.
+        let threadCount = ProcessInfo.processInfo.activeProcessorCount
         var args: [String] = [
             swiftcPath,
             "-emit-library",
@@ -134,6 +142,8 @@ public actor Compiler {
             "-module-name", moduleName,
             "-Onone",
             "-gnone",
+            "-wmo",
+            "-num-threads", String(threadCount),
             "-module-cache-path", moduleCachePath.path,
         ]
         args += extraFlags

--- a/Sources/PreviewsCore/Compiler.swift
+++ b/Sources/PreviewsCore/Compiler.swift
@@ -132,7 +132,18 @@ public actor Compiler {
         // codegen parallelizes across N threads. `-num-threads` alone is a
         // no-op without `-wmo`. Onone keeps cross-file inlining off so this
         // doesn't slow down link.
-        let threadCount = ProcessInfo.processInfo.activeProcessorCount
+        //
+        // `PREVIEWSMCP_SWIFTC_THREADS` overrides the thread count for
+        // benchmarking or for users on thermally-constrained machines who
+        // want to leave headroom for the rest of the system.
+        let threadCount: Int = {
+            if let override = ProcessInfo.processInfo.environment["PREVIEWSMCP_SWIFTC_THREADS"],
+                let n = Int(override), n > 0
+            {
+                return n
+            }
+            return ProcessInfo.processInfo.activeProcessorCount
+        }()
         var args: [String] = [
             swiftcPath,
             "-emit-library",


### PR DESCRIPTION
## Summary

- Add `-wmo` and `-num-threads N` to the swiftc invocation in `Compiler.compileCombined`.
- One frontend invocation type-checks the whole module once (instead of repeatedly across batches), then codegen parallelizes across cores.
- `-num-threads` is a no-op without `-wmo`, so both flags land together.
- N defaults to `ProcessInfo.activeProcessorCount` and can be overridden with the `PREVIEWSMCP_SWIFTC_THREADS` env var (for benchmarking and for thermally-constrained machines).

## Why

The structural-recompile path is the user-visible reload latency ceiling for UIKit previews and for SwiftUI structural edits — neither can take the literal-only fast path from #160/#163. On a large target (~339 files) the slow path takes ~115 s end-to-end today, dominated by per-batch re-typechecking under default batched mode.

This is a strictly cheaper precursor to full incremental compilation. No cache management, no driver-state bookkeeping, no invalidation rules. The full incremental work remains worth doing on top, but this should already deliver a meaningful chunk of the speedup with one-line cost.

## Test plan

- [x] \`swift build\` clean
- [x] \`swift test --filter PreviewsCoreTests\` (293 tests, ~17 s)
- [x] \`swift test --filter CLIIntegrationTests\` (69 tests, ~195 s — exercises real swiftc compiles for SPM/Xcode/Bazel example projects)
- [x] \`swift test --filter "MCPIntegrationTests" --skip "IOSMCPTests"\` (16 tests, ~51 s)
- [ ] Anecdotal measurement on a large real-world target to quantify the actual speedup
- [ ] Sweep \`PREVIEWSMCP_SWIFTC_THREADS\` against a representative target to find the practical sweet spot vs. \`activeProcessorCount\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)