### PR TITLE
JIT: fix MachOPlatform bootstrap data race behind the JITLink crash class

### DIFF
--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -11,6 +11,13 @@ struct PreviewsJITLinkTests {
         #expect(result == 42)
     }
 
+    @Test(.timeLimit(.minutes(5))) func survivesRepeatedRemoteSessionBootstrap() throws {
+        let agentPath = try JITSession.bundledAgentPath()
+        for _ in 0..<40 {
+            _ = try JITSession(remoteAgentPath: agentPath)
+        }
+    }
+
     @Test func linksCObjectRemotely() throws {
         let object = try FixtureSupport.compile("answer.c")
         let session = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())

--- a/docs/jit-executor-phase3-plan.md
+++ b/docs/jit-executor-phase3-plan.md
@@ -1049,3 +1049,67 @@ symlink is NOT enough — the content-hash-cached manifest bakes in
 warm the stable module in the background right after start). Then #195,
 session-sized agent renders, content-based assertions, dylib fallback
 decision, iOS JIT.
+
+## Update 2026-06-12 (crash-fix branch): JITLink crash class root-caused and fixed
+
+The crash class that gated PR #201 (daemon SIGABRT "pointer being freed
+was not allocated" in `MachOPlatformPlugin::addSymbolTableRegistration`
+→ `SmallVectorBase::grow_pod` → realloc during linkPhase3; agent SIGSEGV
+`strlen(NULL)` in `runFinalizeActions` under `previewsmcp_anon_initialize`)
+is a data race in the vendored LLVM (swift-6.2.3-RELEASE), fixed upstream
+after our pin.
+
+Root cause: during `MachOPlatform` bootstrap, the orc_rt archive members
+link concurrently (DynamicThreadPoolTaskDispatcher). Two passes push into
+SHARED `BootstrapInfo` vectors with no lock held:
+`addSymbolTableRegistration` → `Bootstrap->SymTab`, and
+`registerObjectPlatformSections` → `Bootstrap->DeferredAAs`
+(`Bootstrap->Mutex` only guarded the `ActiveGraphs` counter). Racing
+`SmallVector` growth double-frees the old heap block — corrupting the
+daemon heap (realloc abort, sometimes later/elsewhere) — and can tear the
+symbol-table entries that the complete-bootstrap graph later ships to the
+agent as finalize actions, where the JIT'd orc_rt register function
+strlen()s a garbage name address: BOTH crash signatures, one race. All
+four daemon .ips show a second link thread plus a MachOPlatform
+constructor parked on the bootstrap CV; every session create runs one
+bootstrap, which is why only multi-session full-suite load fired it.
+Upstream fixed the same race in llvm.org main (locks around both pushes,
+later consolidated onto PlatformMutex: 30b73ed7, e8cc4d24, e2f86b55).
+
+Fix: backport in `scripts/patches/llvm-machoplatform-bootstrap-race.patch`
+(applied idempotently by `scripts/build-jit-llvm.sh`): take
+`Bootstrap->Mutex` around the bootstrap-phase `SymTab` push in
+`addSymbolTableRegistration` and the `DeferredAAs` push in
+`registerObjectPlatformSections` (the non-bootstrap paths are untouched;
+no lock nesting — `PlatformMutex` scopes close before `Bootstrap->Mutex`
+is taken). Rebuild: `ninja -C third_party/llvm-build LLVM` (incremental).
+
+Red-green: new `survivesRepeatedRemoteSessionBootstrap` stress (40 remote
+session creates = 40 bootstraps, no objects added) crashed on unfixed
+libLLVM in run 3 of 15 with the EXACT production signature (grow_pod
+realloc abort inside addSymbolTableRegistration, .ips
+swiftpm-testing-helper-2026-06-12-134114). After the rebuild: 15 of 15
+stress runs clean (600 bootstraps) and 5 of 5 full CLI suite runs clean
+with zero new DiagnosticReports, against the pre-fix 4-failures-in-~10
+full-suite rate (4 of 7 on 2026-06-11).
+
+Audit fallout (separate latent defects, NOT the firing class — queued as
+next work, not silently parked):
+- `MapperJITLinkMemoryManager::InFlightAlloc::abandon` passes a
+  SUBALLOCATION base to `MemoryMapper::release`, which expects
+  reservation bases (ours and LLVM's own mappers key reservations by
+  exact base). A failed link whose alloc was first-in-slab frees the
+  whole slab while `AvailableMemory` still hands out ranges in it →
+  daemon-side wild writes / agent-side unmapped writes on the NEXT link
+  in that session. Needs a red repro (failed link then successful link,
+  same session).
+- `PreviewsAnonymousMapper.prepare/initialize` do unchecked
+  `workingBuf + (addr - base)` arithmetic; out-of-reservation addresses
+  (as produced by the abandon bug) write wild into daemon heap. Cheap
+  bounds checks would turn silent corruption into a loud error.
+- Agent `previewsmcp_anon_initialize` DROPS the dealloc actions returned
+  by `runFinalizeActions`, and `previewsmcp_anon_deinitialize` is a no-op
+  (LLVM's mappers run dealloc actions and restore RW protections there).
+  Today nothing deallocates mid-session so it is latent; it bites the
+  moment generations are torn down for real (orc_rt deregistration never
+  runs, reused pages stay R-X).

--- a/scripts/build-jit-llvm.sh
+++ b/scripts/build-jit-llvm.sh
@@ -42,6 +42,17 @@ if [ "$GOT" != "$LLVM_SHA" ]; then
 fi
 echo "==> source pinned at $LLVM_SHA"
 
+# 1b. Local patches on top of the pinned tag (idempotent).
+for PATCH in "$ROOT"/scripts/patches/llvm-*.patch; do
+  [ -e "$PATCH" ] || continue
+  if git -C "$SRC" apply --reverse --check "$PATCH" 2>/dev/null; then
+    echo "==> patch already applied: $(basename "$PATCH")"
+  else
+    echo "==> applying patch: $(basename "$PATCH")"
+    git -C "$SRC" apply "$PATCH"
+  fi
+done
+
 BUILD_RT="$ROOT/third_party/llvm-build-rt"
 CLANG="$(xcrun -f clang)"
 CLANGXX="$(xcrun -f clang++)"

--- a/scripts/patches/llvm-machoplatform-bootstrap-race.patch
+++ b/scripts/patches/llvm-machoplatform-bootstrap-race.patch
@@ -1,0 +1,91 @@
+diff --git a/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp b/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
+index 0d117f7cf..ef89f51ee 100644
+--- a/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
++++ b/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
+@@ -1399,10 +1399,6 @@ Error MachOPlatform::MachOPlatformPlugin::registerObjectPlatformSections(
+                              SPSExecutorAddrRange, SPSExecutorAddrRange>>,
+         SPSSequence<SPSTuple<SPSString, SPSExecutorAddrRange>>>;
+ 
+-    shared::AllocActions &allocActions = LLVM_LIKELY(!InBootstrapPhase)
+-                                             ? G.allocActions()
+-                                             : MP.Bootstrap.load()->DeferredAAs;
+-
+     ExecutorAddr HeaderAddr;
+     {
+       std::lock_guard<std::mutex> Lock(MP.PlatformMutex);
+@@ -1412,15 +1408,24 @@ Error MachOPlatform::MachOPlatformPlugin::registerObjectPlatformSections(
+       assert(I->second && "Null header registered for JD");
+       HeaderAddr = I->second;
+     }
+-    allocActions.push_back(
+-        {cantFail(
+-             WrapperFunctionCall::Create<SPSRegisterObjectPlatformSectionsArgs>(
+-                 MP.RegisterObjectPlatformSections.Addr, HeaderAddr, UnwindInfo,
+-                 MachOPlatformSecs)),
+-         cantFail(
+-             WrapperFunctionCall::Create<SPSRegisterObjectPlatformSectionsArgs>(
+-                 MP.DeregisterObjectPlatformSections.Addr, HeaderAddr,
+-                 UnwindInfo, MachOPlatformSecs))});
++    shared::AllocActionCallPair RegistrationActions = {
++        cantFail(
++            WrapperFunctionCall::Create<SPSRegisterObjectPlatformSectionsArgs>(
++                MP.RegisterObjectPlatformSections.Addr, HeaderAddr, UnwindInfo,
++                MachOPlatformSecs)),
++        cantFail(
++            WrapperFunctionCall::Create<SPSRegisterObjectPlatformSectionsArgs>(
++                MP.DeregisterObjectPlatformSections.Addr, HeaderAddr,
++                UnwindInfo, MachOPlatformSecs))};
++    if (LLVM_UNLIKELY(InBootstrapPhase)) {
++      // Multiple bootstrap graphs may link concurrently: guard the shared
++      // DeferredAAs vector. (Backport of llvm.org concurrency fixes, see
++      // e2f86b55 / 30b73ed7.)
++      std::lock_guard<std::mutex> Lock(MP.Bootstrap.load()->Mutex);
++      MP.Bootstrap.load()->DeferredAAs.push_back(std::move(RegistrationActions));
++    } else {
++      G.allocActions().push_back(std::move(RegistrationActions));
++    }
+   }
+ 
+   return Error::success();
+@@ -1698,25 +1703,30 @@ Error MachOPlatform::MachOPlatformPlugin::addSymbolTableRegistration(
+   }
+ 
+   SymbolTableVector LocalSymTab;
+-  auto &SymTab = LLVM_LIKELY(!InBootstrapPhase) ? LocalSymTab
+-                                                : MP.Bootstrap.load()->SymTab;
+-  for (auto &[OriginalSymbol, NameSym] : JITSymTabInfo)
+-    SymTab.push_back({NameSym->getAddress(), OriginalSymbol->getAddress(),
+-                      flagsForSymbol(*OriginalSymbol)});
++  {
++    // In the bootstrap phase SymTab points at the shared bootstrap symbol
++    // table, and multiple bootstrap graphs may link concurrently: guard it.
++    // (Backport of llvm.org concurrency fixes, see e2f86b55 / 30b73ed7.)
++    std::unique_lock<std::mutex> Lock;
++    if (LLVM_UNLIKELY(InBootstrapPhase))
++      Lock = std::unique_lock<std::mutex>(MP.Bootstrap.load()->Mutex);
++    auto &SymTab = LLVM_LIKELY(!InBootstrapPhase) ? LocalSymTab
++                                                  : MP.Bootstrap.load()->SymTab;
++    for (auto &[OriginalSymbol, NameSym] : JITSymTabInfo)
++      SymTab.push_back({NameSym->getAddress(), OriginalSymbol->getAddress(),
++                        flagsForSymbol(*OriginalSymbol)});
++  }
+ 
+   // Bail out if we're in the bootstrap phase -- registration of thees symbols
+   // will be attached to the bootstrap graph.
+   if (LLVM_UNLIKELY(InBootstrapPhase))
+     return Error::success();
+ 
+-  shared::AllocActions &allocActions = LLVM_LIKELY(!InBootstrapPhase)
+-                                           ? G.allocActions()
+-                                           : MP.Bootstrap.load()->DeferredAAs;
+-  allocActions.push_back(
++  G.allocActions().push_back(
+       {cantFail(WrapperFunctionCall::Create<SPSRegisterSymbolsArgs>(
+-           MP.RegisterObjectSymbolTable.Addr, HeaderAddr, SymTab)),
++           MP.RegisterObjectSymbolTable.Addr, HeaderAddr, LocalSymTab)),
+        cantFail(WrapperFunctionCall::Create<SPSRegisterSymbolsArgs>(
+-           MP.DeregisterObjectSymbolTable.Addr, HeaderAddr, SymTab))});
++           MP.DeregisterObjectSymbolTable.Addr, HeaderAddr, LocalSymTab))});
+ 
+   return Error::success();
+ }


