### PR TITLE
JIT: start sessions through the agent, one agent per session

### DIFF
--- a/Sources/PreviewsCLI/Handlers/PreviewStartHandler.swift
+++ b/Sources/PreviewsCLI/Handlers/PreviewStartHandler.swift
@@ -400,8 +400,29 @@ private func startMacOSPreview(
         setupDylibPath: setupResult?.dylibPath
     )
 
-    let compileResult = try await session.compile()
     let sessionID = session.id
+
+    let agentBacked = await MainActor.run { host.makeStructuralReloader != nil }
+    if agentBacked {
+        try await host.jitStart(
+            sessionID: sessionID, session: session,
+            title: title, size: NSSize(width: width, height: height),
+            headless: headless
+        )
+        await MainActor.run {
+            host.watchFile(
+                sessionID: sessionID,
+                session: session,
+                filePath: fileURL.path,
+                compiler: compiler,
+                additionalPaths: buildContext?.sourceFiles?.map(\.path) ?? [],
+                buildContext: buildContext
+            )
+        }
+        return sessionID
+    }
+
+    let compileResult = try await session.compile()
     let setupDylibPath = setupResult?.dylibPath
 
     await MainActor.run {

--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -90,7 +90,7 @@ public struct PreviewsMCPApp {
         let app = NSApplication.shared
         let host = PreviewHost()
         #if PREVIEWSMCP_JIT
-        host.structuralReloader = JITStructuralReloader()
+        host.makeStructuralReloader = { JITStructuralReloader() }
         #endif
         ServeCommand.sharedHost = host
         app.delegate = host

--- a/Sources/PreviewsCore/BridgeGenerator.swift
+++ b/Sources/PreviewsCore/BridgeGenerator.swift
@@ -329,6 +329,7 @@ public enum BridgeGenerator {
                 """
             } ?? ""
         let createWindow: String
+        let presentNewWindow: String
         if let window {
             let title = escapedForSwiftStringLiteral(window.title)
             createWindow = """
@@ -341,6 +342,13 @@ public enum BridgeGenerator {
                                     backing: .buffered, defer: false)
                                 created.title = "\(title)"
                 """
+            // A visible window takes key status and activates the agent once, at
+            // creation, matching what the daemon's dylib window start used to do.
+            // Re-renders use orderFrontRegardless so edits never steal focus.
+            presentNewWindow = """
+                window.makeKeyAndOrderFront(nil)
+                                NSApplication.shared.activate(ignoringOtherApps: true)
+                """
         } else {
             createWindow = """
                 let created = NSWindow(
@@ -348,6 +356,7 @@ public enum BridgeGenerator {
                                     styleMask: [.borderless], backing: .buffered, defer: false)
                                 created.setFrameOrigin(NSPoint(x: -10_000, y: -10_000))
                 """
+            presentNewWindow = "window.orderFrontRegardless()"
         }
         return """
             @_cdecl("renderPreviewToFile")
@@ -356,18 +365,24 @@ public enum BridgeGenerator {
                     \(seed)
                     let view = \(viewCode)
                     let identifier = NSUserInterfaceItemIdentifier("previewsmcp-preview")
+                    var isNewWindow = false
                     let window =
                         NSApplication.shared.windows.first { $0.identifier == identifier }
                         ?? {
                             \(createWindow)
                             created.identifier = identifier
                             created.isReleasedWhenClosed = false
+                            isNewWindow = true
                             return created
                         }()
                     let hosting = NSHostingView(rootView: view)
                     hosting.sizingOptions = []
                     window.contentView = hosting
-                    window.orderFrontRegardless()
+                    if isNewWindow {
+                        \(presentNewWindow)
+                    } else {
+                        window.orderFrontRegardless()
+                    }
                     hosting.layoutSubtreeIfNeeded()
                     let bounds = hosting.bounds
                     guard bounds.width > 0, bounds.height > 0,

--- a/Sources/PreviewsEngine/MacOSPreviewHandle.swift
+++ b/Sources/PreviewsEngine/MacOSPreviewHandle.swift
@@ -68,7 +68,7 @@ public actor MacOSPreviewHandle: PreviewSessionHandle {
             case daemonWindow
         }
         let surface: Surface = await MainActor.run {
-            guard host.structuralReloader != nil, host.agentSnapshotPath(for: id) != nil else {
+            guard host.agentSnapshotPath(for: id) != nil else {
                 return .daemonWindow
             }
             return .agent(host.agentWindowSpec(for: id))

--- a/Sources/PreviewsMacOS/HostApp.swift
+++ b/Sources/PreviewsMacOS/HostApp.swift
@@ -135,8 +135,8 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
 
         // The window now reflects the current preview; a stale agent PNG must not
         // shadow it in snapshot(), a live agent must not keep a second window, and
-        // future JIT compiles should derive placement from this window, not a
-        // stale stored spec. The next JIT reload repopulates what it needs.
+        // a dylib-backed session has no agent placement. The next JIT reload
+        // repopulates what it needs.
         agentImagePaths.removeValue(forKey: sessionID)
         reloaders.removeValue(forKey: sessionID)
         agentWindowSpecs.removeValue(forKey: sessionID)
@@ -379,46 +379,44 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
 
     /// Start a session with the agent as its surface from the first render: no
     /// in-daemon dylib compile, no daemon window. The requested placement becomes
-    /// the session's window spec, centered on the main screen for visible sessions.
+    /// the session's window spec, centered on the main screen for visible sessions
+    /// (no spec when there is no screen to place it on). Registers the session up
+    /// front so the reloader can be created, and tears everything down if the
+    /// first render fails.
     public func jitStart(
         sessionID: String, session: PreviewSession,
         title: String, size: NSSize, headless: Bool
     ) async throws {
-        if !headless {
-            let screen = NSScreen.main?.visibleFrame ?? .zero
+        sessions[sessionID] = session
+        if !headless, let screen = NSScreen.main?.visibleFrame {
             agentWindowSpecs[sessionID] = JITRenderWindow(
                 x: screen.midX - size.width / 2,
                 y: screen.midY - size.height / 2,
                 width: size.width, height: size.height,
                 title: title)
         }
-        try await jitStructuralReload(sessionID: sessionID, session: session)
+        do {
+            try await jitStructuralReload(sessionID: sessionID, session: session)
+        } catch {
+            closePreview(sessionID: sessionID)
+            throw error
+        }
     }
 
     /// The session's reloader, created on first use. One per session: each owns
-    /// its own agent process.
+    /// its own agent process. Created only for registered sessions, so a reload
+    /// still in flight when its session closes cannot resurrect an agent.
     private func reloader(for sessionID: String) -> (any StructuralReloader)? {
         if let existing = reloaders[sessionID] { return existing }
-        guard let made = makeStructuralReloader?() else { return nil }
+        guard sessions[sessionID] != nil, let made = makeStructuralReloader?() else { return nil }
         reloaders[sessionID] = made
         return made
     }
 
     /// The window placement to bake into a JIT build for this session: the spec
-    /// stored at agent start, else the daemon window's frame and title when the
-    /// session is visible, nil when headless.
+    /// stored at agent start, nil when headless.
     public func agentWindowSpec(for sessionID: String) -> JITRenderWindow? {
-        if let spec = agentWindowSpecs[sessionID] { return spec }
-        return windows[sessionID].flatMap { window -> JITRenderWindow? in
-            guard window.styleMask.contains(.titled) else { return nil }
-            return JITRenderWindow(
-                x: window.frame.origin.x,
-                y: window.frame.origin.y,
-                width: window.contentLayoutRect.width,
-                height: window.contentLayoutRect.height,
-                title: window.title
-            )
-        }
+        agentWindowSpecs[sessionID]
     }
 
     /// Render a JIT build in the agent and make its PNG the session's snapshot source.

--- a/Sources/PreviewsMacOS/HostApp.swift
+++ b/Sources/PreviewsMacOS/HostApp.swift
@@ -32,10 +32,17 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     /// Callback invoked after NSApplication finishes launching.
     public var onLaunch: (@MainActor () -> Void)?
 
-    /// Structural-reload strategy for the JIT path. Injected at the composition
-    /// root, non-nil only in JIT builds. When set, structural edits render in the
-    /// agent instead of rebuilding an in-daemon dylib.
-    public var structuralReloader: (any StructuralReloader)?
+    /// Makes the structural-reload strategy for the JIT path. Injected at the
+    /// composition root, non-nil only in JIT builds. Each session gets its own
+    /// reloader — its own agent process and window — so respawns, crashes, setup
+    /// state, and window lifetime stay contained to one session.
+    public var makeStructuralReloader: (@MainActor () -> any StructuralReloader)?
+    /// Per-session reloaders. Removing a session's entry releases its agent
+    /// process, which closes the agent-hosted window.
+    private var reloaders: [String: any StructuralReloader] = [:]
+    /// Window placement for sessions started on the agent surface, where no
+    /// daemon window exists to derive it from. Baked into each JIT compile.
+    private var agentWindowSpecs: [String: JITRenderWindow] = [:]
 
     /// Async sink that publishes a snapshot of macOS sessions to the
     /// cross-process registry. Set once by the engine layer at host
@@ -127,8 +134,12 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         loaders[sessionID] = loader
 
         // The window now reflects the current preview; a stale agent PNG must not
-        // shadow it in snapshot(). The next JIT reload repopulates the entry.
+        // shadow it in snapshot(), a live agent must not keep a second window, and
+        // future JIT compiles should derive placement from this window, not a
+        // stale stored spec. The next JIT reload repopulates what it needs.
         agentImagePaths.removeValue(forKey: sessionID)
+        reloaders.removeValue(forKey: sessionID)
+        agentWindowSpecs.removeValue(forKey: sessionID)
 
         // Create the view
         let rawPtr = createView()
@@ -312,30 +323,28 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         fputs("Applied \(changes.count) literal change(s) — @State preserved\n", stderr)
     }
 
-    /// Close and clean up a preview window.
+    /// Close and clean up a preview window. Dropping the session's reloader kills
+    /// its agent process, closing the agent-hosted window with it.
     public func closePreview(sessionID: String) {
-        fputs("closePreview: enter sessionID=\(sessionID)\n", stderr); fflush(stderr)
         fileWatchers[sessionID]?.stop()
         fileWatchers.removeValue(forKey: sessionID)
         sessions.removeValue(forKey: sessionID)
         agentImagePaths.removeValue(forKey: sessionID)
+        reloaders.removeValue(forKey: sessionID)
+        agentWindowSpecs.removeValue(forKey: sessionID)
         notifySessionsChanged()
-        fputs("closePreview: watchers/sessions removed\n", stderr); fflush(stderr)
 
         if let window = windows.removeValue(forKey: sessionID) {
             if let oldView = window.contentView {
                 retainedViews.append(oldView)
             }
             window.contentView = nil
-            fputs("closePreview: about to orderOut window\n", stderr); fflush(stderr)
             window.orderOut(nil)
-            fputs("closePreview: orderOut returned\n", stderr); fflush(stderr)
         }
 
         if let loader = loaders.removeValue(forKey: sessionID) {
             retainedLoaders.append(loader)
         }
-        fputs("closePreview: exit sessionID=\(sessionID)\n", stderr); fflush(stderr)
     }
 
     /// Get the session for a session ID (for reconfiguration).
@@ -363,15 +372,44 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     /// window is the interactive surface from then on.
     @discardableResult
     public func jitStructuralReload(sessionID: String, session: PreviewSession) async throws -> URL? {
-        guard structuralReloader != nil else { return nil }
+        guard makeStructuralReloader != nil else { return nil }
         let build = try await session.compileObjectForJIT(window: agentWindowSpec(for: sessionID))
         return try await jitRender(sessionID: sessionID, build: build)
     }
 
-    /// The window placement to bake into a JIT build for this session: the daemon
-    /// window's frame and title when the session is visible, nil when headless.
+    /// Start a session with the agent as its surface from the first render: no
+    /// in-daemon dylib compile, no daemon window. The requested placement becomes
+    /// the session's window spec, centered on the main screen for visible sessions.
+    public func jitStart(
+        sessionID: String, session: PreviewSession,
+        title: String, size: NSSize, headless: Bool
+    ) async throws {
+        if !headless {
+            let screen = NSScreen.main?.visibleFrame ?? .zero
+            agentWindowSpecs[sessionID] = JITRenderWindow(
+                x: screen.midX - size.width / 2,
+                y: screen.midY - size.height / 2,
+                width: size.width, height: size.height,
+                title: title)
+        }
+        try await jitStructuralReload(sessionID: sessionID, session: session)
+    }
+
+    /// The session's reloader, created on first use. One per session: each owns
+    /// its own agent process.
+    private func reloader(for sessionID: String) -> (any StructuralReloader)? {
+        if let existing = reloaders[sessionID] { return existing }
+        guard let made = makeStructuralReloader?() else { return nil }
+        reloaders[sessionID] = made
+        return made
+    }
+
+    /// The window placement to bake into a JIT build for this session: the spec
+    /// stored at agent start, else the daemon window's frame and title when the
+    /// session is visible, nil when headless.
     public func agentWindowSpec(for sessionID: String) -> JITRenderWindow? {
-        windows[sessionID].flatMap { window -> JITRenderWindow? in
+        if let spec = agentWindowSpecs[sessionID] { return spec }
+        return windows[sessionID].flatMap { window -> JITRenderWindow? in
             guard window.styleMask.contains(.titled) else { return nil }
             return JITRenderWindow(
                 x: window.frame.origin.x,
@@ -388,7 +426,7 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     /// agent's window is the interactive surface.
     @discardableResult
     public func jitRender(sessionID: String, build: JITRenderBuild) async throws -> URL {
-        guard let reloader = structuralReloader else {
+        guard let reloader = reloader(for: sessionID) else {
             throw SnapshotError.captureFailed
         }
         try await reloader.render(build)
@@ -412,7 +450,7 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         changes: [(id: String, newValue: LiteralValue)]
     ) async throws -> URL? {
         guard
-            let reloader = structuralReloader,
+            let reloader = reloader(for: sessionID),
             let build = try await session.applyLiteralValuesForJIT(changes)
         else { return nil }
         try await reloader.render(build)

--- a/Tests/PreviewsEngineTests/MacOSPreviewHandleAgentSnapshotTests.swift
+++ b/Tests/PreviewsEngineTests/MacOSPreviewHandleAgentSnapshotTests.swift
@@ -41,7 +41,7 @@ struct MacOSPreviewHandleAgentSnapshotTests {
         let compiler = try await Compiler()
         let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
         let host = PreviewHost()
-        host.structuralReloader = RecordingReloader()
+        host.makeStructuralReloader = { RecordingReloader() }
 
         let imagePath = try await host.jitStructuralReload(sessionID: "s1", session: session)
         let imageURL = try #require(imagePath)
@@ -83,7 +83,7 @@ struct MacOSPreviewHandleAgentSnapshotTests {
         let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
         let host = PreviewHost()
         let reloader = RecordingReloader()
-        host.structuralReloader = reloader
+        host.makeStructuralReloader = { reloader }
 
         _ = try await host.jitStructuralReload(sessionID: "s1", session: session)
         #expect(reloader.builds.count == 1)

--- a/Tests/PreviewsEngineTests/MacOSPreviewHandleAgentSnapshotTests.swift
+++ b/Tests/PreviewsEngineTests/MacOSPreviewHandleAgentSnapshotTests.swift
@@ -42,6 +42,7 @@ struct MacOSPreviewHandleAgentSnapshotTests {
         let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
         let host = PreviewHost()
         host.makeStructuralReloader = { RecordingReloader() }
+        host.watchFile(sessionID: "s1", session: session, filePath: sourceFile.path, compiler: compiler)
 
         let imagePath = try await host.jitStructuralReload(sessionID: "s1", session: session)
         let imageURL = try #require(imagePath)
@@ -84,6 +85,7 @@ struct MacOSPreviewHandleAgentSnapshotTests {
         let host = PreviewHost()
         let reloader = RecordingReloader()
         host.makeStructuralReloader = { reloader }
+        host.watchFile(sessionID: "s1", session: session, filePath: sourceFile.path, compiler: compiler)
 
         _ = try await host.jitStructuralReload(sessionID: "s1", session: session)
         #expect(reloader.builds.count == 1)

--- a/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
+++ b/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
@@ -42,6 +42,7 @@ struct PreviewHostJITReloadTests {
         let host = PreviewHost()
         let reloader = RecordingReloader()
         host.makeStructuralReloader = { reloader }
+        host.watchFile(sessionID: "s1", session: session, filePath: sourceFile.path, compiler: compiler)
 
         let imagePath = try await host.jitStructuralReload(sessionID: "s1", session: session)
         #expect(imagePath != nil)
@@ -75,6 +76,8 @@ struct PreviewHostJITReloadTests {
             made.append(reloader)
             return reloader
         }
+        host.watchFile(sessionID: "a", session: session, filePath: sourceFile.path, compiler: compiler)
+        host.watchFile(sessionID: "b", session: session, filePath: sourceFile.path, compiler: compiler)
 
         _ = try await host.jitStructuralReload(sessionID: "a", session: session)
         _ = try await host.jitStructuralReload(sessionID: "b", session: session)
@@ -122,6 +125,7 @@ struct PreviewHostJITReloadTests {
 
         let host = PreviewHost()
         host.makeStructuralReloader = { RecordingReloader() }
+        host.watchFile(sessionID: "s1", session: session, filePath: sourceFile.path, compiler: compiler)
 
         let stringLiteral = try #require(
             build.literals.first { if case .string = $0.value { return true } else { return false } }
@@ -181,6 +185,48 @@ struct PreviewHostJITReloadTests {
 
         host.closePreview(sessionID: "visible")
         #expect(host.agentWindowSpec(for: "visible") == nil)
+    }
+
+    @Test func closedSessionNeverGetsANewAgent() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("p34ci3f-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let sourceFile = dir.appendingPathComponent("ColorView.swift")
+        try """
+        import SwiftUI
+
+        #Preview {
+            Color.red.frame(width: 8, height: 8)
+        }
+        """.write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        let compiler = try await Compiler()
+        let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
+
+        let host = PreviewHost()
+        var madeCount = 0
+        host.makeStructuralReloader = {
+            madeCount += 1
+            return RecordingReloader()
+        }
+
+        try await host.jitStart(
+            sessionID: "s", session: session,
+            title: "t", size: NSSize(width: 8, height: 8), headless: true)
+        #expect(madeCount == 1)
+        #expect(host.allSessions["s"] != nil)
+
+        host.closePreview(sessionID: "s")
+        let build = try await session.compileObjectForJIT()
+        await #expect(throws: (any Error).self) {
+            try await host.jitRender(sessionID: "s", build: build)
+        }
+        #expect(madeCount == 1)
+        let literal = try await host.jitLiteralReload(sessionID: "s", session: session, changes: [])
+        #expect(literal == nil)
+        #expect(madeCount == 1)
     }
 
     @Test func noReloaderFallsThrough() async throws {

--- a/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
+++ b/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
@@ -41,13 +41,58 @@ struct PreviewHostJITReloadTests {
 
         let host = PreviewHost()
         let reloader = RecordingReloader()
-        host.structuralReloader = reloader
+        host.makeStructuralReloader = { reloader }
 
         let imagePath = try await host.jitStructuralReload(sessionID: "s1", session: session)
         #expect(imagePath != nil)
         #expect(host.agentSnapshotPath(for: "s1") == imagePath)
         #expect(reloader.calls.count == 1)
         #expect(reloader.calls.first?.entrySymbol == "renderPreviewToFile")
+    }
+
+    @Test func sessionsGetSeparateReloadersAndCloseReleasesThem() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("p34ci3d-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let sourceFile = dir.appendingPathComponent("ColorView.swift")
+        try """
+        import SwiftUI
+
+        #Preview {
+            Color.red.frame(width: 8, height: 8)
+        }
+        """.write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        let compiler = try await Compiler()
+        let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
+
+        let host = PreviewHost()
+        var made: [RecordingReloader] = []
+        host.makeStructuralReloader = {
+            let reloader = RecordingReloader()
+            made.append(reloader)
+            return reloader
+        }
+
+        _ = try await host.jitStructuralReload(sessionID: "a", session: session)
+        _ = try await host.jitStructuralReload(sessionID: "b", session: session)
+        #expect(made.count == 2)
+        #expect(made.first !== made.last)
+        #expect(made.first?.calls.count == 1)
+        #expect(made.last?.calls.count == 1)
+
+        _ = try await host.jitStructuralReload(sessionID: "a", session: session)
+        #expect(made.count == 2)
+        #expect(made.first?.calls.count == 2)
+
+        weak var first = made.first
+        made.removeFirst()
+        host.closePreview(sessionID: "a")
+        #expect(first == nil)
+        #expect(host.agentSnapshotPath(for: "a") == nil)
+        #expect(host.agentSnapshotPath(for: "b") != nil)
     }
 
     @Test func literalReloadRewritesValuesAndRecordsImage() async throws {
@@ -76,7 +121,7 @@ struct PreviewHostJITReloadTests {
         let build = try await session.compileObjectForJIT()
 
         let host = PreviewHost()
-        host.structuralReloader = RecordingReloader()
+        host.makeStructuralReloader = { RecordingReloader() }
 
         let stringLiteral = try #require(
             build.literals.first { if case .string = $0.value { return true } else { return false } }
@@ -94,6 +139,48 @@ struct PreviewHostJITReloadTests {
             JSONSerialization.jsonObject(with: Data(contentsOf: build.valuesPath)) as? [String: Any]
         )
         #expect((values[stringLiteral.id] as? String) == "world")
+    }
+
+    @Test func jitStartBakesRequestedSpecWithoutDaemonWindow() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("p34ci3e-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let sourceFile = dir.appendingPathComponent("ColorView.swift")
+        try """
+        import SwiftUI
+
+        #Preview {
+            Color.red.frame(width: 8, height: 8)
+        }
+        """.write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        let compiler = try await Compiler()
+        let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
+
+        let host = PreviewHost()
+        host.makeStructuralReloader = { RecordingReloader() }
+
+        try await host.jitStart(
+            sessionID: "visible", session: session,
+            title: "Preview: ColorView.swift",
+            size: NSSize(width: 320, height: 240), headless: false)
+        #expect(host.window(for: "visible") == nil)
+        #expect(host.agentSnapshotPath(for: "visible") != nil)
+        let spec = try #require(host.agentWindowSpec(for: "visible"))
+        #expect(spec.title == "Preview: ColorView.swift")
+        #expect(spec.width == 320)
+        #expect(spec.height == 240)
+
+        try await host.jitStart(
+            sessionID: "hidden", session: session,
+            title: "ignored", size: NSSize(width: 320, height: 240), headless: true)
+        #expect(host.agentWindowSpec(for: "hidden") == nil)
+        #expect(host.agentSnapshotPath(for: "hidden") != nil)
+
+        host.closePreview(sessionID: "visible")
+        #expect(host.agentWindowSpec(for: "visible") == nil)
     }
 
     @Test func noReloaderFallsThrough() async throws {

--- a/docs/jit-executor-phase3-plan.md
+++ b/docs/jit-executor-phase3-plan.md
@@ -980,3 +980,26 @@ non-leaf respawn/double-compile/sticky-latch), agent render size from
 session size (400x600 is baked today), content-based test assertions, dylib
 fallback decision, iOS JIT design, local merge queue (no GH issue exists
 yet; user may want one).
+
+## Update 2026-06-10 (2): start through the agent, one agent per session
+
+Consolidation step (1) landed: `startMacOSPreview` no longer compiles a
+dylib for JIT builds. `PreviewHost.jitStart` stores the requested
+title/size as the session's `JITRenderWindow` spec (centered on the main
+screen, nil for headless) and the agent window is the session surface from
+the first render. The chosen multi-session topology is **one agent per
+session**: `makeStructuralReloader` replaces the host-level reloader, each
+session lazily gets its own `JITStructuralReloader` (own agent process,
+own window, own `didRunSetUp`/`lastObjectPath`), and `closePreview` drops
+the reloader, killing the agent and closing its window. That resolves all
+four #197 items; #195 (frame handover across respawns) remains.
+
+Verified live: two concurrent sessions render distinct content in two
+agent processes, stopping one closes only its window. Cost moved, not
+added: the stable-module bulk compile that start used to pay now lands on
+the first non-leaf edit (~20s on the SPM example), which sharpens the
+existing latency roadmap item.
+
+**Next:** retire the dylib machinery for JIT builds (loaders, dlsym
+literal setters, `agentImagePaths` dance, the `loadPreview` fallback in
+`watchFile`), then the broader roadmap above.


### PR DESCRIPTION
## Summary
- Sessions on JIT builds start through the agent: no `compileCombined` dylib at start, no daemon window. The requested title/size become the session's window spec (centered, nil when headless) and the agent window is the interactive surface from render 1.
- Multi-session topology (#197 decision): **one agent per session**. `PreviewHost.makeStructuralReloader` replaces the shared host-level reloader; each session lazily creates its own `JITStructuralReloader`, so agent respawns, crashes, `previewSetUp` state, and the literal fast path are contained per session.
- `closePreview` drops the session's reloader, which kills its agent process and closes its window.

Fixes #197 (all four items: shared window identity, zombie window on stop, per-process `didRunSetUp`, shared `lastObjectPath`). #195 (frame handover across respawns) remains open, now scoped to a single session.

Note: the stable-module bulk compile that start used to pay now lands on the first non-leaf edit (~20s on the SPM example). Tracked under the existing latency roadmap item.

## Verification
- Units 355/355, JIT suite 55/55 (serial), MCP macOS 16/16, CLI command suites 68/68 (serial).
- integration-test skill, macOS scope, all four examples: render, literal + cross-file hot reload, switch with rollback, configure merge semantics, trait persistence, PreviewProvider.
- Live daemon: two concurrent sessions render distinct content in two agent processes; stopping one closes only its window; no preview windows remain after the last stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)