### PR TITLE
Compile-perf benchmark scripts (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ xcuserdata/
 DerivedData/
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+bench-results.csv

--- a/scripts/bench-matrix.sh
+++ b/scripts/bench-matrix.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# bench-matrix.sh — run a grid of bench-swiftc.sh cells and emit a Markdown
+# table summarizing p50 + p95 wall time and median frontend job count.
+#
+# By default, runs a sensible exploratory grid that fits in a few minutes:
+#   modes: baseline, wmo, incremental
+#   files: 50, 200
+#   edits: cold, body, cascade-wide, leaf, noop
+#   wmo threads: activeProcessorCount
+#   runs: 5
+#
+# Override the grid via env vars:
+#   MODES, FILES, EDITS, THREADS, RUNS — space-separated lists.
+#
+# Output is written to stdout as Markdown. Raw CSV is also written to
+# $OUT_CSV (default: bench-results.csv) so you can re-aggregate later.
+#
+# Usage:
+#   Scripts/bench-matrix.sh
+#   MODES="wmo incremental" FILES="50 200 500" Scripts/bench-matrix.sh
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+BENCH="$HERE/bench-swiftc.sh"
+
+MODES="${MODES:-baseline wmo incremental}"
+FILES="${FILES:-50 200}"
+EDITS="${EDITS:-cold body cascade-wide leaf noop}"
+THREADS="${THREADS:-$(sysctl -n hw.activeCPU 2>/dev/null || sysctl -n hw.ncpu)}"
+RUNS="${RUNS:-5}"
+OUT_CSV="${OUT_CSV:-bench-results.csv}"
+
+# Single shared work dir so we don't keep recreating temp dirs.
+WORK=$(mktemp -d -t bench-matrix)
+trap 'rm -rf "$WORK"' EXIT
+
+echo "mode,files,threads,edit,run,wall_seconds,frontend_jobs" >"$OUT_CSV"
+
+total_cells=$(echo "$MODES $FILES $EDITS $THREADS" | awk '{print NF}')  # rough only
+echo "# Bench matrix" >&2
+echo "modes=[$MODES] files=[$FILES] edits=[$EDITS] threads=[$THREADS] runs=$RUNS" >&2
+echo "csv → $OUT_CSV" >&2
+echo "" >&2
+
+for mode in $MODES; do
+  for files in $FILES; do
+    for edit in $EDITS; do
+      # Threads only varies WMO; for other modes it's a no-op.
+      thread_grid="$THREADS"
+      if [[ "$mode" != "wmo" ]]; then thread_grid=$(echo "$THREADS" | awk '{print $1}'); fi
+      for threads in $thread_grid; do
+        echo "[run] mode=$mode files=$files edit=$edit threads=$threads runs=$RUNS" >&2
+        "$BENCH" \
+          --files "$files" --mode "$mode" --threads "$threads" --edit "$edit" \
+          --runs "$RUNS" --work "$WORK" --no-header >>"$OUT_CSV"
+      done
+    done
+  done
+done
+
+# Aggregate CSV → Markdown via python (statistics in stdlib).
+python3 - "$OUT_CSV" <<'PY'
+import csv, statistics, sys
+from collections import defaultdict
+
+path = sys.argv[1]
+groups = defaultdict(lambda: {"wall": [], "jobs": []})
+
+with open(path) as f:
+    reader = csv.DictReader(f)
+    for row in reader:
+        key = (row["mode"], row["files"], row["threads"], row["edit"])
+        groups[key]["wall"].append(float(row["wall_seconds"]))
+        groups[key]["jobs"].append(int(row["frontend_jobs"]))
+
+def pct(xs, p):
+    if not xs:
+        return float("nan")
+    xs = sorted(xs)
+    if len(xs) == 1:
+        return xs[0]
+    k = (len(xs) - 1) * (p / 100.0)
+    lo = int(k)
+    hi = min(lo + 1, len(xs) - 1)
+    return xs[lo] + (xs[hi] - xs[lo]) * (k - lo)
+
+print("| Mode | Files | Threads | Edit | p50 (s) | p95 (s) | Jobs (median) | N |")
+print("|---|---:|---:|---|---:|---:|---:|---:|")
+for key in sorted(groups, key=lambda k: (k[0], int(k[1]), int(k[2]), k[3])):
+    mode, files, threads, edit = key
+    walls = groups[key]["wall"]
+    jobs = groups[key]["jobs"]
+    p50 = statistics.median(walls)
+    p95v = pct(walls, 95)
+    jmed = int(statistics.median(jobs))
+    th = "-" if mode != "wmo" else threads
+    print(f"| {mode} | {files} | {th} | {edit} | {p50:.2f} | {p95v:.2f} | {jmed} | {len(walls)} |")
+PY

--- a/scripts/bench-swiftc.sh
+++ b/scripts/bench-swiftc.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+# bench-swiftc.sh — single-shot swiftc compile benchmark.
+#
+# Generates N chained Swift files (File_K depends on File_(K-1) so cascades
+# fan out predictably), runs a clean cold build, then applies one edit and
+# times the rebuild. Emits one CSV row per run.
+#
+# Used by bench-matrix.sh to populate a grid; can also be run standalone.
+#
+# Usage:
+#   Scripts/bench-swiftc.sh \
+#       --files 50 --mode wmo --threads 10 --edit body --runs 5
+#
+# Modes:
+#   baseline    — -Onone -gnone (pre-#173 default)
+#   wmo         — baseline + -wmo -num-threads N
+#   incremental — baseline + -incremental + -output-file-map
+#
+# Edits (applied AFTER a cold build, then time the rebuild):
+#   cold            — no edit; just measures the cold build
+#   body            — body change in middle file (no interface change)
+#   cascade-narrow  — interface change in second-to-last file (~2 files cascade)
+#   cascade-wide    — interface change in middle file (~half cascade)
+#   leaf            — body change in last file (no downstream dependents)
+#   noop            — touch mtime only, no content change
+set -euo pipefail
+
+FILES=50
+MODE=wmo
+THREADS=$(sysctl -n hw.activeCPU 2>/dev/null || sysctl -n hw.ncpu)
+EDIT=cold
+RUNS=5
+WORK=""
+HEADER=1
+
+usage() {
+  sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --files) FILES="$2"; shift 2 ;;
+    --mode) MODE="$2"; shift 2 ;;
+    --threads) THREADS="$2"; shift 2 ;;
+    --edit) EDIT="$2"; shift 2 ;;
+    --runs) RUNS="$2"; shift 2 ;;
+    --work) WORK="$2"; shift 2 ;;
+    --no-header) HEADER=0; shift ;;
+    -h|--help) usage ;;
+    *) echo "unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+case "$MODE" in baseline|wmo|incremental) ;; *) echo "bad --mode: $MODE" >&2; exit 2 ;; esac
+case "$EDIT" in cold|body|cascade-narrow|cascade-wide|leaf|noop) ;; *) echo "bad --edit: $EDIT" >&2; exit 2 ;; esac
+
+if [[ -z "$WORK" ]]; then
+  WORK=$(mktemp -d -t bench-swiftc)
+  trap 'rm -rf "$WORK"' EXIT
+fi
+SRC="$WORK/src"
+BUILD="$WORK/build"
+mkdir -p "$SRC" "$BUILD"
+
+SDK=$(xcrun --show-sdk-path --sdk macosx)
+SWIFTC=$(xcrun --find swiftc)
+TARGET=$(uname -m)-apple-macos14.0
+
+# Generate N chained Swift files. File_1 is a leaf; each File_K (K>1) depends
+# on File_(K-1) so changing File_X's public interface cascades to File_(X+1)..N.
+gen_sources() {
+  local n=$1
+  rm -rf "$SRC" && mkdir -p "$SRC"
+  for k in $(seq 1 "$n"); do
+    if [[ $k -eq 1 ]]; then
+      cat >"$SRC/File_$k.swift" <<EOF
+import Foundation
+public struct Type_$k: Sendable {
+    public let value: Int
+    public init(value: Int) { self.value = value }
+    public func describe() -> String { "Type_$k(\\(value))" }
+}
+public func make_$k() -> Type_$k { Type_$k(value: $k) }
+EOF
+    else
+      local prev=$((k - 1))
+      cat >"$SRC/File_$k.swift" <<EOF
+import Foundation
+public struct Type_$k: Sendable {
+    public let prev: Type_$prev
+    public let value: Int
+    public init(prev: Type_$prev, value: Int) { self.prev = prev; self.value = value }
+    public func describe() -> String { "Type_$k(\\(value)) <- \\(prev.describe())" }
+}
+public func make_$k() -> Type_$k { Type_$k(prev: make_$prev(), value: $k) }
+EOF
+    fi
+  done
+}
+
+# Generate output-file-map.json (used only in incremental mode).
+gen_fmap() {
+  local fmap="$BUILD/output-file-map.json"
+  {
+    echo '{'
+    echo '  "": {'
+    echo "    \"swift-dependencies\": \"$BUILD/master.swiftdeps\""
+    echo '  },'
+    local first=1
+    for f in "$SRC"/*.swift; do
+      local base
+      base=$(basename "$f" .swift)
+      if [[ $first -eq 1 ]]; then first=0; else echo ','; fi
+      cat <<EOF
+  "$f": {
+    "object": "$BUILD/$base.o",
+    "swift-dependencies": "$BUILD/$base.swiftdeps",
+    "swiftmodule": "$BUILD/$base.partial.swiftmodule"
+  }
+EOF
+    done
+    echo
+    echo '}'
+  } >"$fmap"
+}
+
+# Compose the swiftc invocation for the active mode.
+swiftc_args() {
+  local args=(
+    "$SWIFTC"
+    -emit-library
+    -parse-as-library
+    -target "$TARGET"
+    -sdk "$SDK"
+    -module-name Bench
+    -Onone
+    -gnone
+  )
+  case "$MODE" in
+    wmo)
+      args+=(-wmo -num-threads "$THREADS")
+      ;;
+    incremental)
+      args+=(-incremental -output-file-map "$BUILD/output-file-map.json" -driver-show-job-lifecycle)
+      ;;
+  esac
+  args+=(-o "$BUILD/libBench.dylib")
+  for f in "$SRC"/*.swift; do args+=("$f"); done
+  printf '%s\n' "${args[@]}"
+}
+
+# Apply the configured edit to the source tree. Idempotent — each run mutates
+# a unique file/spot using $i so repeated runs keep producing real changes.
+apply_edit() {
+  local i=$1
+  case "$EDIT" in
+    cold) : ;;
+    body)
+      local mid=$((FILES / 2))
+      perl -i -pe "s/Type_${mid}\\(value\\)/Type_${mid}(value+0+$i)/" "$SRC/File_${mid}.swift"
+      ;;
+    cascade-narrow)
+      local target=$((FILES - 1))
+      perl -i -pe "s/(public func describe)/public func bench_${i}() -> Int { $i }\n    \$1/" "$SRC/File_${target}.swift"
+      ;;
+    cascade-wide)
+      local mid=$((FILES / 2))
+      perl -i -pe "s/(public func describe)/public func bench_${i}() -> Int { $i }\n    \$1/" "$SRC/File_${mid}.swift"
+      ;;
+    leaf)
+      perl -i -pe "s/Type_${FILES}\\(value\\)/Type_${FILES}(value+0+$i)/" "$SRC/File_${FILES}.swift"
+      ;;
+    noop)
+      local mid=$((FILES / 2))
+      touch "$SRC/File_${mid}.swift"
+      ;;
+  esac
+}
+
+# Run swiftc and capture wall time + frontend job count. Echoes "wall jobs".
+run_once() {
+  local stderr_file="$BUILD/last.stderr"
+  local args
+  IFS=$'\n' read -r -d '' -a args < <(swiftc_args && printf '\0') || true
+  local t0 t1
+  t0=$(python3 -c 'import time; print(time.monotonic())')
+  "${args[@]}" 2>"$stderr_file"
+  t1=$(python3 -c 'import time; print(time.monotonic())')
+  local wall
+  wall=$(python3 -c "print(f'{$t1 - $t0:.3f}')")
+  local jobs
+  if [[ "$MODE" == incremental ]]; then
+    jobs=$(grep -c "Starting Compiling" "$stderr_file" || true)
+  else
+    jobs=1
+  fi
+  printf '%s %s\n' "$wall" "$jobs"
+}
+
+# Emit CSV header unless suppressed (for matrix runs).
+if [[ $HEADER -eq 1 ]]; then
+  echo "mode,files,threads,edit,run,wall_seconds,frontend_jobs"
+fi
+
+# Generate fresh sources for the whole batch. Each run gets a fresh cold build
+# (rm -rf build) so timings are independent of prior incremental state.
+gen_sources "$FILES"
+
+for run in $(seq 1 "$RUNS"); do
+  rm -rf "$BUILD" && mkdir -p "$BUILD"
+  if [[ "$MODE" == incremental ]]; then gen_fmap; fi
+
+  # Cold build (always — establishes the baseline state for the edit).
+  read -r _cold_wall _cold_jobs < <(run_once)
+
+  if [[ "$EDIT" == cold ]]; then
+    echo "$MODE,$FILES,$THREADS,$EDIT,$run,$_cold_wall,$_cold_jobs"
+    # Regenerate sources so each subsequent run starts from a clean slate.
+    gen_sources "$FILES"
+    continue
+  fi
+
+  apply_edit "$run"
+  read -r wall jobs < <(run_once)
+  echo "$MODE,$FILES,$THREADS,$EDIT,$run,$wall,$jobs"
+
+  # Reset sources between runs so cumulative edits don't drift the workload.
+  gen_sources "$FILES"
+done


### PR DESCRIPTION
## Summary

Two scripts for measuring \`swiftc\` compile cost across the modes we're considering for the preview dylib pipeline. Independent of the perf change in #173 — these inform follow-up decisions.

- \`scripts/bench-swiftc.sh\` — single-shot benchmark. Generates N chained Swift files (File_K depends on File_(K-1) so cascades fan out predictably), runs a cold build, applies an edit, times the rebuild. CSV output.
- \`scripts/bench-matrix.sh\` — runs a grid of bench-swiftc.sh cells across modes, file counts, and edit types. Aggregates to a Markdown table with p50/p95 wall time + median frontend-job count.

## Why

#173 added \`-wmo -num-threads N\` based on diagnostic reasoning. Two open questions remain:

1. **Quantify the actual speedup** of #173 on real workloads — at 50 files, ~12× over baseline; need to confirm scaling at 200/500/real-target sizes.
2. **Inform the incremental-compilation decision** — \`-wmo\` and \`-incremental\` are mutually exclusive (verified in the spike). Picking between them needs measurements at scale, not just intuition.

## Sample output (50 files, M-class hardware, 5 runs/cell)

\`\`\`
FILES=50 RUNS=5 scripts/bench-matrix.sh
\`\`\`

| Mode        | Files | Threads | Edit          | p50 (s) | p95 (s) | Jobs (median) |
|-------------|------:|--------:|---------------|--------:|--------:|--------------:|
| baseline    | 50    | -       | cold          | 4.25    | 4.28    | 1             |
| baseline    | 50    | -       | body          | 4.24    | 4.35    | 1             |
| baseline    | 50    | -       | cascade-wide  | 4.23    | 4.27    | 1             |
| wmo         | 50    | 8       | cold          | 0.35    | 0.37    | 1             |
| wmo         | 50    | 8       | body          | 0.35    | 0.37    | 1             |
| wmo         | 50    | 8       | cascade-wide  | 0.36    | 0.38    | 1             |
| incremental | 50    | -       | cold          | 4.27    | 4.32    | 50            |
| incremental | 50    | -       | body          | 0.28    | 0.29    | 1             |
| incremental | 50    | -       | cascade-wide  | 2.28    | 2.29    | 26            |
| incremental | 50    | -       | leaf          | 0.28    | 0.30    | 1             |
| incremental | 50    | -       | noop          | 0.29    | 0.30    | 1             |

Already visible from this slice: \`wmo\` is ~12× faster than baseline regardless of edit type (predictable). \`incremental\` is faster on body/leaf edits (~0.28s) but loses parallelism on cold and cascades because incremental and wmo can't coexist.

The shape is clean. The next questions are scaling (does \`wmo\` cold stay sub-second at 339 files? does incremental cascade still beat \`wmo\` at any scale?) and that's exactly what these scripts are for.

## Test plan

- [x] Smoke runs pass (\`MODES="wmo incremental" FILES=20 RUNS=3\`).
- [x] Real 50-file matrix produces sensible numbers (table above).
- [ ] Run on a representative large target (~339 files) to populate the test plan in #173.
- [ ] Optional: thread-count sweep (\`THREADS="1 4 8 16"\`) to validate the \`activeProcessorCount\` default.

## Non-goals

- Phase 2 (Compiler-actor integration bench) and Phase 3 (daemon-level reload-latency probe) are deferred. They build on top of this and run only if Phase 1 data calls for it.
- CI integration. These are exploratory tools; we'll wire them into CI only if regressions become a recurring problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)