### PR TITLE
JIT: render headless previews at the session's requested size

### DIFF
--- a/Sources/PreviewsCore/BridgeGenerator.swift
+++ b/Sources/PreviewsCore/BridgeGenerator.swift
@@ -1,22 +1,27 @@
 import Foundation
 
-/// On-screen placement for the agent's persistent preview window, baked into the render
-/// entry. Applied only when the agent creates the window, so a user's later drag or resize
-/// survives leaf edits. Nil means the window stays borderless and off-screen (tests,
-/// headless daemons).
+/// Placement and size for the agent's preview window, baked into the render entry. The size is
+/// always honored; `headless` selects presentation: a visible titled window placed at `x`/`y`,
+/// or a borderless off-screen window used only to render at the requested size (snapshots,
+/// headless daemons). Applied only when the agent creates the window, so a user's later drag or
+/// resize survives leaf edits. Nil means no spec at all — a borderless off-screen default size.
 public struct JITRenderWindow: Sendable {
     public let x: Double
     public let y: Double
     public let width: Double
     public let height: Double
     public let title: String
+    public let headless: Bool
 
-    public init(x: Double, y: Double, width: Double, height: Double, title: String) {
+    public init(
+        x: Double, y: Double, width: Double, height: Double, title: String, headless: Bool = false
+    ) {
         self.x = x
         self.y = y
         self.width = width
         self.height = height
         self.title = title
+        self.headless = headless
     }
 }
 
@@ -330,7 +335,7 @@ public enum BridgeGenerator {
             } ?? ""
         let createWindow: String
         let presentNewWindow: String
-        if let window {
+        if let window, !window.headless {
             let title = escapedForSwiftStringLiteral(window.title)
             createWindow = """
                 NSApplication.shared.setActivationPolicy(.accessory)
@@ -350,9 +355,13 @@ public enum BridgeGenerator {
                                 NSApplication.shared.activate(ignoringOtherApps: true)
                 """
         } else {
+            // Headless spec or no spec: a borderless off-screen window used only to render at
+            // the requested size, never shown or activated. Falls back to 400x600 with no spec.
+            let offscreenWidth = window?.width.description ?? "400"
+            let offscreenHeight = window?.height.description ?? "600"
             createWindow = """
                 let created = NSWindow(
-                                    contentRect: NSRect(x: 0, y: 0, width: 400, height: 600),
+                                    contentRect: NSRect(x: 0, y: 0, width: \(offscreenWidth), height: \(offscreenHeight)),
                                     styleMask: [.borderless], backing: .buffered, defer: false)
                                 created.setFrameOrigin(NSPoint(x: -10_000, y: -10_000))
                 """

--- a/Sources/PreviewsMacOS/HostApp.swift
+++ b/Sources/PreviewsMacOS/HostApp.swift
@@ -388,6 +388,11 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
                 y: screen.midY - size.height / 2,
                 width: size.width, height: size.height,
                 title: title)
+        } else {
+            // Headless, or no screen to place a visible window on: still bake the requested size
+            // so the render matches it; the bridge keeps this window off-screen and unshown.
+            agentWindowSpecs[sessionID] = JITRenderWindow(
+                x: 0, y: 0, width: size.width, height: size.height, title: title, headless: true)
         }
         do {
             try await jitStructuralReload(sessionID: sessionID, session: session)
@@ -407,8 +412,8 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         return made
     }
 
-    /// The window placement to bake into a JIT build for this session: the spec
-    /// stored at agent start, nil when headless.
+    /// The window spec (size + placement + headless flag) to bake into a JIT build for this
+    /// session, stored at agent start. Nil only when the session never went through `jitStart`.
     public func agentWindowSpec(for sessionID: String) -> JITRenderWindow? {
         agentWindowSpecs[sessionID]
     }

--- a/Tests/MCPIntegrationTests/MacOSMCPTests.swift
+++ b/Tests/MCPIntegrationTests/MacOSMCPTests.swift
@@ -638,4 +638,38 @@ struct MacOSMCPTests {
             "subprocess should be terminated by the pthread on timeout"
         )
     }
+
+    @Test("headless snapshot renders at the requested size", .timeLimit(.minutes(20)))
+    func headlessSnapshotUsesRequestedSize() async throws {
+        let server = try await MCPTestServer.start()
+        defer { server.stop() }
+
+        let (startContent, startError) = try await server.callTool(
+            name: "preview_start",
+            arguments: [
+                "filePath": .string(MCPTestServer.toDoViewPath),
+                "projectPath": .string(MCPTestServer.spmExampleRoot.path),
+                "width": .int(800),
+                "height": .int(1000),
+            ]
+        )
+        #expect(startError != true, "preview_start should succeed")
+        let sessionID = try MCPTestServer.extractSessionID(from: startContent)
+        try await Task.sleep(for: .milliseconds(500))
+
+        let (pngContent, pngError) = try await server.callTool(
+            name: "preview_snapshot",
+            arguments: [
+                "sessionID": .string(sessionID),
+                "quality": .double(1.0),
+            ]
+        )
+        #expect(pngError != true, "Snapshot should succeed")
+        try MCPTestServer.assertValidImage(
+            pngContent, expectedMimeType: "image/png",
+            minSize: 10_000, expectedWidth: 800, expectedHeight: 1000)
+
+        _ = try await server.callTool(
+            name: "preview_stop", arguments: ["sessionID": .string(sessionID)])
+    }
 }