### PR DESCRIPTION
## Root cause

The crash class that gates #201 — daemon SIGABRT `pointer being freed was not allocated` in `MachOPlatformPlugin::addSymbolTableRegistration` → `SmallVectorBase::grow_pod` → realloc (linkPhase3), and agent SIGSEGV `strlen(NULL)` in `runFinalizeActions` under `previewsmcp_anon_initialize` — is a data race in the vendored LLVM (swift-6.2.3-RELEASE), fixed upstream after our pin.

During `MachOPlatform` bootstrap the orc_rt archive members link concurrently. Two plugin passes push into shared `BootstrapInfo` vectors with no lock held: `addSymbolTableRegistration` → `Bootstrap->SymTab` and `registerObjectPlatformSections` → `Bootstrap->DeferredAAs` (`Bootstrap->Mutex` only guarded the `ActiveGraphs` counter). Racing `SmallVector` growth double-frees the old block, corrupting the daemon heap, and tears the symbol-table entries the complete-bootstrap graph later ships to the agent as finalize actions, where JIT'd orc_rt `strlen()`s a garbage name address. One race, both crash signatures. Every session create runs one bootstrap, which is why only multi-session full-suite load fired it. All four daemon `.ips` show a second link thread plus a `MachOPlatform` constructor parked on the bootstrap CV.

