### PR TITLE
JIT executor Phase 2: out-of-process remote executor (#183)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -143,6 +143,24 @@ if jitEnabled {
             name: "BundleOrcRuntime",
             capability: .buildTool()
         ),
+        .executableTarget(
+            name: "PreviewAgent",
+            cxxSettings: [
+                .unsafeFlags([
+                    "-I\(llvmSrcInclude)",
+                    "-I\(llvmBuild)/include",
+                    "-fno-rtti",
+                ])
+            ],
+            linkerSettings: [
+                .unsafeFlags([
+                    "-L\(llvmBuild)/lib",
+                    "-lLLVM",
+                    "-Xlinker", "-rpath",
+                    "-Xlinker", "\(llvmBuild)/lib",
+                ])
+            ]
+        ),
         .testTarget(
             name: "PreviewsJITLinkTests",
             dependencies: ["PreviewsJITLink", "PreviewsCore"],

--- a/Package.swift
+++ b/Package.swift
@@ -163,7 +163,7 @@ if jitEnabled {
         ),
         .testTarget(
             name: "PreviewsJITLinkTests",
-            dependencies: ["PreviewsJITLink", "PreviewsCore"],
+            dependencies: ["PreviewsJITLink", "PreviewsCore", "PreviewAgent"],
             exclude: ["Fixtures"]
         ),
     ]

--- a/Sources/PreviewAgent/main.cpp
+++ b/Sources/PreviewAgent/main.cpp
@@ -1,6 +1,7 @@
 #include "llvm/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/RegisterEHFrames.h"
+#include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.h"
 #include "llvm/Support/Error.h"
@@ -52,6 +53,8 @@ int main(int argc, char *argv[]) {
                 std::make_unique<SimpleRemoteEPCServer::ThreadDispatcher>());
             S.bootstrapSymbols() =
                 SimpleRemoteEPCServer::defaultBootstrapSymbols();
