### PR TITLE
JIT: retire dylib machinery routing — agent-backed is per-build, not per-session

### DIFF
--- a/Sources/PreviewsCLI/Handlers/PreviewStartHandler.swift
+++ b/Sources/PreviewsCLI/Handlers/PreviewStartHandler.swift
@@ -402,26 +402,23 @@ private func startMacOSPreview(
 
     let sessionID = session.id
 
-    let agentBacked = await MainActor.run { host.makeStructuralReloader != nil }
-    if agentBacked {
-        try await host.jitStart(
-            sessionID: sessionID, session: session,
-            title: title, size: NSSize(width: width, height: height),
-            headless: headless
+    #if PREVIEWSMCP_JIT
+    try await host.jitStart(
+        sessionID: sessionID, session: session,
+        title: title, size: NSSize(width: width, height: height),
+        headless: headless
+    )
+    await MainActor.run {
+        host.watchFile(
+            sessionID: sessionID,
+            session: session,
+            filePath: fileURL.path,
+            compiler: compiler,
+            additionalPaths: buildContext?.sourceFiles?.map(\.path) ?? [],
+            buildContext: buildContext
         )
-        await MainActor.run {
-            host.watchFile(
-                sessionID: sessionID,
-                session: session,
-                filePath: fileURL.path,
-                compiler: compiler,
-                additionalPaths: buildContext?.sourceFiles?.map(\.path) ?? [],
-                buildContext: buildContext
-            )
-        }
-        return sessionID
     }
-
+    #else
     let compileResult = try await session.compile()
     let setupDylibPath = setupResult?.dylibPath
 
@@ -447,6 +444,7 @@ private func startMacOSPreview(
             Log.error("MCP: Failed to load preview: \(error)")
         }
     }
+    #endif
 
     return sessionID
 }

--- a/Sources/PreviewsEngine/MacOSPreviewHandle.swift
+++ b/Sources/PreviewsEngine/MacOSPreviewHandle.swift
@@ -56,9 +56,9 @@ public actor MacOSPreviewHandle: PreviewSessionHandle {
             dylib: { try await self.session.switchPreview(to: index) })
     }
 
