### PR TITLE
JIT executor Phase 1: in-process JIT-link mechanism

### DIFF
--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bootstrap
-description: Set up the development environment for this repository. Installs dependencies via Homebrew, configures git hooks, and builds the project. Pass `--examples` to also install dependencies for the example projects (Bazel, Xcode).
+description: Set up the development environment for this repository. Installs dependencies via Homebrew, configures git hooks, and builds the project. Pass `--examples` to also install dependencies for the example projects (Bazel, Xcode). Pass `--jit` to build the LLVM and orc-runtime dependencies the JIT executor links.
 allowed-tools: Bash, Read, Glob
 ---
 
@@ -9,6 +9,7 @@ Bootstrap the PreviewsMCP development environment.
 ## Arguments
 
 - `--examples` — Also install dependencies and build the example projects (Bazel and Xcode).
+- `--jit` — Also build the LLVM and orc-runtime archives the JIT executor links, via `scripts/build-jit-llvm.sh`. Opt-in and slow (a multi-GB sparse clone plus build). Only contributors working on the JIT executor need this.
 
 ## Steps
 
@@ -18,10 +19,12 @@ Bootstrap the PreviewsMCP development environment.
 
 3. **Build the project.** Run `swift build` from the repo root. If the build fails, stop and report the error.
 
-4. **Bazel example (if `--examples`).** Set up bazelisk: run `cd examples/bazel && mise install` (requires mise) or `brew install bazelisk`. Verify with `cd examples/bazel && bazel build //Sources/ToDo`.
+4. **JIT dependencies (if `--jit`).** Ensure `cmake` and `ninja` are installed (`brew install cmake ninja`). Run `scripts/build-jit-llvm.sh` from the repo root to build the Swift-fork LLVM and orc runtime into `third_party/` (gitignored, opt-in, slow). Verify with `swift test --filter PreviewsJITLinkTests`.
 
-5. **Xcode example (if `--examples`).** Install Mint and XcodeGen: run `brew install mint && cd examples/xcodeproj && mint bootstrap`. Generate the project with `mint run xcodegen generate`. Verify with `xcodebuild build -project ToDo.xcodeproj -scheme ToDo -destination 'platform=macOS'`.
+5. **Bazel example (if `--examples`).** Set up bazelisk: run `cd examples/bazel && mise install` (requires mise) or `brew install bazelisk`. Verify with `cd examples/bazel && bazel build //Sources/ToDo`.
 
-6. **Verify setup.** Run `swift-format --version`, `swiftlint version`, and `swift --version` to confirm tool availability. If `--examples` was passed, also verify `bazel --version` and `mint version`.
+6. **Xcode example (if `--examples`).** Install Mint and XcodeGen: run `brew install mint && cd examples/xcodeproj && mint bootstrap`. Generate the project with `mint run xcodegen generate`. Verify with `xcodebuild build -project ToDo.xcodeproj -scheme ToDo -destination 'platform=macOS'`.
 
-7. **Report.** Summarize what was set up and confirm the environment is ready.
+7. **Verify setup.** Run `swift-format --version`, `swiftlint version`, and `swift --version` to confirm tool availability. If `--examples` was passed, also verify `bazel --version` and `mint version`.
+
+8. **Report.** Summarize what was set up and confirm the environment is ready.

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ DerivedData/
 .claude/worktrees/
 .claude/scheduled_tasks.lock
 
-# JIT LLVM build (scripts/build-jit-llvm.sh)
 /third_party/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ xcuserdata/
 DerivedData/
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+
+# JIT LLVM build (scripts/build-jit-llvm.sh)
+/third_party/

--- a/Package.swift
+++ b/Package.swift
@@ -7,11 +7,15 @@ import PackageDescription
 let packageDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
 let llvmBuild = "\(packageDir)/third_party/llvm-build"
 let llvmSrcInclude = "\(packageDir)/third_party/llvm-project/llvm/include"
+let orcRuntimeArchive = "\(packageDir)/third_party/llvm-build-rt/lib/darwin/liborc_rt_osx.a"
 
-// The JIT targets link a locally-built LLVM under third_party/ (gitignored, via
-// `bootstrap --jit`). Omit them when those deps are absent so CI and non-JIT
-// contributors build the rest of the package.
-let jitEnabled = FileManager.default.fileExists(atPath: llvmBuild)
+// The JIT targets link a locally-built LLVM and copy the orc runtime archive,
+// both under third_party/ (gitignored, via `bootstrap --jit`). Require both so a
+// partial build does not turn the targets on with the archive missing. Omit them
+// otherwise so CI and non-JIT contributors build the rest of the package.
+let jitEnabled =
+    FileManager.default.fileExists(atPath: llvmBuild)
+    && FileManager.default.fileExists(atPath: orcRuntimeArchive)
 
 var targets: [Target] = [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -8,36 +8,115 @@ let packageDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().pat
 let llvmBuild = "\(packageDir)/third_party/llvm-build"
 let llvmSrcInclude = "\(packageDir)/third_party/llvm-project/llvm/include"
 
-let package = Package(
-    name: "PreviewsMCP",
-    platforms: [.macOS(.v14), .iOS(.v16)],
-    products: [
-        .executable(name: "previewsmcp", targets: ["previewsmcp"]),
-        .library(name: "PreviewsCore", targets: ["PreviewsCore"]),
-        .library(name: "PreviewsSetupKit", targets: ["PreviewsSetupKit"]),
-    ],
-    dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.1"),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
-        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.7.1"),
-    ],
-    targets: [
-        .target(
-            name: "SimulatorBridge",
-            linkerSettings: [
-                .linkedFramework("IOSurface"),
-                .linkedFramework("CoreImage"),
-                .linkedFramework("ImageIO"),
-                .linkedFramework("UniformTypeIdentifiers"),
-            ]
-        ),
-        .target(
-            name: "PreviewsCore",
-            dependencies: [
-                .product(name: "SwiftParser", package: "swift-syntax"),
-                .product(name: "SwiftSyntax", package: "swift-syntax"),
-            ]
-        ),
+// The JIT targets link a locally-built LLVM under third_party/ (gitignored, via
+// `bootstrap --jit`). Omit them when those deps are absent so CI and non-JIT
+// contributors build the rest of the package.
+let jitEnabled = FileManager.default.fileExists(atPath: llvmBuild)
+
+var targets: [Target] = [
+    .target(
+        name: "SimulatorBridge",
+        linkerSettings: [
+            .linkedFramework("IOSurface"),
+            .linkedFramework("CoreImage"),
+            .linkedFramework("ImageIO"),
+            .linkedFramework("UniformTypeIdentifiers"),
+        ]
+    ),
+    .target(
+        name: "PreviewsCore",
+        dependencies: [
+            .product(name: "SwiftParser", package: "swift-syntax"),
+            .product(name: "SwiftSyntax", package: "swift-syntax"),
+        ]
+    ),
+    .target(
+        name: "PreviewsSetupKit"
+    ),
+    .target(
+        name: "PreviewsMacOS",
+        dependencies: ["PreviewsCore"]
+    ),
+    .target(
+        name: "PreviewsIOS",
+        dependencies: ["PreviewsCore", "SimulatorBridge"],
+        plugins: [.plugin(name: "EmbedHostAppSource")]
+    ),
+    .target(
+        name: "PreviewsEngine",
+        dependencies: ["PreviewsCore", "PreviewsIOS", "PreviewsMacOS"]
+    ),
+    .target(
+        name: "PreviewsCLI",
+        dependencies: [
+            "PreviewsCore",
+            "PreviewsMacOS",
+            "PreviewsIOS",
+            "PreviewsEngine",
+            .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            .product(name: "MCP", package: "swift-sdk"),
+        ],
+        plugins: [.plugin(name: "GenerateVersion")]
+    ),
+    .executableTarget(
+        name: "previewsmcp",
+        dependencies: ["PreviewsCLI"]
+    ),
+    .executableTarget(
+        name: "GenerateVersionTool"
+    ),
+    .plugin(
+        name: "GenerateVersion",
+        capability: .buildTool(),
+        dependencies: ["GenerateVersionTool"]
+    ),
+    .executableTarget(
+        name: "EmbedHostAppSourceTool"
+    ),
+    .plugin(
+        name: "EmbedHostAppSource",
+        capability: .buildTool(),
+        dependencies: ["EmbedHostAppSourceTool"]
+    ),
+    .testTarget(
+        name: "PreviewsCoreTests",
+        dependencies: ["PreviewsCore"]
+    ),
+    .testTarget(
+        name: "PreviewsMacOSTests",
+        dependencies: ["PreviewsMacOS"]
+    ),
+    .testTarget(
+        name: "PreviewsIOSTests",
+        dependencies: ["PreviewsIOS"]
+    ),
+    .testTarget(
+        name: "PreviewsEngineTests",
+        dependencies: ["PreviewsEngine"]
+    ),
+    .testTarget(
+        name: "CLIIntegrationTests",
+        dependencies: []
+    ),
+    .testTarget(
+        name: "PreviewsCLITests",
+        dependencies: [
+            "PreviewsCLI",
+            .product(name: "MCP", package: "swift-sdk"),
+        ],
+        exclude: ["list_tools_snapshot.json"]
+    ),
+    .testTarget(
+        name: "MCPIntegrationTests",
+        dependencies: [
+            "PreviewsCLI",
+            .product(name: "MCP", package: "swift-sdk"),
+        ]
+    ),
+]
+
+if jitEnabled {
+    targets += [
         .target(
             name: "PreviewsJITLink",
             dependencies: ["PreviewsJITLinkCxx"],
@@ -62,98 +141,31 @@ let package = Package(
                 ])
             ]
         ),
-        .testTarget(
-            name: "PreviewsJITLinkTests",
-            dependencies: ["PreviewsJITLink", "PreviewsCore"],
-            exclude: ["Fixtures"]
-        ),
-        .target(
-            name: "PreviewsSetupKit"
-        ),
-        .target(
-            name: "PreviewsMacOS",
-            dependencies: ["PreviewsCore"]
-        ),
-        .target(
-            name: "PreviewsIOS",
-            dependencies: ["PreviewsCore", "SimulatorBridge"],
-            plugins: [.plugin(name: "EmbedHostAppSource")]
-        ),
-        .target(
-            name: "PreviewsEngine",
-            dependencies: ["PreviewsCore", "PreviewsIOS", "PreviewsMacOS"]
-        ),
-        .target(
-            name: "PreviewsCLI",
-            dependencies: [
-                "PreviewsCore",
-                "PreviewsMacOS",
-                "PreviewsIOS",
-                "PreviewsEngine",
-                .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "MCP", package: "swift-sdk"),
-            ],
-            plugins: [.plugin(name: "GenerateVersion")]
-        ),
-        .executableTarget(
-            name: "previewsmcp",
-            dependencies: ["PreviewsCLI"]
-        ),
-        .executableTarget(
-            name: "GenerateVersionTool"
-        ),
-        .plugin(
-            name: "GenerateVersion",
-            capability: .buildTool(),
-            dependencies: ["GenerateVersionTool"]
-        ),
-        .executableTarget(
-            name: "EmbedHostAppSourceTool"
-        ),
-        .plugin(
-            name: "EmbedHostAppSource",
-            capability: .buildTool(),
-            dependencies: ["EmbedHostAppSourceTool"]
-        ),
         .plugin(
             name: "BundleOrcRuntime",
             capability: .buildTool()
         ),
         .testTarget(
-            name: "PreviewsCoreTests",
-            dependencies: ["PreviewsCore"]
+            name: "PreviewsJITLinkTests",
+            dependencies: ["PreviewsJITLink", "PreviewsCore"],
+            exclude: ["Fixtures"]
         ),
-        .testTarget(
-            name: "PreviewsMacOSTests",
-            dependencies: ["PreviewsMacOS"]
-        ),
-        .testTarget(
-            name: "PreviewsIOSTests",
-            dependencies: ["PreviewsIOS"]
-        ),
-        .testTarget(
-            name: "PreviewsEngineTests",
-            dependencies: ["PreviewsEngine"]
-        ),
-        .testTarget(
-            name: "CLIIntegrationTests",
-            dependencies: []
-        ),
-        .testTarget(
-            name: "PreviewsCLITests",
-            dependencies: [
-                "PreviewsCLI",
-                .product(name: "MCP", package: "swift-sdk"),
-            ],
-            exclude: ["list_tools_snapshot.json"]
-        ),
-        .testTarget(
-            name: "MCPIntegrationTests",
-            dependencies: [
-                "PreviewsCLI",
-                .product(name: "MCP", package: "swift-sdk"),
-            ]
-        ),
+    ]
+}
+
+let package = Package(
+    name: "PreviewsMCP",
+    platforms: [.macOS(.v14), .iOS(.v16)],
+    products: [
+        .executable(name: "previewsmcp", targets: ["previewsmcp"]),
+        .library(name: "PreviewsCore", targets: ["PreviewsCore"]),
+        .library(name: "PreviewsSetupKit", targets: ["PreviewsSetupKit"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.1"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
+        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.7.1"),
+    ],
+    targets: targets,
     cxxLanguageStandard: .cxx17
 )

--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         ),
         .testTarget(
             name: "PreviewsJITLinkTests",
-            dependencies: ["PreviewsJITLink"],
+            dependencies: ["PreviewsJITLink", "PreviewsCore"],
             exclude: ["Fixtures"]
         ),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -128,7 +128,8 @@ let package = Package(
             dependencies: [
                 "PreviewsCLI",
                 .product(name: "MCP", package: "swift-sdk"),
-            ]
+            ],
+            exclude: ["list_tools_snapshot.json"]
         ),
         .testTarget(
             name: "MCPIntegrationTests",

--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,29 @@ let package = Package(
             ]
         ),
         .target(
+            name: "PreviewsJITLink",
+            dependencies: ["PreviewsJITLinkCxx"]
+        ),
+        .target(
+            // TODO: need to update to bundled version of LLVM in the future
+            name: "PreviewsJITLinkCxx",
+            cxxSettings: [
+                .unsafeFlags(["-I/opt/homebrew/opt/llvm/include"])
+            ],
+            linkerSettings: [
+                .unsafeFlags([
+                    "-L/opt/homebrew/opt/llvm/lib",
+                    "-lLLVM",
+                    "-Xlinker", "-rpath",
+                    "-Xlinker", "/opt/homebrew/opt/llvm/lib",
+                ])
+            ]
+        ),
+        .testTarget(
+            name: "PreviewsJITLinkTests",
+            dependencies: ["PreviewsJITLink"]
+        ),
+        .target(
             name: "PreviewsSetupKit"
         ),
         .target(
@@ -113,5 +136,6 @@ let package = Package(
                 .product(name: "MCP", package: "swift-sdk"),
             ]
         ),
-    ]
+    ],
+    cxxLanguageStandard: .cxx17
 )