--- a/Tests/PreviewsCoreTests/BridgeGeneratorRenderSizeTests.swift
+++ b/Tests/PreviewsCoreTests/BridgeGeneratorRenderSizeTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+
+@testable import PreviewsCore
+
+@Suite("BridgeGenerator render size")
+struct BridgeGeneratorRenderSizeTests {
+    static let source = """
+        import SwiftUI
+
+        struct TestView: View {
+            var body: some View {
+                Text("Hello")
+            }
+        }
+
+        #Preview { TestView() }
+        """
+
+    @Test("headless render window renders at the session size, off-screen, without activating")
+    func headlessUsesSessionSizeOffScreen() {
+        let generated = BridgeGenerator.generateCombinedSource(
+            originalSource: Self.source,
+            closureBody: "TestView()",
+            renderOutputPath: "/tmp/out.png",
+            renderWindow: JITRenderWindow(
+                x: 0, y: 0, width: 800, height: 1000, title: "t", headless: true))
+        #expect(generated.source.contains("width: 800.0, height: 1000.0"))
+        #expect(!generated.source.contains("width: 400, height: 600"))
+        #expect(generated.source.contains(".borderless"))
+        #expect(generated.source.contains("-10_000"))
+        #expect(!generated.source.contains("makeKeyAndOrderFront"))
+    }
+
+    @Test("visible render window renders at the session size in a titled key window")
+    func visibleUsesSessionSizeTitled() {
+        let generated = BridgeGenerator.generateCombinedSource(
+            originalSource: Self.source,
+            closureBody: "TestView()",
+            renderOutputPath: "/tmp/out.png",
+            renderWindow: JITRenderWindow(
+                x: 0, y: 0, width: 800, height: 1000, title: "t", headless: false))
+        #expect(generated.source.contains("width: 800.0, height: 1000.0"))
+        #expect(generated.source.contains(".titled"))
+        #expect(generated.source.contains("makeKeyAndOrderFront"))
+    }
+}

--- a/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
+++ b/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
@@ -180,7 +180,10 @@ struct PreviewHostJITReloadTests {
         try await host.jitStart(
             sessionID: "hidden", session: session,
             title: "ignored", size: NSSize(width: 320, height: 240), headless: true)
-        #expect(host.agentWindowSpec(for: "hidden") == nil)
+        let hiddenSpec = try #require(host.agentWindowSpec(for: "hidden"))
+        #expect(hiddenSpec.headless)
+        #expect(hiddenSpec.width == 320)
+        #expect(hiddenSpec.height == 240)
         #expect(host.agentSnapshotPath(for: "hidden") != nil)
 
         host.closePreview(sessionID: "visible")


### PR DESCRIPTION
## What

The JIT agent renders into an NSWindow whose content size becomes the PNG size. That size was coupled to *visibility*: `HostApp.jitStart` only stored a `JITRenderWindow` spec for visible sessions, so headless renders fell to a hardcoded `400x600` in `BridgeGenerator`. Headless is exactly the ephemeral-snapshot path, so `previewsmcp snapshot --width 800 --height 1000` silently produced a 400x600 image.

## Fix

Decouple size from visibility:
- `JITRenderWindow` carries a `headless: Bool` (default false).
- `HostApp.jitStart` always stores a sized spec (`headless: true` for the headless / no-screen case).
- `BridgeGenerator` branches presentation on `window.headless` (visible titled window vs borderless off-screen) while always honoring `window.width/height`. The `400x600` literal remains only as the no-spec fallback for direct test calls.

## Verification

- `previewsmcp snapshot --width 800 --height 1000` now produces an 800x1000 PNG (confirmed via `sips`).
- New `BridgeGeneratorRenderSizeTests` (red-green): headless spec renders at the requested size, off-screen, without activating; visible spec stays titled/key.
- New `MacOSMCPTests.headlessSnapshotUsesRequestedSize`: end-to-end headless snapshot at 800x1000 asserts the PNG dimensions.
- Updated `PreviewHostJITReloadTests` to the new contract (headless start stores a sized `headless: true` spec, not nil).
- Local merge bar green: JIT 60, units 344, MCP 19, CLI 83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)