### PR TITLE
JIT: fix mapper-glue memory defects found in the crash-class audit

### DIFF
--- a/Sources/PreviewAgent/main.cpp
+++ b/Sources/PreviewAgent/main.cpp
@@ -93,8 +93,14 @@ CWrapperFunctionResult previewsmcp_run_on_main(const char *ArgData,
       .release();
 }
 
+struct AnonAllocation {
+  size_t Size;
+  std::vector<WrapperFunctionCall> DeallocActions;
+};
+
 std::mutex AnonMapperMutex;
 std::map<void *, size_t> AnonReservations;
+std::map<llvm::orc::ExecutorAddr, AnonAllocation> AnonAllocations;
 
 CWrapperFunctionResult previewsmcp_anon_reserve(const char *ArgData,
                                                 size_t ArgSize) {
@@ -121,8 +127,11 @@ CWrapperFunctionResult previewsmcp_anon_initialize(const char *ArgData,
       handle(ArgData, ArgSize,
              [](FinalizeRequest FR) -> Expected<llvm::orc::ExecutorAddr> {
                llvm::orc::ExecutorAddr Base(~0ULL);
-               for (auto &Seg : FR.Segments)
+               llvm::orc::ExecutorAddr End(0);
+               for (auto &Seg : FR.Segments) {
                  Base = std::min(Base, Seg.Addr);
+                 End = std::max(End, Seg.Addr + Seg.Size);
+               }
                for (auto &Seg : FR.Segments) {
                  char *Mem = Seg.Addr.toPtr<char *>();
                  if (!Seg.Content.empty())
@@ -139,6 +148,8 @@ CWrapperFunctionResult previewsmcp_anon_initialize(const char *ArgData,
                auto Dealloc = runFinalizeActions(FR.Actions);
                if (!Dealloc)
                  return Dealloc.takeError();
+               std::lock_guard<std::mutex> Lock(AnonMapperMutex);
+               AnonAllocations[Base] = {End - Base, std::move(*Dealloc)};
                return Base;
              })
           .release();
@@ -148,8 +159,22 @@ CWrapperFunctionResult previewsmcp_anon_deinitialize(const char *ArgData,
                                                      size_t ArgSize) {
   return WrapperFunction<SPSError(SPSSequence<SPSExecutorAddr>)>::handle(
              ArgData, ArgSize,
-             [](std::vector<llvm::orc::ExecutorAddr>) -> Error {
-               return Error::success();
+             [](std::vector<llvm::orc::ExecutorAddr> Bases) -> Error {
+               Error Err = Error::success();
+               std::lock_guard<std::mutex> Lock(AnonMapperMutex);
+               for (auto B : llvm::reverse(Bases)) {
+                 auto I = AnonAllocations.find(B);
+                 if (I == AnonAllocations.end())
+                   continue;
+                 if (auto E = runDeallocActions(I->second.DeallocActions))
+                   Err = joinErrors(std::move(Err), std::move(E));
+                 sys::MemoryBlock MB(B.toPtr<void *>(), I->second.Size);
+                 if (auto EC = sys::Memory::protectMappedMemory(
+                         MB, sys::Memory::MF_READ | sys::Memory::MF_WRITE))
+                   Err = joinErrors(std::move(Err), errorCodeToError(EC));
+                 AnonAllocations.erase(I);
+               }
+               return Err;
              })
       .release();
 }

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -110,6 +110,9 @@ public:
       return nullptr;
     }
     --r;
+    if (addr + contentSize > r->first + r->second.size) {
+      return nullptr;
+    }
     return r->second.workingBuf + (addr - r->first);
   }
 
@@ -126,6 +129,15 @@ public:
             "initialize: no reservation covers mapping base"));
       }
       --r;
+      auto resEnd = r->first + r->second.size;
+      for (auto &seg : ai.Segments) {
+        if (ai.MappingBase + seg.Offset + seg.ContentSize + seg.ZeroFillSize >
+            resEnd) {
+          return onInitialized(llvm::createStringError(
+              llvm::inconvertibleErrorCode(),
+              "initialize: segment extends past reservation"));
+        }
+      }
       base = r->second.workingBuf + (ai.MappingBase - r->first);
     }
     fr.Segments.reserve(ai.Segments.size());

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -5,6 +5,7 @@
 #include <crt_externs.h>
 #include <csignal>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
