### PR TITLE
JIT: hot-reload non-leaf files via single-module incremental split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ DerivedData/
 .claude/worktrees/
 .claude/scheduled_tasks.lock
 
-/third_party/
+/third_party

--- a/Sources/PreviewsCore/BridgeGenerator.swift
+++ b/Sources/PreviewsCore/BridgeGenerator.swift
@@ -259,9 +259,12 @@ public enum BridgeGenerator {
     }
 
     /// Generate the `@_cdecl("renderPreviewToFile")` entry point (macOS, model-A JIT path).
-    /// Builds the same preview view as `createPreviewView`, rasterizes it headless via
-    /// `ImageRenderer`, and writes a PNG to `path`. Nullary so it runs over the agent's
-    /// `runOnMain` surface; the path is baked in (the daemon recompiles per structural edit).
+    /// Builds the same preview view as `createPreviewView`, hosts it in a borderless
+    /// `NSWindow` positioned off-screen via `NSHostingView` (AppKit-backed views like
+    /// `List` need a real window's backing hierarchy — `ImageRenderer` returns nil or a
+    /// blank raster for them), captures at a deterministic 1x like `Snapshot.capture`,
+    /// and writes a PNG to `path`. Nullary so it runs over the agent's `runOnMain`
+    /// surface; the path is baked in (the daemon recompiles per structural edit).
     private static func renderToFileEntryPoint(
         viewCode: String, path: String, valuesPath: String?
     ) -> String {
@@ -282,10 +285,32 @@ public enum BridgeGenerator {
                 MainActor.assumeIsolated {
                     \(seed)
                     let view = \(viewCode)
-                    let renderer = ImageRenderer(content: view)
-                    renderer.scale = 1
-                    guard let cgImage = renderer.cgImage else { return Int32(-1) }
-                    let rep = NSBitmapImageRep(cgImage: cgImage)
+                    let bounds = NSRect(x: 0, y: 0, width: 400, height: 600)
+                    let window = NSWindow(
+                        contentRect: bounds, styleMask: [.borderless], backing: .buffered,
+                        defer: false)
+                    let hosting = NSHostingView(rootView: view)
+                    window.contentView = hosting
+                    window.setFrameOrigin(NSPoint(x: -10_000, y: -10_000))
+                    window.orderFrontRegardless()
+                    hosting.layoutSubtreeIfNeeded()
+                    defer { window.orderOut(nil) }
+                    guard
+                        let rep = NSBitmapImageRep(
+                            bitmapDataPlanes: nil,
+                            pixelsWide: Int(bounds.width),
+                            pixelsHigh: Int(bounds.height),
+                            bitsPerSample: 8,
+                            samplesPerPixel: 4,
+                            hasAlpha: true,
+                            isPlanar: false,
+                            colorSpaceName: .deviceRGB,
+                            bytesPerRow: 0,
+                            bitsPerPixel: 0
+                        )
+                    else { return Int32(-1) }
+                    rep.size = bounds.size
+                    hosting.cacheDisplay(in: bounds, to: rep)
                     guard let data = rep.representation(using: .png, properties: [:]) else {
                         return Int32(-2)
                     }

--- a/Sources/PreviewsCore/Compiler.swift
+++ b/Sources/PreviewsCore/Compiler.swift
@@ -259,6 +259,79 @@ public actor Compiler {
         return StableModule(moduleName: moduleName, modulesDir: moduleDir, objectPath: objectFile)
     }
 
+    /// Per-module incremental build directory, reused across edits so the driver's
+    /// `.swiftdeps` records and the unchanged-file objects persist between compiles.
+    private var incrementalDirs: [String: URL] = [:]
+
+    /// Compile the whole target module incrementally: the editable `overlaySource` plus the
+    /// target's other `bulkFiles`, all under one `moduleName`. The Swift driver recompiles only
+    /// what changed — the overlay alone on a body edit, the overlay plus its dependents on an
+    /// interface edit — and reuses the rest from the persistent build dir. Returns the overlay's
+    /// object and the bulk objects (in `bulkFiles` order). This is the non-leaf structural split:
+    /// the bulk references the edited file, so a one-directional prebuilt stable module cannot be
+    /// used, but a single module resolves references in both directions.
+    public func compileModuleIncremental(
+        overlaySource: String,
+        bulkFiles: [URL],
+        moduleName: String,
+        extraFlags: [String] = []
+    ) async throws -> (overlayObject: URL, bulkObjects: [URL]) {
+        let dir: URL
+        if let existing = incrementalDirs[moduleName] {
+            dir = existing
+        } else {
+            dir = workDir.appendingPathComponent("incremental-\(moduleName)", isDirectory: true)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            incrementalDirs[moduleName] = dir
+        }
+
+        let overlayFile = dir.appendingPathComponent("overlay.swift")
+        try overlaySource.write(to: overlayFile, atomically: true, encoding: .utf8)
+        let overlayObject = dir.appendingPathComponent("overlay.o")
+
+        // The output-file-map keys must match the command-line paths exactly, or the driver
+        // disables incremental ("no swiftDeps file") and recompiles everything every edit.
+        var fileMap: [String: [String: String]] = [
+            "": ["swift-dependencies": dir.appendingPathComponent("master.swiftdeps").path],
+            overlayFile.path: [
+                "object": overlayObject.path,
+                "swift-dependencies": dir.appendingPathComponent("overlay.swiftdeps").path,
+            ],
+        ]
+        var bulkObjects: [URL] = []
+        for (index, file) in bulkFiles.enumerated() {
+            let object = dir.appendingPathComponent("bulk_\(index).o")
+            bulkObjects.append(object)
+            fileMap[file.path] = [
+                "object": object.path,
+                "swift-dependencies": dir.appendingPathComponent("bulk_\(index).swiftdeps").path,
+            ]
+        }
+        let mapFile = dir.appendingPathComponent("output-file-map.json")
+        let mapData = try JSONSerialization.data(withJSONObject: fileMap, options: [.sortedKeys])
+        try mapData.write(to: mapFile)
+
+        var args: [String] = [
+            swiftcPath,
+            "-incremental",
+            "-emit-object",
+            "-parse-as-library",
+            "-target", targetTriple,
+            "-sdk", sdkPath,
+            "-module-name", moduleName,
+            "-Onone",
+            "-gnone",
+            "-module-cache-path", moduleCachePath.path,
+            "-output-file-map", mapFile.path,
+        ]
+        args += extraFlags
+        args += [overlayFile.path]
+        args += bulkFiles.map(\.path)
+
+        try await run(args)
+        return (overlayObject, bulkObjects)
+    }
+
     // MARK: - Private
 
     @discardableResult

--- a/Sources/PreviewsCore/PreviewSession.swift
+++ b/Sources/PreviewsCore/PreviewSession.swift
@@ -26,6 +26,11 @@ public struct JITRenderBuild: Sendable {
     /// Binary dynamic libraries (the target's `-F`/`-framework` dependency frameworks) the
     /// agent must `dlopen` so their symbols resolve. Empty for standalone.
     public let dylibPaths: [URL]
+    /// Require a freshly respawned agent for this render instead of a new generation on the
+    /// live one. The non-leaf incremental split compiles under the target's own (stable) module
+    /// name, so its `@Observable DesignTimeStore` would re-register across generations in one
+    /// process; a fresh process each structural edit sidesteps the duplicate registration.
+    public let requiresFreshAgent: Bool
 
     public init(
         objectPath: URL,
@@ -35,7 +40,8 @@ public struct JITRenderBuild: Sendable {
         literals: [LiteralEntry],
         supportObjectPaths: [URL] = [],
         archivePaths: [URL] = [],
-        dylibPaths: [URL] = []
+        dylibPaths: [URL] = [],
+        requiresFreshAgent: Bool = false
     ) {
         self.objectPath = objectPath
         self.imagePath = imagePath
@@ -45,6 +51,7 @@ public struct JITRenderBuild: Sendable {
         self.supportObjectPaths = supportObjectPaths
         self.archivePaths = archivePaths
         self.dylibPaths = dylibPaths
+        self.requiresFreshAgent = requiresFreshAgent
     }
 }
 
@@ -237,19 +244,45 @@ public actor PreviewSession {
         var supportObjectPaths: [URL] = []
         var archivePaths: [URL] = []
         var dylibPaths: [URL] = []
+        var requiresFreshAgent = false
         if let (ctx, bulk) = splitContext {
-            let stable = try await stableModule(for: bulk, context: ctx)
-            supportObjectPaths = [stable.objectPath]
             archivePaths = Self.dependencyArchives(in: ctx.compilerFlags)
             if let runtimeArchive = try await Toolchain.compilerRuntimeArchivePath() {
                 archivePaths.append(URL(fileURLWithPath: runtimeArchive))
             }
             dylibPaths = Self.dependencyDylibs(in: ctx.compilerFlags)
-            objectPath = try await compiler.compileObject(
-                source: generated.source,
-                moduleName: "PreviewEdit_\(ctx.moduleName)_\(Self.uniqueModuleToken())",
-                extraFlags: ["-I", stable.modulesDir.path] + ctx.compilerFlags
-            )
+
+            if let stable = try await stableModuleIfLeaf(for: bulk, context: ctx) {
+                supportObjectPaths = [stable.objectPath]
+                objectPath = try await compiler.compileObject(
+                    source: generated.source,
+                    moduleName: "PreviewEdit_\(ctx.moduleName)_\(Self.uniqueModuleToken())",
+                    extraFlags: ["-I", stable.modulesDir.path] + ctx.compilerFlags
+                )
+            } else {
+                // Non-leaf: the bulk references the edited file, so it cannot be prebuilt as a
+                // one-directional stable module. Compile the whole module incrementally with the
+                // overlay in-module (no `@testable import`); only the hot file recompiles per edit.
+                let overlay = BridgeGenerator.generateCombinedSource(
+                    originalSource: source,
+                    closureBody: preview.closureBody,
+                    previewIndex: previewIndex,
+                    platform: platform,
+                    traits: traits,
+                    renderOutputPath: imagePath.path,
+                    designTimeValuesPath: valuesPath.path,
+                    stableModuleImport: nil
+                )
+                let built = try await compiler.compileModuleIncremental(
+                    overlaySource: overlay.source,
+                    bulkFiles: bulk,
+                    moduleName: ctx.moduleName,
+                    extraFlags: ctx.compilerFlags
+                )
+                supportObjectPaths = built.bulkObjects
+                objectPath = try Self.uniqueObjectCopy(of: built.overlayObject)
+                requiresFreshAgent = true
+            }
         } else {
             objectPath = try await compiler.compileObject(
                 source: generated.source,
@@ -269,7 +302,8 @@ public actor PreviewSession {
             literals: generated.literals,
             supportObjectPaths: supportObjectPaths,
             archivePaths: archivePaths,
-            dylibPaths: dylibPaths
+            dylibPaths: dylibPaths,
+            requiresFreshAgent: requiresFreshAgent
         )
         lastJITBuild = build
         return build
@@ -342,6 +376,35 @@ public actor PreviewSession {
     /// Return the stable module for `bulk`, reusing the cached one when no bulk file has
     /// changed (the common case: repeated edits to the hot preview file). Rebuilds only when
     /// a bulk file's modification date changes, so the per-edit compile stays narrow.
+    private var bulkIsNonLeaf = false
+
+    /// The stable half of the leaf split, or nil when the bulk references the hot file (non-leaf)
+    /// and so cannot compile without it. Cached per session: once the bulk fails to compile on its
+    /// own, every later edit takes the incremental whole-module path. A genuine bulk error surfaces
+    /// again from that path, so the fallback never hides it.
+    private func stableModuleIfLeaf(
+        for bulk: [URL], context ctx: BuildContext
+    ) async throws -> Compiler.StableModule? {
+        if bulkIsNonLeaf { return nil }
+        do {
+            return try await stableModule(for: bulk, context: ctx)
+        } catch is CompilationError {
+            bulkIsNonLeaf = true
+            return nil
+        }
+    }
+
+    /// Copy the incremental build's reused `overlay.o` (a stable path) to a unique path, so each
+    /// structural edit presents a distinct `objectPath`. The reloader keys its literal fast path on
+    /// object-path identity, which a stable path would falsely trigger.
+    private static func uniqueObjectCopy(of object: URL) throws -> URL {
+        let dest = object.deletingLastPathComponent()
+            .appendingPathComponent("overlay-\(uniqueModuleToken()).o")
+        try? FileManager.default.removeItem(at: dest)
+        try FileManager.default.copyItem(at: object, to: dest)
+        return dest
+    }
+
     private func stableModule(
         for bulk: [URL], context ctx: BuildContext
     ) async throws -> Compiler.StableModule {

--- a/Sources/PreviewsJITLink/JITStructuralReloader.swift
+++ b/Sources/PreviewsJITLink/JITStructuralReloader.swift
@@ -25,7 +25,7 @@ public actor JITStructuralReloader: StructuralReloader {
             return
         }
 
-        let session = try nextSession()
+        let session = try nextSession(forceFresh: build.requiresFreshAgent)
         for dylib in build.dylibPaths {
             try session.addDylib(path: dylib.path)
         }
@@ -49,9 +49,10 @@ public actor JITStructuralReloader: StructuralReloader {
 
     /// The session to link this edit into: a fresh `JITDylib` on the live agent while under
     /// the cap, otherwise a freshly respawned agent (replacing the old one, whose `deinit`
-    /// kills its process). The first edit and each post-cap edit start a new agent.
-    private func nextSession() throws -> JITSession {
-        if let session, generation < generationCap {
+    /// kills its process). The first edit, each post-cap edit, and any `forceFresh` edit (the
+    /// non-leaf incremental split, which reuses the target's stable module name) start a new agent.
+    private func nextSession(forceFresh: Bool) throws -> JITSession {
+        if let session, !forceFresh, generation < generationCap {
             generation += 1
             try session.newGeneration()
             return session

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -106,6 +106,9 @@ public:
   char *prepare(llvm::orc::ExecutorAddr addr, size_t contentSize) override {
     std::lock_guard<std::mutex> lock(mutex);
     auto r = reservations.upper_bound(addr);
+    if (r == reservations.begin()) {
+      return nullptr;
+    }
     --r;
     return r->second.workingBuf + (addr - r->first);
   }
@@ -117,6 +120,11 @@ public:
     {
       std::lock_guard<std::mutex> lock(mutex);
       auto r = reservations.upper_bound(ai.MappingBase);
+      if (r == reservations.begin()) {
+        return onInitialized(llvm::createStringError(
+            llvm::inconvertibleErrorCode(),
+            "initialize: no reservation covers mapping base"));
+      }
       --r;
       base = r->second.workingBuf + (ai.MappingBase - r->first);
     }
@@ -273,13 +281,17 @@ struct previewsmcp_jit_session {
 namespace {
 llvm::Expected<llvm::orc::ExecutorAddr>
 lookupInitialized(previewsmcp_jit_session *session, const char *symbol_name) {
-  if (!session->initialized) {
+  {
     static std::mutex initMutex;
     std::lock_guard<std::mutex> lock(initMutex);
-    if (auto err = session->jit->initialize(*session->jd)) {
-      return std::move(err);
+    // Re-check under the lock: the flag is read and written only here, so two
+    // threads cannot both pass the check and double-initialize the JITDylib.
+    if (!session->initialized) {
+      if (auto err = session->jit->initialize(*session->jd)) {
+        return std::move(err);
+      }
+      session->initialized = true;
     }
-    session->initialized = true;
   }
   return session->jit->lookup(*session->jd, symbol_name);
 }

--- a/Sources/PreviewsMacOS/HostApp.swift
+++ b/Sources/PreviewsMacOS/HostApp.swift
@@ -126,6 +126,10 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         }
         loaders[sessionID] = loader
 
+        // The window now reflects the current preview; a stale agent PNG must not
+        // shadow it in snapshot(). The next JIT reload repopulates the entry.
+        agentImagePaths.removeValue(forKey: sessionID)
+
         // Create the view
         let rawPtr = createView()
         let hostingView = Unmanaged<NSView>.fromOpaque(rawPtr).takeRetainedValue()

--- a/Sources/PreviewsMacOS/Snapshot.swift
+++ b/Sources/PreviewsMacOS/Snapshot.swift
@@ -26,13 +26,27 @@ public enum Snapshot {
         guard bounds.width > 0, bounds.height > 0 else {
             throw SnapshotError.captureFailed
         }
-        // Note: bitmapImageRepForCachingDisplay produces 1x images. Off-screen headless
-        // windows aren't associated with a display, so backingScaleFactor is 1.0 anyway.
-        // To capture at a specific scale, create an NSBitmapImageRep manually with scaled
-        // pixel dimensions. (pointfreeco/swift-snapshot-testing has the same limitation.)
-        guard let bitmapRep = contentView.bitmapImageRepForCachingDisplay(in: bounds) else {
+        // Pin the raster to a deterministic 1x (one pixel per point). bitmapImageRepForCachingDisplay
+        // inherits the host window's backingScaleFactor — 2x on a Retina display — which made the
+        // snapshot's pixel dimensions depend on which machine the daemon ran on. Building the rep
+        // manually with pixel dimensions equal to the point bounds keeps output reproducible.
+        guard
+            let bitmapRep = NSBitmapImageRep(
+                bitmapDataPlanes: nil,
+                pixelsWide: Int(bounds.width.rounded()),
+                pixelsHigh: Int(bounds.height.rounded()),
+                bitsPerSample: 8,
+                samplesPerPixel: 4,
+                hasAlpha: true,
+                isPlanar: false,
+                colorSpaceName: .deviceRGB,
+                bytesPerRow: 0,
+                bitsPerPixel: 0
+            )
+        else {
             throw SnapshotError.captureFailed
         }
+        bitmapRep.size = bounds.size
         contentView.cacheDisplay(in: bounds, to: bitmapRep)
 
         switch format {

--- a/Tests/MCPIntegrationTests/MacOSMCPTests.swift
+++ b/Tests/MCPIntegrationTests/MacOSMCPTests.swift
@@ -525,7 +525,9 @@ struct MacOSMCPTests {
             to: URL(fileURLWithPath: filePath), atomically: false, encoding: .utf8)
 
         // CI swiftc on cold caches is slow; AGENTS.md notes daemon startup alone is 5–10s.
-        try await server.awaitStderrContains("Compiled:", timeout: .seconds(90))
+        // "Reloaded" matches both daemon kinds: the JIT agent logs "Reloaded (JIT agent)!" and
+        // the non-JIT recompile logs "Reloaded!". Both fire only after a successful structural edit.
+        try await server.awaitStderrContains("Reloaded", timeout: .seconds(90))
         _ = try await server.awaitSnapshotChange(
             sessionID: sessionID, baseline: baseline, timeout: .seconds(15)
         )

--- a/Tests/PreviewsJITLinkTests/ExamplesSplitE2ETests.swift
+++ b/Tests/PreviewsJITLinkTests/ExamplesSplitE2ETests.swift
@@ -83,6 +83,20 @@ struct ExamplesSplitE2ETests {
     /// twice through one reloader, so generation 2 re-links ToDoExtras / Lottie / the builtins
     /// archive into a fresh JITDylib. Guards against duplicate Swift-metadata registration
     /// across generations (item 2, U2).
+    @Test func nonLeafRendersUneditedPreviewInAgent() async throws {
+        let hot = Self.spmRoot.appendingPathComponent("Sources/ToDo/ToDoView.swift")
+        let ctx = try await Self.context(for: hot)
+        let compiler = try await Compiler()
+        let session = PreviewSession(sourceFile: hot, compiler: compiler, buildContext: ctx)
+        let build = try await session.compileObjectForJIT()
+
+        let reloader = JITStructuralReloader()
+        try await reloader.render(build)
+        let png = try Data(contentsOf: build.imagePath)
+        #expect(!png.isEmpty)
+        #expect(NSBitmapImageRep(data: png) != nil)
+    }
+
     @Test func splitRendersRealPreviewAcrossGenerations() async throws {
         let hot = Self.spmRoot.appendingPathComponent("Sources/ToDo/Summary.swift")
         let ctx = try await Self.context(for: hot)

--- a/docs/jit-executor-phase3-plan.md
+++ b/docs/jit-executor-phase3-plan.md
@@ -717,6 +717,87 @@ P3.3 (in-place `write_mem` + Begin/End/cancelUpdate handshake) stays conditional
   leaves files CI rejects; a file list after `--recursive` only formats the first
   arg, so loop). build-and-test can pass while `lint` fails — check all four jobs.
 
+## Update 2026-06-09: non-leaf hot-reload fix, CI removed, merge status
+
+This section SUPERSEDES the "Immediate next step" pointer above and every "CI
+green" claim in this doc. PR #190 merged to `main` (`a5b58cc`), GitHub Actions
+CI is disabled (the `CI` and `Cache warmer` workflows are off; the
+`required_status_checks` rule was removed), and the merge bar is now LOCAL:
+all unit tests plus the example integration tests via the `integration-test`
+skill (AGENTS.md). The CI-replacement design is `docs/local-merge-queue.md`.
+
+### The non-leaf duplicate/missing-symbol bug (the fix this branch lands)
+
+The recompile-narrowing split as merged on `main` handled only the LEAF case:
+it prebuilds a stable module from the target's other sources and the edited
+file `@testable import`s it. When the edited file is NON-LEAF — another file in
+the target references it (e.g. `examples/spm` `ToDoView.swift` is used by
+`ToDoProviderPreview.swift`) — the stable compile excludes the hot file but the
+bulk still references it, so it fails with `cannot find 'ToDoView' in scope` and
+the hot reload times out. (This is a missing symbol, not a duplicate; a true
+duplicate-in-both would require a build system whose `sourceFiles` does NOT
+exclude the hot file. SPM excludes it in `collectSourceFiles`.)
+
+**Fix (branch `jit-nonleaf-hotreload`, PR #194):** detect the non-leaf case
+(the stable compile throws → `bulkIsNonLeaf` latches for the session) and
+compile the whole target module INCREMENTALLY instead — the edited file as an
+overlay plus the other sources under the target's own module name, where the
+Swift driver recompiles only the hot file and reuses the bulk objects.
+References resolve both directions and the hot file lives in exactly one module.
+Because the overlay then uses the real module name, its `@Observable`
+`DesignTimeStore` would re-register across generations, so non-leaf builds
+respawn the agent each structural edit (`requiresFreshAgent`).
+
+Code: `Compiler.compileModuleIncremental`, `PreviewSession.compileObjectForJIT()`
+non-leaf branch + `stableModuleIfLeaf`/`bulkIsNonLeaf`,
+`JITStructuralReloader`/`render(_:)`, plus the C++ `lookupInitialized` lock and
+anon-mapper bounds fix in `PreviewsJITLinkCxx.cpp`.
+
+**Known tradeoffs (performance, not correctness; follow-up candidates):**
+- Non-leaf edits lose capped-persistent and respawn the agent each edit. Leaf
+  edits keep the persistent path via a unique module token.
+- Leaf vs non-leaf is detected by compile-and-catch and `bulkIsNonLeaf` latches
+  per session. A real error in another bulk file is misread as non-leaf and pins
+  the session to the slower whole-module path. Degrades speed, not correctness;
+  the error still surfaces. Static reference analysis would avoid this but is
+  itself a compile (Swift same-module refs carry no `import`), so compile-and-
+  catch was chosen.
+- The first non-leaf edit compiles the bulk twice (once to fail-detect).
+
+### Verification (local, this branch, worktree with `third_party` symlinked)
+
+| Check | Result |
+| --- | --- |
+| `hotReloadStructural` (edits `ToDoView.swift`, the non-leaf file), JIT daemon | green, ~24s (on `main` it times out at 90s) |
+| `PreviewsJITLinkTests` isolated, `--no-parallel` | 50/50 |
+| macOS CLI suites (Snapshot/Configure/Switch/Elements/Variants/Stop), serial | 46/46 |
+| Non-JIT unit suite, default PARALLEL | 6–30 nondeterministic issues — ALL parallel session contention ("multiple sessions are running" / "No session found") or missing iOS example artifacts |
+| iOS suites (`IOSMCPTests`, `IOSCLIWorkflowTests`) | FAIL — missing iOS-sim example build (`ToDo.swiftmodule`, `ToDoPreviewSetup`); environment, not code |
+| Whole suite in ONE `swift test --no-parallel` | crashes (`SmallVector set_size`) — known shared in-process LLJIT flakiness; why the doc runs JIT separately |
+
+Conclusion: nothing the three commits touch is failing. The CLI integration
+suites are not parallel-safe with each other (shared daemon); run them serial.
+
+### JIT is macOS-only — iOS is NOT covered
+
+The JIT executor renders on macOS only: `JITStructuralReloader` is wired solely
+onto the macOS `PreviewHost` (`PreviewsMCPApp.swift`), and `PreviewAgent`
+`dlopen`s AppKit/SwiftUI and renders with `ImageRenderer` on the Mac. The iOS
+path is separate (`IOSPreviewSession` + `IOSHostBuilder`): a structural edit
+does a FULL host-app recompile reloaded on the simulator
+(`IOSPreviewSession.swift`), not the JIT split/agent. An iOS device/simulator
+JIT agent is a DEFERRED line item in all three phase docs (Phase 1 §356, Phase 2
+§193/199, Phase 3 §662) with no design, subproblems, or verification criteria.
+Fixing iOS JIT is net-new planning work, not a bug in this fix.
+
+### Outstanding
+
+- Run the `integration-test` skill (the other half of the merge bar). Not yet run.
+- iOS unit suites need the iOS-sim example built first (`bootstrap --examples`).
+- PR #193 (`docs-no-ci-verification`) still carries these same three commits; once
+  #194 lands, rebase #193 down to just its docs commit.
+- Decide whether to merge #194 once the full local bar is met.
+
 ## P4.1 recompile-narrowing (#191 item 1) — IN PROGRESS
 
 **Decision: Fork B (project/Tier-2 split), file-granularity, hot-leaf heuristic.**


### PR DESCRIPTION
## Problem

`main` (`a5b58cc`, the #190 merge) shipped the JIT split-compile path with only
the **leaf** case handled. The split prebuilds a stable module from the target's
other sources and `@testable import`s it from the edited file. When the edited
file is **non-leaf** (another file in the target references it, e.g.
`ToDoView.swift` is used by `ToDoProviderPreview.swift`), the stable compile
excludes the hot file but the bulk still references it, so it fails with
`cannot find 'ToDoView' in scope` and the hot reload times out.

Running the full local merge bar (the `integration-test` skill) against this
branch then exposed two further agent-render bugs that `main` also has:

1. **`ImageRenderer` cannot rasterize AppKit-backed SwiftUI.** With
   `NavigationStack { List }` as the root it returns a nil `cgImage` (the agent
   entry fails with status -1, surfaced as `Recompilation failed: JIT render
   entry returned non-zero status -1` on any cross-file edit that was a
   session's first structural reload). With a modifier wrapping the `List` it
   returns a tiny blank raster instead. Existing tests passed because they only
   asserted "snapshot changed" / "PNG non-empty".
2. **Stale agent PNG shadowed the window.** `snapshot()` prefers the
   agent-rendered PNG once a session is agent-backed, but the dylib window
   paths (`preview_switch`, `preview_configure`) never cleared it, so
   snapshots kept serving the pre-switch image.

## Fix

Detect the non-leaf case (the stable-module compile throws) and compile the
whole target module **incrementally** instead: the edited file as an overlay
plus the other sources under one module name, where the Swift driver recompiles
only the hot file and reuses the bulk objects. References resolve both
directions, so the hot file lives in exactly one module.

Because the overlay then uses the target's own module name, its `@Observable`
`DesignTimeStore` would re-register across generations, so non-leaf builds
respawn the JIT agent each structural edit (`requiresFreshAgent`).

For the render bugs:

- `renderPreviewToFile` now hosts the view in a borderless off-screen
  `NSWindow` via `NSHostingView` and captures at a deterministic 1x, the same
  mechanism as `Snapshot.capture`. AppKit-backed views get a real backing
  hierarchy and render with full content.
- `loadPreview` drops the session's `agentImagePaths` entry, making the window
  the source of truth again until the next JIT reload repopulates it.

## Design notes / known tradeoffs

- The leaf fast path (stable module + capped-persistent agent) is unchanged and
  still serves the common case (editing the preview-bearing leaf file).
- Non-leaf edits lose capped-persistent and respawn the agent each edit.
- Leaf vs non-leaf is detected by compile-and-catch and latches per session
  (`bulkIsNonLeaf`). A real error in another bulk file would pin the session to
  the slower whole-module path. Acceptable: it degrades speed, not correctness,
  and the error still surfaces. Follow-up candidate.
- The first non-leaf edit compiles the bulk twice (once to fail-detect).

## Verification

- `hotReloadStructural` (edits `ToDoView.swift`, the non-leaf file) passes
  against the JIT daemon, where `main` times out at 90s.
- New `nonLeafRendersUneditedPreviewInAgent` renders the unedited non-leaf
  `ToDoView.swift` through `compileObjectForJIT` + the reloader (the exact
  cross-file-first path), failing on `main`'s `ImageRenderer` entry.
- Full `PreviewsJITLinkTests`: 51/51 serially. Touched-module unit suites
  (Core/MacOS/Engine): 320/320. macOS CLI command suites: 46/46 serially.
  macOS MCP integration suite: 7/7.
- `integration-test` skill, macOS scope, all four examples (SPM, Bazel,
  xcodeproj, xcworkspace): rendering, literal + cross-file hot reload,
  multi-preview switch with invalid-index rollback, trait injection +
  persistence across switch, PreviewProvider. Daemon log clean of reload
  failures.

## Commits

- `Snapshot: pin window capture to deterministic 1x` (independent, also stranded
  off `main`)
- `JIT: hot-reload non-leaf files via single-module incremental split` (the fix)
- `JIT C++: fix lookupInitialized lock and anon-mapper bounds` (JIT-link
  hardening)
- `Docs: record non-leaf fix, CI removal, and local merge bar in Phase 3 plan`
- `JIT: render agent preview in an off-screen NSWindow, not ImageRenderer`
- `HostApp: drop stale agent PNG when the window reloads a dylib`
- `gitignore: match the third_party symlink in worktrees`

🤖 Generated with [Claude Code](https://claude.com/claude-code)