### PR TITLE
JIT latency: bypass the swiftc driver on steady-state structural edits

### DIFF
--- a/Sources/PreviewsCore/Compiler.swift
+++ b/Sources/PreviewsCore/Compiler.swift
@@ -243,6 +243,16 @@ public actor Compiler {
     /// `.swiftdeps` records and the unchanged-file objects persist between compiles.
     private var incrementalDirs: [String: URL] = [:]
 
+    /// The overlay's `swift-frontend` argv, captured once from the driver's own compile plan and
+    /// replayed verbatim on later edits. The driver only spawns the frontend after a round of job
+    /// planning and `.swiftdeps` bookkeeping; replaying the frontend job directly skips that.
+    /// Reusable verbatim because the overlay path and output stay constant per module — only the
+    /// overlay file's contents change. The fingerprint regenerates the template (and rebuilds the
+    /// bulk objects via the driver) if the build context (target, sdk, flags) or any bulk file
+    /// changes — the bypass only recompiles the overlay, so a stale bulk object would otherwise
+    /// be reused.
+    private var frontendTemplates: [String: (fingerprint: String, argv: [String])] = [:]
+
     /// Compile the whole target module incrementally: the editable `overlaySource` plus the
     /// target's other `bulkFiles`, all under one `moduleName`. The Swift driver recompiles only
     /// what changed — the overlay alone on a body edit, the overlay plus its dependents on an
@@ -256,6 +266,21 @@ public actor Compiler {
         moduleName: String,
         extraFlags: [String] = [],
         overrideSDK: String? = nil
+    ) async throws -> (overlayObject: URL, bulkObjects: [URL]) {
+        try await compileModuleIncremental(
+            overlaySource: overlaySource, bulkFiles: bulkFiles, moduleName: moduleName,
+            extraFlags: extraFlags, overrideSDK: overrideSDK, bypassDriver: true)
+    }
+
+    /// `bypassDriver` is an internal seam: production always bypasses; tests pass `false` to
+    /// measure the driver baseline against the bypass.
+    func compileModuleIncremental(
+        overlaySource: String,
+        bulkFiles: [URL],
+        moduleName: String,
+        extraFlags: [String] = [],
+        overrideSDK: String? = nil,
+        bypassDriver: Bool
     ) async throws -> (overlayObject: URL, bulkObjects: [URL]) {
         let dir: URL
         if let existing = incrementalDirs[moduleName] {
@@ -309,8 +334,130 @@ public actor Compiler {
         args += [overlayFile.path]
         args += bulkFiles.map(\.path)
 
+        let bulkStamps = bulkFiles.map { url -> String in
+            let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
+            let mtime = (attrs?[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+            let size = (attrs?[.size] as? Int) ?? 0
+            return "\(url.path)@\(mtime):\(size)"
+        }
+        let fingerprint = (args.dropFirst() + bulkStamps).joined(separator: "\u{1f}")
+
+        if bypassDriver, let cached = frontendTemplates[moduleName], cached.fingerprint == fingerprint {
+            do {
+                try await run(cached.argv)
+                return (overlayObject, bulkObjects)
+            } catch {
+                Log.warn("jit_latency: frontend bypass failed, falling back to driver (\(error))")
+                frontendTemplates[moduleName] = nil
+            }
+        }
+
         try await run(args)
+
+        if bypassDriver {
+            if let argv = try? await captureOverlayFrontendJob(
+                moduleName: moduleName, overlayFile: overlayFile, overlayObject: overlayObject,
+                bulkFiles: bulkFiles, extraFlags: extraFlags, overrideSDK: overrideSDK)
+            {
+                frontendTemplates[moduleName] = (fingerprint, argv)
+            }
+        }
         return (overlayObject, bulkObjects)
+    }
+
+    /// Ask the driver (`-###`) for the `swift-frontend` job it would run to compile the overlay as
+    /// the single primary file, then rewrite that job's `-o` to the overlay object. Captured
+    /// without `-incremental`/`-output-file-map` so the plan never depends on stale `.swiftdeps`
+    /// state and always prints one `-primary-file` job per source. The bulk files stay as secondary
+    /// inputs (parsed, not emitted), which preserves the two-way reference resolution the single
+    /// module relies on. Returns nil if the overlay job can't be found, so the caller keeps using
+    /// the driver.
+    private func captureOverlayFrontendJob(
+        moduleName: String,
+        overlayFile: URL,
+        overlayObject: URL,
+        bulkFiles: [URL],
+        extraFlags: [String],
+        overrideSDK: String?
+    ) async throws -> [String]? {
+        var capture: [String] = [
+            swiftcPath,
+            "-###",
+            "-emit-object",
+            "-parse-as-library",
+            "-target", targetTriple,
+            "-sdk", try resolveSDK(overrideSDK),
+            "-module-name", moduleName,
+            "-Onone",
+            "-gnone",
+            "-module-cache-path", moduleCachePath.path,
+        ]
+        capture += extraFlags
+        capture += [overlayFile.path]
+        capture += bulkFiles.map(\.path)
+
+        let plan = try await run(capture)
+        for line in plan.split(whereSeparator: \.isNewline) {
+            let toks = Self.shellSplit(String(line))
+            guard let pf = toks.firstIndex(of: "-primary-file"), pf + 1 < toks.count,
+                toks[pf + 1] == overlayFile.path,
+                let o = toks.firstIndex(of: "-o"), o + 1 < toks.count
+            else { continue }
+            var argv = toks
+            argv[o + 1] = overlayObject.path
+            return argv
+        }
+        return nil
+    }
+
+    /// Split a `-###` plan line into argv. The driver shell-quotes only tokens with special
+    /// characters (e.g. `-external-plugin-path` values containing `#`), so this honors single
+    /// quotes, double quotes, and backslash escapes.
+    private static func shellSplit(_ line: String) -> [String] {
+        let chars = Array(line)
+        var tokens: [String] = []
+        var cur = ""
+        var hasToken = false
+        var inSingle = false
+        var inDouble = false
+        var i = 0
+        while i < chars.count {
+            let c = chars[i]
+            if inSingle {
+                if c == "'" { inSingle = false } else { cur.append(c) }
+            } else if inDouble {
+                if c == "\"" {
+                    inDouble = false
+                } else if c == "\\", i + 1 < chars.count {
+                    i += 1
+                    cur.append(chars[i])
+                } else {
+                    cur.append(c)
+                }
+            } else if c == "'" {
+                inSingle = true
+                hasToken = true
+            } else if c == "\"" {
+                inDouble = true
+                hasToken = true
+            } else if c == "\\", i + 1 < chars.count {
+                i += 1
+                cur.append(chars[i])
+                hasToken = true
+            } else if c == " " || c == "\t" {
+                if hasToken {
+                    tokens.append(cur)
+                    cur = ""
+                    hasToken = false
+                }
+            } else {
+                cur.append(c)
+                hasToken = true
+            }
+            i += 1
+        }
+        if hasToken { tokens.append(cur) }
+        return tokens
     }
 
     // MARK: - Private

--- a/Tests/PreviewsJITLinkTests/StructuralReloadLatencyTests.swift
+++ b/Tests/PreviewsJITLinkTests/StructuralReloadLatencyTests.swift
@@ -1,7 +1,8 @@
 import Foundation
-import PreviewsCore
 import PreviewsJITLink
 import Testing
+
+@testable import PreviewsCore
 
 struct StructuralReloadLatencyTests {
     private static func ms(_ duration: Duration) -> Double {
@@ -54,5 +55,105 @@ struct StructuralReloadLatencyTests {
         )
 
         #expect(compileMs + renderMs < 30000)
+    }
+
+    @Test func driverBypassProducesEquivalentObjectAndIsFaster() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dbypass-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let bulkFile = dir.appendingPathComponent("bulk_0.swift")
+        try "func bulkValue() -> Int32 { 42 }\n"
+            .write(to: bulkFile, atomically: true, encoding: .utf8)
+
+        // The overlay references a bulk declaration (two-way resolution) and the token forces a
+        // textually different source each edit, so the driver recompiles instead of no-opping.
+        func overlay(_ token: Int32) -> String {
+            "@_cdecl(\"answer\") func answer() -> Int32 { bulkValue() + \(token) - \(token) }\n"
+        }
+        // Correctness: the driver path and the frontend-bypass path both produce a working object.
+        let driverCompiler = try await Compiler()
+        let driverBuild = try await driverCompiler.compileModuleIncremental(
+            overlaySource: overlay(0), bulkFiles: [bulkFile], moduleName: "DBypass",
+            bypassDriver: false)
+        #expect(try linkedAnswer(driverBuild) == 42)
+
+        let bypassCompiler = try await Compiler()
+        // First call seeds the template via the driver; the second exercises the frontend bypass.
+        _ = try await bypassCompiler.compileModuleIncremental(
+            overlaySource: overlay(0), bulkFiles: [bulkFile], moduleName: "DBypass",
+            bypassDriver: true)
+        let bypassBuild = try await bypassCompiler.compileModuleIncremental(
+            overlaySource: overlay(1), bulkFiles: [bulkFile], moduleName: "DBypass",
+            bypassDriver: true)
+        #expect(try linkedAnswer(bypassBuild) == 42)
+
+        // Latency: comparative, so it self-normalizes for machine load. Each edit changes the
+        // overlay so both paths actually recompile it.
+        func median(_ values: [Double]) -> Double { values.sorted()[values.count / 2] }
+        let clock = ContinuousClock()
+        var driverMs: [Double] = []
+        var bypassMs: [Double] = []
+        for i in 0..<5 {
+            let token = Int32(i + 2)
+            let d0 = clock.now
+            _ = try await driverCompiler.compileModuleIncremental(
+                overlaySource: overlay(token), bulkFiles: [bulkFile], moduleName: "DBypass",
+                bypassDriver: false)
+            driverMs.append(Self.ms(d0.duration(to: clock.now)))
+
+            let b0 = clock.now
+            _ = try await bypassCompiler.compileModuleIncremental(
+                overlaySource: overlay(token), bulkFiles: [bulkFile], moduleName: "DBypass",
+                bypassDriver: true)
+            bypassMs.append(Self.ms(b0.duration(to: clock.now)))
+        }
+        let driverMedian = median(driverMs)
+        let bypassMedian = median(bypassMs)
+        print(
+            "driver-bypass: driver median=\(Int(driverMedian))ms "
+                + "bypass median=\(Int(bypassMedian))ms "
+                + "driver=\(driverMs.map { Int($0) }) bypass=\(bypassMs.map { Int($0) })")
+
+        #expect(bypassMedian < driverMedian)
+        #expect(bypassMedian < 30000)
+    }
+
+    @Test func rebuildsBulkObjectWhenBulkFileChanges() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dbypass-bulk-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let bulkFile = dir.appendingPathComponent("bulk_0.swift")
+        let overlay = "@_cdecl(\"answer\") func answer() -> Int32 { bulkValue() }\n"
+
+        try "func bulkValue() -> Int32 { 42 }\n"
+            .write(to: bulkFile, atomically: true, encoding: .utf8)
+
+        let compiler = try await Compiler()
+        // Seed the template, then take the bypass path; both see bulkValue() == 42.
+        _ = try await compiler.compileModuleIncremental(
+            overlaySource: overlay, bulkFiles: [bulkFile], moduleName: "BulkChange", bypassDriver: true)
+        let before = try await compiler.compileModuleIncremental(
+            overlaySource: overlay, bulkFiles: [bulkFile], moduleName: "BulkChange", bypassDriver: true)
+        #expect(try linkedAnswer(before) == 42)
+
+        // Change a bulk file out of band (the overlay is unchanged). The bypass only rebuilds the
+        // overlay, so without busting the cache it would reuse the stale bulk object and still
+        // return 42. The mtime in the fingerprint must force the driver to rebuild bulk -> 99.
+        try "func bulkValue() -> Int32 { 99 }\n"
+            .write(to: bulkFile, atomically: true, encoding: .utf8)
+        let after = try await compiler.compileModuleIncremental(
+            overlaySource: overlay, bulkFiles: [bulkFile], moduleName: "BulkChange", bypassDriver: true)
+        #expect(try linkedAnswer(after) == 99)
+    }
+
+    private func linkedAnswer(_ build: (overlayObject: URL, bulkObjects: [URL])) throws -> Int32 {
+        let session = try JITSession()
+        for object in build.bulkObjects { try session.addObject(path: object.path) }
+        try session.addObject(path: build.overlayObject.path)
+        return try session.call(symbol: "answer")
     }
 }


### PR DESCRIPTION
## What

On a structural edit the per-edit recompile ran the full `swiftc` driver, whose job planning and `.swiftdeps` bookkeeping dominate over the frontend's real work. This captures the overlay's `swift-frontend` job once from the driver's own `-###` plan, caches it per module, and replays it directly on later edits.

## Result (real SPM example, same temp copy, same edits, only the binary differs)

- Driver (main): ~910ms per structural edit
- Bypass (this branch): ~403ms per structural edit (~56% cut), renders correct, no fallback

## Design

- Public API unchanged. Production always bypasses; an internal `bypassDriver` seam lets the comparative latency test measure the driver baseline.
- The cache fingerprint includes each bulk file's mtime+size, so an out-of-band bulk edit busts the cache and the driver rebuilds the bulk object instead of the bypass reusing a stale one.
- On any frontend-bypass failure the code falls back to the driver, which then produces the authoritative result or surfaces the real source error.

## Verification

- New `driverBypassProducesEquivalentObjectAndIsFaster` Swift Testing guard: both paths link and return the same value, and bypass median < driver median.
- New red-green `rebuildsBulkObjectWhenBulkFileChanges` test (returns 42 unfixed, 99 fixed).
- Local merge bar green on final code: JIT 60, units 342, MCP 18, CLI 83.

Follow-up agreed with the user: re-profile, then decide together whether to chase sub-200ms structural via a persistent frontend (beyond Apple, unproven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)