@@ -106,11 +107,16 @@ public:
   char *prepare(llvm::orc::ExecutorAddr addr, size_t contentSize) override {
     std::lock_guard<std::mutex> lock(mutex);
     auto r = reservations.upper_bound(addr);
-    if (r == reservations.begin()) {
-      return nullptr;
+    bool covered = r != reservations.begin();
+    if (covered) {
+      --r;
+      covered = addr + contentSize <= r->first + r->second.size;
     }
-    --r;
-    if (addr + contentSize > r->first + r->second.size) {
+    if (!covered) {
+      fprintf(stderr,
+              "PreviewsAnonymousMapper::prepare: no reservation covers "
+              "[0x%llx, +%zu)\n",
+              addr.getValue(), contentSize);
       return nullptr;
     }
     return r->second.workingBuf + (addr - r->first);

--- a/Tests/PreviewsJITLinkTests/Fixtures/abandon_drain.c
+++ b/Tests/PreviewsJITLinkTests/Fixtures/abandon_drain.c
@@ -1,0 +1,10 @@
+#include <stdint.h>
+
+extern int32_t previewsmcp_absent_symbol(void);
+
+static char drain_bss[900u << 20];
+
+int32_t abandon_drain_entry(void) {
+  drain_bss[0] = 1;
+  return previewsmcp_absent_symbol() + drain_bss[0];
+}

--- a/Tests/PreviewsJITLinkTests/Fixtures/abandon_probe.c
+++ b/Tests/PreviewsJITLinkTests/Fixtures/abandon_probe.c
@@ -1,0 +1,8 @@
+#include <stdint.h>
+
+static char probe_bss[300u << 20];
+
+int32_t abandon_probe_value(void) {
+  probe_bss[0] = 42;
+  return probe_bss[0];
+}

--- a/Tests/PreviewsJITLinkTests/Fixtures/abandon_slab.c
+++ b/Tests/PreviewsJITLinkTests/Fixtures/abandon_slab.c
@@ -1,0 +1,10 @@
+#include <stdint.h>
+
+extern int32_t previewsmcp_absent_symbol(void);
+
+static char slab_bss[200u << 20];
+
+int32_t abandon_slab_entry(void) {
+  slab_bss[0] = 1;
+  return previewsmcp_absent_symbol() + slab_bss[0];
+}

--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -18,6 +18,23 @@ struct PreviewsJITLinkTests {
         }
     }
 
+    @Test(.timeLimit(.minutes(5))) func reusesMemoryAfterAbandonedLinksRemotely() throws {
+        let drain = try FixtureSupport.compile("abandon_drain.c")
+        let slab = try FixtureSupport.compile("abandon_slab.c")
+        let probe = try FixtureSupport.compile("abandon_probe.c")
+        let session = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
+        try session.addObject(path: drain.path)
+        #expect(throws: JITLinkError.self) {
+            try session.runMain(symbol: "abandon_drain_entry")
+        }
+        try session.addObject(path: slab.path)
+        #expect(throws: JITLinkError.self) {
+            try session.runMain(symbol: "abandon_slab_entry")
+        }
+        try session.addObject(path: probe.path)
+        #expect(try session.runMain(symbol: "abandon_probe_value") == 42)
+    }
+
     @Test func linksCObjectRemotely() throws {
         let object = try FixtureSupport.compile("answer.c")
         let session = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())

--- a/docs/jit-executor-phase3-plan.md
+++ b/docs/jit-executor-phase3-plan.md
@@ -1241,7 +1241,12 @@ leaving its 824MB remainder dangling in AvailableMemory), and a normal
 300MB link lands in the freed slab. On unfixed libLLVM the agent died
 in `__bzero` inside `previewsmcp_anon_initialize` at the munmapped
 slab-2 address (PreviewAgent-2026-06-12-175151.ips) and the daemon's
