### PR TITLE
Fix Xcode test builds: demote PreviewsCLI to library, add previewsmcp shim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,9 +50,12 @@ Sources/
 ├── PreviewsCore/        # Platform-agnostic: parser, compiler, bridge gen, differ, file watcher
 ├── PreviewsMacOS/       # macOS host: NSApplication + NSWindow + Snapshot (runs inside the daemon)
 ├── PreviewsIOS/         # iOS simulator: SimulatorManager, IOSHostBuilder, IOSPreviewSession
-├── PreviewsCLI/         # CLI (ArgumentParser) + daemon + MCP server (swift-sdk)
+├── PreviewsCLI/         # CLI (ArgumentParser) + daemon + MCP server (swift-sdk) — library target
+├── previewsmcp/         # Thin executable shim: one-line main.swift → PreviewsMCPApp.main()
 └── PreviewsSetupKit/    # Setup plugin protocol (PreviewSetup) — zero-dependency SwiftUI-only library
 ```
+
+`PreviewsCLI` is a library, not an `executableTarget`, so the test targets in `Tests/PreviewsCLITests/` and `Tests/MCPIntegrationTests/` can `@testable import PreviewsCLI` under both `swift test` and Xcode-driven SPM builds (Xcode's dependency scanner refuses to expose an executable target's swiftmodule to dependent tests, which broke `xcodebuild build-for-testing` before PR #184). `Sources/previewsmcp/` is a three-line shim that imports `PreviewsCLI` and calls `PreviewsMCPApp.main()` — the only purpose of that target is to be the executable product. Match the `previewsmcp` directory/target naming if `PreviewsCLI` is sliced further (see `prompts/modularization.md` on the `previews-research` branch).
 
 - **PreviewsCore** has no platform-specific dependencies (no AppKit, no CoreSimulator)
 - **SimulatorBridge** is ObjC because it uses `objc_lookUpClass` / protocol casts for private API access

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "PreviewsMCP",
     platforms: [.macOS(.v14), .iOS(.v16)],
     products: [
-        .executable(name: "previewsmcp", targets: ["PreviewsCLI"]),
+        .executable(name: "previewsmcp", targets: ["previewsmcp"]),
         .library(name: "PreviewsCore", targets: ["PreviewsCore"]),
         .library(name: "PreviewsSetupKit", targets: ["PreviewsSetupKit"]),
     ],
@@ -47,7 +47,7 @@ let package = Package(
             name: "PreviewsEngine",
             dependencies: ["PreviewsCore", "PreviewsIOS", "PreviewsMacOS"]
         ),
-        .executableTarget(
+        .target(
             name: "PreviewsCLI",
             dependencies: [
                 "PreviewsCore",
@@ -58,6 +58,10 @@ let package = Package(
                 .product(name: "MCP", package: "swift-sdk"),
             ],
             plugins: [.plugin(name: "GenerateVersion")]
+        ),
+        .executableTarget(
+            name: "previewsmcp",
+            dependencies: ["PreviewsCLI"]
         ),
         .executableTarget(
             name: "GenerateVersionTool"

--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -20,9 +20,9 @@ enum ProcessStartup {
     static let time = Date()
 }
 
-@main
-struct PreviewsMCPApp {
-    static func main() {
+public struct PreviewsMCPApp {
+    @MainActor
+    public static func main() {
         // Touch ProcessStartup.time at the earliest possible point so its
         // lazy-init resolves to the actual app-birth instant.
         _ = ProcessStartup.time

--- a/Sources/previewsmcp/main.swift
+++ b/Sources/previewsmcp/main.swift
@@ -1,0 +1,3 @@
+import PreviewsCLI
+
+PreviewsMCPApp.main()

--- a/Sources/previewsmcp/main.swift
+++ b/Sources/previewsmcp/main.swift
@@ -1,3 +1,6 @@
+// Thin shim. PreviewsCLI is a library so test targets can @testable
+// import it under Xcode (PR #184); this target is the executable
+// product `previewsmcp` and exists only to call into it.
 import PreviewsCLI
 
 PreviewsMCPApp.main()


### PR DESCRIPTION
## Summary

Xcode-driven SPM builds were failing in `PreviewsCLITests` and `MCPIntegrationTests` with:

```
error: Unable to find module dependency: 'PreviewsCLI'
@testable import PreviewsCLI
```

`@testable import` of an `executableTarget` works under `swift test` but not in Xcode — its dependency scanner doesn't expose the executable's swiftmodule to dependent test targets.

- Demote `PreviewsCLI` from `executableTarget` to library `target` (keeps name, so existing `@testable import PreviewsCLI` in 7 test files keeps working).
- Add a thin `previewsmcp` executable target with a one-line `main.swift` that calls `PreviewsMCPApp.main()`.
- Repoint the `previewsmcp` product at the new exec target — on-disk binary path is unchanged (`.build/debug/previewsmcp`).
- Annotate `PreviewsMCPApp.main()` `@MainActor` to restore the isolation `@main` was giving implicitly (otherwise `NSApplication.shared.run()` and `host.onLaunch =` fail Swift 6 actor checks).

The target/directory name `previewsmcp` matches the layout in `prompts/modularization.md` on `previews-research`, which plans to slice this library further into Server/Client/Protocol modules — this is a small step toward that layout.

## Test plan

- [x] `swift build` clean
- [x] `swift test --filter PreviewsCLITests` — 14/14 pass
- [x] `xcodebuild ... -scheme PreviewsMCP-Package build-for-testing` — `** TEST BUILD SUCCEEDED **`
- [x] `.build/debug/previewsmcp --version` / `--help` work
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)