### PR TITLE
JIT: free remote-session slab buffers on teardown

### DIFF
--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -77,6 +77,13 @@ public:
                           AnonMapperSymbols sas)
       : epc(epc), sas(sas) {}
 
+  ~PreviewsAnonymousMapper() override {
+    std::lock_guard<std::mutex> lock(mutex);
+    for (auto &entry : reservations) {
+      free(entry.second.workingBuf);
+    }
+  }
+
   unsigned int getPageSize() override { return epc.getPageSize(); }
 
   void reserve(size_t numBytes, OnReservedFunction onReserved) override {

--- a/Tests/PreviewsJITLinkTests/Fixtures/leak_probe.c
+++ b/Tests/PreviewsJITLinkTests/Fixtures/leak_probe.c
@@ -1,0 +1,8 @@
+#include <stdint.h>
+
+static char leak_probe_bss[200u << 20];
+
+int32_t leak_probe_value(void) {
+  leak_probe_bss[0] = 7;
+  return leak_probe_bss[0] + 35;
+}

--- a/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -2,6 +2,18 @@ import Foundation
 import PreviewsJITLink
 import Testing
 
+private func residentBytes() -> Int {
+    var info = mach_task_basic_info()
+    var count = mach_msg_type_number_t(
+        MemoryLayout<mach_task_basic_info>.size / MemoryLayout<natural_t>.size)
+    let kr = withUnsafeMutablePointer(to: &info) {
+        $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+            task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+        }
+    }
+    return kr == KERN_SUCCESS ? Int(info.resident_size) : 0
+}
+
 struct PreviewsJITLinkTests {
     @Test func linksCObject() throws {
         let object = try FixtureSupport.compile("answer.c")
@@ -16,6 +28,19 @@ struct PreviewsJITLinkTests {
         for _ in 0..<40 {
             _ = try JITSession(remoteAgentPath: agentPath)
         }
+    }
+
+    @Test(.timeLimit(.minutes(5))) func freesHostSlabBuffersOnRemoteSessionDestroy() throws {
+        let object = try FixtureSupport.compile("leak_probe.c")
+        let agentPath = try JITSession.bundledAgentPath()
+        let before = residentBytes()
+        for _ in 0..<8 {
+            let session = try JITSession(remoteAgentPath: agentPath)
+            try session.addObject(path: object.path)
+            #expect(try session.runMain(symbol: "leak_probe_value") == 42)
+        }
+        let growth = residentBytes() - before
+        #expect(growth < 600 << 20)
     }
 
     @Test(.timeLimit(.minutes(5))) func reusesMemoryAfterAbandonedLinksRemotely() throws {


### PR DESCRIPTION
## Problem

`PreviewsAnonymousMapper` (the remote/agent JIT memory mapper) had no destructor. Its `reserve()` mallocs a host `workingBuf` per slab (up to the 1GB `kSlabSize`), but `MapperJITLinkMemoryManager` never calls `Mapper->release()` and has no destructor of its own. So on `previewsmcp_jit_session_destroy` the `reservations` map was destroyed without freeing those buffers, leaking them for the life of the long-lived daemon. Measured at ~200MB resident leaked per remote session. Found in the #203 mapper-glue review.

## Fix

Add `~PreviewsAnonymousMapper()` that frees the leftover `workingBuf`s, mirroring upstream `InProcessMemoryMapper::~InProcessMemoryMapper()` / `SharedMemoryMapper`'s destructor. Host-side free only is correct here: the agent process is `SIGKILL`'d immediately after in `previewsmcp_jit_session_destroy`, so executor-side memory dies with it, and `release()` is never invoked in the remote lifecycle (no double-free).

## Verification (red-green)

New `freesHostSlabBuffersOnRemoteSessionDestroy` links a 200MB-`bss` fixture into 8 remote sessions and asserts process resident growth stays under 600MB.

- Unfixed: **1.69GB** growth over 8 iterations (fails).
- Fixed: passes in 0.24s.

Full local bar green: JIT 58, units 342, MCP 18, CLI 83.

Note: the RSS bound is empirical (wide 1.69GB-vs-600MB margin), and the test inherits the JIT suite's mandated `--no-parallel` run policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)