-working-buffer write went into freed heap pages. Fixed: passes in 60ms.
+working-buffer write went into freed heap pages. That signature is for
+the fully unfixed combination (red run predated the defect-2 glue
+checks); re-verifying red with the glue checks in place but libLLVM
+unfixed instead crashes the daemon at a near-null address after
+`prepare` logs "no reservation covers" and returns nullptr. Fixed:
+passes in 60ms.
 
 Defect 2: `PreviewsAnonymousMapper::prepare` now bounds-checks
 `addr + contentSize` against the covering reservation (nullptr on
@@ -1258,6 +1263,14 @@ abandoned allocs never initialize), mirroring
 this on every remote test (deinitialize runs over EPC before the agent
 is killed): 57 JIT + 18 MCP + 356 unit tests green with zero new
 DiagnosticReports.
+
+Roadmap addition (from the PR 203 review): `PreviewsAnonymousMapper`
+has no destructor, so the daemon's malloc'd slab working buffers (1GB
+virtual per remote session, touched pages committed) leak in the
+long-lived daemon at session destroy — `InProcessMemoryMapper` releases
+reservations in its destructor; ours relies on the agent's SIGKILL and
+frees nothing daemon-side. Pre-existing, queue with session-lifecycle
+work.
 
 Flake note: the first-ever `IOSMCPTests` run in the fresh mapper-glue
 worktree failed once with "Setup module 'ToDoPreviewSetup' not found

--- a/docs/jit-executor-phase3-plan.md
+++ b/docs/jit-executor-phase3-plan.md
@@ -1215,3 +1215,53 @@ next work, not silently parked):
   Today nothing deallocates mid-session so it is latent; it bites the
   moment generations are torn down for real (orc_rt deregistration never
   runs, reused pages stay R-X).