--- a/Package.swift
+++ b/Package.swift
@@ -51,6 +51,7 @@ let package = Package(
                     "-I\(llvmSrcInclude)",
                     "-I\(llvmBuild)/include",
                     "-DPREVIEWSMCP_ORC_RT_PATH=\"\(orcRuntimePath)\"",
+                    "-fno-rtti",
                 ])
             ],
             linkerSettings: [

--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,8 @@ let package = Package(
         ),
         .testTarget(
             name: "PreviewsJITLinkTests",
-            dependencies: ["PreviewsJITLink"]
+            dependencies: ["PreviewsJITLink"],
+            exclude: ["Fixtures"]
         ),
         .target(
             name: "PreviewsSetupKit"

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,6 @@ import PackageDescription
 let packageDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
 let llvmBuild = "\(packageDir)/third_party/llvm-build"
 let llvmSrcInclude = "\(packageDir)/third_party/llvm-project/llvm/include"
-let orcRuntimePath = "\(packageDir)/third_party/llvm-build-rt/lib/darwin/liborc_rt_osx.a"
 
 let package = Package(
     name: "PreviewsMCP",
@@ -41,7 +40,8 @@ let package = Package(
         ),
         .target(
             name: "PreviewsJITLink",
-            dependencies: ["PreviewsJITLinkCxx"]
+            dependencies: ["PreviewsJITLinkCxx"],
+            plugins: [.plugin(name: "BundleOrcRuntime")]
         ),
         .target(
             // TODO: need to update to bundled version of LLVM in the future
@@ -50,7 +50,6 @@ let package = Package(
                 .unsafeFlags([
                     "-I\(llvmSrcInclude)",
                     "-I\(llvmBuild)/include",
-                    "-DPREVIEWSMCP_ORC_RT_PATH=\"\(orcRuntimePath)\"",
                     "-fno-rtti",
                 ])
             ],
@@ -115,6 +114,10 @@ let package = Package(
             name: "EmbedHostAppSource",
             capability: .buildTool(),
             dependencies: ["EmbedHostAppSourceTool"]
+        ),
+        .plugin(
+            name: "BundleOrcRuntime",
+            capability: .buildTool()
         ),
         .testTarget(
             name: "PreviewsCoreTests",

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,13 @@
 // swift-tools-version: 6.0
+import Foundation
 import PackageDescription
+
+// LLVM built from swiftlang/llvm-project via scripts/build-jit-llvm.sh.
+// Scaffolding: paths are relative to the package dir; shipping will bundle LLVM.
+let packageDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
+let llvmBuild = "\(packageDir)/third_party/llvm-build"
+let llvmSrcInclude = "\(packageDir)/third_party/llvm-project/llvm/include"
+let orcRuntimePath = "\(packageDir)/third_party/llvm-build-rt/lib/darwin/liborc_rt_osx.a"
 
 let package = Package(
     name: "PreviewsMCP",
@@ -39,14 +47,18 @@ let package = Package(
             // TODO: need to update to bundled version of LLVM in the future
             name: "PreviewsJITLinkCxx",
             cxxSettings: [
-                .unsafeFlags(["-I/opt/homebrew/opt/llvm/include"])
+                .unsafeFlags([
+                    "-I\(llvmSrcInclude)",
+                    "-I\(llvmBuild)/include",
+                    "-DPREVIEWSMCP_ORC_RT_PATH=\"\(orcRuntimePath)\"",
+                ])
             ],
             linkerSettings: [
                 .unsafeFlags([
-                    "-L/opt/homebrew/opt/llvm/lib",
+                    "-L\(llvmBuild)/lib",
                     "-lLLVM",
                     "-Xlinker", "-rpath",
-                    "-Xlinker", "/opt/homebrew/opt/llvm/lib",
+                    "-Xlinker", "\(llvmBuild)/lib",
                 ])
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -2,17 +2,11 @@
 import Foundation
 import PackageDescription
 
-// LLVM built from swiftlang/llvm-project via scripts/build-jit-llvm.sh.
-// Scaffolding: paths are relative to the package dir; shipping will bundle LLVM.
 let packageDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
 let llvmBuild = "\(packageDir)/third_party/llvm-build"
 let llvmSrcInclude = "\(packageDir)/third_party/llvm-project/llvm/include"
 let orcRuntimeArchive = "\(packageDir)/third_party/llvm-build-rt/lib/darwin/liborc_rt_osx.a"
 
-// The JIT targets link a locally-built LLVM and copy the orc runtime archive,
-// both under third_party/ (gitignored, via `bootstrap --jit`). Require both so a
-// partial build does not turn the targets on with the archive missing. Omit them
-// otherwise so CI and non-JIT contributors build the rest of the package.
 let jitEnabled =
     FileManager.default.fileExists(atPath: llvmBuild)
     && FileManager.default.fileExists(atPath: orcRuntimeArchive)
@@ -127,7 +121,7 @@ if jitEnabled {
             plugins: [.plugin(name: "BundleOrcRuntime")]
         ),
         .target(
-            // TODO: need to update to bundled version of LLVM in the future
+            // TODO: bundle libLLVM (U3); links the third_party build for now.
             name: "PreviewsJITLinkCxx",
             cxxSettings: [
                 .unsafeFlags([

--- a/Plugins/BundleOrcRuntime/BundleOrcRuntime.swift
+++ b/Plugins/BundleOrcRuntime/BundleOrcRuntime.swift
@@ -1,0 +1,24 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct BundleOrcRuntime: BuildToolPlugin {
+    func createBuildCommands(
+        context: PluginContext,
+        target: Target
+    ) throws -> [Command] {
+        let archive = context.package.directoryURL
+            .appending(path: "third_party/llvm-build-rt/lib/darwin/liborc_rt_osx.a")
+        let outputDir = context.pluginWorkDirectoryURL
+        let output = outputDir.appending(path: "liborc_rt_osx.a")
+
+        return [
+            .prebuildCommand(
+                displayName: "Bundle orc runtime",
+                executable: URL(fileURLWithPath: "/bin/cp"),
+                arguments: [archive.path(), output.path()],
+                outputFilesDirectory: outputDir
+            )
+        ]
+    }
+}

--- a/Sources/PreviewsCore/Compiler.swift
+++ b/Sources/PreviewsCore/Compiler.swift
@@ -148,6 +148,36 @@ public actor Compiler {
         return CompilationResult(dylibPath: dylibFile, diagnostics: "")
     }
 
+    public func compileObject(
+        source: String,
+        moduleName: String,
+        extraFlags: [String] = []
+    ) async throws -> URL {
+        compilationCounter += 1
+        let uniqueName = "\(moduleName)_\(compilationCounter)"
+        let sourceFile = workDir.appendingPathComponent("\(uniqueName).swift")
+        let objectFile = workDir.appendingPathComponent("\(uniqueName).o")
+
+        try source.write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        var args: [String] = [
+            swiftcPath,
+            "-emit-object",
+            "-parse-as-library",
+            "-target", targetTriple,
+            "-sdk", sdkPath,
+            "-module-name", moduleName,
+            "-Onone",
+            "-gnone",
+            "-module-cache-path", moduleCachePath.path,
+        ]
+        args += extraFlags
+        args += ["-o", objectFile.path, sourceFile.path]
+
+        try await run(args)
+        return objectFile
+    }
+
     // MARK: - Private
 
     @discardableResult

--- a/Sources/PreviewsIOS/SimulatorManager.swift
+++ b/Sources/PreviewsIOS/SimulatorManager.swift
@@ -1,6 +1,6 @@
 import Foundation
 import PreviewsCore
-import SimulatorBridge
+@preconcurrency import SimulatorBridge
 import os
 
 /// Manages iOS simulator devices via CoreSimulator.framework (loaded at runtime).

--- a/Sources/PreviewsJITLink/PreviewsJITLink.swift
+++ b/Sources/PreviewsJITLink/PreviewsJITLink.swift
@@ -1,13 +1,14 @@
+import Foundation
 import PreviewsJITLinkCxx
 
 public enum PreviewsJITLink {
     public static func mainDylibName() throws -> String {
         var name: UnsafeMutablePointer<CChar>?
         if let error = previewsmcp_jit_main_dylib_name(&name) {
-            throw JITLinkError.jitCreationFailed(error.string())
+            throw JITLinkError.failed(error.string())
         }
         guard let name else {
-            throw JITLinkError.jitCreationFailed("no name returned")
+            throw JITLinkError.failed("no name returned")
         }
         return UnsafePointer(name).string()
     }
@@ -16,23 +17,34 @@ public enum PreviewsJITLink {
         previewsmcp_jit_target_triple().string()
     }
 
-    public static func linkAndCall<T>(objectPath: String, symbol: String) throws -> T {
+    public static func linkAndCall<T>(objectPaths: [String], symbol: String) throws -> T {
         var raw: UInt64 = 0
-        if let error = previewsmcp_jit_link_and_call(objectPath, symbol, &raw) {
-            throw JITLinkError.linkFailed(error.string())
+        let error = objectPaths.withCStringArray { paths in
+            previewsmcp_jit_link_and_call(paths, objectPaths.count, symbol, &raw)
+        }
+        if let error {
+            throw JITLinkError.failed(error.string())
         }
         return withUnsafeBytes(of: &raw) { $0.load(as: T.self) }
     }
 }
 
 public enum JITLinkError: Error {
-    case jitCreationFailed(String)
-    case linkFailed(String)
+    case failed(String)
 }
 
 private extension UnsafePointer where Pointee == CChar {
     func string() -> String {
         defer { previewsmcp_jit_dispose_string(self) }
         return String(cString: self)
+    }
+}
+
+private extension Array where Element == String {
+    func withCStringArray<R>(_ body: (UnsafePointer<UnsafePointer<CChar>>) -> R) -> R {
+        let cStrings: [UnsafeMutablePointer<CChar>] = map { strdup($0)! }
+        defer { cStrings.forEach { free($0) } }
+        let pointers: [UnsafePointer<CChar>] = cStrings.map { UnsafePointer($0) }
+        return pointers.withUnsafeBufferPointer { body($0.baseAddress!) }
     }
 }

--- a/Sources/PreviewsJITLink/PreviewsJITLink.swift
+++ b/Sources/PreviewsJITLink/PreviewsJITLink.swift
@@ -45,6 +45,9 @@ public final class JITSession {
     }
 }
 
+@available(*, unavailable)
+extension JITSession: Sendable {}
+
 public enum JITLinkError: Error {
     case failed(String)
 }

--- a/Sources/PreviewsJITLink/PreviewsJITLink.swift
+++ b/Sources/PreviewsJITLink/PreviewsJITLink.swift
@@ -1,11 +1,17 @@
+import Foundation
 import PreviewsJITLinkCxx
 
 public final class JITSession {
     private let handle: OpaquePointer
 
     public init() throws {
+        guard let orcRuntimePath = Bundle.module
+            .url(forResource: "liborc_rt_osx", withExtension: "a")?.path
+        else {
+            throw JITLinkError.failed("orc runtime archive missing from bundle")
+        }
         var session: OpaquePointer?
-        if let error = previewsmcp_jit_session_create(&session) {
+        if let error = previewsmcp_jit_session_create(&session, orcRuntimePath) {
             throw JITLinkError.failed(error.string())
         }
         guard let session else {

--- a/Sources/PreviewsJITLink/PreviewsJITLink.swift
+++ b/Sources/PreviewsJITLink/PreviewsJITLink.swift
@@ -17,7 +17,7 @@ public enum PreviewsJITLink {
         previewsmcp_jit_target_triple().string()
     }
 
-    public static func linkAndCall<T>(objectPaths: [String], symbol: String) throws -> T {
+    public static func linkAndCall<T: FixedWidthInteger>(objectPaths: [String], symbol: String) throws -> T {
         var raw: UInt64 = 0
         let error = objectPaths.withCStringArray { paths in
             previewsmcp_jit_link_and_call(paths, objectPaths.count, symbol, &raw)

--- a/Sources/PreviewsJITLink/PreviewsJITLink.swift
+++ b/Sources/PreviewsJITLink/PreviewsJITLink.swift
@@ -14,13 +14,6 @@ public final class JITSession {
         handle = session
     }
 
-    deinit {
-        // TODO(SP0d-D): call previewsmcp_jit_session_destroy once Swift metadata
-        // deregistration exists. Freeing the image now would dangle the
-        // process-global conformance and type registry that
-        // SwiftEntrySectionPlugin populated, and crash a later registry walk.
-    }
-
     public func addObject(path: String) throws {
         if let error = previewsmcp_jit_session_add_object(handle, path) {
             throw JITLinkError.failed(error.string())

--- a/Sources/PreviewsJITLink/PreviewsJITLink.swift
+++ b/Sources/PreviewsJITLink/PreviewsJITLink.swift
@@ -1,9 +1,26 @@
 import PreviewsJITLinkCxx
 
 public enum PreviewsJITLink {
+    public static func mainDylibName() throws -> String {
+        let result = previewsmcp_jit_main_dylib_name()
+        guard let name = result.value else {
+            throw JITLinkError.jitCreationFailed(result.error?.string() ?? "")
+        }
+        return name.string()
+    }
+
     public static func targetTriple() -> String {
-        let cString = previewsmcp_jit_target_triple()
-        defer { previewsmcp_jit_dispose_string(cString) }
-        return String(cString: cString)
+        previewsmcp_jit_target_triple().string()
+    }
+}
+
+public enum JITLinkError: Error {
+    case jitCreationFailed(String)
+}
+
+private extension UnsafePointer where Pointee == CChar {
+    func string() -> String {
+        defer { previewsmcp_jit_dispose_string(self) }
+        return String(cString: self)
     }
 }

--- a/Sources/PreviewsJITLink/PreviewsJITLink.swift
+++ b/Sources/PreviewsJITLink/PreviewsJITLink.swift
@@ -2,20 +2,32 @@ import PreviewsJITLinkCxx
 
 public enum PreviewsJITLink {
     public static func mainDylibName() throws -> String {
-        let result = previewsmcp_jit_main_dylib_name()
-        guard let name = result.value else {
-            throw JITLinkError.jitCreationFailed(result.error?.string() ?? "")
+        var name: UnsafeMutablePointer<CChar>?
+        if let error = previewsmcp_jit_main_dylib_name(&name) {
+            throw JITLinkError.jitCreationFailed(error.string())
         }
-        return name.string()
+        guard let name else {
+            throw JITLinkError.jitCreationFailed("no name returned")
+        }
+        return UnsafePointer(name).string()
     }
 
     public static func targetTriple() -> String {
         previewsmcp_jit_target_triple().string()
     }
+
+    public static func linkAndCall<T>(objectPath: String, symbol: String) throws -> T {
+        var raw: UInt64 = 0
+        if let error = previewsmcp_jit_link_and_call(objectPath, symbol, &raw) {
+            throw JITLinkError.linkFailed(error.string())
+        }
+        return withUnsafeBytes(of: &raw) { $0.load(as: T.self) }
+    }
 }
 
 public enum JITLinkError: Error {
     case jitCreationFailed(String)
+    case linkFailed(String)
 }
 
 private extension UnsafePointer where Pointee == CChar {

--- a/Sources/PreviewsJITLink/PreviewsJITLink.swift
+++ b/Sources/PreviewsJITLink/PreviewsJITLink.swift
@@ -1,30 +1,46 @@
-import Foundation
 import PreviewsJITLinkCxx
 
-public enum PreviewsJITLink {
-    public static func mainDylibName() throws -> String {
-        var name: UnsafeMutablePointer<CChar>?
-        if let error = previewsmcp_jit_main_dylib_name(&name) {
+public final class JITSession {
+    private let handle: OpaquePointer
+
+    public init() throws {
+        var session: OpaquePointer?
+        if let error = previewsmcp_jit_session_create(&session) {
             throw JITLinkError.failed(error.string())
         }
-        guard let name else {
-            throw JITLinkError.failed("no name returned")
+        guard let session else {
+            throw JITLinkError.failed("no session returned")
         }
-        return UnsafePointer(name).string()
+        handle = session
     }
 
-    public static func targetTriple() -> String {
-        previewsmcp_jit_target_triple().string()
+    deinit {
+        // TODO(SP0d-D): call previewsmcp_jit_session_destroy once Swift metadata
+        // deregistration exists. Freeing the image now would dangle the
+        // process-global conformance and type registry that
+        // SwiftEntrySectionPlugin populated, and crash a later registry walk.
     }
 
-    public static func linkAndCall<T: FixedWidthInteger>(objectPaths: [String], symbol: String) throws -> T {
-        var raw: UInt64 = 0
-        let error = objectPaths.withCStringArray { paths in
-            previewsmcp_jit_link_and_call(paths, objectPaths.count, symbol, &raw)
-        }
-        if let error {
+    public func addObject(path: String) throws {
+        if let error = previewsmcp_jit_session_add_object(handle, path) {
             throw JITLinkError.failed(error.string())
         }
+    }
+
+    public func address(of symbol: String) throws -> UInt64 {
+        var address: UInt64 = 0
+        if let error = previewsmcp_jit_session_lookup(handle, symbol, &address) {
+            throw JITLinkError.failed(error.string())
+        }
+        return address
+    }
+
+    public func call<T: FixedWidthInteger>(symbol: String) throws -> T {
+        guard let pointer = UnsafeRawPointer(bitPattern: UInt(try address(of: symbol))) else {
+            throw JITLinkError.failed("symbol \(symbol) resolved to null")
+        }
+        let function = unsafeBitCast(pointer, to: (@convention(c) () -> UInt64).self)
+        var raw = function()
         return withUnsafeBytes(of: &raw) { $0.load(as: T.self) }
     }
 }
@@ -37,14 +53,5 @@ private extension UnsafePointer where Pointee == CChar {
     func string() -> String {
         defer { previewsmcp_jit_dispose_string(self) }
         return String(cString: self)
-    }
-}
-
-private extension Array where Element == String {
-    func withCStringArray<R>(_ body: (UnsafePointer<UnsafePointer<CChar>>) -> R) -> R {
-        let cStrings: [UnsafeMutablePointer<CChar>] = map { strdup($0)! }
-        defer { cStrings.forEach { free($0) } }
-        let pointers: [UnsafePointer<CChar>] = cStrings.map { UnsafePointer($0) }
-        return pointers.withUnsafeBufferPointer { body($0.baseAddress!) }
     }
 }

--- a/Sources/PreviewsJITLink/PreviewsJITLink.swift
+++ b/Sources/PreviewsJITLink/PreviewsJITLink.swift
@@ -5,8 +5,9 @@ public final class JITSession {
     private let handle: OpaquePointer
 
     public init() throws {
-        guard let orcRuntimePath = Bundle.module
-            .url(forResource: "liborc_rt_osx", withExtension: "a")?.path
+        guard
+            let orcRuntimePath = Bundle.module
+                .url(forResource: "liborc_rt_osx", withExtension: "a")?.path
         else {
             throw JITLinkError.failed("orc runtime archive missing from bundle")
         }

--- a/Sources/PreviewsJITLink/PreviewsJITLink.swift
+++ b/Sources/PreviewsJITLink/PreviewsJITLink.swift
@@ -1,0 +1,9 @@
+import PreviewsJITLinkCxx
+
+public enum PreviewsJITLink {
+    public static func targetTriple() -> String {
+        let cString = previewsmcp_jit_target_triple()
+        defer { previewsmcp_jit_dispose_string(cString) }
+        return String(cString: cString)
+    }
+}

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -121,7 +121,3 @@ const char *previewsmcp_jit_session_lookup(previewsmcp_jit_session *session,
   *out_address = sym->getValue();
   return nullptr;
 }
-
-void previewsmcp_jit_session_destroy(previewsmcp_jit_session *session) {
-  delete session;
-}

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -10,6 +10,7 @@
 #include <llvm/ExecutionEngine/Orc/MemoryMapper.h>
 #include <llvm/ExecutionEngine/Orc/ExecutorProcessControl.h>
 #include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
+#include <llvm/Support/Debug.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <mutex>
 #include <string>
@@ -46,6 +47,11 @@ llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> makeJIT() {
   std::call_once(once, [] {
     LLVMInitializeNativeTarget();
     LLVMInitializeNativeAsmPrinter();
+    if (getenv("PREVIEWSMCP_JIT_DEBUG")) {
+      static const char *types[] = {"jitlink", "orc"};
+      llvm::DebugFlag = true;
+      llvm::setCurrentDebugTypes(types, 2);
+    }
   });
 
   auto epc = llvm::orc::SelfExecutorProcessControl::Create();

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -6,12 +6,37 @@
 #include <llvm-c/Core.h>
 #include <llvm-c/TargetMachine.h>
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
+#include <llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h>
+#include <llvm/ExecutionEngine/Orc/MemoryMapper.h>
+#include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
 #include <llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <mutex>
 #include <string>
 
 namespace {
+
+// Brew scaffolding. When LLVM is bundled with the app this path must change
+// to resolve from the bundle, ideally lifted into a Swift-resolved parameter
+// passed into makeJIT rather than a constant here.
+const char *kOrcRuntimePath =
+    "/opt/homebrew/opt/llvm/lib/clang/22/lib/darwin/liborc_rt_osx.a";
+
+// One contiguous reservation so code, data, and synthesized unwind info land
+// within 32-bit reach of each other. The default per-allocation mmap scatters
+// them past 4GB under ASLR, which breaks __unwind_info's 32-bit deltas.
+constexpr size_t kSlabSize = size_t(1) << 30;
+
+llvm::Expected<std::unique_ptr<llvm::orc::ObjectLayer>>
+slabLinkingLayer(llvm::orc::ExecutionSession &es) {
+  auto memMgr = llvm::orc::MapperJITLinkMemoryManager::CreateWithMapper<
+      llvm::orc::InProcessMemoryMapper>(kSlabSize);
+  if (!memMgr) {
+    return memMgr.takeError();
+  }
+  return std::make_unique<llvm::orc::ObjectLinkingLayer>(es,
+                                                         std::move(*memMgr));
+}
 
 llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> makeJIT() {
   static std::once_flag once;
@@ -27,6 +52,8 @@ llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> makeJIT() {
 
   return llvm::orc::LLJITBuilder()
       .setExecutorProcessControl(std::move(*epc))
+      .setPlatformSetUp(llvm::orc::ExecutorNativePlatform(kOrcRuntimePath))
+      .setObjectLinkingLayerCreator(slabLinkingLayer)
       .create();
 }
 
@@ -54,6 +81,10 @@ llvm::Expected<uint64_t> linkAndCall(const char *const *object_paths,
     if (auto err = (*jit)->addObjectFile(std::move(*buf))) {
       return std::move(err);
     }
+  }
+
+  if (auto err = (*jit)->initialize((*jit)->getMainJITDylib())) {
+    return std::move(err);
   }
 
   auto sym = (*jit)->lookup(symbol_name);

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -4,6 +4,32 @@
 #include <cstring>
 #include <llvm-c/Core.h>
 #include <llvm-c/TargetMachine.h>
+#include <llvm/ExecutionEngine/Orc/LLJIT.h>
+#include <string>
+
+namespace {
+
+previewsmcp_jit_string_result_t okResult(const std::string &value) {
+  return {strdup(value.c_str()), nullptr};
+}
+
+previewsmcp_jit_string_result_t errResult(const std::string &msg) {
+  return {nullptr, strdup(msg.c_str())};
+}
+
+} // namespace
+
+previewsmcp_jit_string_result_t previewsmcp_jit_main_dylib_name(void) {
+  LLVMInitializeNativeTarget();
+  LLVMInitializeNativeAsmPrinter();
+
+  auto jitOrErr = llvm::orc::LLJITBuilder().create();
+  if (!jitOrErr) {
+    return errResult(llvm::toString(jitOrErr.takeError()));
+  }
+  auto &jit = **jitOrErr;
+  return okResult(jit.getMainJITDylib().getName());
+}
 
 const char *previewsmcp_jit_target_triple(void) {
   char *targetTriple = LLVMGetDefaultTargetTriple();

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -1,6 +1,7 @@
 #include "PreviewsJITLinkCxx.h"
 #include "SwiftEntrySectionPlugin.hpp"
 
+#include <atomic>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -68,10 +69,30 @@ const char *toCStr(llvm::Error err) {
   return strdup(llvm::toString(std::move(err)).c_str());
 }
 
+llvm::orc::LLJIT *sharedJIT(const char *orc_rt_path, std::string &err) {
+  static std::unique_ptr<llvm::orc::LLJIT> jit;
+  static std::string initError;
+  static std::once_flag once;
+  std::call_once(once, [&] {
+    auto created = makeJIT(orc_rt_path);
+    if (!created) {
+      initError = llvm::toString(created.takeError());
+      return;
+    }
+    jit = std::move(*created);
+  });
+  if (!jit) {
+    err = initError;
+    return nullptr;
+  }
+  return jit.get();
+}
+
 } // namespace
 
 struct previewsmcp_jit_session {
-  std::unique_ptr<llvm::orc::LLJIT> jit;
+  llvm::orc::LLJIT *jit;
+  llvm::orc::JITDylib *jd;
   bool initialized = false;
 };
 
@@ -81,11 +102,18 @@ void previewsmcp_jit_dispose_string(const char *str) {
 
 const char *previewsmcp_jit_session_create(previewsmcp_jit_session **out_session,
                                            const char *orc_rt_path) {
-  auto jit = makeJIT(orc_rt_path);
+  std::string err;
+  auto *jit = sharedJIT(orc_rt_path, err);
   if (!jit) {
-    return strdup(llvm::toString(jit.takeError()).c_str());
+    return strdup(err.c_str());
   }
-  *out_session = new previewsmcp_jit_session{std::move(*jit), false};
+  static std::atomic<uint64_t> counter{0};
+  auto jd = jit->createJITDylib("session." +
+                                std::to_string(counter.fetch_add(1)));
+  if (!jd) {
+    return toCStr(jd.takeError());
+  }
+  *out_session = new previewsmcp_jit_session{jit, &*jd, false};
   return nullptr;
 }
 
@@ -95,19 +123,19 @@ const char *previewsmcp_jit_session_add_object(previewsmcp_jit_session *session,
   if (!buf) {
     return toCStr(llvm::errorCodeToError(buf.getError()));
   }
-  return toCStr(session->jit->addObjectFile(std::move(*buf)));
+  return toCStr(session->jit->addObjectFile(*session->jd, std::move(*buf)));
 }
 
 const char *previewsmcp_jit_session_lookup(previewsmcp_jit_session *session,
                                            const char *symbol_name,
                                            uint64_t *out_address) {
   if (!session->initialized) {
-    if (auto err = session->jit->initialize(session->jit->getMainJITDylib())) {
+    if (auto err = session->jit->initialize(*session->jd)) {
       return toCStr(std::move(err));
     }
     session->initialized = true;
   }
-  auto sym = session->jit->lookup(symbol_name);
+  auto sym = session->jit->lookup(*session->jd, symbol_name);
   if (!sym) {
     return toCStr(sym.takeError());
   }

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -29,20 +29,22 @@ llvm::Expected<std::string> mainDylibName() {
   return (*jit)->getMainJITDylib().getName();
 }
 
-llvm::Expected<uint64_t> linkAndCall(const char *object_path,
+llvm::Expected<uint64_t> linkAndCall(const char *const *object_paths,
+                                     size_t object_count,
                                      const char *symbol_name) {
   auto jit = makeJIT();
   if (!jit) {
     return jit.takeError();
   }
 
-  auto buf = llvm::MemoryBuffer::getFile(object_path);
-  if (!buf) {
-    return llvm::errorCodeToError(buf.getError());
-  }
-
-  if (auto err = (*jit)->addObjectFile(std::move(*buf))) {
-    return std::move(err);
+  for (size_t i = 0; i < object_count; ++i) {
+    auto buf = llvm::MemoryBuffer::getFile(object_paths[i]);
+    if (!buf) {
+      return llvm::errorCodeToError(buf.getError());
+    }
+    if (auto err = (*jit)->addObjectFile(std::move(*buf))) {
+      return std::move(err);
+    }
   }
 
   auto sym = (*jit)->lookup(symbol_name);
@@ -67,10 +69,11 @@ void previewsmcp_jit_dispose_string(const char *str) {
   free(const_cast<char *>(str));
 }
 
-const char *previewsmcp_jit_link_and_call(const char *object_path,
+const char *previewsmcp_jit_link_and_call(const char *const *object_paths,
+                                          size_t object_count,
                                           const char *symbol_name,
                                           uint64_t *out_value) {
-  return marshal(linkAndCall(object_path, symbol_name),
+  return marshal(linkAndCall(object_paths, object_count, symbol_name),
                  [&](uint64_t value) { *out_value = value; });
 }
 

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -18,15 +18,6 @@
 
 namespace {
 
-// Path to the orc runtime archive, injected by Package.swift (built from the
-// Swift LLVM fork via scripts/build-jit-llvm.sh). Scaffolding: when LLVM is
-// bundled this should resolve from the bundle, ideally a Swift-resolved param.
-#ifndef PREVIEWSMCP_ORC_RT_PATH
-#define PREVIEWSMCP_ORC_RT_PATH                                                 \
-  "/opt/homebrew/opt/llvm/lib/clang/22/lib/darwin/liborc_rt_osx.a"
-#endif
-const char *kOrcRuntimePath = PREVIEWSMCP_ORC_RT_PATH;
-
 // One contiguous reservation so code, data, and synthesized unwind info land
 // within 32-bit reach of each other. The default per-allocation mmap scatters
 // them past 4GB under ASLR, which breaks __unwind_info's 32-bit deltas.
@@ -45,7 +36,8 @@ slabLinkingLayer(llvm::orc::ExecutionSession &es, const llvm::Triple &) {
   return layer;
 }
 
-llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> makeJIT() {
+llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>>
+makeJIT(const char *orc_rt_path) {
   static std::once_flag once;
   std::call_once(once, [] {
     LLVMInitializeNativeTarget();
@@ -64,7 +56,7 @@ llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> makeJIT() {
 
   return llvm::orc::LLJITBuilder()
       .setExecutorProcessControl(std::move(*epc))
-      .setPlatformSetUp(llvm::orc::ExecutorNativePlatform(kOrcRuntimePath))
+      .setPlatformSetUp(llvm::orc::ExecutorNativePlatform(orc_rt_path))
       .setObjectLinkingLayerCreator(slabLinkingLayer)
       .create();
 }
@@ -87,8 +79,9 @@ void previewsmcp_jit_dispose_string(const char *str) {
   free(const_cast<char *>(str));
 }
 
-const char *previewsmcp_jit_session_create(previewsmcp_jit_session **out_session) {
-  auto jit = makeJIT();
+const char *previewsmcp_jit_session_create(previewsmcp_jit_session **out_session,
+                                           const char *orc_rt_path) {
+  auto jit = makeJIT(orc_rt_path);
   if (!jit) {
     return strdup(llvm::toString(jit.takeError()).c_str());
   }

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -8,19 +8,22 @@
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
 #include <llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h>
 #include <llvm/ExecutionEngine/Orc/MemoryMapper.h>
+#include <llvm/ExecutionEngine/Orc/ExecutorProcessControl.h>
 #include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
-#include <llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <mutex>
 #include <string>
 
 namespace {
 
-// Brew scaffolding. When LLVM is bundled with the app this path must change
-// to resolve from the bundle, ideally lifted into a Swift-resolved parameter
-// passed into makeJIT rather than a constant here.
-const char *kOrcRuntimePath =
-    "/opt/homebrew/opt/llvm/lib/clang/22/lib/darwin/liborc_rt_osx.a";
+// Path to the orc runtime archive, injected by Package.swift (built from the
+// Swift LLVM fork via scripts/build-jit-llvm.sh). Scaffolding: when LLVM is
+// bundled this should resolve from the bundle, ideally a Swift-resolved param.
+#ifndef PREVIEWSMCP_ORC_RT_PATH
+#define PREVIEWSMCP_ORC_RT_PATH                                                 \
+  "/opt/homebrew/opt/llvm/lib/clang/22/lib/darwin/liborc_rt_osx.a"
+#endif
+const char *kOrcRuntimePath = PREVIEWSMCP_ORC_RT_PATH;
 
 // One contiguous reservation so code, data, and synthesized unwind info land
 // within 32-bit reach of each other. The default per-allocation mmap scatters
@@ -28,7 +31,7 @@ const char *kOrcRuntimePath =
 constexpr size_t kSlabSize = size_t(1) << 30;
 
 llvm::Expected<std::unique_ptr<llvm::orc::ObjectLayer>>
-slabLinkingLayer(llvm::orc::ExecutionSession &es) {
+slabLinkingLayer(llvm::orc::ExecutionSession &es, const llvm::Triple &) {
   auto memMgr = llvm::orc::MapperJITLinkMemoryManager::CreateWithMapper<
       llvm::orc::InProcessMemoryMapper>(kSlabSize);
   if (!memMgr) {

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -1,4 +1,5 @@
 #include "PreviewsJITLinkCxx.h"
+#include "SwiftEntrySectionPlugin.hpp"
 
 #include <cstdint>
 #include <cstdlib>
@@ -38,8 +39,10 @@ slabLinkingLayer(llvm::orc::ExecutionSession &es, const llvm::Triple &) {
   if (!memMgr) {
     return memMgr.takeError();
   }
-  return std::make_unique<llvm::orc::ObjectLinkingLayer>(es,
-                                                         std::move(*memMgr));
+  auto layer = std::make_unique<llvm::orc::ObjectLinkingLayer>(
+      es, std::move(*memMgr));
+  layer->addPlugin(std::make_shared<previewsmcp::SwiftEntrySectionPlugin>());
+  return layer;
 }
 
 llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> makeJIT() {
@@ -66,74 +69,59 @@ llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> makeJIT() {
       .create();
 }
 
-llvm::Expected<std::string> mainDylibName() {
-  auto jit = makeJIT();
-  if (!jit) {
-    return jit.takeError();
+const char *toCStr(llvm::Error err) {
+  if (!err) {
+    return nullptr;
   }
-  return (*jit)->getMainJITDylib().getName();
-}
-
-llvm::Expected<uint64_t> linkAndCall(const char *const *object_paths,
-                                     size_t object_count,
-                                     const char *symbol_name) {
-  auto jit = makeJIT();
-  if (!jit) {
-    return jit.takeError();
-  }
-
-  for (size_t i = 0; i < object_count; ++i) {
-    auto buf = llvm::MemoryBuffer::getFile(object_paths[i]);
-    if (!buf) {
-      return llvm::errorCodeToError(buf.getError());
-    }
-    if (auto err = (*jit)->addObjectFile(std::move(*buf))) {
-      return std::move(err);
-    }
-  }
-
-  if (auto err = (*jit)->initialize((*jit)->getMainJITDylib())) {
-    return std::move(err);
-  }
-
-  auto sym = (*jit)->lookup(symbol_name);
-  if (!sym) {
-    return sym.takeError();
-  }
-  return sym->toPtr<uint64_t (*)()>()();
-}
-
-template <typename T, typename Writer>
-const char *marshal(llvm::Expected<T> result, Writer write) {
-  if (!result) {
-    return strdup(llvm::toString(result.takeError()).c_str());
-  }
-  write(std::move(*result));
-  return nullptr;
+  return strdup(llvm::toString(std::move(err)).c_str());
 }
 
 } // namespace
+
+struct previewsmcp_jit_session {
+  std::unique_ptr<llvm::orc::LLJIT> jit;
+  bool initialized = false;
+};
 
 void previewsmcp_jit_dispose_string(const char *str) {
   free(const_cast<char *>(str));
 }
 
-const char *previewsmcp_jit_link_and_call(const char *const *object_paths,
-                                          size_t object_count,
-                                          const char *symbol_name,
-                                          uint64_t *out_value) {
-  return marshal(linkAndCall(object_paths, object_count, symbol_name),
-                 [&](uint64_t value) { *out_value = value; });
+const char *previewsmcp_jit_session_create(previewsmcp_jit_session **out_session) {
+  auto jit = makeJIT();
+  if (!jit) {
+    return strdup(llvm::toString(jit.takeError()).c_str());
+  }
+  *out_session = new previewsmcp_jit_session{std::move(*jit), false};
+  return nullptr;
 }
 
-const char *previewsmcp_jit_main_dylib_name(char **out_name) {
-  return marshal(mainDylibName(),
-                 [&](std::string name) { *out_name = strdup(name.c_str()); });
+const char *previewsmcp_jit_session_add_object(previewsmcp_jit_session *session,
+                                               const char *object_path) {
+  auto buf = llvm::MemoryBuffer::getFile(object_path);
+  if (!buf) {
+    return toCStr(llvm::errorCodeToError(buf.getError()));
+  }
+  return toCStr(session->jit->addObjectFile(std::move(*buf)));
 }
 
-const char *previewsmcp_jit_target_triple(void) {
-  char *targetTriple = LLVMGetDefaultTargetTriple();
-  char *copy = strdup(targetTriple);
-  LLVMDisposeMessage(targetTriple);
-  return copy;
+const char *previewsmcp_jit_session_lookup(previewsmcp_jit_session *session,
+                                           const char *symbol_name,
+                                           uint64_t *out_address) {
+  if (!session->initialized) {
+    if (auto err = session->jit->initialize(session->jit->getMainJITDylib())) {
+      return toCStr(std::move(err));
+    }
+    session->initialized = true;
+  }
+  auto sym = session->jit->lookup(symbol_name);
+  if (!sym) {
+    return toCStr(sym.takeError());
+  }
+  *out_address = sym->getValue();
+  return nullptr;
+}
+
+void previewsmcp_jit_session_destroy(previewsmcp_jit_session *session) {
+  delete session;
 }

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -6,6 +6,7 @@
 #include <llvm-c/Core.h>
 #include <llvm-c/TargetMachine.h>
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
+#include <llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <mutex>
 #include <string>
@@ -18,7 +19,15 @@ llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> makeJIT() {
     LLVMInitializeNativeTarget();
     LLVMInitializeNativeAsmPrinter();
   });
-  return llvm::orc::LLJITBuilder().create();
+
+  auto epc = llvm::orc::SelfExecutorProcessControl::Create();
+  if (!epc) {
+    return epc.takeError();
+  }
+
+  return llvm::orc::LLJITBuilder()
+      .setExecutorProcessControl(std::move(*epc))
+      .create();
 }
 
 llvm::Expected<std::string> mainDylibName() {

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -1,0 +1,17 @@
+#include "PreviewsJITLinkCxx.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <llvm-c/Core.h>
+#include <llvm-c/TargetMachine.h>
+
+const char *previewsmcp_jit_target_triple(void) {
+  char *targetTriple = LLVMGetDefaultTargetTriple();
+  char *copy = strdup(targetTriple);
+  LLVMDisposeMessage(targetTriple);
+  return copy;
+}
+
+void previewsmcp_jit_dispose_string(const char *str) {
+  free(const_cast<char *>(str));
+}

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -1,34 +1,82 @@
 #include "PreviewsJITLinkCxx.h"
 
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <llvm-c/Core.h>
 #include <llvm-c/TargetMachine.h>
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
+#include <llvm/Support/MemoryBuffer.h>
+#include <mutex>
 #include <string>
 
 namespace {
 
-previewsmcp_jit_string_result_t okResult(const std::string &value) {
-  return {strdup(value.c_str()), nullptr};
+llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> makeJIT() {
+  static std::once_flag once;
+  std::call_once(once, [] {
+    LLVMInitializeNativeTarget();
+    LLVMInitializeNativeAsmPrinter();
+  });
+  return llvm::orc::LLJITBuilder().create();
 }
 
-previewsmcp_jit_string_result_t errResult(const std::string &msg) {
-  return {nullptr, strdup(msg.c_str())};
+llvm::Expected<std::string> mainDylibName() {
+  auto jit = makeJIT();
+  if (!jit) {
+    return jit.takeError();
+  }
+  return (*jit)->getMainJITDylib().getName();
+}
+
+llvm::Expected<uint64_t> linkAndCall(const char *object_path,
+                                     const char *symbol_name) {
+  auto jit = makeJIT();
+  if (!jit) {
+    return jit.takeError();
+  }
+
+  auto buf = llvm::MemoryBuffer::getFile(object_path);
+  if (!buf) {
+    return llvm::errorCodeToError(buf.getError());
+  }
+
+  if (auto err = (*jit)->addObjectFile(std::move(*buf))) {
+    return std::move(err);
+  }
+
+  auto sym = (*jit)->lookup(symbol_name);
+  if (!sym) {
+    return sym.takeError();
+  }
+  return sym->toPtr<uint64_t (*)()>()();
+}
+
+template <typename T, typename Writer>
+const char *marshal(llvm::Expected<T> result, Writer write) {
+  if (!result) {
+    return strdup(llvm::toString(result.takeError()).c_str());
+  }
+  write(std::move(*result));
+  return nullptr;
 }
 
 } // namespace
 
-previewsmcp_jit_string_result_t previewsmcp_jit_main_dylib_name(void) {
-  LLVMInitializeNativeTarget();
-  LLVMInitializeNativeAsmPrinter();
+void previewsmcp_jit_dispose_string(const char *str) {
+  free(const_cast<char *>(str));
+}
 
-  auto jitOrErr = llvm::orc::LLJITBuilder().create();
-  if (!jitOrErr) {
-    return errResult(llvm::toString(jitOrErr.takeError()));
-  }
-  auto &jit = **jitOrErr;
-  return okResult(jit.getMainJITDylib().getName());
+const char *previewsmcp_jit_link_and_call(const char *object_path,
+                                          const char *symbol_name,
+                                          uint64_t *out_value) {
+  return marshal(linkAndCall(object_path, symbol_name),
+                 [&](uint64_t value) { *out_value = value; });
+}
+
+const char *previewsmcp_jit_main_dylib_name(char **out_name) {
+  return marshal(mainDylibName(),
+                 [&](std::string name) { *out_name = strdup(name.c_str()); });
 }
 
 const char *previewsmcp_jit_target_triple(void) {
@@ -36,8 +84,4 @@ const char *previewsmcp_jit_target_triple(void) {
   char *copy = strdup(targetTriple);
   LLVMDisposeMessage(targetTriple);
   return copy;
-}
-
-void previewsmcp_jit_dispose_string(const char *str) {
-  free(const_cast<char *>(str));
 }

--- a/Sources/PreviewsJITLinkCxx/SwiftEntrySectionPlugin.cpp
+++ b/Sources/PreviewsJITLinkCxx/SwiftEntrySectionPlugin.cpp
@@ -63,13 +63,15 @@ void registerSection(LinkGraph &G, StringRef Name,
   auto *Sec = G.findSectionByName(Name);
   if (!Sec)
     return;
-  SectionRange R(*Sec);
-  if (R.empty())
-    return;
-  G.allocActions().push_back(
-      {cantFail(WrapperFunctionCall::Create<SPSArgList<SPSExecutorAddrRange>>(
-           ExecutorAddr::fromPtr(Fn), R.getRange())),
-       {}});
+  for (auto *B : Sec->blocks()) {
+    if (B->getSize() == 0)
+      continue;
+    ExecutorAddrRange range(B->getAddress(), B->getAddress() + B->getSize());
+    G.allocActions().push_back(
+        {cantFail(WrapperFunctionCall::Create<SPSArgList<SPSExecutorAddrRange>>(
+             ExecutorAddr::fromPtr(Fn), range)),
+         {}});
+  }
 }
 
 } // namespace

--- a/Sources/PreviewsJITLinkCxx/SwiftEntrySectionPlugin.cpp
+++ b/Sources/PreviewsJITLinkCxx/SwiftEntrySectionPlugin.cpp
@@ -1,0 +1,92 @@
+#include "SwiftEntrySectionPlugin.hpp"
+
+#include "llvm/ExecutionEngine/Orc/Shared/AllocationActions.h"
+#include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Error.h"
+
+using namespace llvm;
+using namespace llvm::jitlink;
+using namespace llvm::orc;
+using namespace llvm::orc::shared;
+
+extern "C" void swift_registerProtocolConformances(const void *begin,
+                                                   const void *end);
+extern "C" void swift_registerTypeMetadataRecords(const void *begin,
+                                                  const void *end);
+
+namespace previewsmcp {
+namespace {
+
+constexpr StringRef Swift5ProtoSection = "__TEXT,__swift5_proto";
+constexpr StringRef Swift5TypesSection = "__TEXT,__swift5_types";
+constexpr StringRef HiddenProtoSection = "__DATA,__pvz_s5proto";
+constexpr StringRef HiddenTypesSection = "__DATA,__pvz_s5types";
+
+CWrapperFunctionResult registerConformances(const char *ArgData,
+                                            size_t ArgSize) {
+  return WrapperFunction<SPSError(SPSExecutorAddrRange)>::handle(
+             ArgData, ArgSize,
+             [](ExecutorAddrRange R) -> Error {
+               swift_registerProtocolConformances(
+                   R.Start.toPtr<const void *>(), R.End.toPtr<const void *>());
+               return Error::success();
+             })
+      .release();
+}
+
+CWrapperFunctionResult registerTypes(const char *ArgData, size_t ArgSize) {
+  return WrapperFunction<SPSError(SPSExecutorAddrRange)>::handle(
+             ArgData, ArgSize,
+             [](ExecutorAddrRange R) -> Error {
+               swift_registerTypeMetadataRecords(
+                   R.Start.toPtr<const void *>(), R.End.toPtr<const void *>());
+               return Error::success();
+             })
+      .release();
+}
+
+void hideSection(LinkGraph &G, StringRef From, StringRef To) {
+  auto *Src = G.findSectionByName(From);
+  if (!Src)
+    return;
+  auto &Dst = G.createSection(To, Src->getMemProt());
+  G.mergeSections(Dst, *Src);
+  SmallVector<Block *> Blocks(Dst.blocks().begin(), Dst.blocks().end());
+  for (auto *B : Blocks)
+    G.addAnonymousSymbol(*B, 0, B->getSize(), false, true);
+}
+
+void registerSection(LinkGraph &G, StringRef Name,
+                     CWrapperFunctionResult (*Fn)(const char *, size_t)) {
+  auto *Sec = G.findSectionByName(Name);
+  if (!Sec)
+    return;
+  SectionRange R(*Sec);
+  if (R.empty())
+    return;
+  G.allocActions().push_back(
+      {cantFail(WrapperFunctionCall::Create<SPSArgList<SPSExecutorAddrRange>>(
+           ExecutorAddr::fromPtr(Fn), R.getRange())),
+       {}});
+}
+
+} // namespace
+
+void SwiftEntrySectionPlugin::modifyPassConfig(
+    MaterializationResponsibility &MR, LinkGraph &G,
+    PassConfiguration &Config) {
+  Config.PrePrunePasses.push_back([](LinkGraph &G) -> Error {
+    hideSection(G, Swift5ProtoSection, HiddenProtoSection);
+    hideSection(G, Swift5TypesSection, HiddenTypesSection);
+    return Error::success();
+  });
+  Config.PostFixupPasses.push_back([](LinkGraph &G) -> Error {
+    registerSection(G, HiddenProtoSection, registerConformances);
+    registerSection(G, HiddenTypesSection, registerTypes);
+    return Error::success();
+  });
+}
+
+} // namespace previewsmcp

--- a/Sources/PreviewsJITLinkCxx/SwiftEntrySectionPlugin.hpp
+++ b/Sources/PreviewsJITLinkCxx/SwiftEntrySectionPlugin.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "llvm/ExecutionEngine/JITLink/JITLink.h"
+#include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
+#include "llvm/Support/Error.h"
+
+namespace previewsmcp {
+
+class SwiftEntrySectionPlugin
+    : public llvm::orc::ObjectLinkingLayer::Plugin {
+public:
+  void modifyPassConfig(llvm::orc::MaterializationResponsibility &MR,
+                        llvm::jitlink::LinkGraph &G,
+                        llvm::jitlink::PassConfiguration &Config) override;
+
+  llvm::Error
+  notifyFailed(llvm::orc::MaterializationResponsibility &MR) override {
+    return llvm::Error::success();
+  }
+  llvm::Error notifyRemovingResources(llvm::orc::JITDylib &JD,
+                                      llvm::orc::ResourceKey K) override {
+    return llvm::Error::success();
+  }
+  void notifyTransferringResources(llvm::orc::JITDylib &JD,
+                                   llvm::orc::ResourceKey DstKey,
+                                   llvm::orc::ResourceKey SrcKey) override {}
+};
+
+} // namespace previewsmcp

--- a/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
+++ b/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -8,16 +10,16 @@ extern "C" {
 #pragma clang assume_nonnull begin
 #endif
 
-typedef struct {
-  const char *_Nullable value;
-  const char *_Nullable error;
-} previewsmcp_jit_string_result_t;
+void previewsmcp_jit_dispose_string(const char *str);
 
-previewsmcp_jit_string_result_t previewsmcp_jit_main_dylib_name(void);
+const char *_Nullable
+previewsmcp_jit_link_and_call(const char *object_path, const char *symbol_name,
+                              uint64_t *out_value);
+
+const char *_Nullable
+previewsmcp_jit_main_dylib_name(char *_Nullable *out_name);
 
 const char *previewsmcp_jit_target_triple(void);
-
-void previewsmcp_jit_dispose_string(const char *str);
 
 #if __has_feature(nullability)
 #pragma clang assume_nonnull end

--- a/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
+++ b/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
@@ -13,15 +13,20 @@ extern "C" {
 
 void previewsmcp_jit_dispose_string(const char *str);
 
-const char *_Nullable
-previewsmcp_jit_link_and_call(const char *_Nonnull const *_Nonnull object_paths,
-                             size_t object_count, const char *symbol_name,
-                             uint64_t *out_value);
+typedef struct previewsmcp_jit_session previewsmcp_jit_session;
 
 const char *_Nullable
-previewsmcp_jit_main_dylib_name(char *_Nullable *_Nonnull out_name);
+previewsmcp_jit_session_create(previewsmcp_jit_session *_Nullable *_Nonnull out_session);
 
-const char *previewsmcp_jit_target_triple(void);
+const char *_Nullable
+previewsmcp_jit_session_add_object(previewsmcp_jit_session *session,
+                                   const char *object_path);
+
+const char *_Nullable
+previewsmcp_jit_session_lookup(previewsmcp_jit_session *session,
+                              const char *symbol_name, uint64_t *out_address);
+
+void previewsmcp_jit_session_destroy(previewsmcp_jit_session *session);
 
 #if __has_feature(nullability)
 #pragma clang assume_nonnull end

--- a/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
+++ b/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
@@ -26,8 +26,6 @@ const char *_Nullable
 previewsmcp_jit_session_lookup(previewsmcp_jit_session *session,
                               const char *symbol_name, uint64_t *out_address);
 
-void previewsmcp_jit_session_destroy(previewsmcp_jit_session *session);
-
 #if __has_feature(nullability)
 #pragma clang assume_nonnull end
 #endif

--- a/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
+++ b/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
@@ -16,7 +16,8 @@ void previewsmcp_jit_dispose_string(const char *str);
 typedef struct previewsmcp_jit_session previewsmcp_jit_session;
 
 const char *_Nullable
-previewsmcp_jit_session_create(previewsmcp_jit_session *_Nullable *_Nonnull out_session);
+previewsmcp_jit_session_create(previewsmcp_jit_session *_Nullable *_Nonnull out_session,
+                              const char *orc_rt_path);
 
 const char *_Nullable
 previewsmcp_jit_session_add_object(previewsmcp_jit_session *session,

--- a/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
+++ b/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -13,11 +14,12 @@ extern "C" {
 void previewsmcp_jit_dispose_string(const char *str);
 
 const char *_Nullable
-previewsmcp_jit_link_and_call(const char *object_path, const char *symbol_name,
-                              uint64_t *out_value);
+previewsmcp_jit_link_and_call(const char *_Nonnull const *_Nonnull object_paths,
+                             size_t object_count, const char *symbol_name,
+                             uint64_t *out_value);
 
 const char *_Nullable
-previewsmcp_jit_main_dylib_name(char *_Nullable *out_name);
+previewsmcp_jit_main_dylib_name(char *_Nullable *_Nonnull out_name);
 
 const char *previewsmcp_jit_target_triple(void);
 

--- a/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
+++ b/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull begin
+#endif
+
+const char *previewsmcp_jit_target_triple(void);
+
+void previewsmcp_jit_dispose_string(const char *str);
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
+++ b/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
@@ -8,6 +8,13 @@ extern "C" {
 #pragma clang assume_nonnull begin
 #endif
 
+typedef struct {
+  const char *_Nullable value;
+  const char *_Nullable error;
+} previewsmcp_jit_string_result_t;
+
+previewsmcp_jit_string_result_t previewsmcp_jit_main_dylib_name(void);
+
 const char *previewsmcp_jit_target_triple(void);
 
 void previewsmcp_jit_dispose_string(const char *str);

--- a/Tests/PreviewsJITLinkTests/CompilerObjectTests.swift
+++ b/Tests/PreviewsJITLinkTests/CompilerObjectTests.swift
@@ -7,9 +7,9 @@ struct CompilerObjectTests {
         let compiler = try await Compiler()
         let object = try await compiler.compileObject(
             source: """
-            @_cdecl("compiler_answer")
-            public func compilerAnswer() -> Int32 { 42 }
-            """,
+                @_cdecl("compiler_answer")
+                public func compilerAnswer() -> Int32 { 42 }
+                """,
             moduleName: "CompilerObjectFixture"
         )
 
@@ -24,16 +24,16 @@ struct CompilerObjectTests {
 
         let v1 = try await compiler.compileObject(
             source: """
-            @_cdecl("reload_value")
-            public func reloadValue() -> Int32 { 42 }
-            """,
+                @_cdecl("reload_value")
+                public func reloadValue() -> Int32 { 42 }
+                """,
             moduleName: "ReloadFixture"
         )
         let v2 = try await compiler.compileObject(
             source: """
-            @_cdecl("reload_value")
-            public func reloadValue() -> Int32 { 43 }
-            """,
+                @_cdecl("reload_value")
+                public func reloadValue() -> Int32 { 43 }
+                """,
             moduleName: "ReloadFixture"
         )
 

--- a/Tests/PreviewsJITLinkTests/CompilerObjectTests.swift
+++ b/Tests/PreviewsJITLinkTests/CompilerObjectTests.swift
@@ -1,0 +1,21 @@
+import PreviewsCore
+import PreviewsJITLink
+import Testing
+
+struct CompilerObjectTests {
+    @Test func compilesAndLinksObjectViaCompiler() async throws {
+        let compiler = try await Compiler()
+        let object = try await compiler.compileObject(
+            source: """
+            @_cdecl("compiler_answer")
+            public func compilerAnswer() -> Int32 { 42 }
+            """,
+            moduleName: "CompilerObjectFixture"
+        )
+
+        let session = try JITSession()
+        try session.addObject(path: object.path)
+        let result: Int32 = try session.call(symbol: "compiler_answer")
+        #expect(result == 42)
+    }
+}

--- a/Tests/PreviewsJITLinkTests/CompilerObjectTests.swift
+++ b/Tests/PreviewsJITLinkTests/CompilerObjectTests.swift
@@ -18,4 +18,37 @@ struct CompilerObjectTests {
         let result: Int32 = try session.call(symbol: "compiler_answer")
         #expect(result == 42)
     }
+
+    @Test func reResolvesSymbolAfterRecompile() async throws {
+        let compiler = try await Compiler()
+
+        let v1 = try await compiler.compileObject(
+            source: """
+            @_cdecl("reload_value")
+            public func reloadValue() -> Int32 { 42 }
+            """,
+            moduleName: "ReloadFixture"
+        )
+        let v2 = try await compiler.compileObject(
+            source: """
+            @_cdecl("reload_value")
+            public func reloadValue() -> Int32 { 43 }
+            """,
+            moduleName: "ReloadFixture"
+        )
+
+        let session1 = try JITSession()
+        try session1.addObject(path: v1.path)
+        let address1 = try session1.address(of: "reload_value")
+        let result1: Int32 = try session1.call(symbol: "reload_value")
+
+        let session2 = try JITSession()
+        try session2.addObject(path: v2.path)
+        let address2 = try session2.address(of: "reload_value")
+        let result2: Int32 = try session2.call(symbol: "reload_value")
+
+        #expect(result1 == 42)
+        #expect(result2 == 43)
+        #expect(address1 != address2)
+    }
 }

--- a/Tests/PreviewsJITLinkTests/FixtureSupport.swift
+++ b/Tests/PreviewsJITLinkTests/FixtureSupport.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+enum FixtureSupport {
+    enum FixtureError: Error, CustomStringConvertible {
+        case compileFailed(source: String, status: Int32, output: String)
+
+        var description: String {
+            switch self {
+            case let .compileFailed(source, status, output):
+                return "compiling \(source) failed (status \(status)):\n\(output)"
+            }
+        }
+    }
+
+    private static var fixturesDirectory: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures", isDirectory: true)
+    }
+
+    static func compile(_ source: String, extraFlags: [String] = []) throws -> URL {
+        let input = fixturesDirectory.appendingPathComponent(source)
+        let output = outputURL(for: source)
+
+        if isUpToDate(output: output, input: input) {
+            return output
+        }
+
+        try FileManager.default.createDirectory(
+            at: output.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        let arguments = ["clang", "-c", input.path, "-o", output.path] + extraFlags
+        let result = try run("/usr/bin/xcrun", arguments)
+        guard result.status == 0 else {
+            throw FixtureError.compileFailed(
+                source: source,
+                status: result.status,
+                output: result.output
+            )
+        }
+        return output
+    }
+
+    private static func outputURL(for source: String) -> URL {
+        let stem = (source as NSString).deletingPathExtension
+        return FileManager.default.temporaryDirectory
+            .appendingPathComponent("PreviewsJITLinkFixtures", isDirectory: true)
+            .appendingPathComponent("\(stem).o")
+    }
+
+    private static func isUpToDate(output: URL, input: URL) -> Bool {
+        let fm = FileManager.default
+        guard
+            let outDate = try? fm.attributesOfItem(atPath: output.path)[.modificationDate] as? Date,
+            let inDate = try? fm.attributesOfItem(atPath: input.path)[.modificationDate] as? Date
+        else {
+            return false
+        }
+        return outDate >= inDate
+    }
+
+    private static func run(_ executable: String, _ arguments: [String]) throws
+        -> (status: Int32, output: String)
+    {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (process.terminationStatus, String(decoding: data, as: UTF8.self))
+    }
+}

--- a/Tests/PreviewsJITLinkTests/FixtureSupport.swift
+++ b/Tests/PreviewsJITLinkTests/FixtureSupport.swift
@@ -31,7 +31,7 @@ enum FixtureSupport {
             withIntermediateDirectories: true
         )
 
-        let arguments = ["clang", "-c", input.path, "-o", output.path] + extraFlags
+        let arguments = compileArguments(input: input, output: output) + extraFlags
         let result = try run("/usr/bin/xcrun", arguments)
         guard result.status == 0 else {
             throw FixtureError.compileFailed(
@@ -41,6 +41,19 @@ enum FixtureSupport {
             )
         }
         return output
+    }
+
+    private static func compileArguments(input: URL, output: URL) -> [String] {
+        switch input.pathExtension {
+        case "swift":
+            return [
+                "swiftc", "-c", "-parse-as-library",
+                "-module-name", "Fixtures",
+                input.path, "-o", output.path,
+            ]
+        default:
+            return ["clang", "-c", input.path, "-o", output.path]
+        }
     }
 
     private static func outputURL(for source: String) -> URL {

--- a/Tests/PreviewsJITLinkTests/Fixtures/answer.c
+++ b/Tests/PreviewsJITLinkTests/Fixtures/answer.c
@@ -1,0 +1,3 @@
+#include <stdint.h>
+
+int32_t answer(void) { return 42; }

--- a/Tests/PreviewsJITLinkTests/Fixtures/async_value.swift
+++ b/Tests/PreviewsJITLinkTests/Fixtures/async_value.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+func computeAsync() async -> Int32 {
+    try? await Task.sleep(nanoseconds: 1_000_000)
+    return 11
+}
+
+@_cdecl("async_value")
+public func asyncValue() -> Int32 {
+    let semaphore = DispatchSemaphore(value: 0)
+    let slot = UnsafeMutablePointer<Int32>.allocate(capacity: 1)
+    slot.initialize(to: 0)
+    Task {
+        slot.pointee = await computeAsync()
+        semaphore.signal()
+    }
+    semaphore.wait()
+    let result = slot.pointee
+    slot.deinitialize(count: 1)
+    slot.deallocate()
+    return result
+}

--- a/Tests/PreviewsJITLinkTests/Fixtures/caller.c
+++ b/Tests/PreviewsJITLinkTests/Fixtures/caller.c
@@ -1,3 +1,0 @@
-extern int helper(void);
-
-int composed(void) { return helper() + 2; }

--- a/Tests/PreviewsJITLinkTests/Fixtures/caller.c
+++ b/Tests/PreviewsJITLinkTests/Fixtures/caller.c
@@ -1,0 +1,3 @@
+extern int helper(void);
+
+int composed(void) { return helper() + 2; }

--- a/Tests/PreviewsJITLinkTests/Fixtures/ctor.c
+++ b/Tests/PreviewsJITLinkTests/Fixtures/ctor.c
@@ -1,0 +1,5 @@
+static int value = 0;
+
+__attribute__((constructor)) static void initialize(void) { value = 42; }
+
+int ctor_answer(void) { return value; }

--- a/Tests/PreviewsJITLinkTests/Fixtures/dynamic_cast.swift
+++ b/Tests/PreviewsJITLinkTests/Fixtures/dynamic_cast.swift
@@ -1,0 +1,14 @@
+protocol Castable {
+    func value() -> Int32
+}
+
+struct DefaultCastable: Castable {
+    func value() -> Int32 { 9 }
+}
+
+@_cdecl("dynamic_cast_value")
+public func dynamicCastValue() -> Int32 {
+    let boxed: Any = DefaultCastable()
+    guard let castable = boxed as? Castable else { return -1 }
+    return castable.value()
+}

--- a/Tests/PreviewsJITLinkTests/Fixtures/external.c
+++ b/Tests/PreviewsJITLinkTests/Fixtures/external.c
@@ -1,0 +1,3 @@
+#include <stdlib.h>
+
+int compute(void) { return abs(-42); }

--- a/Tests/PreviewsJITLinkTests/Fixtures/helper.c
+++ b/Tests/PreviewsJITLinkTests/Fixtures/helper.c
@@ -1,0 +1,1 @@
+int helper(void) { return 40; }

--- a/Tests/PreviewsJITLinkTests/Fixtures/helper.c
+++ b/Tests/PreviewsJITLinkTests/Fixtures/helper.c
@@ -1,1 +1,0 @@
-int helper(void) { return 40; }

--- a/Tests/PreviewsJITLinkTests/Fixtures/objc_class.swift
+++ b/Tests/PreviewsJITLinkTests/Fixtures/objc_class.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+class JITCounter: NSObject {
+    @objc func answer() -> Int32 { 42 }
+}
+
+@_cdecl("objc_class_value")
+public func objcClassValue() -> Int32 {
+    JITCounter().answer()
+}

--- a/Tests/PreviewsJITLinkTests/Fixtures/objc_selref.swift
+++ b/Tests/PreviewsJITLinkTests/Fixtures/objc_selref.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+@_cdecl("objc_selref_value")
+public func objcSelrefValue() -> Int32 {
+    let formatted = NSString(format: "%d", Int32(42))
+    return formatted.intValue
+}

--- a/Tests/PreviewsJITLinkTests/Fixtures/swift_answer.swift
+++ b/Tests/PreviewsJITLinkTests/Fixtures/swift_answer.swift
@@ -1,0 +1,4 @@
+@_cdecl("swift_answer")
+public func swiftAnswer() -> Int32 {
+    return 42
+}

--- a/Tests/PreviewsJITLinkTests/Fixtures/swift_once.swift
+++ b/Tests/PreviewsJITLinkTests/Fixtures/swift_once.swift
@@ -1,0 +1,10 @@
+let swiftOnceComputed: Int32 = {
+    var sum: Int32 = 0
+    for i in 1...100 { sum &+= Int32(i) }
+    return sum
+}()
+
+@_cdecl("swift_once_value")
+public func swiftOnceValue() -> Int32 {
+    swiftOnceComputed
+}

--- a/Tests/PreviewsJITLinkTests/Fixtures/tlv.c
+++ b/Tests/PreviewsJITLinkTests/Fixtures/tlv.c
@@ -1,0 +1,6 @@
+_Thread_local int tlv_counter = 42;
+
+int tlv_value(void) {
+    tlv_counter += 1;
+    return tlv_counter;
+}

--- a/Tests/PreviewsJITLinkTests/Fixtures/witness.swift
+++ b/Tests/PreviewsJITLinkTests/Fixtures/witness.swift
@@ -1,0 +1,13 @@
+protocol Valued {
+    func value() -> Int32
+}
+
+struct DefaultValued: Valued {
+    func value() -> Int32 { 7 }
+}
+
+@_cdecl("witness_value")
+public func witnessValue() -> Int32 {
+    let v: any Valued = DefaultValued()
+    return v.value()
+}

--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -57,7 +57,7 @@ struct PreviewsJITLinkTests {
         #expect(result == 42)
     }
 
-    @Test(.disabled("SP1/U1: JIT-linked Swift conformance records poison the global swift_conformsToProtocol registry under the platform-first path, segfaulting later lookups. Needs explicit Swift metadata-section handling (SwiftEntrySectionPlugin)."))
+    @Test(.disabled("SP0a/SP0b: JIT-linked Swift conformance records crash swift_conformsToProtocol. Version-independent (reproduces on fork LLVM 19.1.5, the Swift 6.2.3 base, and brew 22). orc_rt registers the metadata fine; a relative pointer in the __swift5_proto record resolves to a wild address. JITLink relocation/layout of Swift conformance metadata."))
     func dispatchesThroughWitnessTable() throws {
         let object = try FixtureSupport.compile("witness.swift")
         let result: Int32 = try PreviewsJITLink.linkAndCall(

--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -2,8 +2,11 @@ import PreviewsJITLink
 import Testing
 
 struct PreviewsJITLinkTests {
+    @Test func mainDylibName() throws {
+        #expect(try PreviewsJITLink.mainDylibName() == "main")
+    }
+
     @Test func targetTripleIsArm64Apple() {
-        let triple = PreviewsJITLink.targetTriple()
-        #expect(triple.hasPrefix("arm64-apple"))
+        #expect(PreviewsJITLink.targetTriple().hasPrefix("arm64-apple"))
     }
 }

--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -56,4 +56,14 @@ struct PreviewsJITLinkTests {
         )
         #expect(result == 42)
     }
+
+    @Test(.disabled("SP1/U1: JIT-linked Swift conformance records poison the global swift_conformsToProtocol registry under the platform-first path, segfaulting later lookups. Needs explicit Swift metadata-section handling (SwiftEntrySectionPlugin)."))
+    func dispatchesThroughWitnessTable() throws {
+        let object = try FixtureSupport.compile("witness.swift")
+        let result: Int32 = try PreviewsJITLink.linkAndCall(
+            objectPaths: [object.path],
+            symbol: "witness_value"
+        )
+        #expect(result == 7)
+    }
 }

--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -59,4 +59,20 @@ struct PreviewsJITLinkTests {
         let result: Int32 = try session.call(symbol: "dynamic_cast_value")
         #expect(result == 9)
     }
+
+    @Test func resolvesThreadLocalStorage() throws {
+        let object = try FixtureSupport.compile("tlv.c")
+        let session = try JITSession()
+        try session.addObject(path: object.path)
+        let result: Int32 = try session.call(symbol: "tlv_value")
+        #expect(result == 43)
+    }
+
+    @Test func dispatchesObjCSelector() throws {
+        let object = try FixtureSupport.compile("objc_selref.swift")
+        let session = try JITSession()
+        try session.addObject(path: object.path)
+        let result: Int32 = try session.call(symbol: "objc_selref_value")
+        #expect(result == 42)
+    }
 }

--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -38,4 +38,22 @@ struct PreviewsJITLinkTests {
         )
         #expect(result == 42)
     }
+
+    @Test func linksTrivialSwiftObject() throws {
+        let object = try FixtureSupport.compile("swift_answer.swift")
+        let result: Int32 = try PreviewsJITLink.linkAndCall(
+            objectPaths: [object.path],
+            symbol: "swift_answer"
+        )
+        #expect(result == 42)
+    }
+
+    @Test func resolvesSwiftMangledSymbol() throws {
+        let object = try FixtureSupport.compile("swift_answer.swift")
+        let result: Int32 = try PreviewsJITLink.linkAndCall(
+            objectPaths: [object.path],
+            symbol: "$s8Fixtures11swiftAnswers5Int32VyF"
+        )
+        #expect(result == 42)
+    }
 }

--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -75,4 +75,28 @@ struct PreviewsJITLinkTests {
         let result: Int32 = try session.call(symbol: "objc_selref_value")
         #expect(result == 42)
     }
+
+    @Test func runsSwiftOnceInitializer() throws {
+        let object = try FixtureSupport.compile("swift_once.swift")
+        let session = try JITSession()
+        try session.addObject(path: object.path)
+        let result: Int32 = try session.call(symbol: "swift_once_value")
+        #expect(result == 5050)
+    }
+
+    @Test func registersObjCClass() throws {
+        let object = try FixtureSupport.compile("objc_class.swift")
+        let session = try JITSession()
+        try session.addObject(path: object.path)
+        let result: Int32 = try session.call(symbol: "objc_class_value")
+        #expect(result == 42)
+    }
+
+    @Test func runsAsyncFunction() throws {
+        let object = try FixtureSupport.compile("async_value.swift")
+        let session = try JITSession()
+        try session.addObject(path: object.path)
+        let result: Int32 = try session.call(symbol: "async_value")
+        #expect(result == 11)
+    }
 }

--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -3,67 +3,60 @@ import PreviewsJITLink
 import Testing
 
 struct PreviewsJITLinkTests {
-    @Test func mainDylibName() throws {
-        #expect(try PreviewsJITLink.mainDylibName() == "main")
-    }
-
-    @Test func targetTripleIsArm64Apple() {
-        #expect(PreviewsJITLink.targetTriple().hasPrefix("arm64-apple"))
-    }
-
     @Test func linksCObject() throws {
         let object = try FixtureSupport.compile("answer.c")
-        let result: Int32 = try PreviewsJITLink.linkAndCall(
-            objectPaths: [object.path],
-            symbol: "answer"
-        )
+        let session = try JITSession()
+        try session.addObject(path: object.path)
+        let result: Int32 = try session.call(symbol: "answer")
         #expect(result == 42)
     }
 
     @Test func linksSwiftObject() throws {
         let object = try FixtureSupport.compile("swift_answer.swift")
-        let result: Int32 = try PreviewsJITLink.linkAndCall(
-            objectPaths: [object.path],
-            symbol: "swift_answer"
-        )
+        let session = try JITSession()
+        try session.addObject(path: object.path)
+        let result: Int32 = try session.call(symbol: "swift_answer")
         #expect(result == 42)
     }
 
     @Test func resolvesProcessSymbolThroughExecutor() throws {
         let object = try FixtureSupport.compile("external.c", extraFlags: ["-fno-builtin"])
-        let result: Int32 = try PreviewsJITLink.linkAndCall(
-            objectPaths: [object.path],
-            symbol: "compute"
-        )
+        let session = try JITSession()
+        try session.addObject(path: object.path)
+        let result: Int32 = try session.call(symbol: "compute")
         #expect(result == 42)
     }
 
     @Test func throwsOnMissingSymbol() throws {
         let object = try FixtureSupport.compile("answer.c")
+        let session = try JITSession()
+        try session.addObject(path: object.path)
         #expect(throws: JITLinkError.self) {
-            let _: Int32 = try PreviewsJITLink.linkAndCall(
-                objectPaths: [object.path],
-                symbol: "does_not_exist"
-            )
+            let _: Int32 = try session.call(symbol: "does_not_exist")
         }
     }
 
     @Test func runsObjectInitializer() throws {
         let object = try FixtureSupport.compile("ctor.c")
-        let result: Int32 = try PreviewsJITLink.linkAndCall(
-            objectPaths: [object.path],
-            symbol: "ctor_answer"
-        )
+        let session = try JITSession()
+        try session.addObject(path: object.path)
+        let result: Int32 = try session.call(symbol: "ctor_answer")
         #expect(result == 42)
     }
 
-    @Test(.disabled("SP0c: JIT-linked Swift conformance crashes swift_conformsToProtocol. Root-caused: not relocs (Delta32 edges are correct intra-image), not the slab, not LLVM version. The runtime accesses the __swift5_proto section at a wrong base (0x300000000 region, unmapped) vs JITLink's link address (0x124e...). Section-address registration mismatch in ExecutorNativePlatform's Swift handling. Fix is the design's SwiftEntrySectionPlugin: register conformances with the correct final addresses."))
-    func dispatchesThroughWitnessTable() throws {
+    @Test func dispatchesThroughWitnessTable() throws {
         let object = try FixtureSupport.compile("witness.swift")
-        let result: Int32 = try PreviewsJITLink.linkAndCall(
-            objectPaths: [object.path],
-            symbol: "witness_value"
-        )
+        let session = try JITSession()
+        try session.addObject(path: object.path)
+        let result: Int32 = try session.call(symbol: "witness_value")
         #expect(result == 7)
+    }
+
+    @Test func resolvesConformanceThroughRuntimeRegistry() throws {
+        let object = try FixtureSupport.compile("dynamic_cast.swift")
+        let session = try JITSession()
+        try session.addObject(path: object.path)
+        let result: Int32 = try session.call(symbol: "dynamic_cast_value")
+        #expect(result == 9)
     }
 }

--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -57,7 +57,7 @@ struct PreviewsJITLinkTests {
         #expect(result == 42)
     }
 
-    @Test(.disabled("SP0a/SP0b: JIT-linked Swift conformance records crash swift_conformsToProtocol. Version-independent (reproduces on fork LLVM 19.1.5, the Swift 6.2.3 base, and brew 22). orc_rt registers the metadata fine; a relative pointer in the __swift5_proto record resolves to a wild address. JITLink relocation/layout of Swift conformance metadata."))
+    @Test(.disabled("SP0c: JIT-linked Swift conformance crashes swift_conformsToProtocol. Root-caused: not relocs (Delta32 edges are correct intra-image), not the slab, not LLVM version. The runtime accesses the __swift5_proto section at a wrong base (0x300000000 region, unmapped) vs JITLink's link address (0x124e...). Section-address registration mismatch in ExecutorNativePlatform's Swift handling. Fix is the design's SwiftEntrySectionPlugin: register conformances with the correct final addresses."))
     func dispatchesThroughWitnessTable() throws {
         let object = try FixtureSupport.compile("witness.swift")
         let result: Int32 = try PreviewsJITLink.linkAndCall(

--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -1,0 +1,9 @@
+import PreviewsJITLink
+import Testing
+
+struct PreviewsJITLinkTests {
+    @Test func targetTripleIsArm64Apple() {
+        let triple = PreviewsJITLink.targetTriple()
+        #expect(triple.hasPrefix("arm64-apple"))
+    }
+}

--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -14,8 +14,27 @@ struct PreviewsJITLinkTests {
     @Test func linkAndCallAnswerReturns42() throws {
         let object = try FixtureSupport.compile("answer.c")
         let result: Int32 = try PreviewsJITLink.linkAndCall(
-            objectPath: object.path,
+            objectPaths: [object.path],
             symbol: "answer"
+        )
+        #expect(result == 42)
+    }
+
+    @Test func resolvesExternalSymbolFromHost() throws {
+        let object = try FixtureSupport.compile("external.c", extraFlags: ["-fno-builtin"])
+        let result: Int32 = try PreviewsJITLink.linkAndCall(
+            objectPaths: [object.path],
+            symbol: "compute"
+        )
+        #expect(result == 42)
+    }
+
+    @Test func resolvesSymbolAcrossObjects() throws {
+        let caller = try FixtureSupport.compile("caller.c")
+        let helper = try FixtureSupport.compile("helper.c")
+        let result: Int32 = try PreviewsJITLink.linkAndCall(
+            objectPaths: [caller.path, helper.path],
+            symbol: "composed"
         )
         #expect(result == 42)
     }

--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import PreviewsJITLink
 import Testing
 
@@ -8,5 +9,14 @@ struct PreviewsJITLinkTests {
 
     @Test func targetTripleIsArm64Apple() {
         #expect(PreviewsJITLink.targetTriple().hasPrefix("arm64-apple"))
+    }
+
+    @Test func linkAndCallAnswerReturns42() throws {
+        let object = try FixtureSupport.compile("answer.c")
+        let result: Int32 = try PreviewsJITLink.linkAndCall(
+            objectPath: object.path,
+            symbol: "answer"
+        )
+        #expect(result == 42)
     }
 }

--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -11,7 +11,7 @@ struct PreviewsJITLinkTests {
         #expect(PreviewsJITLink.targetTriple().hasPrefix("arm64-apple"))
     }
 
-    @Test func linkAndCallAnswerReturns42() throws {
+    @Test func linksCObject() throws {
         let object = try FixtureSupport.compile("answer.c")
         let result: Int32 = try PreviewsJITLink.linkAndCall(
             objectPaths: [object.path],
@@ -20,26 +20,7 @@ struct PreviewsJITLinkTests {
         #expect(result == 42)
     }
 
-    @Test func resolvesExternalSymbolFromHost() throws {
-        let object = try FixtureSupport.compile("external.c", extraFlags: ["-fno-builtin"])
-        let result: Int32 = try PreviewsJITLink.linkAndCall(
-            objectPaths: [object.path],
-            symbol: "compute"
-        )
-        #expect(result == 42)
-    }
-
-    @Test func resolvesSymbolAcrossObjects() throws {
-        let caller = try FixtureSupport.compile("caller.c")
-        let helper = try FixtureSupport.compile("helper.c")
-        let result: Int32 = try PreviewsJITLink.linkAndCall(
-            objectPaths: [caller.path, helper.path],
-            symbol: "composed"
-        )
-        #expect(result == 42)
-    }
-
-    @Test func linksTrivialSwiftObject() throws {
+    @Test func linksSwiftObject() throws {
         let object = try FixtureSupport.compile("swift_answer.swift")
         let result: Int32 = try PreviewsJITLink.linkAndCall(
             objectPaths: [object.path],
@@ -48,11 +29,30 @@ struct PreviewsJITLinkTests {
         #expect(result == 42)
     }
 
-    @Test func resolvesSwiftMangledSymbol() throws {
-        let object = try FixtureSupport.compile("swift_answer.swift")
+    @Test func resolvesProcessSymbolThroughExecutor() throws {
+        let object = try FixtureSupport.compile("external.c", extraFlags: ["-fno-builtin"])
         let result: Int32 = try PreviewsJITLink.linkAndCall(
             objectPaths: [object.path],
-            symbol: "$s8Fixtures11swiftAnswers5Int32VyF"
+            symbol: "compute"
+        )
+        #expect(result == 42)
+    }
+
+    @Test func throwsOnMissingSymbol() throws {
+        let object = try FixtureSupport.compile("answer.c")
+        #expect(throws: JITLinkError.self) {
+            let _: Int32 = try PreviewsJITLink.linkAndCall(
+                objectPaths: [object.path],
+                symbol: "does_not_exist"
+            )
+        }
+    }
+
+    @Test func runsObjectInitializer() throws {
+        let object = try FixtureSupport.compile("ctor.c")
+        let result: Int32 = try PreviewsJITLink.linkAndCall(
+            objectPaths: [object.path],
+            symbol: "ctor_answer"
         )
         #expect(result == 42)
     }

--- a/docs/jit-executor-phase1-plan.md
+++ b/docs/jit-executor-phase1-plan.md
@@ -281,12 +281,29 @@ the design's `JITLinkSession` / `SessionResolver` (SP5).
     memory as non-reclaimable mid-life, bounding it by PID lifetime instead. A
     future Swift deregister API is not on the critical path.
 
-### SP1 — Port the six POC scenarios as tests (acceptance core)
+### SP1 — Port the six POC scenarios as tests (acceptance core, IN PROGRESS)
 Translate `research/jit-poc/swift/*.swift` (greet/witness, tlv, swift_once,
 objc selref, objc class, async) into `PreviewsJITLinkTests` fixtures.
 - **Verify:** each scenario links and its symbol returns the expected value,
   in-process, under path A. Any scenario that fails under A names the specific
   plugin to port (resolves U1).
+- **Probed first (both pass under path A):** real Mach-O TLV via a C
+  `_Thread_local` (`tlv.c`, exercises the platform's `fixTLVSectionsAndEdges`
+  and orc_rt TLV path) and ObjC selref via Foundation (`objc_selref.swift`,
+  `NSString(format:)` + `intValue`). The selref one matters: the POC needed a
+  hand-rolled `ObjCSelrefPlugin` on its bare layer, but under path A the
+  platform's objc-image registration uniques the selectors, so **that plugin is
+  not needed**. Strong evidence path A is sufficient (U1). Remaining: swift_once,
+  objc class, async.
+- **Architecture fix surfaced by the probe:** a per-session `LLJIT` does not
+  work. Each `ExecutorNativePlatform` bootstrap registers process-global state
+  (`findDynamicUnwindSections`), so concurrent sessions under the parallel test
+  runner raced and the second failed to materialize
+  `__orc_rt_macho_complete_bootstrap`. Fixed by one process-shared `LLJIT` built
+  behind `std::call_once`, with each session a `JITDylib` created via
+  `LLJIT::createJITDylib` (which runs platform setup so the dylib resolves
+  process and stdlib symbols). This also matches D3, the shared JIT is
+  process-lived. 9 tests pass, stable across repeated parallel runs.
 
 ### SP2 — Wire `Compiler.swift` for `.o` production
 Replace the test-only `swiftc` shell-out with `Sources/PreviewsCore/Compiler.swift`

--- a/docs/jit-executor-phase1-plan.md
+++ b/docs/jit-executor-phase1-plan.md
@@ -168,13 +168,43 @@ registration code is identical fork vs vanilla). So diagnose first:
     out). Deeper tracing of the registered range needs either lldb (no build) or
     a debug/asserts `orc_rt` (build).
 
-### SP0b — Build LLVM from the Swift fork (ONLY if SP0a points to orc_rt)
-Contingent on SP0a. If the cause is the `orc_rt`↔runtime contract, the lever is
-a fork-matched `liborc_rt`, possibly not a full `libLLVM` rebuild. Build per the
-vendoring decision above (pinned-clone script, sparse, out-of-tree cache). Fix
-the `SelfExecutorProcessControl` include (now in `ExecutorProcessControl.h`).
-- **Verify:** re-enabled `dispatchesThroughWitnessTable` no longer segfaults and
-  the existing tests still pass.
+### SP0b — Build LLVM from the Swift fork (DONE; result: did NOT fix it)
+Built `swiftlang/llvm-project` @ `swift-6.2.3-RELEASE` via
+`scripts/build-jit-llvm.sh` (pinned-clone, shallow+sparse+partial, two-phase:
+libLLVM dylib with asserts, then standalone compiler-rt orc runtime).
+Repointed `PreviewsJITLinkCxx` (`Package.swift` computes paths from the package
+dir; orc path injected via `-DPREVIEWSMCP_ORC_RT_PATH`; `SelfExecutorProcessControl`
+include → `ExecutorProcessControl.h`; `slabLinkingLayer` gained the
+`const Triple&` param the older `ObjectLinkingLayerCreator` requires).
+- **Result:** the fork LLVM is **19.1.5** (Swift 6.2.3's exact base; brew was
+  22.1.5). The 8 non-witness tests pass on it. **`dispatchesThroughWitnessTable`
+  still segfaults.** So the version-skew theory is **dead** — matching the
+  runtime's exact LLVM did not fix it. The subagent was right.
+- **What the debug orc_rt trace showed** (`ORC_RT_DEBUG=1`, needs a Debug-built
+  orc_rt, NDEBUG gates the logging): metadata registration **succeeds**
+  (`Registering object sections for 0x11fe4c000` → `Registering Objective-C /
+  Swift metadata`). The crash is in the **content**: `swift_conformsToProtocol`
+  follows a relative pointer in the registered `__swift5_proto` record to a wild
+  address `0x3000580e8` (consistent `0x580e8` = 360681 low offset across runs),
+  ~12GB away from the JIT'd image at `0x11fe4c000`. So the real bug is **JITLink
+  relocation/layout of Swift conformance metadata**, version-independent.
+- **Keep the fork build anyway:** it gives asserts (JITLink diagnostics), a
+  Debug orc_rt (logging), and ios/iossim orc runtimes for the Phase 2 simulator
+  work. The brew dependency is gone.
+
+### SP0c — Root-cause the conformance relocation (NEXT, the real bug)
+The crash is a relative pointer in the JIT-linked `__swift5_proto` record
+resolving to a wild address. Hypotheses to test: JITLink mis-relocates the
+`SUBTRACTOR/UNSIGNED` delta for these Swift sections; or the slab placement puts
+the conformance target >±2GB from the record (the relative pointer is signed
+32-bit, same reach class as the unwind issue, note the 1GB slab); or a Swift
+relative-*indirectable* pointer (low-bit tag) is mishandled. Use the asserts
+libLLVM (`--debug-only=jitlink` is now possible) and lldb at the crash to read
+the record and the offending pointer. Also worth: a known-issue search and
+checking whether the design's `SwiftEntrySectionPlugin` (explicit conformance
+registration with resolved addresses) sidesteps it.
+- **Verify:** name the exact miscomputation, then `dispatchesThroughWitnessTable`
+  passes.
 
 ### SP1 — Port the six POC scenarios as tests (acceptance core)
 Translate `research/jit-poc/swift/*.swift` (greet/witness, tlv, swift_once,

--- a/docs/jit-executor-phase1-plan.md
+++ b/docs/jit-executor-phase1-plan.md
@@ -58,6 +58,18 @@ LLVM ORC harness)." Resume from here across sessions. Update it as work lands.
     `swift_once` fine, but not conformance/type metadata. This is the gap the
     design's `SwiftEntrySectionPlugin` targets. Test `dispatchesThroughWitnessTable`
     is `.disabled` because the segfault takes down the whole runner.
+  - **Sharpened by two diagnostic probes:** the fault is narrow.
+    - Type metadata is fine: `String(describing: Box.self)` on a JIT'd struct
+      (no protocol) passes, so `__swift5_types` registration and demangling work.
+    - It is conformance-record registration specifically, and it happens at
+      *link time*, not at the call: an object whose called function never touches
+      its protocol still poisons the registry merely by being linked (its
+      `__swift5_proto` record registers). So the broken thing is exactly the
+      JIT-linked protocol-conformance records, not the existential dispatch.
+    - **Open root-cause question:** are the conformance records mis-relocated
+      (relative pointers wrong), double-registered (platform + something), or
+      registered in a form the runtime mis-walks? Decides whether the fix is a
+      relocation fix, suppressing the platform's auto-registration, or the plugin.
 - **U2:** Does the Swift calling convention hold when we call a real `View` body
   thunk, versus the trivial nullary functions tested so far?
 - **U3:** LLVM integration strategy for shipping (vendor xcframework vs CMake

--- a/docs/jit-executor-phase1-plan.md
+++ b/docs/jit-executor-phase1-plan.md
@@ -39,9 +39,21 @@ LLVM ORC harness)." Resume from here across sessions. Update it as work lands.
 - We build on public LLVM ORC + JITLink, not Apple's runtime (verdict #1).
 - Phase 1 validates the JIT-link plus re-resolution mechanism in-process only.
   Propagating new addresses into running callers is Phase 2+.
-- brew LLVM 22 is acceptable scaffolding for Phase 1; bundling is later.
 - The full `MachOPlatform` (via `ExecutorNativePlatform`) performs the ObjC and
   Swift runtime registration that the POC hand-rolled with plugins.
+
+### LLVM source decision (resolves U3, was: brew scaffolding)
+
+Build LLVM from source from `swiftlang/llvm-project` at the tag matching the
+installed Swift (`swift-6.2.3-RELEASE`), not vanilla brew LLVM 22. Rationale:
+the Swift runtime in-process (`libswiftCore`) is built from this fork, and the
+SP1 conformance segfault is most plausibly a registration-mechanism skew between
+brew LLVM 22's ORC `MachOPlatform` and that older runtime. The fork has full ORC
++ JITLink (46 headers) and `compiler-rt/lib/orc` (builds `liborc_rt_osx.a`).
+Note `swift-llvm-bindings` is NOT the vehicle: it is a Swift-API binding layer
+that itself needs a local LLVM checkout. We link the C++ libraries directly.
+Known API skew vs brew 22: `SelfExecutorProcessControl` lives in
+`ExecutorProcessControl.h` here, not its own header.
 
 ## Unknowns
 
@@ -93,6 +105,18 @@ sufficient. This is a legitimate Phase-1 discovery, exactly what the seed prompt
 says to expect.
 
 ## Subproblems and verification criteria
+
+### SP0 — Build LLVM from the Swift fork and repoint the C++ target (prerequisite)
+Build `swiftlang/llvm-project` @ `swift-6.2.3-RELEASE` (matches installed Swift)
+with `compiler-rt` for the orc runtime, AArch64 + X86 targets (X86 for the
+simulator later). Repoint `PreviewsJITLinkCxx` include/lib paths and
+`kOrcRuntimePath` at the build output; fix the `SelfExecutorProcessControl`
+include (now in `ExecutorProcessControl.h`).
+- **Verify:** the existing 8 tests still pass against the fork build, and the
+  `dispatchesThroughWitnessTable` scenario, re-enabled, no longer segfaults. If
+  it passes, the conformance bug was the LLVM/runtime skew and SP0 also resolves
+  U1 for Swift metadata. If it still crashes, the fix is a real plugin/relocation
+  problem, not version skew.
 
 ### SP1 — Port the six POC scenarios as tests (acceptance core)
 Translate `research/jit-poc/swift/*.swift` (greet/witness, tlv, swift_once,

--- a/docs/jit-executor-phase1-plan.md
+++ b/docs/jit-executor-phase1-plan.md
@@ -1,0 +1,115 @@
+# JIT Executor — Phase 1 plan and state
+
+Living plan for issue #183, "Implement custom JIT executor (Phase 1: host-side
+LLVM ORC harness)." Resume from here across sessions. Update it as work lands.
+
+## Sources of truth
+
+- Issue #183 (acceptance criteria).
+- `prompts/jit-executor-design.md` §§3, 4, 8.1 (on `previews-research`).
+- `prompts/jit-executor-impl-phase1.md` (seed prompt, on `previews-research`).
+- W2 POC `research/jit-poc/` (on `previews-research`), six green scenarios.
+- Branch: `183-jit-executor`. Compiler driver: `Sources/PreviewsCore/Compiler.swift`.
+
+## What is built (commits cf12422..064a26c)
+
+- Targets `PreviewsJITLinkCxx` (C++ shim, C ABI over brew LLVM 22) and
+  `PreviewsJITLink` (Swift wrapper).
+- `linkAndCall(objectPaths:symbol:) -> T: FixedWidthInteger`: links one or many
+  `.o` into one LLJIT, runs initializers, resolves the symbol, calls it.
+- LLJIT built on an explicit `SelfExecutorProcessControl`, an
+  `ExecutorNativePlatform(liborc_rt_osx.a)`, and a slab `MapperJITLinkMemoryManager`.
+- Unified error-string channel marshalled to Swift `throws`.
+- Tests: C and Swift smoke, process-symbol resolution, missing-symbol failure,
+  initializer probe.
+
+## Discoveries to preserve (not in the design doc)
+
+- Running load-time initializers requires the native MachO platform set up with
+  the orc runtime. A bare `LLJIT` plus `initialize()` does nothing.
+- Unwind/EH needs a slab-reserving memory manager. The default per-allocation
+  mmap scatters code and `__unwind_info` past 4GB under ASLR and trips a 32-bit
+  delta error. This gotcha is absent from the design's §5 list.
+- The JIT calling surface is integer/pointer only, because we only call our own
+  thunk and edited methods are redirected by the runtime via dynamic
+  replacement. See memory `project_jit_dynamic_replacement`.
+
+## Assumptions
+
+- We build on public LLVM ORC + JITLink, not Apple's runtime (verdict #1).
+- Phase 1 validates the JIT-link plus re-resolution mechanism in-process only.
+  Propagating new addresses into running callers is Phase 2+.
+- brew LLVM 22 is acceptable scaffolding for Phase 1; bundling is later.
+- The full `MachOPlatform` (via `ExecutorNativePlatform`) performs the ObjC and
+  Swift runtime registration that the POC hand-rolled with plugins.
+
+## Unknowns
+
+- **U1 (load-bearing):** Does `MachOPlatform` + orc runtime fully subsume the
+  three prescribed plugins for all six scenarios, or does some scenario still
+  need a custom plugin? Resolve empirically by running the six scenarios.
+- **U2:** Does the Swift calling convention hold when we call a real `View` body
+  thunk, versus the trivial nullary functions tested so far?
+- **U3:** LLVM integration strategy for shipping (vendor xcframework vs CMake
+  bridge vs SwiftPM binary target). Phase 1 defers, but it gates Phase 2 hardening.
+
+## Alternatives — the central decision (U1)
+
+The design §4 prescribes porting three hand-rolled JITLink plugins
+(`ObjCSelrefPlugin`, `ObjCClassPlugin`, `SwiftEntrySectionPlugin`) because the
+POC ran a bare `ObjectLinkingLayer` with no platform.
+
+- **A. Platform-first (current path).** Use `ExecutorNativePlatform` + orc
+  runtime so the real `MachOPlatform` does selref/class/metadata registration and
+  initializers. Port a custom plugin only for a scenario the platform misses.
+- **B. Plugins-first (design as written).** Bare `ObjectLinkingLayer`, port all
+  three plugins verbatim from the POC.
+
+Lean A: less hand-rolled code, mirrors how the runtime actually works, already
+runs initializers. Treat the six scenarios as the test that decides whether A is
+sufficient. This is a legitimate Phase-1 discovery, exactly what the seed prompt
+says to expect.
+
+## Subproblems and verification criteria
+
+### SP1 — Port the six POC scenarios as tests (acceptance core)
+Translate `research/jit-poc/swift/*.swift` (greet/witness, tlv, swift_once,
+objc selref, objc class, async) into `PreviewsJITLinkTests` fixtures.
+- **Verify:** each scenario links and its symbol returns the expected value,
+  in-process, under path A. Any scenario that fails under A names the specific
+  plugin to port (resolves U1).
+
+### SP2 — Wire `Compiler.swift` for `.o` production
+Replace the test-only `swiftc` shell-out with `Sources/PreviewsCore/Compiler.swift`
+for producing objects from a Swift source + target View symbol.
+- **Verify:** a test compiles a source via `Compiler.swift`, links it, and calls
+  the View symbol, with no direct `swiftc` invocation in the path.
+
+### SP3 — Re-resolution on source change
+Recompile a changed source, add the new `.o` to the JIT, re-resolve the symbol.
+- **Verify:** the re-resolved symbol points at the new object and calling it
+  returns the new behavior. (Phase 1 stops here; address propagation is Phase 2+.)
+
+### SP4 — Custom plugin(s) only if SP1 demands
+If a scenario fails under path A, port the matching plugin
+(`LinkGraphLinkingLayer::Plugin`, `PostPrunePasses`, canonical `__SEG,__sect`
+names, graceful early-out, no-op `notifyFailed`/`notifyRemovingResources`/
+`notifyTransferringResources`).
+- **Verify:** the previously failing scenario passes with the plugin added.
+
+### SP5 — Swift API surface + SessionResolver (lighter weight, can trail)
+Grow `JITLinkError` toward the design's `JITLinkSession`/`JITLinkResult`/`Symbol`
+and add a `jit-linked` session kind to `SessionResolver`.
+- **Verify:** `SessionResolver` can hand a session to the JIT path and back.
+
+## Scope boundaries
+
+- **Phase 1 (this branch):** SP1–SP5 in-process inside the test runner / daemon.
+- **Deferred Phase 2+:** out-of-process agent + `SimpleRemoteEPC`; the sidecar
+  symbol-discovery format (§3); patch-point publishing / `write_mem`; LLVM
+  bundling; iOS device support; in-place patching.
+
+## Immediate next step
+
+SP1. Start with the witness/greet scenario from the POC, confirm it passes under
+path A, and let the six scenarios decide U1.

--- a/docs/jit-executor-phase1-plan.md
+++ b/docs/jit-executor-phase1-plan.md
@@ -192,19 +192,39 @@ include → `ExecutorProcessControl.h`; `slabLinkingLayer` gained the
   Debug orc_rt (logging), and ios/iossim orc runtimes for the Phase 2 simulator
   work. The brew dependency is gone.
 
-### SP0c — Root-cause the conformance relocation (NEXT, the real bug)
-The crash is a relative pointer in the JIT-linked `__swift5_proto` record
-resolving to a wild address. Hypotheses to test: JITLink mis-relocates the
-`SUBTRACTOR/UNSIGNED` delta for these Swift sections; or the slab placement puts
-the conformance target >±2GB from the record (the relative pointer is signed
-32-bit, same reach class as the unwind issue, note the 1GB slab); or a Swift
-relative-*indirectable* pointer (low-bit tag) is mishandled. Use the asserts
-libLLVM (`--debug-only=jitlink` is now possible) and lldb at the crash to read
-the record and the offending pointer. Also worth: a known-issue search and
-checking whether the design's `SwiftEntrySectionPlugin` (explicit conformance
-registration with resolved addresses) sidesteps it.
-- **Verify:** name the exact miscomputation, then `dispatchesThroughWitnessTable`
-  passes.
+### SP0c — Root-cause the conformance crash (DONE; it's a section-address mismatch)
+Enabled JITLink logging (env `PREVIEWSMCP_JIT_DEBUG=1`, works on the asserts
+fork build) and a Debug orc_rt (`ORC_RT_DEBUG=1`). Findings:
+- The conformance record's relative pointers are **correct**. JITLink emits
+  `edge@0x260: Delta32 -> ...DefaultValuedVAA0C0AAMc` (the conformance
+  descriptor) and the descriptor's own `Delta32` edges to protocol/type/witness,
+  all small intra-image deltas. Not a relocation bug.
+- JITLink places the `__swift5_proto` block at `0x124e580e8`. The crash reads
+  `0x3000580e8` — **same low offset `0x580e8`, different base**. So the runtime
+  accesses the section at a `0x300000000`-region address that is **not mapped**,
+  while the linked address is `0x124e...`. A base / address-space mismatch in how
+  the section is registered with the runtime, not the record content.
+- **Not the slab:** removing the slab linking layer still crashes (different
+  memory manager, same class of crash). **Not LLVM version** (SP0b). **Not
+  relocs** (above).
+- Conclusion: `ExecutorNativePlatform`'s automatic Swift-section registration
+  hands the runtime an address the in-process executor doesn't back. This is
+  exactly the gap the design's **`SwiftEntrySectionPlugin`** fills: at
+  link-finalize, walk the new image's `__swift5_*` sections and register them
+  with the Swift runtime using the **correct JIT-final addresses**.
+
+### SP0d — Implement SwiftEntrySectionPlugin (NEXT, the fix)
+Per design §4. A `LinkGraphLinkingLayer::Plugin` that, in `PostFixupPasses` (or
+on emission, when final addresses are known), finds `__swift5_proto` /
+`__swift5_types` / `__swift5_protos` and calls the Swift runtime registration
+entry points (`swift_registerProtocolConformances`,
+`swift_registerTypeMetadataRecords`, …) with the resolved addresses, instead of
+relying on the platform's auto-registration. May also need to suppress the
+platform's own (wrong-address) Swift registration to avoid a double/garbage
+record. Note the POC's plugin constraints (PostPrunePasses, no-op
+`notifyFailed`/`notifyRemovingResources`/`notifyTransferringResources`,
+canonical `__SEG,__sect` names, graceful early-out).
+- **Verify:** `dispatchesThroughWitnessTable` passes; the other 8 stay green.
 
 ### SP1 — Port the six POC scenarios as tests (acceptance core)
 Translate `research/jit-poc/swift/*.swift` (greet/witness, tlv, swift_once,

--- a/docs/jit-executor-phase1-plan.md
+++ b/docs/jit-executor-phase1-plan.md
@@ -213,18 +213,52 @@ fork build) and a Debug orc_rt (`ORC_RT_DEBUG=1`). Findings:
   link-finalize, walk the new image's `__swift5_*` sections and register them
   with the Swift runtime using the **correct JIT-final addresses**.
 
-### SP0d — Implement SwiftEntrySectionPlugin (NEXT, the fix)
-Per design §4. A `LinkGraphLinkingLayer::Plugin` that, in `PostFixupPasses` (or
-on emission, when final addresses are known), finds `__swift5_proto` /
-`__swift5_types` / `__swift5_protos` and calls the Swift runtime registration
-entry points (`swift_registerProtocolConformances`,
-`swift_registerTypeMetadataRecords`, …) with the resolved addresses, instead of
-relying on the platform's auto-registration. May also need to suppress the
-platform's own (wrong-address) Swift registration to avoid a double/garbage
-record. Note the POC's plugin constraints (PostPrunePasses, no-op
-`notifyFailed`/`notifyRemovingResources`/`notifyTransferringResources`,
-canonical `__SEG,__sect` names, graceful early-out).
-- **Verify:** `dispatchesThroughWitnessTable` passes; the other 8 stay green.
+### SP0d — SwiftEntrySectionPlugin + session lifetime (IN PROGRESS)
+Per design §4. A `ObjectLinkingLayer::Plugin` (`SwiftEntrySectionPlugin`) that, in
+`PrePrunePasses`, moves `__swift5_proto` / `__swift5_types` into private sections
+so the platform's wrong-address registration path skips them, keeping the blocks
+live with anonymous symbols so pruning does not drop the conformance records.
+Then in `PostFixupPasses` it registers each section at its final JIT address via
+`swift_registerProtocolConformances` / `swift_registerTypeMetadataRecords` through
+alloc actions. Built with `-fno-rtti` to match LLVM (the derived plugin otherwise
+needs the base class typeinfo, which LLVM does not export).
+
+**What landed and is verified:** suppression. `dispatchesThroughWitnessTable`
+passes, the witness call dispatches through the statically-emitted witness table
+and never needs the global registry, exactly as the W2 POC's bare layer did.
+
+**Root cause found, this is the real blocker:** the re-registration itself is an
+ownership bug, not an address bug. A new test `resolvesConformanceThroughRuntimeRegistry`
+forces a runtime conformance lookup via a dynamic cast, which is the lookup the
+witness test never exercised. With registration on it segfaults. Same-process
+diagnostics proved the registered record address is correct (e.g.
+`0x300054124`) but unmapped at fault time. `linkAndCall` is spike code that links,
+calls, then destroys a per-call `LLJIT`, freeing the slab. The records were
+registered into the process-global Swift conformance registry, which is then left
+holding a dangling pointer. Confirmed by keeping the `LLJIT` alive (the dynamic
+cast then returns the correct value).
+
+**How Xcode Previews avoids this:** its agent is long-lived and `XOJITExecutor`
+holds the image as a `JITDylibHandle` session (see
+`research/scripts/analysis/q6-jit-runtime-findings.md`). The pseudodylib stays
+resident for the whole preview, edits arrive via dynamic replacement, the image
+memory and the global registry share one lifetime. There is no fire-and-forget.
+
+**Decision (agreed): rearchitect around a session, drop `linkAndCall`.** The
+session owns the image and its lifetime equals the image lifetime. Name to match
+the design's `JITLinkSession` / `SessionResolver` (SP5).
+- **SP0d-A:** `JITSession` C++ type + handle ABI (`session_create`,
+  `session_add_object`, `session_lookup`, `session_destroy`); keep free
+  `target_triple`. Verify: a C smoke test resolves and calls a symbol through a handle.
+- **SP0d-B:** Swift `JITSession` class owning the handle, `deinit` destroys,
+  `lookup` returns an address, typed `call<T>` helper. Verify:
+  `dispatchesThroughWitnessTable` returns 7 and `resolvesConformanceThroughRuntimeRegistry`
+  returns 9 while the test holds the session, no leak hack.
+- **SP0d-C:** port the existing 8 tests onto sessions, delete `linkAndCall` and
+  the spike entry points. Verify: all prior tests stay green, no fire-and-forget path left.
+- **SP0d-D:** teardown / deregister. Deferred. `destroy` is only safe when nothing
+  global was registered, since Swift conformance deregistration is not cleanly
+  public. Document the constraint, revisit in Phase 2.
 
 ### SP1 — Port the six POC scenarios as tests (acceptance core)
 Translate `research/jit-poc/swift/*.swift` (greet/witness, tlv, swift_once,
@@ -265,5 +299,6 @@ and add a `jit-linked` session kind to `SessionResolver`.
 
 ## Immediate next step
 
-SP1. Start with the witness/greet scenario from the POC, confirm it passes under
-path A, and let the six scenarios decide U1.
+SP0d-A. Build the `JITSession` C++ type and handle ABI, then port the witness and
+dynamic-cast tests onto it (SP0d-B). Only after the session lands and both tests
+pass without a leak hack do we move to SP1.

--- a/docs/jit-executor-phase1-plan.md
+++ b/docs/jit-executor-phase1-plan.md
@@ -44,16 +44,54 @@ LLVM ORC harness)." Resume from here across sessions. Update it as work lands.
 
 ### LLVM source decision (resolves U3, was: brew scaffolding)
 
-Build LLVM from source from `swiftlang/llvm-project` at the tag matching the
-installed Swift (`swift-6.2.3-RELEASE`), not vanilla brew LLVM 22. Rationale:
-the Swift runtime in-process (`libswiftCore`) is built from this fork, and the
-SP1 conformance segfault is most plausibly a registration-mechanism skew between
-brew LLVM 22's ORC `MachOPlatform` and that older runtime. The fork has full ORC
-+ JITLink (46 headers) and `compiler-rt/lib/orc` (builds `liborc_rt_osx.a`).
-Note `swift-llvm-bindings` is NOT the vehicle: it is a Swift-API binding layer
-that itself needs a local LLVM checkout. We link the C++ libraries directly.
-Known API skew vs brew 22: `SelfExecutorProcessControl` lives in
-`ExecutorProcessControl.h` here, not its own header.
+Original rationale (now contested, see counter-evidence): the Swift runtime
+in-process (`libswiftCore`) is built from `swiftlang/llvm-project` at
+`swift-6.2.3-RELEASE`, so building our LLVM from that fork might fix the SP1
+conformance segfault by matching the runtime. The fork has full ORC + JITLink
+(46 headers) and `compiler-rt/lib/orc` (builds `liborc_rt_osx.a`).
+`swift-llvm-bindings` is NOT the vehicle: it is a Swift-API binding layer that
+itself needs a local LLVM checkout; we link the C++ libraries directly. Known
+API skew vs brew 22: `SelfExecutorProcessControl` lives in
+`ExecutorProcessControl.h` in the fork, not its own header.
+
+**Counter-evidence (subagent review, do not skip):** building the fork's
+`libLLVM` is unlikely on its own to fix the conformance segfault. A diff of
+`MachOPlatform`'s Swift-section registration between the fork at
+`swift-6.2.3-RELEASE` and vanilla `llvmorg-22.1.5` found it **byte-for-byte
+identical** (same `__swift5_proto` handling, same synthetic
+`__llvm_jitlink_ObjCRuntimeRegistrationObject` + `RegisterObjCRuntimeObject`
+bootstrap). The real runtime coupling lives in **`orc_rt`**
+(`compiler-rt/lib/orc/macho_platform.cpp`), which calls private dyld/objc entry
+points (`_objc_map_images`, `_objc_load_image`) that drive `libswiftCore`'s
+conformance registration; and in **JITLink relocation correctness** of the
+`__swift5_proto` block (bad relative pointers or >±2GB reach would make
+`swift_conformsToProtocol` walk garbage and crash regardless of which LLVM we
+build). So the only thing a rebuild meaningfully changes is a fork-matched
+`liborc_rt`, not the LLVM libraries.
+
+Also confirmed by the review: **no prebuilt Swift-fork LLVM with linkable C++
+ORC/JITLink exists.** swift.org toolchains and Xcode's toolchain ship llvm
+*tools* but no `ExecutionEngine/Orc` headers and no `liborc_rt*.a`. The iOS/sim
+SDK `libLLVM.dylib` is Apple's Metal shader-compiler LLVM (C API only, zero
+`llvm::orc::`/`llvm::jitlink::` symbols). If we ever do build, building from
+source is unavoidable.
+
+**Revised next step:** diagnose cheaply before any LLVM build. Turn on
+`ORC_RT_DEBUG`, and inspect whether `witness.o`'s `__swift5_proto` block is
+correctly relocated (dump section + relocations, check relative-pointer reach,
+same class as the unwind slab issue). Treat `orc_rt` as the lever, not
+`libLLVM`.
+
+**Vendoring decision (when/if we do build):** pinned-clone script, NOT a git
+submodule (mirrors how `swiftlang/swift` pulls llvm-project via
+`update-checkout`, not submodules). Pin a full commit SHA, `git clone --depth 1
+--filter=blob:none` + `git sparse-checkout` over
+`llvm/ compiler-rt/ cmake/ third-party/ runtimes/`, into a gitignored,
+SHA-keyed out-of-tree cache (not in-tree). Build Release `libLLVM` dylib +
+orc_rt only into `.llvm-build/`. Gate behind an opt-in `bootstrap --jit` so
+non-JIT contributors pay nothing. Scoped build est. ~8-15GB, ~20-45min on a
+fast Apple Silicon. Keep `LLVM_ENABLE_RUNTIMES` empty and build compiler-rt
+standalone to avoid pulling in libcxx/libunwind.
 
 ## Unknowns
 
@@ -106,17 +144,25 @@ says to expect.
 
 ## Subproblems and verification criteria
 
-### SP0 — Build LLVM from the Swift fork and repoint the C++ target (prerequisite)
-Build `swiftlang/llvm-project` @ `swift-6.2.3-RELEASE` (matches installed Swift)
-with `compiler-rt` for the orc runtime, AArch64 + X86 targets (X86 for the
-simulator later). Repoint `PreviewsJITLinkCxx` include/lib paths and
-`kOrcRuntimePath` at the build output; fix the `SelfExecutorProcessControl`
-include (now in `ExecutorProcessControl.h`).
-- **Verify:** the existing 8 tests still pass against the fork build, and the
-  `dispatchesThroughWitnessTable` scenario, re-enabled, no longer segfaults. If
-  it passes, the conformance bug was the LLVM/runtime skew and SP0 also resolves
-  U1 for Swift metadata. If it still crashes, the fix is a real plugin/relocation
-  problem, not version skew.
+### SP0a — Diagnose the conformance crash cheaply (do this BEFORE any LLVM build)
+The subagent counter-evidence says a fork rebuild likely won't fix it (platform
+registration code is identical fork vs vanilla). So diagnose first:
+- Dump `witness.o`'s `__swift5_proto` section + relocations
+  (`llvm-objdump`/`otool`), reason about relative-pointer correctness and ±2GB
+  reach after JIT placement (same class as the unwind slab issue).
+- Run with `ORC_RT_DEBUG` to watch the orc_rt registration hand-off
+  (`_objc_map_images` / `_objc_load_image`).
+- **Verify:** we can name the actual cause, JITLink relocation of `__swift5_proto`
+  vs an `orc_rt`↔dyld/objc contract mismatch. That decides whether the fix is a
+  relocation/plugin change (no build) or specifically a fork-matched `liborc_rt`.
+
+### SP0b — Build LLVM from the Swift fork (ONLY if SP0a points to orc_rt)
+Contingent on SP0a. If the cause is the `orc_rt`↔runtime contract, the lever is
+a fork-matched `liborc_rt`, possibly not a full `libLLVM` rebuild. Build per the
+vendoring decision above (pinned-clone script, sparse, out-of-tree cache). Fix
+the `SelfExecutorProcessControl` include (now in `ExecutorProcessControl.h`).
+- **Verify:** re-enabled `dispatchesThroughWitnessTable` no longer segfaults and
+  the existing tests still pass.
 
 ### SP1 — Port the six POC scenarios as tests (acceptance core)
 Translate `research/jit-poc/swift/*.swift` (greet/witness, tlv, swift_once,

--- a/docs/jit-executor-phase1-plan.md
+++ b/docs/jit-executor-phase1-plan.md
@@ -213,7 +213,7 @@ fork build) and a Debug orc_rt (`ORC_RT_DEBUG=1`). Findings:
   link-finalize, walk the new image's `__swift5_*` sections and register them
   with the Swift runtime using the **correct JIT-final addresses**.
 
-### SP0d — SwiftEntrySectionPlugin + session lifetime (IN PROGRESS)
+### SP0d — SwiftEntrySectionPlugin + session lifetime (DONE)
 Per design §4. A `ObjectLinkingLayer::Plugin` (`SwiftEntrySectionPlugin`) that, in
 `PrePrunePasses`, moves `__swift5_proto` / `__swift5_types` into private sections
 so the platform's wrong-address registration path skips them, keeping the blocks
@@ -223,9 +223,11 @@ Then in `PostFixupPasses` it registers each section at its final JIT address via
 alloc actions. Built with `-fno-rtti` to match LLVM (the derived plugin otherwise
 needs the base class typeinfo, which LLVM does not export).
 
-**What landed and is verified:** suppression. `dispatchesThroughWitnessTable`
-passes, the witness call dispatches through the statically-emitted witness table
-and never needs the global registry, exactly as the W2 POC's bare layer did.
+**What landed and is verified:** suppression plus correct re-registration plus
+session lifetime. `dispatchesThroughWitnessTable` passes via the
+statically-emitted witness table, and `resolvesConformanceThroughRuntimeRegistry`
+forces a real global-registry lookup through a dynamic cast and also passes, both
+driven through a `JITSession` that owns the image. Committed as `cd4e54f`.
 
 **Root cause found, this is the real blocker:** the re-registration itself is an
 ownership bug, not an address bug. A new test `resolvesConformanceThroughRuntimeRegistry`
@@ -248,17 +250,36 @@ memory and the global registry share one lifetime. There is no fire-and-forget.
 session owns the image and its lifetime equals the image lifetime. Name to match
 the design's `JITLinkSession` / `SessionResolver` (SP5).
 - **SP0d-A:** `JITSession` C++ type + handle ABI (`session_create`,
-  `session_add_object`, `session_lookup`, `session_destroy`); keep free
-  `target_triple`. Verify: a C smoke test resolves and calls a symbol through a handle.
-- **SP0d-B:** Swift `JITSession` class owning the handle, `deinit` destroys,
+  `session_add_object`, `session_lookup`). Verify: resolves and calls a symbol through a handle.
+- **SP0d-B:** Swift `JITSession` class owning the handle,
   `lookup` returns an address, typed `call<T>` helper. Verify:
   `dispatchesThroughWitnessTable` returns 7 and `resolvesConformanceThroughRuntimeRegistry`
   returns 9 while the test holds the session, no leak hack.
 - **SP0d-C:** port the existing 8 tests onto sessions, delete `linkAndCall` and
   the spike entry points. Verify: all prior tests stay green, no fire-and-forget path left.
-- **SP0d-D:** teardown / deregister. Deferred. `destroy` is only safe when nothing
-  global was registered, since Swift conformance deregistration is not cleanly
-  public. Document the constraint, revisit in Phase 2.
+- **SP0d-D (resolved):** there is no in-process teardown, by design. A dlsym probe
+  of the in-process `libswiftCore` (Xcode 26.2) confirmed **no public
+  `swift_unregister*` / `swift_deregister*` exists**, only the register entry
+  points. So once `__swift5_proto` / `__swift5_types` records are registered at
+  JIT addresses, that memory can never be safely freed while the process runs.
+  Apple unloads only because its pseudodylib is a real dyld image whose
+  image-remove hook drives the cleanup, a private dyld API we do not have.
+  Decision **D3:** a `JITSession` owns an image that lives until process exit,
+  there is no `session_destroy` and no `deinit` free. This is consistent and
+  honest, the same lifetime the Previews agent uses. The leak is the runtime
+  constraint surfaced, not a shortcut.
+  - **Phase 2 teardown (investigated):** kill the agent process. A subagent
+    confirmed the Swift runtime has no remove-image hook and no deregister on any
+    branch (`ProtocolConformance.cpp`, `ImageInspectionMachO.cpp`), registration
+    is one-way by design. dyld's pseudodylib unload (`_dyld_pseudodylib_deregister`,
+    private SPI) runs deinitializers but does not make the runtime forget the
+    records, and orc_rt's `macho_platform.cpp` has TODOs that a Swift/ObjC image
+    is meant to be permanent and non-dlclose-able. Apple's own `XOJITExecutor`
+    does not unload in-process, it respawns the agent on every edit
+    (`research/scripts/analysis/w3-empirical-capture.md`), so teardown is process
+    death. Phase 2 should adopt the out-of-process agent and treat one agent's JIT
+    memory as non-reclaimable mid-life, bounding it by PID lifetime instead. A
+    future Swift deregister API is not on the critical path.
 
 ### SP1 — Port the six POC scenarios as tests (acceptance core)
 Translate `research/jit-poc/swift/*.swift` (greet/witness, tlv, swift_once,

--- a/docs/jit-executor-phase1-plan.md
+++ b/docs/jit-executor-phase1-plan.md
@@ -316,10 +316,16 @@ symbol, no direct `swiftc` in that path. The test target gained a `PreviewsCore`
 dependency. The six scenario fixtures stay on `FixtureSupport` (fast, cached).
 - **Verify (met):** `compilesAndLinksObjectViaCompiler` returns 42. 13 tests green.
 
-### SP3 — Re-resolution on source change
-Recompile a changed source, add the new `.o` to the JIT, re-resolve the symbol.
-- **Verify:** the re-resolved symbol points at the new object and calling it
-  returns the new behavior. (Phase 1 stops here; address propagation is Phase 2+.)
+### SP3 — Re-resolution on source change (DONE)
+ORC will not redefine a symbol inside one `JITDylib`, and a session is one
+`JITDylib`, so re-resolution is a fresh `JITSession` per recompile. The
+`reResolvesSymbolAfterRecompile` test compiles two versions of one `@_cdecl`
+symbol (42, then 43) via `Compiler.compileObject`, links each in its own session,
+and confirms v1 resolves to addr1 returning 42, v2 to a different addr2 returning
+43, with no duplicate-definition error. No production code, the existing
+`address(of:)` and `call` cover it.
+- **Verify (met):** values 42 vs 43, addresses differ. Phase 1 stops here,
+  propagating the new address into a running caller is Phase 2.
 
 ### SP4 — Custom plugin(s) only if SP1 demands (NOT NEEDED)
 SP1 passed all six scenarios under path A, so no objc selref/class plugin is

--- a/docs/jit-executor-phase1-plan.md
+++ b/docs/jit-executor-phase1-plan.md
@@ -307,11 +307,14 @@ completion). 12 tests, stable across repeated parallel runs.
   process and stdlib symbols). This also matches D3, the shared JIT is
   process-lived.
 
-### SP2 — Wire `Compiler.swift` for `.o` production
-Replace the test-only `swiftc` shell-out with `Sources/PreviewsCore/Compiler.swift`
-for producing objects from a Swift source + target View symbol.
-- **Verify:** a test compiles a source via `Compiler.swift`, links it, and calls
-  the View symbol, with no direct `swiftc` invocation in the path.
+### SP2 — Wire `Compiler.swift` for `.o` production (DONE)
+Added `Compiler.compileObject(source:moduleName:extraFlags:) -> URL`, a sibling to
+`compileCombined` that emits a `.o` via `-emit-object -parse-as-library` with no
+link and no codesign. A `CompilerObjectTests` integration test compiles a source
+through `Compiler.swift`, links the object with a `JITSession`, and calls the
+symbol, no direct `swiftc` in that path. The test target gained a `PreviewsCore`
+dependency. The six scenario fixtures stay on `FixtureSupport` (fast, cached).
+- **Verify (met):** `compilesAndLinksObjectViaCompiler` returns 42. 13 tests green.
 
 ### SP3 — Re-resolution on source change
 Recompile a changed source, add the new `.o` to the JIT, re-resolve the symbol.

--- a/docs/jit-executor-phase1-plan.md
+++ b/docs/jit-executor-phase1-plan.md
@@ -48,6 +48,16 @@ LLVM ORC harness)." Resume from here across sessions. Update it as work lands.
 - **U1 (load-bearing):** Does `MachOPlatform` + orc runtime fully subsume the
   three prescribed plugins for all six scenarios, or does some scenario still
   need a custom plugin? Resolve empirically by running the six scenarios.
+  - **Partial answer (SP1, witness scenario):** No, not for Swift protocol
+    conformance. A JIT-linked object with a `protocol` + conformance + an
+    `any`-existential call segfaults. The crash is in the Swift runtime, in
+    `swift_conformsToProtocol` → `swift_getTypeByMangledName`, triggered by an
+    *unrelated* later lookup (Swift Testing's own). So our JIT'd `__swift5_proto`
+    / `__swift5_types` records register but are malformed and poison the
+    process-global conformance registry. The platform handles initializers and
+    `swift_once` fine, but not conformance/type metadata. This is the gap the
+    design's `SwiftEntrySectionPlugin` targets. Test `dispatchesThroughWitnessTable`
+    is `.disabled` because the segfault takes down the whole runner.
 - **U2:** Does the Swift calling convention hold when we call a real `View` body
   thunk, versus the trivial nullary functions tested so far?
 - **U3:** LLVM integration strategy for shipping (vendor xcframework vs CMake

--- a/docs/jit-executor-phase1-plan.md
+++ b/docs/jit-executor-phase1-plan.md
@@ -155,6 +155,18 @@ registration code is identical fork vs vanilla). So diagnose first:
 - **Verify:** we can name the actual cause, JITLink relocation of `__swift5_proto`
   vs an `orc_rt`↔dyld/objc contract mismatch. That decides whether the fix is a
   relocation/plugin change (no build) or specifically a fork-matched `liborc_rt`.
+- **Findings so far (points at orc_rt section-range registration, not relocs):**
+  - Static: `witness.o`'s `__swift5_proto` record uses a normal
+    `ARM64_RELOC_SUBTRACTOR` + `ARM64_RELOC_UNSIGNED` 32-bit intra-object delta.
+    Not exotic, not out of range. So a gross per-record relocation bug is unlikely.
+  - Dynamic: the crash is `EXC_BAD_ACCESS` reading `0x3000580e8`, which the crash
+    report says is "not in any region, 360681 bytes after previous region." The
+    conformance-registry walk ran ~360KB **off the end of a mapped region** into
+    unmapped space. Consistent with a wrongly-sized/based registered section
+    range (orc_rt registration contract), not a bad relative pointer in a record.
+  - `ORC_RT_DEBUG` is a no-op with brew's release `orc_rt` (logging compiled
+    out). Deeper tracing of the registered range needs either lldb (no build) or
+    a debug/asserts `orc_rt` (build).
 
 ### SP0b — Build LLVM from the Swift fork (ONLY if SP0a points to orc_rt)
 Contingent on SP0a. If the cause is the `orc_rt`↔runtime contract, the lever is

--- a/docs/jit-executor-phase1-plan.md
+++ b/docs/jit-executor-phase1-plan.md
@@ -95,9 +95,11 @@ standalone to avoid pulling in libcxx/libunwind.
 
 ## Unknowns
 
-- **U1 (load-bearing):** Does `MachOPlatform` + orc runtime fully subsume the
-  three prescribed plugins for all six scenarios, or does some scenario still
-  need a custom plugin? Resolve empirically by running the six scenarios.
+- **U1 (load-bearing, RESOLVED):** Does `MachOPlatform` + orc runtime subsume the
+  prescribed plugins? **Yes.** SP1 ran all six scenarios under path A and they
+  pass. The only custom plugin needed is `SwiftEntrySectionPlugin` for Swift
+  conformance/type metadata. The objc selref and class plugins the POC needed on
+  its bare layer are unnecessary under the full platform. History below.
   - **Partial answer (SP1, witness scenario):** No, not for Swift protocol
     conformance. A JIT-linked object with a `protocol` + conformance + an
     `any`-existential call segfaults. The crash is in the Swift runtime, in
@@ -281,20 +283,20 @@ the design's `JITLinkSession` / `SessionResolver` (SP5).
     memory as non-reclaimable mid-life, bounding it by PID lifetime instead. A
     future Swift deregister API is not on the critical path.
 
-### SP1 — Port the six POC scenarios as tests (acceptance core, IN PROGRESS)
-Translate `research/jit-poc/swift/*.swift` (greet/witness, tlv, swift_once,
-objc selref, objc class, async) into `PreviewsJITLinkTests` fixtures.
-- **Verify:** each scenario links and its symbol returns the expected value,
-  in-process, under path A. Any scenario that fails under A names the specific
-  plugin to port (resolves U1).
-- **Probed first (both pass under path A):** real Mach-O TLV via a C
-  `_Thread_local` (`tlv.c`, exercises the platform's `fixTLVSectionsAndEdges`
-  and orc_rt TLV path) and ObjC selref via Foundation (`objc_selref.swift`,
-  `NSString(format:)` + `intValue`). The selref one matters: the POC needed a
-  hand-rolled `ObjCSelrefPlugin` on its bare layer, but under path A the
-  platform's objc-image registration uniques the selectors, so **that plugin is
-  not needed**. Strong evidence path A is sufficient (U1). Remaining: swift_once,
-  objc class, async.
+### SP1 — Port the six POC scenarios as tests (acceptance core, DONE)
+All six POC scenarios are session-driven tests and **all pass under path A**:
+greet/witness conformance (SP0d), real Mach-O TLV (`tlv.c`, C `_Thread_local`),
+swift_once (`swift_once.swift`, lazy global), ObjC selref (`objc_selref.swift`),
+ObjC class (`objc_class.swift`, a JIT-defined `NSObject` subclass instantiated
+and messaged), and async (`async_value.swift`, a suspending `Task` driven to
+completion). 12 tests, stable across repeated parallel runs.
+- **Resolves U1: path A is sufficient, no hand-rolled plugins needed.** The POC
+  needed `ObjCSelrefPlugin` and a planned `ObjCClassPlugin` only because it ran a
+  bare `ObjectLinkingLayer`. Under the full `MachOPlatform` the objc-image-load
+  path (`_objc_map_images` / `_objc_load_image`) uniques selectors and registers
+  classes. Our only custom plugin is `SwiftEntrySectionPlugin` for Swift
+  conformance and type metadata, which the platform mis-registers. So **SP4 is
+  not required**.
 - **Architecture fix surfaced by the probe:** a per-session `LLJIT` does not
   work. Each `ExecutorNativePlatform` bootstrap registers process-global state
   (`findDynamicUnwindSections`), so concurrent sessions under the parallel test
@@ -303,7 +305,7 @@ objc selref, objc class, async) into `PreviewsJITLinkTests` fixtures.
   behind `std::call_once`, with each session a `JITDylib` created via
   `LLJIT::createJITDylib` (which runs platform setup so the dylib resolves
   process and stdlib symbols). This also matches D3, the shared JIT is
-  process-lived. 9 tests pass, stable across repeated parallel runs.
+  process-lived.
 
 ### SP2 — Wire `Compiler.swift` for `.o` production
 Replace the test-only `swiftc` shell-out with `Sources/PreviewsCore/Compiler.swift`
@@ -316,12 +318,10 @@ Recompile a changed source, add the new `.o` to the JIT, re-resolve the symbol.
 - **Verify:** the re-resolved symbol points at the new object and calling it
   returns the new behavior. (Phase 1 stops here; address propagation is Phase 2+.)
 
-### SP4 — Custom plugin(s) only if SP1 demands
-If a scenario fails under path A, port the matching plugin
-(`LinkGraphLinkingLayer::Plugin`, `PostPrunePasses`, canonical `__SEG,__sect`
-names, graceful early-out, no-op `notifyFailed`/`notifyRemovingResources`/
-`notifyTransferringResources`).
-- **Verify:** the previously failing scenario passes with the plugin added.
+### SP4 — Custom plugin(s) only if SP1 demands (NOT NEEDED)
+SP1 passed all six scenarios under path A, so no objc selref/class plugin is
+required. The only custom plugin is `SwiftEntrySectionPlugin` (SP0d). Revisit
+only if a future scenario surfaces a gap.
 
 ### SP5 — Swift API surface + SessionResolver (lighter weight, can trail)
 Grow `JITLinkError` toward the design's `JITLinkSession`/`JITLinkResult`/`Symbol`

--- a/docs/jit-executor-phase1-plan.md
+++ b/docs/jit-executor-phase1-plan.md
@@ -332,10 +332,21 @@ SP1 passed all six scenarios under path A, so no objc selref/class plugin is
 required. The only custom plugin is `SwiftEntrySectionPlugin` (SP0d). Revisit
 only if a future scenario surfaces a gap.
 
-### SP5 — Swift API surface + SessionResolver (lighter weight, can trail)
-Grow `JITLinkError` toward the design's `JITLinkSession`/`JITLinkResult`/`Symbol`
-and add a `jit-linked` session kind to `SessionResolver`.
-- **Verify:** `SessionResolver` can hand a session to the JIT path and back.
+### SP5 — Swift API surface + SessionResolver (DEFERRED to Phase 3)
+Deferred deliberately. The real `SessionResolver` is CLI session-targeting, not
+an execution backend, and wiring JIT into the session lifecycle is the design's
+Phase 3 goal (FileWatcher + Compiler + SessionResolver routing structural edits
+to JIT-link). A richer API (`JITLinkResult`/`Symbol`) has no consumer in Phase 1,
+the tests already drove the minimal `JITSession` surface (`addObject`,
+`address(of:)`, `call`). Adding types now would be speculative. Let the Phase 3
+daemon consumer pull whatever API it needs.
+
+## Phase 1 status: COMPLETE
+
+The JIT-link mechanism is validated end to end in-process. SP0d (plugin + shared
+`LLJIT`, sessions as `JITDylib`s), SP1 (all six POC scenarios under path A), SP2
+(`Compiler.compileObject`), and SP3 (re-resolution) are done. SP4 is unnecessary
+and SP5 is deferred. 14 tests, stable under the parallel runner.
 
 ## Scope boundaries
 

--- a/scripts/build-jit-llvm.sh
+++ b/scripts/build-jit-llvm.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Builds the LLVM that PreviewsJITLink links against, from swiftlang/llvm-project
+# pinned to the tag matching the installed Swift toolchain. We build from the
+# Swift fork (not vanilla brew LLVM) so the ORC/JITLink + orc runtime we link
+# match the in-process Swift runtime that consumes the sections we register.
+#
+# Opt-in: only contributors working on the JIT need to run this. The clone is
+# shallow + sparse (no clang/swift/lldb source), and both source and build are
+# gitignored under third_party/.
+#
+# Usage: scripts/build-jit-llvm.sh
+set -euo pipefail
+
+LLVM_TAG="swift-6.2.3-RELEASE"
+LLVM_SHA="9784760565e8cae0bc0b97bad69aaf498408dc3d"
+LLVM_REPO="https://github.com/swiftlang/llvm-project.git"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="$ROOT/third_party/llvm-project"
+BUILD="$ROOT/third_party/llvm-build"
+
+command -v cmake >/dev/null || { echo "error: cmake not found (brew install cmake)"; exit 1; }
+command -v ninja >/dev/null || { echo "error: ninja not found (brew install ninja)"; exit 1; }
+
+# 1. Shallow + sparse + partial clone, pinned to the exact commit.
+if [ ! -e "$SRC/.git" ]; then
+  echo "==> cloning llvm-project @ $LLVM_TAG (shallow, sparse)"
+  mkdir -p "$SRC"
+  git -C "$SRC" init -q
+  git -C "$SRC" remote add origin "$LLVM_REPO"
+  git -C "$SRC" config extensions.partialClone origin
+  git -C "$SRC" sparse-checkout set --cone llvm compiler-rt cmake third-party runtimes
+  git -C "$SRC" fetch -q --depth 1 --filter=blob:none origin "refs/tags/$LLVM_TAG"
+  git -C "$SRC" checkout -q FETCH_HEAD
+fi
+
+GOT="$(git -C "$SRC" rev-parse HEAD)"
+if [ "$GOT" != "$LLVM_SHA" ]; then
+  echo "error: pinned SHA mismatch: got $GOT, expected $LLVM_SHA"
+  exit 1
+fi
+echo "==> source pinned at $LLVM_SHA"
+
+BUILD_RT="$ROOT/third_party/llvm-build-rt"
+CLANG="$(xcrun -f clang)"
+CLANGXX="$(xcrun -f clang++)"
+
+# 2. Phase 1: libLLVM dylib with ORC/JITLink. No runtimes (that path wants a
+#    freshly-built clang for clang-resource-headers). Asserts on for JITLink
+#    diagnostics.
+echo "==> [1/4] configuring llvm"
+cmake -G Ninja -S "$SRC/llvm" -B "$BUILD" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DCMAKE_OSX_ARCHITECTURES=arm64 \
+  -DLLVM_TARGETS_TO_BUILD="AArch64;X86" \
+  -DLLVM_BUILD_LLVM_DYLIB=ON \
+  -DLLVM_LINK_LLVM_DYLIB=ON \
+  -DLLVM_ENABLE_PROJECTS="" \
+  -DLLVM_ENABLE_RUNTIMES="" \
+  -DLLVM_INCLUDE_TESTS=OFF \
+  -DLLVM_INCLUDE_BENCHMARKS=OFF \
+  -DLLVM_INCLUDE_EXAMPLES=OFF
+
+echo "==> [2/4] building libLLVM + llvm-config"
+ninja -C "$BUILD" LLVM llvm-config
+
+# 3. Phase 2: compiler-rt's orc runtime, standalone, built with the system
+#    clang against the LLVM we just built. COMPILER_RT_DEBUG on for ORC_RT_DEBUG.
+echo "==> [3/4] configuring compiler-rt (orc runtime, standalone)"
+cmake -G Ninja -S "$SRC/compiler-rt" -B "$BUILD_RT" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_OSX_ARCHITECTURES=arm64 \
+  -DCMAKE_C_COMPILER="$CLANG" \
+  -DCMAKE_CXX_COMPILER="$CLANGXX" \
+  -DCOMPILER_RT_STANDALONE_BUILD=ON \
+  -DLLVM_CONFIG_PATH="$BUILD/bin/llvm-config" \
+  -DLLVM_CMAKE_DIR="$SRC/llvm/cmake/modules" \
+  -DCOMPILER_RT_BUILD_ORC=ON \
+  -DCOMPILER_RT_BUILD_BUILTINS=OFF \
+  -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+  -DCOMPILER_RT_BUILD_XRAY=OFF \
+  -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+  -DCOMPILER_RT_BUILD_PROFILE=OFF \
+  -DCOMPILER_RT_BUILD_MEMPROF=OFF \
+  -DCOMPILER_RT_DEBUG=ON
+
+echo "==> [4/4] building orc runtime"
+ninja -C "$BUILD_RT" orc
+
+echo "==> done"
+echo "    libLLVM: $BUILD/lib"
+find "$BUILD" "$BUILD_RT" -name "liborc_rt_osx.a" -print


### PR DESCRIPTION
Implements Phase 1 of #183, the host-side LLVM ORC + JITLink harness, validated end to end in-process.

## What this delivers

- **`PreviewsJITLink` + `PreviewsJITLinkCxx`**: a `JITSession` that links `.o` objects into one process-shared `LLJIT` (built on `SelfExecutorProcessControl` + `ExecutorNativePlatform` + a slab memory manager), resolves a symbol, and calls it. Each session is a `JITDylib` in the shared JIT.
- **`SwiftEntrySectionPlugin`**: registers JIT-linked Swift conformance and type metadata (`__swift5_proto` / `__swift5_types`) at their correct JIT-final addresses, working around the platform's wrong-base registration. This is the only custom plugin needed.
- **`Compiler.compileObject`**: emits a `.o` from Swift source via `-emit-object`, no link or codesign, for the JIT path.
- **orc runtime bundling**: a `BundleOrcRuntime` prebuild plugin ships `liborc_rt_osx.a` as a `PreviewsJITLink` resource, resolved at runtime via `Bundle.module`, replacing a baked-in absolute path.
- **`bootstrap --jit`**: builds the LLVM and orc-runtime deps via `scripts/build-jit-llvm.sh`.

## Key findings (see `docs/jit-executor-phase1-plan.md`)

- All six POC scenarios pass under the platform path: conformance, TLV, swift_once, ObjC selref, ObjC class, async. The full `MachOPlatform` subsumes the POC's hand-rolled ObjC selref and class plugins, so they are not ported (U1 resolved).
- A per-session `LLJIT` raced on the orc_rt platform bootstrap, fixed by one process-shared `LLJIT`.
- The Swift runtime exposes no deregistration, so a session that registered metadata is process-lived. There is no in-process teardown by design, matching how the Previews agent respawns per edit. Teardown returns in Phase 2 as kill-the-agent-PID.

## Tests

14 tests in `PreviewsJITLinkTests`, stable under the parallel runner. Running them needs the JIT deps: `/bootstrap --jit` (or `scripts/build-jit-llvm.sh`).

## Deferred

SP5 (richer API + `SessionResolver` wiring) waits for the Phase 3 daemon consumer. Phase 2 (out-of-process agent, teardown, address propagation) and U3 (bundling libLLVM itself) are future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)