Upstream fixed the same race on llvm.org main (locks around both pushes, later consolidated onto `PlatformMutex`: 30b73ed7, e8cc4d24, e2f86b55).

## Fix

`scripts/patches/llvm-machoplatform-bootstrap-race.patch`, applied idempotently by `scripts/build-jit-llvm.sh`: take `Bootstrap->Mutex` around the bootstrap-phase `SymTab` push and the `DeferredAAs` push. Non-bootstrap paths untouched, no lock nesting. Rebuild is incremental: `ninja -C third_party/llvm-build LLVM`. Note: `third_party` is shared across worktrees, so the rebuilt dylib fixes #201's binaries too (it links libLLVM at runtime).

## Verification (red-green)

- New `survivesRepeatedRemoteSessionBootstrap` stress: 40 remote session creates (= 40 bootstraps, no objects ever linked). On UNFIXED libLLVM it crashed on run 3 of 15 with the exact production signature (`grow_pod` realloc abort inside `addSymbolTableRegistration`, `.ips` swiftpm-testing-helper-2026-06-12-134114).
- On fixed libLLVM: 15/15 stress runs clean (600 bootstraps), 5/5 full CLI suite runs clean (`--filter CLIIntegrationTests --skip IOSCLIWorkflowTests --no-parallel`), zero new DiagnosticReports. Pre-fix rate was 4 failures in ~10 full-suite runs (4 of 7 on 2026-06-11).
- Bar: units 356, JIT 56, MCP 18 all green.

## Audit fallout (queued as next work, documented in the plan doc)

The bridge audit also found latent defects that are NOT the firing class: `InFlightAlloc::abandon` passes suballocation bases to `MemoryMapper::release` (slab poisoning after a failed link), `PreviewsAnonymousMapper.prepare/initialize` lack bounds checks, and the agent drops dealloc actions / never restores RW protections in `anon_deinitialize`. Detailed in the plan-doc update; each needs its own red repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)