+
+## Update 2026-06-12 (mapper-glue)
+
+All three audit-fallout defects above are fixed.
+
+Defect 1 (abandon frees the slab) is upstream-confirmed: llvm.org
+dad86f5931453ff3d14ba5adb93855ee780298b2 ("MapperJITLinkMemoryManager
+should deinitialize on abandon, not deallocate", 2025-03-31, post-pin)
+fixes the exact bug with the exact symptom we predicted ("an entire
+underlying slab was deallocated, resulting in segfaults in other
+concurrent links"). Backported as
+`scripts/patches/llvm-mapperjitlink-abandon-slab.patch` (one line:
+`abandon` now calls `Mapper->deinitialize` instead of `release`),
+applied by the existing patch loop in `scripts/build-jit-llvm.sh`.
+
+Red repro: `reusesMemoryAfterAbandonedLinksRemotely`. orc_rt owns the
+slab base after bootstrap, so a failed first user link only leaks a
+suballocation — the crash needs a failed link that OPENS a slab. The
+test gets there with zerofill-heavy fixtures (failing links never reach
+initialize, so the BSS is never committed): a failing 900MB link drains
+slab 1's remainder via the abandon leak, a failing 200MB link then
+opens slab 2 (first-in-slab → unfixed abandon frees the whole slab,
+leaving its 824MB remainder dangling in AvailableMemory), and a normal
+300MB link lands in the freed slab. On unfixed libLLVM the agent died
+in `__bzero` inside `previewsmcp_anon_initialize` at the munmapped
+slab-2 address (PreviewAgent-2026-06-12-175151.ips) and the daemon's
+working-buffer write went into freed heap pages. Fixed: passes in 60ms.
+
+Defect 2: `PreviewsAnonymousMapper::prepare` now bounds-checks
+`addr + contentSize` against the covering reservation (nullptr on
+miss — LLVM's prepare contract has no error path; upstream
+SharedMemoryMapper uses a bare assert), and `initialize` rejects
+segments extending past the reservation with a loud error.
+
+Defect 3: the agent now records `{size, dealloc actions}` per
+allocation base in `previewsmcp_anon_initialize` and
+`previewsmcp_anon_deinitialize` runs the actions in reverse base order,
+restores RW protections, and erases the entry (unknown bases skipped —
+abandoned allocs never initialize), mirroring
+`InProcessMemoryMapper::deinitialize`. Session destroy now exercises
+this on every remote test (deinitialize runs over EPC before the agent
+is killed): 57 JIT + 18 MCP + 356 unit tests green with zero new
+DiagnosticReports.
+
+Flake note: the first-ever `IOSMCPTests` run in the fresh mapper-glue
+worktree failed once with "Setup module 'ToDoPreviewSetup' not found
+after build" (swift build exit 0, no arm64-apple-ios-simulator dir).
+Not reproducible afterwards, including from a fully wiped
+`examples/PreviewSetup/.build` and setup cache; passes on main. Filed
+mentally as first-run worktree state; unrelated to this change.

--- a/scripts/patches/llvm-mapperjitlink-abandon-slab.patch
+++ b/scripts/patches/llvm-mapperjitlink-abandon-slab.patch
@@ -1,0 +1,15 @@
+diff --git a/llvm/lib/ExecutionEngine/Orc/MapperJITLinkMemoryManager.cpp b/llvm/lib/ExecutionEngine/Orc/MapperJITLinkMemoryManager.cpp
+--- a/llvm/lib/ExecutionEngine/Orc/MapperJITLinkMemoryManager.cpp
++++ b/llvm/lib/ExecutionEngine/Orc/MapperJITLinkMemoryManager.cpp
+@@ -44,7 +44,10 @@
+   }
+
+   void abandon(OnAbandonedFunction OnFinalize) override {
+-    Parent.Mapper->release({AllocAddr}, std::move(OnFinalize));
++    // Backport of llvm.org dad86f5931453ff3d14ba5adb93855ee780298b2: release()
++    // keys reservations by slab base, so abandoning a first-in-slab alloc
++    // freed the whole shared slab. Deinitialize only this allocation.
++    Parent.Mapper->deinitialize({AllocAddr}, std::move(OnFinalize));
+   }
+
+ private:


### PR DESCRIPTION
## Summary
- Backport llvm.org `dad86f5931453ff3d14ba5adb93855ee780298b2` ("MapperJITLinkMemoryManager should deinitialize on abandon, not deallocate") as `scripts/patches/llvm-mapperjitlink-abandon-slab.patch`. Before this, a failed link whose allocation opened a slab freed the WHOLE slab (daemon working buffer freed, agent munmapped 1GB) while `AvailableMemory` kept handing out ranges inside it.
- Bounds-check `PreviewsAnonymousMapper::prepare` (nullptr on out-of-reservation; LLVM's prepare contract has no error path) and `initialize` (loud error when a segment extends past the reservation).
- Agent `previewsmcp_anon_initialize` now records `{size, dealloc actions}` per allocation base; `previewsmcp_anon_deinitialize` runs the actions in reverse order, restores RW protections, and erases the entry, mirroring `InProcessMemoryMapper::deinitialize`. Previously dealloc actions were dropped and deinitialize was a no-op.

## Red-green proof
New test `reusesMemoryAfterAbandonedLinksRemotely`: orc_rt owns slab 1's base after bootstrap, so the repro uses zerofill-heavy fixtures (failing links never commit their BSS) — a failing 900MB link drains slab 1 via the abandon leak, a failing 200MB link opens slab 2 first-in-slab, and a normal 300MB link then lands in the slab the unfixed abandon freed. On unfixed libLLVM the agent SIGSEGVs in `__bzero` inside `previewsmcp_anon_initialize` at the munmapped slab-2 address (PreviewAgent-2026-06-12-175151.ips). With the patch it passes in 60ms.

## Verification
- JIT suite: 57/57 (`--filter PreviewsJITLinkTests --no-parallel`)
- Units: 356/356, MCP integration: 18/18, CLI integration: 69/69
- Zero new DiagnosticReports across all runs (session destroy now exercises agent deinitialize over EPC on every remote test)
- One non-reproducible first-run flake in the fresh worktree (IOSMCPTests, "Setup module 'ToDoPreviewSetup' not found after build"); passes from fully wiped setup `.build`, passes on main — documented in the plan doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)