### PR TITLE
Replace FileWatcher polling with FSEvents

### DIFF
--- a/Sources/PreviewsCore/FileWatcher.swift
+++ b/Sources/PreviewsCore/FileWatcher.swift
@@ -11,7 +11,6 @@ import Foundation
 /// One watch is installed per unique canonical parent directory; the callback
 /// fires when any event under those directories matches a watched path.
 public final class FileWatcher: @unchecked Sendable {
-    private let userPaths: [String]
     private let box: CallbackBox
     private let queue = DispatchQueue(label: "com.previewsmcp.filewatcher")
     private var stream: FSEventStreamRef?
@@ -46,7 +45,6 @@ public final class FileWatcher: @unchecked Sendable {
             parentDirs.insert((resolved as NSString).deletingLastPathComponent)
         }
 
-        self.userPaths = paths
         self.box = CallbackBox(canonicalPaths: canonical, callback: callback)
 
         // Hand FSEvents a retained pointer to `box`, not to `self`. The

--- a/Sources/PreviewsCore/FileWatcher.swift
+++ b/Sources/PreviewsCore/FileWatcher.swift
@@ -1,29 +1,31 @@
+import CoreServices
 import Foundation
 
-/// Watches one or more files for changes using polling.
-/// Checks file modification dates at a regular interval.
+/// Watches one or more files for changes using FSEvents.
+///
+/// FSEvents watches directories (not inodes), so atomic-rename saves —
+/// NSDocument, Xcode, JetBrains, default-config vim — surface as changes to
+/// the same path rather than vanishing into a deleted-inode hole the way a
+/// kqueue/`DispatchSource.makeFileSystemObjectSource` watcher would.
+///
+/// One watch is installed per unique canonical parent directory; the callback
+/// fires when any event under those directories matches a watched path.
 public final class FileWatcher: @unchecked Sendable {
-    private let filePaths: [String]
+    private let userPaths: [String]
+    private let canonicalPaths: Set<String>
     private let callback: @Sendable () -> Void
-    private var timer: DispatchSourceTimer?
-    private var lastModDates: [String: Date]
     private let queue = DispatchQueue(label: "com.previewsmcp.filewatcher")
+    private var stream: FSEventStreamRef?
 
-    /// Watch a file and call the callback when it's modified.
-    /// Polls every `interval` seconds (default: 0.5s).
     public convenience init(
         path: String,
-        interval: TimeInterval = 0.5,
         callback: @escaping @Sendable () -> Void
     ) throws {
-        try self.init(paths: [path], interval: interval, callback: callback)
+        try self.init(paths: [path], callback: callback)
     }
 
-    /// Watch multiple files and call the callback when any is modified.
-    /// Polls every `interval` seconds (default: 0.5s).
     public init(
         paths: [String],
-        interval: TimeInterval = 0.5,
         callback: @escaping @Sendable () -> Void
     ) throws {
         guard !paths.isEmpty else {
@@ -35,50 +37,85 @@ public final class FileWatcher: @unchecked Sendable {
             }
         }
 
-        self.filePaths = paths
+        self.userPaths = paths
         self.callback = callback
 
-        var dates: [String: Date] = [:]
+        var canonical = Set<String>()
+        var parentDirs = Set<String>()
         for path in paths {
-            dates[path] = Self.modDate(of: path)
+            let resolved = Self.canonicalize(path)
+            canonical.insert(resolved)
+            parentDirs.insert((resolved as NSString).deletingLastPathComponent)
         }
-        self.lastModDates = dates
+        self.canonicalPaths = canonical
 
-        let timer = DispatchSource.makeTimerSource(queue: queue)
-        timer.schedule(
-            deadline: .now() + interval,
-            repeating: interval
+        var context = FSEventStreamContext(
+            version: 0,
+            info: nil,
+            retain: nil,
+            release: nil,
+            copyDescription: nil
         )
-        timer.setEventHandler { [weak self] in
-            self?.checkForChanges()
+        context.info = Unmanaged.passUnretained(self).toOpaque()
+
+        let flags = UInt32(
+            kFSEventStreamCreateFlagFileEvents
+                | kFSEventStreamCreateFlagNoDefer
+                | kFSEventStreamCreateFlagUseCFTypes
+        )
+
+        let callbackTrampoline: FSEventStreamCallback = { _, info, numEvents, eventPaths, _, _ in
+            guard let info, numEvents > 0 else { return }
+            let watcher = Unmanaged<FileWatcher>.fromOpaque(info).takeUnretainedValue()
+            let cfPaths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue()
+            let nsPaths = cfPaths as NSArray
+            for case let path as String in nsPaths where watcher.canonicalPaths.contains(path) {
+                watcher.callback()
+                return
+            }
         }
-        self.timer = timer
-        timer.resume()
+
+        guard
+            let stream = FSEventStreamCreate(
+                kCFAllocatorDefault,
+                callbackTrampoline,
+                &context,
+                Array(parentDirs) as CFArray,
+                FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+                0.05,
+                flags
+            )
+        else {
+            throw FileWatcherError.cannotOpen(path: paths.first ?? "<unknown>")
+        }
+
+        self.stream = stream
+        FSEventStreamSetDispatchQueue(stream, queue)
+        FSEventStreamStart(stream)
     }
 
     public func stop() {
-        timer?.cancel()
-        timer = nil
+        // Drain any in-flight callback on `queue` before tearing down the
+        // stream — the callback dereferences `self` via an unretained info
+        // pointer, so it must not run after `stop()` returns to a deiniting
+        // owner.
+        queue.sync {
+            guard let stream else { return }
+            FSEventStreamStop(stream)
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+            self.stream = nil
+        }
     }
 
     deinit {
         stop()
     }
 
-    private func checkForChanges() {
-        for path in filePaths {
-            guard let newDate = Self.modDate(of: path) else { continue }
-            if newDate != lastModDates[path] {
-                lastModDates[path] = newDate
-                callback()
-                return  // Fire once per poll cycle
-            }
-        }
-    }
-
-    private static func modDate(of path: String) -> Date? {
-        let attrs = try? FileManager.default.attributesOfItem(atPath: path)
-        return attrs?[.modificationDate] as? Date
+    private static func canonicalize(_ path: String) -> String {
+        guard let resolved = realpath(path, nil) else { return path }
+        defer { free(resolved) }
+        return String(cString: resolved)
     }
 }
 

--- a/Sources/PreviewsCore/FileWatcher.swift
+++ b/Sources/PreviewsCore/FileWatcher.swift
@@ -12,8 +12,7 @@ import Foundation
 /// fires when any event under those directories matches a watched path.
 public final class FileWatcher: @unchecked Sendable {
     private let userPaths: [String]
-    private let canonicalPaths: Set<String>
-    private let callback: @Sendable () -> Void
+    private let box: CallbackBox
     private let queue = DispatchQueue(label: "com.previewsmcp.filewatcher")
     private var stream: FSEventStreamRef?
 
@@ -37,18 +36,24 @@ public final class FileWatcher: @unchecked Sendable {
             }
         }
 
-        self.userPaths = paths
-        self.callback = callback
-
         var canonical = Set<String>()
         var parentDirs = Set<String>()
         for path in paths {
-            let resolved = Self.canonicalize(path)
+            guard let resolved = Self.canonicalize(path) else {
+                throw FileWatcherError.cannotOpen(path: path)
+            }
             canonical.insert(resolved)
             parentDirs.insert((resolved as NSString).deletingLastPathComponent)
         }
-        self.canonicalPaths = canonical
 
+        self.userPaths = paths
+        self.box = CallbackBox(canonicalPaths: canonical, callback: callback)
+
+        // Hand FSEvents a retained pointer to `box`, not to `self`. The
+        // context's `release` callback drops the +1 when the stream is
+        // released by `stop()`. The callback trampoline dereferences `box`
+        // via unretained — safe because `box`'s lifetime is anchored to
+        // the stream itself, independent of `self`.
         var context = FSEventStreamContext(
             version: 0,
             info: nil,
@@ -56,7 +61,11 @@ public final class FileWatcher: @unchecked Sendable {
             release: nil,
             copyDescription: nil
         )
-        context.info = Unmanaged.passUnretained(self).toOpaque()
+        context.info = Unmanaged.passRetained(self.box).toOpaque()
+        context.release = { info in
+            guard let info else { return }
+            Unmanaged<CallbackBox>.fromOpaque(info).release()
+        }
 
         let flags = UInt32(
             kFSEventStreamCreateFlagFileEvents
@@ -66,11 +75,14 @@ public final class FileWatcher: @unchecked Sendable {
 
         let callbackTrampoline: FSEventStreamCallback = { _, info, numEvents, eventPaths, _, _ in
             guard let info, numEvents > 0 else { return }
-            let watcher = Unmanaged<FileWatcher>.fromOpaque(info).takeUnretainedValue()
+            let box = Unmanaged<CallbackBox>.fromOpaque(info).takeUnretainedValue()
             let cfPaths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue()
             let nsPaths = cfPaths as NSArray
-            for case let path as String in nsPaths where watcher.canonicalPaths.contains(path) {
-                watcher.callback()
+            // First match wins: a single change-event burst yields one
+            // callback regardless of how many watched paths it touched,
+            // matching the "one reload per change burst" intent.
+            for case let path as String in nsPaths where box.canonicalPaths.contains(path) {
+                box.callback()
                 return
             }
         }
@@ -86,19 +98,24 @@ public final class FileWatcher: @unchecked Sendable {
                 flags
             )
         else {
+            // FSEventStreamCreate did not take ownership; drop our +1 on box.
+            Unmanaged<CallbackBox>.fromOpaque(context.info!).release()
             throw FileWatcherError.cannotOpen(path: paths.first ?? "<unknown>")
         }
 
-        self.stream = stream
         FSEventStreamSetDispatchQueue(stream, queue)
-        FSEventStreamStart(stream)
+        guard FSEventStreamStart(stream) else {
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+            throw FileWatcherError.cannotOpen(path: paths.first ?? "<unknown>")
+        }
+        self.stream = stream
     }
 
     public func stop() {
         // Drain any in-flight callback on `queue` before tearing down the
-        // stream — the callback dereferences `self` via an unretained info
-        // pointer, so it must not run after `stop()` returns to a deiniting
-        // owner.
+        // stream. `FSEventStreamRelease` triggers the context's release
+        // callback, dropping the +1 on `box`.
         queue.sync {
             guard let stream else { return }
             FSEventStreamStop(stream)
@@ -112,10 +129,26 @@ public final class FileWatcher: @unchecked Sendable {
         stop()
     }
 
-    private static func canonicalize(_ path: String) -> String {
-        guard let resolved = realpath(path, nil) else { return path }
+    private static func canonicalize(_ path: String) -> String? {
+        guard let resolved = realpath(path, nil) else { return nil }
         defer { free(resolved) }
         return String(cString: resolved)
+    }
+}
+
+/// Immutable state read by the FSEvents callback trampoline.
+///
+/// The callback dereferences this via an unretained pointer; the stream's
+/// context release callback drops the matching +1 when the stream is
+/// released. Decoupling the callback from `FileWatcher` lets the watcher
+/// deinit without racing in-flight callbacks against partial destruction.
+private final class CallbackBox: @unchecked Sendable {
+    let canonicalPaths: Set<String>
+    let callback: @Sendable () -> Void
+
+    init(canonicalPaths: Set<String>, callback: @escaping @Sendable () -> Void) {
+        self.canonicalPaths = canonicalPaths
+        self.callback = callback
     }
 }
 

--- a/Tests/PreviewsCoreTests/BuildSystemTests.swift
+++ b/Tests/PreviewsCoreTests/BuildSystemTests.swift
@@ -382,17 +382,17 @@ struct BuildSystemTests {
         try "initial 2".write(to: file2, atomically: true, encoding: .utf8)
 
         let changed = Mutex(false)
-        let watcher = try FileWatcher(paths: [file1.path, file2.path], interval: 0.1) {
+        let watcher = try FileWatcher(paths: [file1.path, file2.path]) {
             changed.withLock { $0 = true }
         }
         defer { watcher.stop() }
 
-        // Wait a moment, then modify only the SECOND file
-        try await Task.sleep(for: .milliseconds(200))
+        // Give FSEvents time to install its watch before mutating.
+        try await Task.sleep(for: .milliseconds(100))
         try "modified 2".write(to: file2, atomically: true, encoding: .utf8)
 
-        // Wait for the watcher to detect the change
-        try await Task.sleep(for: .milliseconds(500))
+        // Wait for the watcher to detect the change (FSEvents latency ~50ms).
+        try await Task.sleep(for: .milliseconds(200))
 
         let didChange = changed.withLock { $0 }
         #expect(didChange, "FileWatcher should detect modification of the second watched file")

--- a/Tests/PreviewsCoreTests/IntegrationTests.swift
+++ b/Tests/PreviewsCoreTests/IntegrationTests.swift
@@ -225,20 +225,123 @@ struct IntegrationTests {
         try "initial content".write(to: file, atomically: true, encoding: .utf8)
 
         let changed = Mutex(false)
-        let watcher = try FileWatcher(path: file.path, interval: 0.1) {
+        let watcher = try FileWatcher(path: file.path) {
             changed.withLock { $0 = true }
         }
         defer { watcher.stop() }
 
-        // Wait a moment, then modify the file
-        try await Task.sleep(for: .milliseconds(200))
+        // Give FSEvents time to install its watch before mutating.
+        try await Task.sleep(for: .milliseconds(100))
         try "modified content".write(to: file, atomically: true, encoding: .utf8)
 
-        // Wait for the watcher to detect the change
-        try await Task.sleep(for: .milliseconds(500))
+        // Wait for the watcher to detect the change (FSEvents latency ~50ms).
+        try await Task.sleep(for: .milliseconds(200))
 
         let didChange = changed.withLock { $0 }
         #expect(didChange, "FileWatcher should detect the file modification")
+    }
+
+    /// Atomic-rename is how NSDocument, Xcode, JetBrains, and default-config
+    /// vim save. The original inode is unlinked and replaced — a kqueue/
+    /// inode-based watcher would go silent here; FSEvents reports the event
+    /// at path granularity.
+    @Test("FileWatcher detects atomic-rename save")
+    func fileWatcherAtomicRename() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previews-mcp-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let file = tempDir.appendingPathComponent("watched.swift")
+        try "initial".write(to: file, atomically: false, encoding: .utf8)
+
+        let changed = Mutex(false)
+        let watcher = try FileWatcher(path: file.path) {
+            changed.withLock { $0 = true }
+        }
+        defer { watcher.stop() }
+
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Explicit write-temp + rename, not `atomically: true` (which would
+        // hide whether the rename path is what we actually exercise).
+        let tmp = tempDir.appendingPathComponent("watched.swift.tmp")
+        try "modified".write(to: tmp, atomically: false, encoding: .utf8)
+        let renamed = rename(tmp.path, file.path)
+        #expect(renamed == 0, "rename(2) should succeed")
+
+        try await Task.sleep(for: .milliseconds(200))
+
+        #expect(
+            changed.withLock { $0 },
+            "FileWatcher should detect an atomic-rename save"
+        )
+    }
+
+    /// FSEvents coalesces successive writes inside its latency window into a
+    /// single delivery. The contract we care about is "at least one
+    /// callback" — zero would be a regression.
+    @Test("FileWatcher fires at least once for back-to-back saves")
+    func fileWatcherBackToBackSaves() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previews-mcp-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let file = tempDir.appendingPathComponent("watched.swift")
+        try "initial".write(to: file, atomically: false, encoding: .utf8)
+
+        let callCount = Mutex(0)
+        let watcher = try FileWatcher(path: file.path) {
+            callCount.withLock { $0 += 1 }
+        }
+        defer { watcher.stop() }
+
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Two writes inside the ~50ms latency window. FSEvents may coalesce
+        // them into a single callback — that is expected and fine.
+        try "write 1".write(to: file, atomically: false, encoding: .utf8)
+        try "write 2".write(to: file, atomically: false, encoding: .utf8)
+
+        try await Task.sleep(for: .milliseconds(200))
+
+        let count = callCount.withLock { $0 }
+        #expect(count >= 1, "Back-to-back saves should produce at least one callback, got \(count)")
+    }
+
+    /// Some editors (and some Foundation paths) delete the file and create
+    /// a new one on every save. A path-based watcher must survive this; an
+    /// inode-bound one would not.
+    @Test("FileWatcher survives delete-and-recreate save pattern")
+    func fileWatcherDeleteRecreate() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previews-mcp-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let file = tempDir.appendingPathComponent("watched.swift")
+        try "initial".write(to: file, atomically: false, encoding: .utf8)
+
+        let callCount = Mutex(0)
+        let watcher = try FileWatcher(path: file.path) {
+            callCount.withLock { $0 += 1 }
+        }
+        defer { watcher.stop() }
+
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Two delete-and-recreate cycles, spaced past the latency window so
+        // each one gets its own delivery rather than being coalesced into
+        // the first.
+        for i in 1...2 {
+            try FileManager.default.removeItem(at: file)
+            try "save \(i)".write(to: file, atomically: false, encoding: .utf8)
+            try await Task.sleep(for: .milliseconds(150))
+        }
+
+        let count = callCount.withLock { $0 }
+        #expect(count >= 1, "Watcher should still be firing after delete+recreate, got \(count)")
     }
 }
 

--- a/Tests/PreviewsCoreTests/IntegrationTests.swift
+++ b/Tests/PreviewsCoreTests/IntegrationTests.swift
@@ -263,12 +263,24 @@ struct IntegrationTests {
 
         try await Task.sleep(for: .milliseconds(100))
 
+        let initialInode =
+            try FileManager.default.attributesOfItem(atPath: file.path)[.systemFileNumber]
+            as? UInt64
+
         // Explicit write-temp + rename, not `atomically: true` (which would
         // hide whether the rename path is what we actually exercise).
         let tmp = tempDir.appendingPathComponent("watched.swift.tmp")
         try "modified".write(to: tmp, atomically: false, encoding: .utf8)
         let renamed = rename(tmp.path, file.path)
         #expect(renamed == 0, "rename(2) should succeed")
+
+        let finalInode =
+            try FileManager.default.attributesOfItem(atPath: file.path)[.systemFileNumber]
+            as? UInt64
+        #expect(
+            initialInode != nil && finalInode != nil && initialInode != finalInode,
+            "rename(2) should have replaced the file's inode (so this exercises the inode-vanish hole, not an in-place write)"
+        )
 
         try await Task.sleep(for: .milliseconds(200))
 
@@ -331,17 +343,21 @@ struct IntegrationTests {
 
         try await Task.sleep(for: .milliseconds(100))
 
-        // Two delete-and-recreate cycles, spaced past the latency window so
-        // each one gets its own delivery rather than being coalesced into
-        // the first.
+        // Two delete-and-recreate cycles, spaced well past the latency
+        // window so each cycle gets its own delivery rather than being
+        // coalesced into the first. Per-cycle assertion catches the
+        // regression where only the initial cycle fires.
         for i in 1...2 {
+            let beforeCycle = callCount.withLock { $0 }
             try FileManager.default.removeItem(at: file)
             try "save \(i)".write(to: file, atomically: false, encoding: .utf8)
-            try await Task.sleep(for: .milliseconds(150))
+            try await Task.sleep(for: .milliseconds(300))
+            let afterCycle = callCount.withLock { $0 }
+            #expect(
+                afterCycle > beforeCycle,
+                "Cycle \(i): watcher should have fired after delete+recreate (before=\(beforeCycle), after=\(afterCycle))"
+            )
         }
-
-        let count = callCount.withLock { $0 }
-        #expect(count >= 1, "Watcher should still be firing after delete+recreate, got \(count)")
     }
 }
 

--- a/Tests/PreviewsCoreTests/IntegrationTests.swift
+++ b/Tests/PreviewsCoreTests/IntegrationTests.swift
@@ -346,12 +346,13 @@ struct IntegrationTests {
         // Two delete-and-recreate cycles, spaced well past the latency
         // window so each cycle gets its own delivery rather than being
         // coalesced into the first. Per-cycle assertion catches the
-        // regression where only the initial cycle fires.
+        // regression where only the initial cycle fires. 500ms leaves
+        // ~10× the FSEvents latency for headroom on heavily-loaded CI.
         for i in 1...2 {
             let beforeCycle = callCount.withLock { $0 }
             try FileManager.default.removeItem(at: file)
             try "save \(i)".write(to: file, atomically: false, encoding: .utf8)
-            try await Task.sleep(for: .milliseconds(300))
+            try await Task.sleep(for: .milliseconds(500))
             let afterCycle = callCount.withLock { $0 }
             #expect(
                 afterCycle > beforeCycle,

--- a/Tests/PreviewsMacOSTests/PreviewHostTests.swift
+++ b/Tests/PreviewsMacOSTests/PreviewHostTests.swift
@@ -10,13 +10,13 @@ struct PreviewHostTests {
 
     /// Regression guard for the iOS `run` hot-reload bug.
     ///
-    /// `FileWatcher`'s timer closure captures self weakly, so a watcher goes
-    /// silent as soon as the binding that owns it falls out of scope. The
-    /// iOS `launchIOSPreview` path creates a watcher inside a function that
-    /// returns, so without an external retain the watcher deinits and hot
-    /// reload silently stops firing. `PreviewHost.retainFileWatcher` is the
-    /// hand-off that keeps it alive — if that mechanism breaks, this test
-    /// should go red.
+    /// `FileWatcher` callbacks dereference `self` via an unretained pointer,
+    /// so a watcher goes silent as soon as the binding that owns it falls
+    /// out of scope. The iOS `launchIOSPreview` path creates a watcher
+    /// inside a function that returns, so without an external retain the
+    /// watcher deinits and hot reload silently stops firing.
+    /// `PreviewHost.retainFileWatcher` is the hand-off that keeps it
+    /// alive — if that mechanism breaks, this test should go red.
     @Test("retainFileWatcher keeps a watcher alive past the creating scope")
     func retainFileWatcherKeepsWatcherAlive() async throws {
         let host = PreviewHost()
@@ -35,18 +35,19 @@ struct PreviewHostTests {
         // before we touch the file. Without `retainFileWatcher` the watcher
         // would deinit here and the callback below would never fire.
         do {
-            let watcher = try FileWatcher(path: file.path, interval: 0.1) {
+            let watcher = try FileWatcher(path: file.path) {
                 fired.withLock { $0 = true }
             }
             host.retainFileWatcher(watcher)
         }
 
-        // Give the inner scope's release a chance to actually run.
-        try await Task.sleep(for: .milliseconds(200))
+        // Give the inner scope's release a chance to actually run, and
+        // FSEvents a moment to install its watch.
+        try await Task.sleep(for: .milliseconds(100))
 
         // Modify the file — the retained watcher should see it.
         try "modified".write(to: file, atomically: true, encoding: .utf8)
-        try await Task.sleep(for: .milliseconds(500))
+        try await Task.sleep(for: .milliseconds(200))
 
         #expect(
             fired.withLock { $0 },


### PR DESCRIPTION
## Summary
- Replaces `Sources/PreviewsCore/FileWatcher.swift`'s 0.5s polling loop with FSEvents: one watch per canonical parent directory, ~50ms latency (~10× faster worst-case), correctly observes atomic-rename saves (NSDocument, Xcode, JetBrains, default-config vim) that a kqueue/inode-based watcher would silently miss.
- Public API unchanged except the now-meaningless `interval:` parameter is removed; no production call sites passed it, three test call sites updated.
- Design rationale: `prompts/filewatcher.md`.

## What changed
- `Sources/PreviewsCore/FileWatcher.swift` — FSEvents rewrite. Resolves each input path through `realpath()` once at init, watches the unique canonical parents with `kFSEventStreamCreateFlagFileEvents | NoDefer | UseCFTypes`, filters incoming event paths against a `Set<String>` of canonical paths.
- FSEvents callback state lives in a separate `CallbackBox` (canonicalPaths + closure) handed to the stream's context with retained semantics + matching `release` callback. The trampoline dereferences `box`, not `self`, so a callback enqueued before `deinit` cannot run against a partially-destroyed `FileWatcher`. `realpath` failure and `FSEventStreamStart == false` both throw.
- Three test call sites drop `interval:` and tighten sleeps from 500ms → 200ms.
- Three new tests in `IntegrationTests.swift`:
  - **atomic-rename save** — explicit write-temp + `rename(2)`; verifies the inode actually changed so the test exercises the inode-vanish hole.
  - **back-to-back saves** — two writes inside the latency window; asserts ≥1 callback (coalescing allowed, zero would be a regression).
  - **delete-and-recreate** — per-cycle assertion with 300ms spacing; catches the regression where only the first cycle fires.

## Test plan
- [x] `swift test --filter "fileWatcher|retainFileWatcher"` → 6/6 pass
- [x] `swift test --filter "PreviewsCoreTests"` → 304/304 pass (no regressions)
- [x] `swift test --filter "PreviewsMacOSTests"` → 1/1 pass (`retainFileWatcher` lifecycle regression)
- [x] `swift build` clean; `swift-format --strict` clean; `swiftlint` clean on changed files
- [ ] Manual smoke against an example project (hot-reload on `examples/spm` or `examples/xcode` with the new watcher) — recommend before merge
- [ ] CI: full `build-and-test` + `ios-tests` jobs

## Notes
- The code-review pass that drove commit 2 caught a UAF race in the original `passUnretained(self)` design (see commit message for details). Worth a second look at the `CallbackBox` indirection in `FileWatcher.swift:53-72` to confirm the lifecycle reasoning holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)