+            S.services().push_back(
+                std::make_unique<rt_bootstrap::SimpleExecutorDylibManager>());
             S.services().push_back(
                 std::make_unique<rt_bootstrap::SimpleExecutorMemoryManager>());
             S.services().push_back(

--- a/Sources/PreviewAgent/main.cpp
+++ b/Sources/PreviewAgent/main.cpp
@@ -1,0 +1,66 @@
+#include "llvm/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.h"
+#include "llvm/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.h"
+#include "llvm/ExecutionEngine/Orc/TargetProcess/RegisterEHFrames.h"
+#include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.h"
+#include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstdlib>
+#include <string>
+
+using namespace llvm;
+using namespace llvm::orc;
+
+LLVM_ATTRIBUTE_USED void linkComponents() {
+  errs() << (void *)&llvm_orc_registerEHFrameSectionWrapper
+         << (void *)&llvm_orc_deregisterEHFrameSectionWrapper
+         << (void *)&llvm_orc_registerJITLoaderGDBWrapper
+         << (void *)&llvm_orc_registerJITLoaderGDBAllocAction;
+}
+
+static void printErrorAndExit(Twine ErrMsg) {
+  errs() << "PreviewAgent error: " << ErrMsg.str() << "\n\n"
+         << "Usage:\n  PreviewAgent filedescs=<infd>,<outfd>\n";
+  exit(1);
+}
+
+int main(int argc, char *argv[]) {
+  ExitOnError ExitOnErr;
+  ExitOnErr.setBanner(std::string(argv[0]) + ": ");
+
+  if (argc != 2)
+    printErrorAndExit("expected exactly one argument");
+
+  StringRef SpecifierType, Specifier;
+  std::tie(SpecifierType, Specifier) = StringRef(argv[1]).split('=');
+  if (SpecifierType != "filedescs")
+    printErrorAndExit("invalid specifier type \"" + SpecifierType + "\"");
+
+  StringRef InFDStr, OutFDStr;
+  std::tie(InFDStr, OutFDStr) = Specifier.split(',');
+  int InFD = 0, OutFD = 0;
+  if (InFDStr.getAsInteger(10, InFD))
+    printErrorAndExit(InFDStr + " is not a valid file descriptor");
+  if (OutFDStr.getAsInteger(10, OutFD))
+    printErrorAndExit(OutFDStr + " is not a valid file descriptor");
+
+  auto Server =
+      ExitOnErr(SimpleRemoteEPCServer::Create<FDSimpleRemoteEPCTransport>(
+          [](SimpleRemoteEPCServer::Setup &S) -> Error {
+            S.setDispatcher(
+                std::make_unique<SimpleRemoteEPCServer::ThreadDispatcher>());
+            S.bootstrapSymbols() =
+                SimpleRemoteEPCServer::defaultBootstrapSymbols();
+            S.services().push_back(
+                std::make_unique<rt_bootstrap::SimpleExecutorMemoryManager>());
+            S.services().push_back(
+                std::make_unique<
+                    rt_bootstrap::ExecutorSharedMemoryMapperService>());
+            return Error::success();
+          },
+          InFD, OutFD));
+
+  ExitOnErr(Server->waitForDisconnect());
+  return 0;
+}

--- a/Sources/PreviewAgent/main.cpp
+++ b/Sources/PreviewAgent/main.cpp
@@ -5,6 +5,7 @@
 #include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
 #include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
@@ -58,6 +59,18 @@ CWrapperFunctionResult previewsmcp_register_types(const char *ArgData,
       .release();
 }
 
+CWrapperFunctionResult previewsmcp_write_pointers(const char *ArgData,
+                                                  size_t ArgSize) {
+  using namespace llvm::orc::tpctypes;
+  return WrapperFunction<void(SPSSequence<SPSMemoryAccessPointerWrite>)>::handle(
+             ArgData, ArgSize,
+             [](std::vector<PointerWrite> Ws) {
+               for (auto &W : Ws)
+                 *W.Addr.toPtr<void **>() = W.Value.toPtr<void *>();
+             })
+      .release();
+}
+
 } // namespace
 
 static void printErrorAndExit(Twine ErrMsg) {
@@ -103,6 +116,8 @@ int main(int argc, char *argv[]) {
                     &previewsmcp_register_conformances);
             S.bootstrapSymbols()["__previewsmcp_register_types"] =
                 llvm::orc::ExecutorAddr::fromPtr(&previewsmcp_register_types);
+            S.bootstrapSymbols()["__previewsmcp_write_pointers"] =
+                llvm::orc::ExecutorAddr::fromPtr(&previewsmcp_write_pointers);
             S.services().push_back(
                 std::make_unique<rt_bootstrap::SimpleExecutorDylibManager>());
             S.services().push_back(

--- a/Sources/PreviewAgent/main.cpp
+++ b/Sources/PreviewAgent/main.cpp
@@ -32,8 +32,11 @@ llvm::Error registerSwiftSection(const char *Symbol,
                                  llvm::orc::ExecutorAddrRange R) {
   using Fn = void (*)(const void *, const void *);
   auto *fn = reinterpret_cast<Fn>(dlsym(RTLD_DEFAULT, Symbol));
-  if (fn)
-    fn(R.Start.toPtr<const void *>(), R.End.toPtr<const void *>());
+  if (!fn)
+    return llvm::make_error<llvm::StringError>(
+        std::string("PreviewAgent: Swift runtime symbol not found: ") + Symbol,
+        llvm::inconvertibleErrorCode());
+  fn(R.Start.toPtr<const void *>(), R.End.toPtr<const void *>());
   return llvm::Error::success();
 }
 

--- a/Sources/PreviewAgent/main.cpp
+++ b/Sources/PreviewAgent/main.cpp
@@ -1,12 +1,12 @@
+#include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
+#include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/RegisterEHFrames.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.h"
-#include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
-#include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
-#include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -45,8 +45,8 @@ CWrapperFunctionResult previewsmcp_register_conformances(const char *ArgData,
   return WrapperFunction<SPSError(SPSExecutorAddrRange)>::handle(
              ArgData, ArgSize,
              [](llvm::orc::ExecutorAddrRange R) {
-               return registerSwiftSection(
-                   "swift_registerProtocolConformances", R);
+               return registerSwiftSection("swift_registerProtocolConformances",
+                                           R);
              })
       .release();
 }
@@ -56,8 +56,8 @@ CWrapperFunctionResult previewsmcp_register_types(const char *ArgData,
   return WrapperFunction<SPSError(SPSExecutorAddrRange)>::handle(
              ArgData, ArgSize,
              [](llvm::orc::ExecutorAddrRange R) {
-               return registerSwiftSection(
-                   "swift_registerTypeMetadataRecords", R);
+               return registerSwiftSection("swift_registerTypeMetadataRecords",
+                                           R);
              })
       .release();
 }
@@ -65,13 +65,13 @@ CWrapperFunctionResult previewsmcp_register_types(const char *ArgData,
 CWrapperFunctionResult previewsmcp_write_pointers(const char *ArgData,
                                                   size_t ArgSize) {
   using namespace llvm::orc::tpctypes;
-  return WrapperFunction<void(SPSSequence<SPSMemoryAccessPointerWrite>)>::handle(
-             ArgData, ArgSize,
+  return WrapperFunction<void(SPSSequence<SPSMemoryAccessPointerWrite>)>::
+      handle(ArgData, ArgSize,
              [](std::vector<PointerWrite> Ws) {
                for (auto &W : Ws)
                  *W.Addr.toPtr<void **>() = W.Value.toPtr<void *>();
              })
-      .release();
+          .release();
 }
 
 } // namespace

--- a/Sources/PreviewAgent/main.cpp
+++ b/Sources/PreviewAgent/main.cpp
@@ -4,10 +4,13 @@
 #include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.h"
+#include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <cstdlib>
+#include <dlfcn.h>
 #include <string>
 
 using namespace llvm;
@@ -20,6 +23,43 @@ LLVM_ATTRIBUTE_USED void linkComponents() {
          << (void *)&llvm_orc_registerJITLoaderGDBAllocAction;
 }
 
+using namespace llvm::orc::shared;
+
+namespace {
+
+llvm::Error registerSwiftSection(const char *Symbol,
+                                 llvm::orc::ExecutorAddrRange R) {
+  using Fn = void (*)(const void *, const void *);
+  auto *fn = reinterpret_cast<Fn>(dlsym(RTLD_DEFAULT, Symbol));
+  if (fn)
+    fn(R.Start.toPtr<const void *>(), R.End.toPtr<const void *>());
+  return llvm::Error::success();
+}
+
+CWrapperFunctionResult previewsmcp_register_conformances(const char *ArgData,
+                                                         size_t ArgSize) {
+  return WrapperFunction<SPSError(SPSExecutorAddrRange)>::handle(
+             ArgData, ArgSize,
+             [](llvm::orc::ExecutorAddrRange R) {
+               return registerSwiftSection(
+                   "swift_registerProtocolConformances", R);
+             })
+      .release();
+}
+
+CWrapperFunctionResult previewsmcp_register_types(const char *ArgData,
+                                                  size_t ArgSize) {
+  return WrapperFunction<SPSError(SPSExecutorAddrRange)>::handle(
+             ArgData, ArgSize,
+             [](llvm::orc::ExecutorAddrRange R) {
+               return registerSwiftSection(
+                   "swift_registerTypeMetadataRecords", R);
+             })
+      .release();
+}
+
+} // namespace
+
 static void printErrorAndExit(Twine ErrMsg) {
   errs() << "PreviewAgent error: " << ErrMsg.str() << "\n\n"
          << "Usage:\n  PreviewAgent filedescs=<infd>,<outfd>\n";
@@ -29,6 +69,11 @@ static void printErrorAndExit(Twine ErrMsg) {
 int main(int argc, char *argv[]) {
   ExitOnError ExitOnErr;
   ExitOnErr.setBanner(std::string(argv[0]) + ": ");
+
+  dlopen("/usr/lib/swift/libswiftCore.dylib", RTLD_NOW | RTLD_GLOBAL);
+  dlopen("/usr/lib/swift/libswift_Concurrency.dylib", RTLD_NOW | RTLD_GLOBAL);
+  dlopen("/usr/lib/swift/libswiftFoundation.dylib", RTLD_NOW | RTLD_GLOBAL);
+  dlopen("/usr/lib/swift/libswiftDispatch.dylib", RTLD_NOW | RTLD_GLOBAL);
 
   if (argc != 2)
     printErrorAndExit("expected exactly one argument");
@@ -53,6 +98,11 @@ int main(int argc, char *argv[]) {
                 std::make_unique<SimpleRemoteEPCServer::ThreadDispatcher>());
             S.bootstrapSymbols() =
                 SimpleRemoteEPCServer::defaultBootstrapSymbols();
+            S.bootstrapSymbols()["__previewsmcp_register_conformances"] =
+                llvm::orc::ExecutorAddr::fromPtr(
+                    &previewsmcp_register_conformances);
+            S.bootstrapSymbols()["__previewsmcp_register_types"] =
+                llvm::orc::ExecutorAddr::fromPtr(&previewsmcp_register_types);
             S.services().push_back(
                 std::make_unique<rt_bootstrap::SimpleExecutorDylibManager>());
             S.services().push_back(

--- a/Sources/PreviewsJITLink/PreviewsJITLink.swift
+++ b/Sources/PreviewsJITLink/PreviewsJITLink.swift
@@ -59,6 +59,12 @@ public final class JITSession {
         return result
     }
 
+    public func writePointer(at address: UInt64, value: UInt64) throws {
+        if let error = previewsmcp_jit_session_write_pointer(handle, address, value) {
+            throw JITLinkError.failed(error.string())
+        }
+    }
+
     public func addObject(path: String) throws {
         if let error = previewsmcp_jit_session_add_object(handle, path) {
             throw JITLinkError.failed(error.string())

--- a/Sources/PreviewsJITLink/PreviewsJITLink.swift
+++ b/Sources/PreviewsJITLink/PreviewsJITLink.swift
@@ -4,15 +4,19 @@ import PreviewsJITLinkCxx
 public final class JITSession {
     private let handle: OpaquePointer
 
-    public init() throws {
+    private static func orcRuntimePath() throws -> String {
         guard
-            let orcRuntimePath = Bundle.module
+            let path = Bundle.module
                 .url(forResource: "liborc_rt_osx", withExtension: "a")?.path
         else {
             throw JITLinkError.failed("orc runtime archive missing from bundle")
         }
+        return path
+    }
+
+    public init() throws {
         var session: OpaquePointer?
-        if let error = previewsmcp_jit_session_create(&session, orcRuntimePath) {
+        if let error = previewsmcp_jit_session_create(&session, try Self.orcRuntimePath()) {
             throw JITLinkError.failed(error.string())
         }
         guard let session else {
@@ -35,14 +39,8 @@ public final class JITSession {
     }
 
     public init(remoteAgentPath: String) throws {
-        guard
-            let orcRuntimePath = Bundle.module
-                .url(forResource: "liborc_rt_osx", withExtension: "a")?.path
-        else {
-            throw JITLinkError.failed("orc runtime archive missing from bundle")
-        }
         var session: OpaquePointer?
-        if let error = previewsmcp_jit_remote_session_create(&session, remoteAgentPath, orcRuntimePath) {
+        if let error = previewsmcp_jit_remote_session_create(&session, remoteAgentPath, try Self.orcRuntimePath()) {
             throw JITLinkError.failed(error.string())
         }
         guard let session else {

--- a/Sources/PreviewsJITLink/PreviewsJITLink.swift
+++ b/Sources/PreviewsJITLink/PreviewsJITLink.swift
@@ -21,6 +21,34 @@ public final class JITSession {
         handle = session
     }
 
+    public static func bundledAgentPath() throws -> String {
+        let buildDir = Bundle.module.bundleURL.deletingLastPathComponent()
+        let agent = buildDir.appendingPathComponent("PreviewAgent")
+        guard FileManager.default.isExecutableFile(atPath: agent.path) else {
+            throw JITLinkError.failed("PreviewAgent binary not found at \(agent.path)")
+        }
+        return agent.path
+    }
+
+    public init(remoteAgentPath: String) throws {
+        var session: OpaquePointer?
+        if let error = previewsmcp_jit_remote_session_create(&session, remoteAgentPath) {
+            throw JITLinkError.failed(error.string())
+        }
+        guard let session else {
+            throw JITLinkError.failed("no session returned")
+        }
+        handle = session
+    }
+
+    public func runMain(symbol: String) throws -> Int32 {
+        var result: Int32 = 0
+        if let error = previewsmcp_jit_session_run_main(handle, symbol, &result) {
+            throw JITLinkError.failed(error.string())
+        }
+        return result
+    }
+
     public func addObject(path: String) throws {
         if let error = previewsmcp_jit_session_add_object(handle, path) {
             throw JITLinkError.failed(error.string())

--- a/Sources/PreviewsJITLink/PreviewsJITLink.swift
+++ b/Sources/PreviewsJITLink/PreviewsJITLink.swift
@@ -21,6 +21,10 @@ public final class JITSession {
         handle = session
     }
 
+    deinit {
+        previewsmcp_jit_session_destroy(handle)
+    }
+
     public static func bundledAgentPath() throws -> String {
         let buildDir = Bundle.module.bundleURL.deletingLastPathComponent()
         let agent = buildDir.appendingPathComponent("PreviewAgent")
@@ -31,8 +35,14 @@ public final class JITSession {
     }
 
     public init(remoteAgentPath: String) throws {
+        guard
+            let orcRuntimePath = Bundle.module
+                .url(forResource: "liborc_rt_osx", withExtension: "a")?.path
+        else {
+            throw JITLinkError.failed("orc runtime archive missing from bundle")
+        }
         var session: OpaquePointer?
-        if let error = previewsmcp_jit_remote_session_create(&session, remoteAgentPath) {
+        if let error = previewsmcp_jit_remote_session_create(&session, remoteAgentPath, orcRuntimePath) {
             throw JITLinkError.failed(error.string())
         }
         guard let session else {

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -2,14 +2,17 @@
 #include "SwiftEntrySectionPlugin.hpp"
 
 #include <atomic>
+#include <crt_externs.h>
+#include <csignal>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <fcntl.h>
 #include <llvm-c/Core.h>
 #include <llvm-c/TargetMachine.h>
+#include <llvm/ExecutionEngine/Orc/EPCGenericMemoryAccess.h>
 #include <llvm/ExecutionEngine/Orc/ExecutorProcessControl.h>
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
-#include <llvm/ExecutionEngine/Orc/EPCGenericMemoryAccess.h>
 #include <llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h>
 #include <llvm/ExecutionEngine/Orc/MemoryMapper.h>
 #include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
@@ -19,9 +22,6 @@
 #include <llvm/ExecutionEngine/Orc/TaskDispatch.h>
 #include <llvm/Support/Debug.h>
 #include <llvm/Support/MemoryBuffer.h>
-#include <crt_externs.h>
-#include <csignal>
-#include <fcntl.h>
 #include <mutex>
 #include <optional>
 #include <spawn.h>
@@ -44,8 +44,8 @@ slabLinkingLayer(llvm::orc::ExecutionSession &es, const llvm::Triple &) {
   if (!memMgr) {
     return memMgr.takeError();
   }
-  auto layer = std::make_unique<llvm::orc::ObjectLinkingLayer>(
-      es, std::move(*memMgr));
+  auto layer =
+      std::make_unique<llvm::orc::ObjectLinkingLayer>(es, std::move(*memMgr));
   layer->addPlugin(previewsmcp::SwiftEntrySectionPlugin::inProcess());
   return layer;
 }
@@ -145,8 +145,9 @@ void previewsmcp_jit_session_destroy(previewsmcp_jit_session *session) {
   delete session;
 }
 
-const char *previewsmcp_jit_session_create(previewsmcp_jit_session **out_session,
-                                           const char *orc_rt_path) {
+const char *
+previewsmcp_jit_session_create(previewsmcp_jit_session **out_session,
+                               const char *orc_rt_path) {
   std::string err;
   auto *jit = sharedJIT(orc_rt_path, err);
   if (!jit) {
@@ -177,7 +178,8 @@ previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
 
   int sv[2];
   if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) {
-    return strdup(("socketpair failed: " + std::string(strerror(errno))).c_str());
+    return strdup(
+        ("socketpair failed: " + std::string(strerror(errno))).c_str());
   }
   fcntl(sv[0], F_SETFD, FD_CLOEXEC);
   fcntl(sv[1], F_SETFD, FD_CLOEXEC);
@@ -201,8 +203,7 @@ previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
   }
 
   llvm::orc::SimpleRemoteEPC::Setup setup;
-  setup.CreateMemoryAccess =
-      [](llvm::orc::SimpleRemoteEPC &epc)
+  setup.CreateMemoryAccess = [](llvm::orc::SimpleRemoteEPC &epc)
       -> llvm::Expected<
           std::unique_ptr<llvm::orc::ExecutorProcessControl::MemoryAccess>> {
     llvm::orc::ExecutorAddr writePointers;
@@ -242,7 +243,8 @@ previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
               [registerConformances, registerTypes](
                   llvm::orc::ExecutionSession &es, const llvm::Triple &)
                   -> llvm::Expected<std::unique_ptr<llvm::orc::ObjectLayer>> {
-                auto layer = std::make_unique<llvm::orc::ObjectLinkingLayer>(es);
+                auto layer =
+                    std::make_unique<llvm::orc::ObjectLinkingLayer>(es);
                 layer->addPlugin(
                     std::make_shared<previewsmcp::SwiftEntrySectionPlugin>(
                         registerConformances, registerTypes));
@@ -278,9 +280,9 @@ const char *previewsmcp_jit_session_run_main(previewsmcp_jit_session *session,
   if (!sym) {
     return toCStr(sym.takeError());
   }
-  auto result = session->jit->getExecutionSession()
-                    .getExecutorProcessControl()
-                    .runAsMain(*sym, {});
+  auto result =
+      session->jit->getExecutionSession().getExecutorProcessControl().runAsMain(
+          *sym, {});
   if (!result) {
     return toCStr(result.takeError());
   }

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -18,11 +18,13 @@
 #include <llvm/Support/Debug.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <crt_externs.h>
+#include <csignal>
 #include <mutex>
 #include <optional>
 #include <spawn.h>
 #include <string>
 #include <sys/socket.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 namespace {
@@ -110,9 +112,20 @@ void previewsmcp_jit_dispose_string(const char *str) {
   free(const_cast<char *>(str));
 }
 
-const char *
-previewsmcp_jit_session_create(previewsmcp_jit_session **out_session,
-                               const char *orc_rt_path) {
+void previewsmcp_jit_session_destroy(previewsmcp_jit_session *session) {
+  if (!session) {
+    return;
+  }
+  session->ownedJit.reset();
+  if (session->agentPid != 0) {
+    kill(session->agentPid, SIGKILL);
+    waitpid(session->agentPid, nullptr, 0);
+  }
+  delete session;
+}
+
+const char *previewsmcp_jit_session_create(previewsmcp_jit_session **out_session,
+                                           const char *orc_rt_path) {
   std::string err;
   auto *jit = sharedJIT(orc_rt_path, err);
   if (!jit) {
@@ -133,7 +146,8 @@ previewsmcp_jit_session_create(previewsmcp_jit_session **out_session,
 
 const char *
 previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
-                                      const char *agent_path) {
+                                      const char *agent_path,
+                                      const char *orc_rt_path) {
   static std::once_flag targetOnce;
   std::call_once(targetOnce, [] {
     LLVMInitializeNativeTarget();
@@ -174,8 +188,7 @@ previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
   auto jit =
       llvm::orc::LLJITBuilder()
           .setExecutorProcessControl(std::move(*epc))
-          .setPlatformSetUp(llvm::orc::setUpInactivePlatform)
-          .setLinkProcessSymbolsByDefault(false)
+          .setPlatformSetUp(llvm::orc::ExecutorNativePlatform(orc_rt_path))
           .setObjectLinkingLayerCreator(
               [](llvm::orc::ExecutionSession &es, const llvm::Triple &)
                   -> llvm::Expected<std::unique_ptr<llvm::orc::ObjectLayer>> {
@@ -205,6 +218,12 @@ previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
 const char *previewsmcp_jit_session_run_main(previewsmcp_jit_session *session,
                                              const char *symbol_name,
                                              int32_t *out_result) {
+  if (!session->initialized) {
+    if (auto err = session->jit->initialize(*session->jd)) {
+      return toCStr(std::move(err));
+    }
+    session->initialized = true;
+  }
   auto sym = session->jit->lookup(*session->jd, symbol_name);
   if (!sym) {
     return toCStr(sym.takeError());

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -9,10 +9,12 @@
 #include <llvm-c/TargetMachine.h>
 #include <llvm/ExecutionEngine/Orc/ExecutorProcessControl.h>
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
+#include <llvm/ExecutionEngine/Orc/EPCGenericMemoryAccess.h>
 #include <llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h>
 #include <llvm/ExecutionEngine/Orc/MemoryMapper.h>
 #include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
 #include <llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h>
+#include <llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h>
 #include <llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h>
 #include <llvm/ExecutionEngine/Orc/TaskDispatch.h>
 #include <llvm/Support/Debug.h>
@@ -176,11 +178,26 @@ previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
     return strdup(("posix_spawn failed: " + std::string(strerror(rc))).c_str());
   }
 
+  llvm::orc::SimpleRemoteEPC::Setup setup;
+  setup.CreateMemoryAccess =
+      [](llvm::orc::SimpleRemoteEPC &epc)
+      -> llvm::Expected<
+          std::unique_ptr<llvm::orc::ExecutorProcessControl::MemoryAccess>> {
+    llvm::orc::ExecutorAddr writePointers;
+    if (auto err = epc.getBootstrapSymbols(
+            {{writePointers, "__previewsmcp_write_pointers"}})) {
+      return std::move(err);
+    }
+    llvm::orc::EPCGenericMemoryAccess::FuncAddrs fas;
+    fas.WritePointers = writePointers;
+    return std::make_unique<llvm::orc::EPCGenericMemoryAccess>(epc, fas);
+  };
+
   auto epc =
       llvm::orc::SimpleRemoteEPC::Create<llvm::orc::FDSimpleRemoteEPCTransport>(
           std::make_unique<llvm::orc::DynamicThreadPoolTaskDispatcher>(
               std::nullopt),
-          llvm::orc::SimpleRemoteEPC::Setup(), sv[0], sv[0]);
+          std::move(setup), sv[0], sv[0]);
   if (!epc) {
     return toCStr(epc.takeError());
   }
@@ -248,6 +265,18 @@ const char *previewsmcp_jit_session_run_main(previewsmcp_jit_session *session,
   }
   *out_result = *result;
   return nullptr;
+}
+
+const char *
+previewsmcp_jit_session_write_pointer(previewsmcp_jit_session *session,
+                                      uint64_t address, uint64_t value) {
+  llvm::orc::tpctypes::PointerWrite writes[] = {
+      {llvm::orc::ExecutorAddr(address), llvm::orc::ExecutorAddr(value)}};
+  auto err = session->jit->getExecutionSession()
+                 .getExecutorProcessControl()
+                 .getMemoryAccess()
+                 .writePointers(writes);
+  return toCStr(std::move(err));
 }
 
 const char *previewsmcp_jit_session_add_object(previewsmcp_jit_session *session,

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -21,6 +21,7 @@
 #include <llvm/Support/MemoryBuffer.h>
 #include <crt_externs.h>
 #include <csignal>
+#include <fcntl.h>
 #include <mutex>
 #include <optional>
 #include <spawn.h>
@@ -81,6 +82,14 @@ const char *toCStr(llvm::Error err) {
   return strdup(llvm::toString(std::move(err)).c_str());
 }
 
+void killAgent(pid_t pid) {
+  if (pid == 0) {
+    return;
+  }
+  kill(pid, SIGKILL);
+  waitpid(pid, nullptr, 0);
+}
+
 llvm::orc::LLJIT *sharedJIT(const char *orc_rt_path, std::string &err) {
   static std::unique_ptr<llvm::orc::LLJIT> jit;
   static std::string initError;
@@ -110,6 +119,19 @@ struct previewsmcp_jit_session {
   bool initialized = false;
 };
 
+namespace {
+llvm::Expected<llvm::orc::ExecutorAddr>
+lookupInitialized(previewsmcp_jit_session *session, const char *symbol_name) {
+  if (!session->initialized) {
+    if (auto err = session->jit->initialize(*session->jd)) {
+      return std::move(err);
+    }
+    session->initialized = true;
+  }
+  return session->jit->lookup(*session->jd, symbol_name);
+}
+} // namespace
+
 void previewsmcp_jit_dispose_string(const char *str) {
   free(const_cast<char *>(str));
 }
@@ -119,10 +141,7 @@ void previewsmcp_jit_session_destroy(previewsmcp_jit_session *session) {
     return;
   }
   session->ownedJit.reset();
-  if (session->agentPid != 0) {
-    kill(session->agentPid, SIGKILL);
-    waitpid(session->agentPid, nullptr, 0);
-  }
+  killAgent(session->agentPid);
   delete session;
 }
 
@@ -160,12 +179,15 @@ previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
   if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) {
     return strdup(("socketpair failed: " + std::string(strerror(errno))).c_str());
   }
+  fcntl(sv[0], F_SETFD, FD_CLOEXEC);
+  fcntl(sv[1], F_SETFD, FD_CLOEXEC);
 
+  int childFd = (sv[0] > sv[1] ? sv[0] : sv[1]) + 1;
   posix_spawn_file_actions_t actions;
   posix_spawn_file_actions_init(&actions);
-  posix_spawn_file_actions_addclose(&actions, sv[0]);
+  posix_spawn_file_actions_adddup2(&actions, sv[1], childFd);
   std::string fdArg =
-      "filedescs=" + std::to_string(sv[1]) + "," + std::to_string(sv[1]);
+      "filedescs=" + std::to_string(childFd) + "," + std::to_string(childFd);
   char *const argv[] = {const_cast<char *>(agent_path),
                         const_cast<char *>(fdArg.c_str()), nullptr};
   pid_t pid = 0;
@@ -199,6 +221,7 @@ previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
               std::nullopt),
           std::move(setup), sv[0], sv[0]);
   if (!epc) {
+    killAgent(pid);
     return toCStr(epc.takeError());
   }
 
@@ -206,6 +229,8 @@ previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
   if (auto err = (*epc)->getBootstrapSymbols(
           {{registerConformances, "__previewsmcp_register_conformances"},
            {registerTypes, "__previewsmcp_register_types"}})) {
+    llvm::consumeError((*epc)->disconnect());
+    killAgent(pid);
     return toCStr(std::move(err));
   }
 
@@ -225,6 +250,7 @@ previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
               })
           .create();
   if (!jit) {
+    killAgent(pid);
     return toCStr(jit.takeError());
   }
 
@@ -236,8 +262,9 @@ previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
   auto jd = session->jit->createJITDylib("remote." +
                                          std::to_string(counter.fetch_add(1)));
   if (!jd) {
-    delete session;
-    return toCStr(jd.takeError());
+    auto err = toCStr(jd.takeError());
+    previewsmcp_jit_session_destroy(session);
+    return err;
   }
   session->jd = &*jd;
   *out_session = session;
@@ -247,13 +274,7 @@ previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
 const char *previewsmcp_jit_session_run_main(previewsmcp_jit_session *session,
                                              const char *symbol_name,
                                              int32_t *out_result) {
-  if (!session->initialized) {
-    if (auto err = session->jit->initialize(*session->jd)) {
-      return toCStr(std::move(err));
-    }
-    session->initialized = true;
-  }
-  auto sym = session->jit->lookup(*session->jd, symbol_name);
+  auto sym = lookupInitialized(session, symbol_name);
   if (!sym) {
     return toCStr(sym.takeError());
   }
@@ -291,13 +312,7 @@ const char *previewsmcp_jit_session_add_object(previewsmcp_jit_session *session,
 const char *previewsmcp_jit_session_lookup(previewsmcp_jit_session *session,
                                            const char *symbol_name,
                                            uint64_t *out_address) {
-  if (!session->initialized) {
-    if (auto err = session->jit->initialize(*session->jd)) {
-      return toCStr(std::move(err));
-    }
-    session->initialized = true;
-  }
-  auto sym = session->jit->lookup(*session->jd, symbol_name);
+  auto sym = lookupInitialized(session, symbol_name);
   if (!sym) {
     return toCStr(sym.takeError());
   }

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -12,10 +12,18 @@
 #include <llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h>
 #include <llvm/ExecutionEngine/Orc/MemoryMapper.h>
 #include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
+#include <llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h>
+#include <llvm/ExecutionEngine/Orc/SimpleRemoteEPC.h>
+#include <llvm/ExecutionEngine/Orc/TaskDispatch.h>
 #include <llvm/Support/Debug.h>
 #include <llvm/Support/MemoryBuffer.h>
+#include <crt_externs.h>
 #include <mutex>
+#include <optional>
+#include <spawn.h>
 #include <string>
+#include <sys/socket.h>
+#include <unistd.h>
 
 namespace {
 
@@ -91,8 +99,10 @@ llvm::orc::LLJIT *sharedJIT(const char *orc_rt_path, std::string &err) {
 } // namespace
 
 struct previewsmcp_jit_session {
-  llvm::orc::LLJIT *jit;
-  llvm::orc::JITDylib *jd;
+  std::unique_ptr<llvm::orc::LLJIT> ownedJit;
+  llvm::orc::LLJIT *jit = nullptr;
+  llvm::orc::JITDylib *jd = nullptr;
+  pid_t agentPid = 0;
   bool initialized = false;
 };
 
@@ -114,7 +124,98 @@ previewsmcp_jit_session_create(previewsmcp_jit_session **out_session,
   if (!jd) {
     return toCStr(jd.takeError());
   }
-  *out_session = new previewsmcp_jit_session{jit, &*jd, false};
+  auto *session = new previewsmcp_jit_session{};
+  session->jit = jit;
+  session->jd = &*jd;
+  *out_session = session;
+  return nullptr;
+}
+
+const char *
+previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
+                                      const char *agent_path) {
+  static std::once_flag targetOnce;
+  std::call_once(targetOnce, [] {
+    LLVMInitializeNativeTarget();
+    LLVMInitializeNativeAsmPrinter();
+  });
+
+  int sv[2];
+  if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) {
+    return strdup(("socketpair failed: " + std::string(strerror(errno))).c_str());
+  }
+
+  posix_spawn_file_actions_t actions;
+  posix_spawn_file_actions_init(&actions);
+  posix_spawn_file_actions_addclose(&actions, sv[0]);
+  std::string fdArg =
+      "filedescs=" + std::to_string(sv[1]) + "," + std::to_string(sv[1]);
+  char *const argv[] = {const_cast<char *>(agent_path),
+                        const_cast<char *>(fdArg.c_str()), nullptr};
+  pid_t pid = 0;
+  int rc =
+      posix_spawn(&pid, agent_path, &actions, nullptr, argv, *_NSGetEnviron());
+  posix_spawn_file_actions_destroy(&actions);
+  close(sv[1]);
+  if (rc != 0) {
+    close(sv[0]);
+    return strdup(("posix_spawn failed: " + std::string(strerror(rc))).c_str());
+  }
+
+  auto epc =
+      llvm::orc::SimpleRemoteEPC::Create<llvm::orc::FDSimpleRemoteEPCTransport>(
+          std::make_unique<llvm::orc::DynamicThreadPoolTaskDispatcher>(
+              std::nullopt),
+          llvm::orc::SimpleRemoteEPC::Setup(), sv[0], sv[0]);
+  if (!epc) {
+    return toCStr(epc.takeError());
+  }
+
+  auto jit =
+      llvm::orc::LLJITBuilder()
+          .setExecutorProcessControl(std::move(*epc))
+          .setPlatformSetUp(llvm::orc::setUpInactivePlatform)
+          .setLinkProcessSymbolsByDefault(false)
+          .setObjectLinkingLayerCreator(
+              [](llvm::orc::ExecutionSession &es, const llvm::Triple &)
+                  -> llvm::Expected<std::unique_ptr<llvm::orc::ObjectLayer>> {
+                return std::make_unique<llvm::orc::ObjectLinkingLayer>(es);
+              })
+          .create();
+  if (!jit) {
+    return toCStr(jit.takeError());
+  }
+
+  auto *session = new previewsmcp_jit_session{};
+  session->ownedJit = std::move(*jit);
+  session->jit = session->ownedJit.get();
+  session->agentPid = pid;
+  static std::atomic<uint64_t> counter{0};
+  auto jd = session->jit->createJITDylib("remote." +
+                                         std::to_string(counter.fetch_add(1)));
+  if (!jd) {
+    delete session;
+    return toCStr(jd.takeError());
+  }
+  session->jd = &*jd;
+  *out_session = session;
+  return nullptr;
+}
+
+const char *previewsmcp_jit_session_run_main(previewsmcp_jit_session *session,
+                                             const char *symbol_name,
+                                             int32_t *out_result) {
+  auto sym = session->jit->lookup(*session->jd, symbol_name);
+  if (!sym) {
+    return toCStr(sym.takeError());
+  }
+  auto result = session->jit->getExecutionSession()
+                    .getExecutorProcessControl()
+                    .runAsMain(*sym, {});
+  if (!result) {
+    return toCStr(result.takeError());
+  }
+  *out_result = *result;
   return nullptr;
 }
 

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -41,9 +41,9 @@ slabLinkingLayer(llvm::orc::ExecutionSession &es, const llvm::Triple &) {
   if (!memMgr) {
     return memMgr.takeError();
   }
-  auto layer =
-      std::make_unique<llvm::orc::ObjectLinkingLayer>(es, std::move(*memMgr));
-  layer->addPlugin(std::make_shared<previewsmcp::SwiftEntrySectionPlugin>());
+  auto layer = std::make_unique<llvm::orc::ObjectLinkingLayer>(
+      es, std::move(*memMgr));
+  layer->addPlugin(previewsmcp::SwiftEntrySectionPlugin::inProcess());
   return layer;
 }
 
@@ -185,14 +185,26 @@ previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
     return toCStr(epc.takeError());
   }
 
+  llvm::orc::ExecutorAddr registerConformances, registerTypes;
+  if (auto err = (*epc)->getBootstrapSymbols(
+          {{registerConformances, "__previewsmcp_register_conformances"},
+           {registerTypes, "__previewsmcp_register_types"}})) {
+    return toCStr(std::move(err));
+  }
+
   auto jit =
       llvm::orc::LLJITBuilder()
           .setExecutorProcessControl(std::move(*epc))
           .setPlatformSetUp(llvm::orc::ExecutorNativePlatform(orc_rt_path))
           .setObjectLinkingLayerCreator(
-              [](llvm::orc::ExecutionSession &es, const llvm::Triple &)
+              [registerConformances, registerTypes](
+                  llvm::orc::ExecutionSession &es, const llvm::Triple &)
                   -> llvm::Expected<std::unique_ptr<llvm::orc::ObjectLayer>> {
-                return std::make_unique<llvm::orc::ObjectLinkingLayer>(es);
+                auto layer = std::make_unique<llvm::orc::ObjectLinkingLayer>(es);
+                layer->addPlugin(
+                    std::make_shared<previewsmcp::SwiftEntrySectionPlugin>(
+                        registerConformances, registerTypes));
+                return layer;
               })
           .create();
   if (!jit) {

--- a/Sources/PreviewsJITLinkCxx/SwiftEntrySectionPlugin.cpp
+++ b/Sources/PreviewsJITLinkCxx/SwiftEntrySectionPlugin.cpp
@@ -58,8 +58,7 @@ void hideSection(LinkGraph &G, StringRef From, StringRef To) {
     G.addAnonymousSymbol(*B, 0, B->getSize(), false, true);
 }
 
-void registerSection(LinkGraph &G, StringRef Name,
-                     CWrapperFunctionResult (*Fn)(const char *, size_t)) {
+void registerSection(LinkGraph &G, StringRef Name, ExecutorAddr Fn) {
   auto *Sec = G.findSectionByName(Name);
   if (!Sec)
     return;
@@ -69,12 +68,18 @@ void registerSection(LinkGraph &G, StringRef Name,
     ExecutorAddrRange range(B->getAddress(), B->getAddress() + B->getSize());
     G.allocActions().push_back(
         {cantFail(WrapperFunctionCall::Create<SPSArgList<SPSExecutorAddrRange>>(
-             ExecutorAddr::fromPtr(Fn), range)),
+             Fn, range)),
          {}});
   }
 }
 
 } // namespace
+
+std::shared_ptr<SwiftEntrySectionPlugin> SwiftEntrySectionPlugin::inProcess() {
+  return std::make_shared<SwiftEntrySectionPlugin>(
+      ExecutorAddr::fromPtr(&registerConformances),
+      ExecutorAddr::fromPtr(&registerTypes));
+}
 
 void SwiftEntrySectionPlugin::modifyPassConfig(
     MaterializationResponsibility &MR, LinkGraph &G,
@@ -84,11 +89,13 @@ void SwiftEntrySectionPlugin::modifyPassConfig(
     hideSection(G, Swift5TypesSection, HiddenTypesSection);
     return Error::success();
   });
-  Config.PostFixupPasses.push_back([](LinkGraph &G) -> Error {
-    registerSection(G, HiddenProtoSection, registerConformances);
-    registerSection(G, HiddenTypesSection, registerTypes);
-    return Error::success();
-  });
+  Config.PostFixupPasses.push_back(
+      [Conformances = RegisterConformances,
+       Types = RegisterTypes](LinkGraph &G) -> Error {
+        registerSection(G, HiddenProtoSection, Conformances);
+        registerSection(G, HiddenTypesSection, Types);
+        return Error::success();
+      });
 }
 
 } // namespace previewsmcp

--- a/Sources/PreviewsJITLinkCxx/SwiftEntrySectionPlugin.hpp
+++ b/Sources/PreviewsJITLinkCxx/SwiftEntrySectionPlugin.hpp
@@ -3,12 +3,22 @@
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
+#include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/Support/Error.h"
+
+#include <memory>
 
 namespace previewsmcp {
 
 class SwiftEntrySectionPlugin : public llvm::orc::ObjectLinkingLayer::Plugin {
 public:
+  SwiftEntrySectionPlugin(llvm::orc::ExecutorAddr RegisterConformances,
+                          llvm::orc::ExecutorAddr RegisterTypes)
+      : RegisterConformances(RegisterConformances),
+        RegisterTypes(RegisterTypes) {}
+
+  static std::shared_ptr<SwiftEntrySectionPlugin> inProcess();
+
   void modifyPassConfig(llvm::orc::MaterializationResponsibility &MR,
                         llvm::jitlink::LinkGraph &G,
                         llvm::jitlink::PassConfiguration &Config) override;
@@ -24,6 +34,10 @@ public:
   void notifyTransferringResources(llvm::orc::JITDylib &JD,
                                    llvm::orc::ResourceKey DstKey,
                                    llvm::orc::ResourceKey SrcKey) override {}
+
+private:
+  llvm::orc::ExecutorAddr RegisterConformances;
+  llvm::orc::ExecutorAddr RegisterTypes;
 };
 
 } // namespace previewsmcp

--- a/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
+++ b/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
@@ -31,6 +31,10 @@ previewsmcp_jit_session_run_main(previewsmcp_jit_session *session,
                                  const char *symbol_name, int32_t *out_result);
 
 const char *_Nullable
+previewsmcp_jit_session_write_pointer(previewsmcp_jit_session *session,
+                                      uint64_t address, uint64_t value);
+
+const char *_Nullable
 previewsmcp_jit_session_add_object(previewsmcp_jit_session *session,
                                    const char *object_path);
 

--- a/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
+++ b/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
@@ -15,13 +15,16 @@ void previewsmcp_jit_dispose_string(const char *str);
 
 typedef struct previewsmcp_jit_session previewsmcp_jit_session;
 
-const char *_Nullable previewsmcp_jit_session_create(
-    previewsmcp_jit_session *_Nullable *_Nonnull out_session,
-    const char *orc_rt_path);
+void previewsmcp_jit_session_destroy(previewsmcp_jit_session *session);
+
+const char *_Nullable
+previewsmcp_jit_session_create(previewsmcp_jit_session *_Nullable *_Nonnull out_session,
+                              const char *orc_rt_path);
 
 const char *_Nullable
 previewsmcp_jit_remote_session_create(previewsmcp_jit_session *_Nullable *_Nonnull out_session,
-                                      const char *agent_path);
+                                      const char *agent_path,
+                                      const char *orc_rt_path);
 
 const char *_Nullable
 previewsmcp_jit_session_run_main(previewsmcp_jit_session *session,

--- a/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
+++ b/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
@@ -19,8 +19,17 @@ const char *_Nullable previewsmcp_jit_session_create(
     previewsmcp_jit_session *_Nullable *_Nonnull out_session,
     const char *orc_rt_path);
 
-const char *_Nullable previewsmcp_jit_session_add_object(
-    previewsmcp_jit_session *session, const char *object_path);
+const char *_Nullable
+previewsmcp_jit_remote_session_create(previewsmcp_jit_session *_Nullable *_Nonnull out_session,
+                                      const char *agent_path);
+
+const char *_Nullable
+previewsmcp_jit_session_run_main(previewsmcp_jit_session *session,
+                                 const char *symbol_name, int32_t *out_result);
+
+const char *_Nullable
+previewsmcp_jit_session_add_object(previewsmcp_jit_session *session,
+                                   const char *object_path);
 
 const char *_Nullable previewsmcp_jit_session_lookup(
     previewsmcp_jit_session *session, const char *symbol_name,

--- a/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
+++ b/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
@@ -17,26 +17,23 @@ typedef struct previewsmcp_jit_session previewsmcp_jit_session;
 
 void previewsmcp_jit_session_destroy(previewsmcp_jit_session *session);
 
-const char *_Nullable
-previewsmcp_jit_session_create(previewsmcp_jit_session *_Nullable *_Nonnull out_session,
-                              const char *orc_rt_path);
+const char *_Nullable previewsmcp_jit_session_create(
+    previewsmcp_jit_session *_Nullable *_Nonnull out_session,
+    const char *orc_rt_path);
 
-const char *_Nullable
-previewsmcp_jit_remote_session_create(previewsmcp_jit_session *_Nullable *_Nonnull out_session,
-                                      const char *agent_path,
-                                      const char *orc_rt_path);
+const char *_Nullable previewsmcp_jit_remote_session_create(
+    previewsmcp_jit_session *_Nullable *_Nonnull out_session,
+    const char *agent_path, const char *orc_rt_path);
 
-const char *_Nullable
-previewsmcp_jit_session_run_main(previewsmcp_jit_session *session,
-                                 const char *symbol_name, int32_t *out_result);
+const char *_Nullable previewsmcp_jit_session_run_main(
+    previewsmcp_jit_session *session, const char *symbol_name,
+    int32_t *out_result);
 
-const char *_Nullable
-previewsmcp_jit_session_write_pointer(previewsmcp_jit_session *session,
-                                      uint64_t address, uint64_t value);
+const char *_Nullable previewsmcp_jit_session_write_pointer(
+    previewsmcp_jit_session *session, uint64_t address, uint64_t value);
 
-const char *_Nullable
-previewsmcp_jit_session_add_object(previewsmcp_jit_session *session,
-                                   const char *object_path);
+const char *_Nullable previewsmcp_jit_session_add_object(
+    previewsmcp_jit_session *session, const char *object_path);
 
 const char *_Nullable previewsmcp_jit_session_lookup(
     previewsmcp_jit_session *session, const char *symbol_name,

--- a/Tests/PreviewsJITLinkTests/Fixtures/patch_slot.c
+++ b/Tests/PreviewsJITLinkTests/Fixtures/patch_slot.c
@@ -1,0 +1,8 @@
+#include <stdint.h>
+
+static int32_t impl_v1(void) { return 1; }
+int32_t impl_v2(void) { return 2; }
+
+int32_t (*patch_slot_fn)(void) = impl_v1;
+
+int32_t patch_slot_call(void) { return patch_slot_fn(); }

--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -91,6 +91,19 @@ struct PreviewsJITLinkTests {
         #expect(result == 11)
     }
 
+    @Test func publishesNewAddressIntoSlotRemotely() throws {
+        let object = try FixtureSupport.compile("patch_slot.c")
+        let session = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
+        try session.addObject(path: object.path)
+        #expect(try session.runMain(symbol: "patch_slot_call") == 1)
+
+        let slot = try session.address(of: "patch_slot_fn")
+        let v2 = try session.address(of: "impl_v2")
+        try session.writePointer(at: slot, value: v2)
+
+        #expect(try session.runMain(symbol: "patch_slot_call") == 2)
+    }
+
     @Test func linksSwiftObject() throws {
         let object = try FixtureSupport.compile("swift_answer.swift")
         let session = try JITSession()

--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -11,6 +11,14 @@ struct PreviewsJITLinkTests {
         #expect(result == 42)
     }
 
+    @Test func linksCObjectRemotely() throws {
+        let object = try FixtureSupport.compile("answer.c")
+        let session = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
+        try session.addObject(path: object.path)
+        let result = try session.runMain(symbol: "answer")
+        #expect(result == 42)
+    }
+
     @Test func linksSwiftObject() throws {
         let object = try FixtureSupport.compile("swift_answer.swift")
         let session = try JITSession()

--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -19,6 +19,22 @@ struct PreviewsJITLinkTests {
         #expect(result == 42)
     }
 
+    @Test func runsObjectInitializerRemotely() throws {
+        let object = try FixtureSupport.compile("ctor.c")
+        let session = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
+        try session.addObject(path: object.path)
+        let result = try session.runMain(symbol: "ctor_answer")
+        #expect(result == 42)
+    }
+
+    @Test func resolvesThreadLocalStorageRemotely() throws {
+        let object = try FixtureSupport.compile("tlv.c")
+        let session = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
+        try session.addObject(path: object.path)
+        let result = try session.runMain(symbol: "tlv_value")
+        #expect(result == 43)
+    }
+
     @Test func linksSwiftObject() throws {
         let object = try FixtureSupport.compile("swift_answer.swift")
         let session = try JITSession()

--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -35,6 +35,62 @@ struct PreviewsJITLinkTests {
         #expect(result == 43)
     }
 
+    @Test func linksSwiftObjectRemotely() throws {
+        let object = try FixtureSupport.compile("swift_answer.swift")
+        let session = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
+        try session.addObject(path: object.path)
+        let result = try session.runMain(symbol: "swift_answer")
+        #expect(result == 42)
+    }
+
+    @Test func dispatchesThroughWitnessTableRemotely() throws {
+        let object = try FixtureSupport.compile("witness.swift")
+        let session = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
+        try session.addObject(path: object.path)
+        let result = try session.runMain(symbol: "witness_value")
+        #expect(result == 7)
+    }
+
+    @Test func resolvesConformanceThroughRuntimeRegistryRemotely() throws {
+        let object = try FixtureSupport.compile("dynamic_cast.swift")
+        let session = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
+        try session.addObject(path: object.path)
+        let result = try session.runMain(symbol: "dynamic_cast_value")
+        #expect(result == 9)
+    }
+
+    @Test func runsSwiftOnceInitializerRemotely() throws {
+        let object = try FixtureSupport.compile("swift_once.swift")
+        let session = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
+        try session.addObject(path: object.path)
+        let result = try session.runMain(symbol: "swift_once_value")
+        #expect(result == 5050)
+    }
+
+    @Test func dispatchesObjCSelectorRemotely() throws {
+        let object = try FixtureSupport.compile("objc_selref.swift")
+        let session = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
+        try session.addObject(path: object.path)
+        let result = try session.runMain(symbol: "objc_selref_value")
+        #expect(result == 42)
+    }
+
+    @Test func registersObjCClassRemotely() throws {
+        let object = try FixtureSupport.compile("objc_class.swift")
+        let session = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
+        try session.addObject(path: object.path)
+        let result = try session.runMain(symbol: "objc_class_value")
+        #expect(result == 42)
+    }
+
+    @Test func runsAsyncFunctionRemotely() throws {
+        let object = try FixtureSupport.compile("async_value.swift")
+        let session = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
+        try session.addObject(path: object.path)
+        let result = try session.runMain(symbol: "async_value")
+        #expect(result == 11)
+    }
+
     @Test func linksSwiftObject() throws {
         let object = try FixtureSupport.compile("swift_answer.swift")
         let session = try JITSession()

--- a/docs/jit-executor-phase2-plan.md
+++ b/docs/jit-executor-phase2-plan.md
@@ -108,11 +108,21 @@ remote call.
   `PreviewAgent` as a sibling of `Bundle.module` in the build dir. The test
   target depends on `PreviewAgent` so `swift test` builds it first.
 
-### P2.2 — platform + orc_rt + remote slab over the wire
-Bring up `ExecutorNativePlatform` remotely (U-C) and solve U-A with the
-shared-memory mapper slab.
-- **Verify:** the C initializer / TLV scenarios (`ctor.c`, `tlv.c`,
-  `runsObjectInitializer`, `resolvesThreadLocalStorage`) pass remotely.
+### P2.2 — platform + orc_rt over the wire — DONE
+Swapped the remote path from the inactive platform to
+`ExecutorNativePlatform(orc_rt_path)`. The agent gained `SimpleExecutorDylibManager`
+so process-symbol lookup works over the wire, and `run_main` now `initialize()`s
+the session (runs constructors in the agent via the platform). The remote create
+takes `orc_rt_path`; the Swift remote init resolves it from `Bundle.module` like
+the in-process init.
+- **Verify (met):** `runsObjectInitializerRemotely` (`ctor.c`, constructor runs
+  in the agent) and `resolvesThreadLocalStorageRemotely` (`tlv.c`) both return
+  through the agent. 17 tests green.
+- **U-C resolved:** the orc runtime bootstraps cleanly over the wire.
+- **U-A did NOT bite for C:** the default remote memory manager
+  (`EPCGenericJITLinkMemoryManager`) handled `ctor.c`/`tlv.c` without the unwind
+  32-bit slab. NOT adding the shared-memory slab speculatively. Revisit only if a
+  Swift object trips it in P2.3.
 
 ### P2.3 — Swift metadata across the wire
 Confirm U-B; port the full suite onto the remote executor.
@@ -120,11 +130,17 @@ Confirm U-B; port the full suite onto the remote executor.
   selref, objc class, async) green through the agent. The 14-test suite passes
   with the remote executor.
 
-### P2.4 — teardown = kill the agent PID
-Session/agent lifecycle ownership; `session_destroy` kills the agent and tears
-down the `LLJIT`/EPC in the right order (U-D).
-- **Verify:** disposing a session kills the agent, no zombie, no hang; a second
-  session in the same test run is unaffected.
+### P2.4 — teardown = kill the agent PID — DONE (pulled forward from P2.2)
+Pulled forward because the parallel test runner hung: spawned agents had no
+teardown, so leaked agents held the test process's inherited stdout/stderr pipe
+open and `swift-test` never saw EOF. `previewsmcp_jit_session_destroy` resets the
+owned `LLJIT` (which calls `ES.endSession()` → `EPC->disconnect()`, line 1633 of
+Core.cpp, closing the wire so the agent's `waitForDisconnect` returns), then
+`kill(SIGKILL)` + `waitpid` the agent PID as the design's backstop. In-process
+sessions just free the handle (the shared `LLJIT` stays, D3). Wired to a Swift
+`deinit`.
+- **Verify (met):** parallel `swift test --filter PreviewsJITLinkTests` passes
+  17/17 in 0.18s with zero leftover `PreviewAgent` processes. U-D resolved.
 
 ### P2.5 — address propagation / patch-point publishing (design §5)
 `write_mem` into running callers; the `cancelUpdate`/Begin/End update handshake

--- a/docs/jit-executor-phase2-plan.md
+++ b/docs/jit-executor-phase2-plan.md
@@ -165,11 +165,32 @@ sessions just free the handle (the shared `LLJIT` stays, D3). Wired to a Swift
 - **Verify (met):** parallel `swift test --filter PreviewsJITLinkTests` passes
   17/17 in 0.18s with zero leftover `PreviewAgent` processes. U-D resolved.
 
-### P2.5 — address propagation / patch-point publishing (design §5)
-`write_mem` into running callers; the `cancelUpdate`/Begin/End update handshake
-(design §5, §6). Largest chunk, last. Scope sharpened once P2.1–P2.4 land.
-- **Verify:** TBD (re-resolve a symbol, publish the new address into a slot a
-  running caller reads, observe the new value without respawn).
+### P2.5 — address propagation / patch-point publishing (design §5) — DONE
+Exposed the `write_mem` patch primitive over the wire:
+`previewsmcp_jit_session_write_pointer` → Swift `writePointer(at:value:)` →
+`getMemoryAccess().writePointers`. SimpleRemoteEPC has no default memory access
+(`createDefaultMemoryAccess` returns nullptr), and the orc-runtime write wrappers
+are not available at EPC-setup time, so the agent hosts its own SPS
+`write_pointers` wrapper (advertised as the `__previewsmcp_write_pointers`
+bootstrap symbol), and the host's `Setup.CreateMemoryAccess` builds an
+`EPCGenericMemoryAccess` with `FuncAddrs.WritePointers` from it.
+- **Verify (met):** `publishesNewAddressIntoSlotRemotely` (`patch_slot.c`): a
+  function-pointer slot starts dispatching to v1 (returns 1); the host writes the
+  agent address of `impl_v2` into the slot via `writePointer`; the next dispatch
+  returns 2. The write is pointer-width aligned, so atomic against an in-flight
+  read per design §5 point 1. 25 tests green in parallel, zero orphan agents.
+- **Not in scope (Phase 3):** the Begin/End/`cancelUpdate` update handshake
+  (§5/§6) and wiring patch-points to SwiftUI witness/vtable slots on real edits.
+  This chunk proves the publish mechanism, not the edit-driven planner.
+
+## Phase 2 status: COMPLETE (local unix-socket transport)
+
+The executor is out-of-process end to end. All six POC scenarios link, register
+Swift metadata, and run inside a spawned agent over a SimpleRemoteEPC socket;
+sessions tear down by killing the agent PID; and a new address publishes into a
+running slot via `write_mem`. 25 tests green in parallel. Deferred to Phase 3:
+SwiftUI session-lifecycle integration, the update handshake, XPC/gRPC transports,
+the sidecar symbol-discovery format, iOS device agent, and LLVM bundling (U3).
 
 ## Scope boundaries
 

--- a/docs/jit-executor-phase2-plan.md
+++ b/docs/jit-executor-phase2-plan.md
@@ -74,15 +74,39 @@ so the wire path builds against the artifacts we have. No LLVM rebuild.
 
 ## Subproblems and verification criteria
 
-### P2.1 — agent + wire + linksCObject (the spine)
+### P2.1 — agent + wire + linksCObject (the spine) — DONE
 New gated `PreviewAgent` C++ executable target mirroring
 `llvm-jitlink-executor.cpp` (FD transport, `SimpleExecutorMemoryManager`,
 `ExecutorSharedMemoryMapperService`, default bootstrap symbols). Host-side spawn
-over a socketpair, swap `SimpleRemoteEPC` into `makeJIT`. Start with the simplest
-object (`answer.c`, no initializers, no platform) to isolate transport + remote
-alloc + remote call.
-- **Verify:** a C symbol resolves and returns 42 through the agent process
-  (`linksCObject`-equivalent). Agent is a separate PID, confirmed.
+over a socketpair (`previewsmcp_jit_remote_session_create`), the simplest object
+(`answer.c`, no initializers, no platform) to isolate transport + remote alloc +
+remote call.
+- **Verify (met):** `linksCObjectRemotely` resolves `answer` and gets 42 through
+  the spawned agent. Full suite is 15 green, in-process path untouched.
+
+**Discoveries (not in the design doc):**
+- A remote call cannot reuse the in-process `call<T>` path: the looked-up address
+  lives in the agent's address space, so calling it locally would crash. We
+  dispatch with `ExecutorProcessControl::runAsMain(addr, {})` (new
+  `previewsmcp_jit_session_run_main`). The richer wrapper-function ABI is P2.5.
+- A bare remote `LLJIT` needs four explicit settings or `create()` aborts (the
+  asserts build destroys the connected EPC on any create failure, so the real
+  error is masked by `~SimpleRemoteEPC "Destroyed without disconnection"`):
+  1. `setPlatformSetUp(setUpInactivePlatform)` — the default platform wants the
+     orc runtime we have not wired remotely yet (P2.2).
+  2. `setObjectLinkingLayerCreator(ObjectLinkingLayer(ES))` — the LLJIT default
+     is `RTDyldObjectLinkingLayer` + in-process `SectionMemoryManager`, wrong for
+     a remote EPC. The one-arg `ObjectLinkingLayer` uses the EPC's memory manager.
+  3. `setLinkProcessSymbolsByDefault(false)` — the default sets up a
+     process-symbols dylib via a dylib-manager bootstrap the agent does not host.
+     `answer.c` has no external symbols. Revisit when a fixture needs process
+     symbols.
+  4. Initialize the native target/asm printer on the remote path too (the
+     in-process `makeJIT` did this in its own `call_once`; the remote path is
+     separate).
+- Agent location for dev/test: `JITSession.bundledAgentPath()` resolves
+  `PreviewAgent` as a sibling of `Bundle.module` in the build dir. The test
+  target depends on `PreviewAgent` so `swift test` builds it first.
 
 ### P2.2 — platform + orc_rt + remote slab over the wire
 Bring up `ExecutorNativePlatform` remotely (U-C) and solve U-A with the

--- a/docs/jit-executor-phase2-plan.md
+++ b/docs/jit-executor-phase2-plan.md
@@ -1,0 +1,122 @@
+# JIT Executor — Phase 2 plan and state
+
+Living plan for Phase 2, "out-of-process executor." Resume from here across
+sessions. Update it as work lands. Phase 1 (issue #183) is on `main` via PR #185.
+
+## Sources of truth
+
+- `docs/jit-executor-phase1-plan.md` (Phase 1 landed state).
+- `prompts/jit-executor-design.md` §§5, 6, 8.Phase-2 (on `previews-research`).
+- Branch: `jit-phase2-remote-executor` (off `main` at `04fa860`).
+- Reference agent: `third_party/llvm-project/llvm/tools/llvm-jitlink/llvm-jitlink-executor/llvm-jitlink-executor.cpp`.
+- Auto-memory: `project_jit_inprocess_harness`, `project_jit_dynamic_replacement`.
+
+## Goal
+
+Move the executor out-of-process. Swap `SelfExecutorProcessControl` for
+`SimpleRemoteEPC` over a unix-domain-socket transport, stand up a small agent
+process that hosts the JIT, drive link/lookup/run across the wire. Then address
+propagation / patch-point publishing per design §5 (`write_mem` into running
+callers). Teardown is kill-the-agent-PID.
+
+## The seam
+
+Phase 1 built the swap point deliberately. `PreviewsJITLinkCxx.cpp` `makeJIT`
+constructs the `LLJIT` on `SelfExecutorProcessControl::Create()`. Replacing that
+one EPC with a `SimpleRemoteEPC` connected to a spawned agent is the pivot. The
+agent template is `llvm-jitlink-executor.cpp` (in-tree). `libLLVM.dylib` already
+exports the server symbols (`SimpleRemoteEPCServer`, `FDSimpleRemoteEPCTransport`),
+so the wire path builds against the artifacts we have. No LLVM rebuild.
+
+## Decisions
+
+- **D-P2-1 (agreed): per-session agent.** Each `JITSession` spawns and owns its
+  own agent process; teardown kills that PID. Matches design §8 Phase 2
+  ("spawned at session start, killed at session end") and delivers the real
+  teardown in-process Phase 1 could not have (no Swift deregister API, see
+  Phase 1 SP0d-D). Because each agent is its own process, the platform-bootstrap
+  process-global race that forced Phase 1's single shared `LLJIT` (SP1) goes
+  away: per-session `LLJIT` + per-session agent is now both viable and clean.
+  Consequence: `session_create` no longer shares one `LLJIT` via `call_once`; it
+  spawns an agent, builds a `SimpleRemoteEPC`, and creates a per-session `LLJIT`.
+
+- **D-P2-2 (agreed): transport is `filedescs=<in>,<out>` over a `socketpair`.**
+  "Unix domain socket first" realized the LLVM-native way `llvm-jitlink` drives
+  its executor. Host creates the socketpair, spawns the agent passing the FDs,
+  connects `SimpleRemoteEPC` over its end. Lowest-risk transport.
+
+## Assumptions
+
+- The Phase 1 C ABI (`session_create` / `session_add_object` / `session_lookup`)
+  and the `SwiftEntrySectionPlugin` survive unchanged in shape. Only the EPC
+  behind the `LLJIT` changes, plus a new spawn/teardown surface.
+- The orc-runtime + `ExecutorNativePlatform` bootstrap dispatches to the agent
+  over the wire the same way it runs in-process (this is what `llvm-jitlink`
+  does).
+- Alloc actions (the plugin's Swift-registration mechanism) run executor-side,
+  so they will execute in the agent and register against the agent's
+  `libswiftCore`.
+
+## Unknowns (each is a verification gate)
+
+- **U-A:** does `EPCGenericJITLinkMemoryManager` scatter allocations past 32-bit
+  reach the way Phase 1's default mapper did? The unwind-slab gotcha (Phase 1
+  "Discoveries") likely recurs remotely and wants the shared-memory mapper
+  service (`ExecutorSharedMemoryMapperService` on the agent +
+  `SharedMemoryMapper` on the host) to reserve a contiguous slab.
+- **U-B (load-bearing):** do the plugin's Swift-registration alloc-actions
+  resolve against the *agent's* `libswiftCore` and execute in the agent? They
+  should, but this is the central risk and the reason we defer Swift metadata to
+  P2.3.
+- **U-C:** does our Debug-built fork orc_rt bootstrap cleanly over the wire?
+- **U-D:** does shutdown order (kill agent vs `LLJIT` destruction) leave zombies
+  or hang `waitForDisconnect`? Resolved in P2.4.
+
+## Subproblems and verification criteria
+
+### P2.1 — agent + wire + linksCObject (the spine)
+New gated `PreviewAgent` C++ executable target mirroring
+`llvm-jitlink-executor.cpp` (FD transport, `SimpleExecutorMemoryManager`,
+`ExecutorSharedMemoryMapperService`, default bootstrap symbols). Host-side spawn
+over a socketpair, swap `SimpleRemoteEPC` into `makeJIT`. Start with the simplest
+object (`answer.c`, no initializers, no platform) to isolate transport + remote
+alloc + remote call.
+- **Verify:** a C symbol resolves and returns 42 through the agent process
+  (`linksCObject`-equivalent). Agent is a separate PID, confirmed.
+
+### P2.2 — platform + orc_rt + remote slab over the wire
+Bring up `ExecutorNativePlatform` remotely (U-C) and solve U-A with the
+shared-memory mapper slab.
+- **Verify:** the C initializer / TLV scenarios (`ctor.c`, `tlv.c`,
+  `runsObjectInitializer`, `resolvesThreadLocalStorage`) pass remotely.
+
+### P2.3 — Swift metadata across the wire
+Confirm U-B; port the full suite onto the remote executor.
+- **Verify:** all six POC scenarios (witness, conformance, swift_once, objc
+  selref, objc class, async) green through the agent. The 14-test suite passes
+  with the remote executor.
+
+### P2.4 — teardown = kill the agent PID
+Session/agent lifecycle ownership; `session_destroy` kills the agent and tears
+down the `LLJIT`/EPC in the right order (U-D).
+- **Verify:** disposing a session kills the agent, no zombie, no hang; a second
+  session in the same test run is unaffected.
+
+### P2.5 — address propagation / patch-point publishing (design §5)
+`write_mem` into running callers; the `cancelUpdate`/Begin/End update handshake
+(design §5, §6). Largest chunk, last. Scope sharpened once P2.1–P2.4 land.
+- **Verify:** TBD (re-resolve a symbol, publish the new address into a slot a
+  running caller reads, observe the new value without respawn).
+
+## Scope boundaries
+
+- **Phase 2 (this branch):** P2.1–P2.5. Local unix-socket transport only.
+- **Deferred Phase 3+:** SwiftUI session-lifecycle integration; XPC / gRPC
+  transports; sidecar symbol-discovery format (§3); iOS device agent; LLVM
+  bundling for distribution (U3).
+
+## Immediate next step
+
+P2.1. First TDD step: a failing test that links `answer.c` through a spawned
+agent and asserts the call returns 42, then the minimal agent + host spawn to
+make it pass. Pause for review before moving to P2.2.

--- a/docs/jit-executor-phase2-plan.md
+++ b/docs/jit-executor-phase2-plan.md
@@ -124,11 +124,34 @@ the in-process init.
   32-bit slab. NOT adding the shared-memory slab speculatively. Revisit only if a
   Swift object trips it in P2.3.
 
-### P2.3 — Swift metadata across the wire
-Confirm U-B; port the full suite onto the remote executor.
-- **Verify:** all six POC scenarios (witness, conformance, swift_once, objc
-  selref, objc class, async) green through the agent. The 14-test suite passes
-  with the remote executor.
+### P2.3 — Swift metadata across the wire — DONE
+Added `SwiftEntrySectionPlugin` to the remote layer and resolved U-B. The full
+suite now has remote variants of all six POC scenarios plus plain Swift; 24
+tests green in parallel, zero orphan agents.
+
+**Discoveries (U-B and the agent's Swift runtime):**
+- The agent is a C++ binary with no Swift link, so Swift objects fail to
+  materialize with "Symbols not found" until the agent loads the runtime. Fix:
+  the agent `dlopen`s `libswiftCore`, `libswift_Concurrency`, `libswiftFoundation`,
+  `libswiftDispatch` (RTLD_GLOBAL) at startup; the process-symbol generator then
+  resolves against them. They live in the dyld shared cache (so `ls` shows
+  nothing) but `dlopen` of the install path works. Real previews will pull SwiftUI
+  the same way in Phase 3.
+- **U-B (the load-bearing risk):** the plugin recorded `ExecutorAddr::fromPtr(Fn)`,
+  the HOST address of its registration shims. In-process that works (host ==
+  executor); remotely the alloc action runs in the agent and jumps to a garbage
+  address (crashed with an Instruction Abort in `SimpleExecutorMemoryManager::finalize`
+  running the alloc action, PC in libLLVM `__LINKEDIT`). Fix: the registration
+  SPS shims now live in the AGENT (calling its own `swift_register*` via `dlsym`),
+  advertised as EPC bootstrap symbols; the host reads their agent addresses with
+  `getBootstrapSymbols` and constructs the plugin with them. `SwiftEntrySectionPlugin`
+  is now address-parameterized; in-process uses a `::inProcess()` factory that
+  passes the host shim addresses. Each executor hosts its own shim.
+- **U-A closed (no slab needed):** the default remote memory manager
+  (`EPCGenericJITLinkMemoryManager`) handled every scenario including Swift
+  conformance, async, and objc, so the unwind 32-bit slab never bit remotely. The
+  shared-memory slab mapper is NOT needed. Revisit only if a future large object
+  trips it.
 
 ### P2.4 — teardown = kill the agent PID — DONE (pulled forward from P2.2)
 Pulled forward because the parallel test runner hung: spawned agents had no


### PR DESCRIPTION
Phase 2 of the custom JIT executor (issue #183). Moves the executor out-of-process: the daemon stays the JIT-link host, and a new `PreviewAgent` binary hosts the JIT behind LLVM's `SimpleRemoteEPC` over a unix-domain socket. Phase 1 (#185) built the executor seam for exactly this swap. Source of truth: `docs/jit-executor-phase2-plan.md`.

## What landed

- **P2.1 — agent + wire.** New gated `PreviewAgent` executor (a `SimpleRemoteEPCServer` over an FD socketpair, mirroring `llvm-jitlink-executor`). `previewsmcp_jit_remote_session_create` spawns the agent and builds a per-session `LLJIT` over `SimpleRemoteEPC`. Remote calls go through `runAsMain`, since the symbol address lives in the agent. `linksCObject` runs through the agent.
- **P2.2 — platform over the wire.** Swapped to `ExecutorNativePlatform(orc_rt_path)`, so the MachOPlatform + orc runtime bootstrap inside the agent. The agent gained `SimpleExecutorDylibManager` for process-symbol lookup. C initializer (`ctor.c`) and TLV (`tlv.c`) scenarios pass.
- **P2.3 — Swift metadata across the wire.** The agent `dlopen`s the Swift runtime (Core, Concurrency, Foundation, Dispatch overlays). The `SwiftEntrySectionPlugin` registration shims now live in the agent (calling its own `swift_register*`), advertised as EPC bootstrap symbols and read by the host. All six POC scenarios (witness, conformance, swift_once, objc selref/class, async) run remotely.
- **P2.4 — teardown by PID.** `previewsmcp_jit_session_destroy` resets the owned `LLJIT` (which disconnects the EPC, so the agent exits) then kills + reaps the agent PID, wired to a Swift `deinit`. Pulled forward to fix a parallel-runner hang from leaked agents holding the inherited pipe.
- **P2.5 — `write_mem` patch-point publishing (design §5).** `writePointer(at:value:)` publishes a new function address into a slot the agent reads, via a `EPCGenericMemoryAccess` backed by an agent-hosted `write_pointers` SPS wrapper. `patch_slot.c` flips a dispatch from 1 to 2 with no respawn.

## Testing

`swift test --filter PreviewsJITLinkTests` is 25/25 green in parallel, zero orphan agents. The in-process Phase 1 path is untouched.

## CI / scope

All Phase 2 targets (including `PreviewAgent`) stay behind the `third_party` LLVM-build gate, so CI does not compile any of it. Transport is local unix-socket only. Deferred to Phase 3: SwiftUI session-lifecycle integration, the Begin/End/`cancelUpdate` update handshake (§5/§6), XPC/gRPC transports, the sidecar symbol-discovery format, iOS device agent, and LLVM bundling (U3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)