-    /// The single routing seam for every mutating reload. An agent-backed session (JIT
-    /// reloader present and an agent render recorded) re-renders in the agent; reloading a
-    /// dylib into the daemon window instead would resurrect it as a second, stale surface.
+    /// The single routing seam for every mutating reload. In a JIT build every
+    /// session re-renders in its agent; in a non-JIT build every session reloads
+    /// a dylib into its daemon window. The split is per-build, never per-session.
     private func reload(
         jit: (JITRenderWindow?) async throws -> JITRenderBuild,
         dylib: () async throws -> CompileResult
@@ -68,7 +68,7 @@ public actor MacOSPreviewHandle: PreviewSessionHandle {
             case daemonWindow
         }
         let surface: Surface = await MainActor.run {
-            guard host.agentSnapshotPath(for: id) != nil else {
+            guard host.agentBacked else {
                 return .daemonWindow
             }
             return .agent(host.agentWindowSpec(for: id))
@@ -89,7 +89,10 @@ public actor MacOSPreviewHandle: PreviewSessionHandle {
         let format: Snapshot.ImageFormat = quality >= 1.0 ? .png : .jpeg(quality: quality)
         let sessionID = id
         return try await MainActor.run {
-            if let imagePath = host.agentSnapshotPath(for: sessionID) {
+            if host.agentBacked {
+                guard let imagePath = host.agentSnapshotPath(for: sessionID) else {
+                    throw SnapshotError.captureFailed
+                }
                 return try Snapshot.encode(imageAt: imagePath, format: format)
             }
             guard let window = host.window(for: sessionID) else {

--- a/Sources/PreviewsMacOS/HostApp.swift
+++ b/Sources/PreviewsMacOS/HostApp.swift
@@ -37,6 +37,10 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     /// reloader — its own agent process and window — so respawns, crashes, setup
     /// state, and window lifetime stay contained to one session.
     public var makeStructuralReloader: (@MainActor () -> any StructuralReloader)?
+    /// Whether sessions render in agent processes. In a JIT build every macOS
+    /// session is agent-backed from its first render until close; in a non-JIT
+    /// build none ever is, so routing is per-build, not per-session.
+    public var agentBacked: Bool { makeStructuralReloader != nil }
     /// Per-session reloaders. Removing a session's entry releases its agent
     /// process, which closes the agent-hosted window.
     private var reloaders: [String: any StructuralReloader] = [:]
@@ -133,14 +137,6 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         }
         loaders[sessionID] = loader
 
-        // The window now reflects the current preview; a stale agent PNG must not
-        // shadow it in snapshot(), a live agent must not keep a second window, and
-        // a dylib-backed session has no agent placement. The next JIT reload
-        // repopulates what it needs.
-        agentImagePaths.removeValue(forKey: sessionID)
-        reloaders.removeValue(forKey: sessionID)
-        agentWindowSpecs.removeValue(forKey: sessionID)
-
         // Create the view
         let rawPtr = createView()
         let hostingView = Unmanaged<NSView>.fromOpaque(rawPtr).takeRetainedValue()
@@ -207,9 +203,7 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
                 // Fast path: try literal-only update. An agent-backed session re-renders
                 // in the agent (rewrite the design-time values JSON, re-run the same
                 // object — no recompile); otherwise the in-daemon DesignTimeStore path.
-                let agentBacked = await MainActor.run {
-                    self.agentSnapshotPath(for: sessionID) != nil
-                }
+                let agentBacked = await MainActor.run { self.agentBacked }
                 if let currentSession = await MainActor.run(body: { self.sessions[sessionID] }),
                     let changes = await currentSession.tryLiteralUpdate(newSource: newSource),
                     !changes.isEmpty
@@ -366,13 +360,12 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     /// object, render it in the agent, and record the agent's PNG for snapshots.
     /// Returns the image path, or nil if no reloader is injected (non-JIT build).
     ///
-    /// For a visible session the daemon's window frame and title are baked into the
-    /// bridge so the agent shows its own live window there, and the daemon's dylib
-    /// window is ordered out after the first successful agent render — the agent
-    /// window is the interactive surface from then on.
+    /// For a visible session the session's window spec is baked into the bridge
+    /// so the agent shows its own live window there — the agent window is the
+    /// session's interactive surface.
     @discardableResult
     public func jitStructuralReload(sessionID: String, session: PreviewSession) async throws -> URL? {
-        guard makeStructuralReloader != nil else { return nil }
+        guard agentBacked else { return nil }
         let build = try await session.compileObjectForJIT(window: agentWindowSpec(for: sessionID))
         return try await jitRender(sessionID: sessionID, build: build)
     }
@@ -420,8 +413,6 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     }
 
     /// Render a JIT build in the agent and make its PNG the session's snapshot source.
-    /// The daemon's dylib window is ordered out — once a session is agent-backed, the
-    /// agent's window is the interactive surface.
     @discardableResult
     public func jitRender(sessionID: String, build: JITRenderBuild) async throws -> URL {
         guard let reloader = reloader(for: sessionID) else {
@@ -429,7 +420,6 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         }
         try await reloader.render(build)
         agentImagePaths[sessionID] = build.imagePath
-        windows[sessionID]?.orderOut(nil)
         return build.imagePath
     }
 

--- a/docs/jit-executor-phase3-plan.md
+++ b/docs/jit-executor-phase3-plan.md
@@ -1018,3 +1018,34 @@ literal setters, `agentImagePaths` dance, the `loadPreview` fallback in
 owns the first-non-leaf-edit ~20s (respawn + bulk compile + sticky
 `bulkIsNonLeaf` latch; candidate fix: warm the stable module in the
 background right after start).
+
+## Update 2026-06-10 (3): dylib machinery retired for JIT builds (routing)
+
+Consolidation step (2) landed as the routing retirement chosen with the
+user (over spreading `#if PREVIEWSMCP_JIT` beyond the composition root or
+an injection refactor): since #198 a session never switches surface
+mid-life, so "agent-backed" is a property of the build, not the session.
+`PreviewHost.agentBacked` (`makeStructuralReloader != nil`) now routes
+`watchFile`'s literal path, `MacOSPreviewHandle.reload`, and `snapshot`;
+the per-session `agentImagePaths` presence check is no longer a routing
+signal and the map is purely the snapshot source. `startMacOSPreview`'s
+dylib branch is compile-time gated behind the existing `#if` in
+PreviewsCLI. Cross-path hygiene that can no longer fire is gone: the
+agent-state clearing in `loadPreview` and the daemon-window `orderOut` in
+`jitRender`.
+
+The dylib machinery itself (`loadPreview`, `loaders`, dlsym literal
+setters, `DylibLoader`, `PreviewSession.compile/setTraits/reconfigure/
+switchPreview`) stays compiled: it is the live path for non-JIT builds
+(no `third_party`) until the dylib fallback decision later in the
+roadmap, at which point it deletes cleanly — no call site routes to it
+in a JIT build any more. Verified non-JIT still compiles by forcing
+`jitEnabled = false` in the manifest (note: removing the `third_party`
+symlink is NOT enough — the content-hash-cached manifest bakes in
+`#filePath` from the main checkout, where `third_party` exists).
+
+**Next:** latency (<200ms), which owns the first-non-leaf-edit ~20s
+(respawn + bulk compile + sticky `bulkIsNonLeaf` latch; candidate fix:
+warm the stable module in the background right after start). Then #195,
+session-sized agent renders, content-based assertions, dylib fallback
+decision, iOS JIT.


### PR DESCRIPTION
## Summary

Next roadmap step after #198 (plan doc "Update 2026-06-10 (2)"): retire the dylib machinery for JIT builds. Approach chosen with the user: retire the **routing**, keep the machinery compiled for non-JIT builds until the dylib fallback decision.

Since #198 a macOS session never switches between the dylib and agent surfaces mid-life, so "agent-backed" is a property of the build, not the session:

- `PreviewHost.agentBacked` (`makeStructuralReloader != nil`) now routes `watchFile`'s literal path, `MacOSPreviewHandle.reload`, and `snapshot`. `agentImagePaths` presence is no longer a routing signal — the map is purely the snapshot source.
- `startMacOSPreview`'s dylib branch is compile-time gated behind the existing `#if PREVIEWSMCP_JIT` in PreviewsCLI (the one target that already has the define).
- Cross-path hygiene that can no longer fire is removed: agent-state clearing in `loadPreview`, daemon-window `orderOut` in `jitRender`.
- Plan doc updated with "Update 2026-06-10 (3)".

The dylib path itself (`loadPreview`, `loaders`, dlsym setters, `DylibLoader`, `PreviewSession.compile/setTraits/...`) stays: it is the live path for non-JIT builds. After this PR no call site routes to it in a JIT build, so it deletes cleanly when the dylib fallback decision lands.

## Verification

- Units: 356 passed. JIT: 55 serial. MCP: 16 serial. CLI: 68 serial.
- Integration skill, macOS scope, all four examples via CLI with the worktree binary: render + literal hot reload on spm/bazel/xcodeproj/xcworkspace; structural reload, preview switch + invalid-switch rollback, dark-mode configure with trait persistence across switch on spm. Daemon log free of reload failures.
- Non-JIT configuration compiles: verified by forcing `jitEnabled = false` in the manifest in a separate scratch path (removing the `third_party` symlink is not enough — the content-hash-cached manifest bakes in `#filePath` from the main checkout).
- Verified by code reading only: the snapshot `captureFailed` throw for an agent-backed session with no recorded render (unreachable today — `jitStart` tears down on a failed first render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)