### PR TITLE
JIT: hand window frame across agent respawns (#195)

### DIFF
--- a/Sources/PreviewsCore/BridgeGenerator.swift
+++ b/Sources/PreviewsCore/BridgeGenerator.swift
@@ -50,7 +50,8 @@ public enum BridgeGenerator {
         renderOutputPath: String? = nil,
         designTimeValuesPath: String? = nil,
         stableModuleImport: String? = nil,
-        renderWindow: JITRenderWindow? = nil
+        renderWindow: JITRenderWindow? = nil,
+        frameSidecarPath: String? = nil
     ) -> (source: String, literals: [LiteralEntry]) {
         // Transform source to replace literals with DesignTimeStore lookups
         let thunkResult = ThunkGenerator.transform(source: originalSource)
@@ -84,7 +85,7 @@ public enum BridgeGenerator {
             renderOutputPath.map {
                 renderToFileEntryPoint(
                     viewCode: viewCode, path: $0, valuesPath: designTimeValuesPath,
-                    window: renderWindow)
+                    window: renderWindow, frameSidecarPath: frameSidecarPath)
             } ?? ""
         let bridgeCode: String
         switch platform {
@@ -320,7 +321,8 @@ public enum BridgeGenerator {
     /// keeps one live window across structural edits (single-renderer consolidation).
     /// AppKit state is shared across JITDylib generations; the entry's own globals are not.
     private static func renderToFileEntryPoint(
-        viewCode: String, path: String, valuesPath: String?, window: JITRenderWindow?
+        viewCode: String, path: String, valuesPath: String?, window: JITRenderWindow?,
+        frameSidecarPath: String?
     ) -> String {
         let seed =
             valuesPath.map {
@@ -335,6 +337,7 @@ public enum BridgeGenerator {
             } ?? ""
         let createWindow: String
         let presentNewWindow: String
+        let frameObservers: String
         if let window, !window.headless {
             let title = escapedForSwiftStringLiteral(window.title)
             createWindow = """
@@ -354,6 +357,7 @@ public enum BridgeGenerator {
                 window.makeKeyAndOrderFront(nil)
                                 NSApplication.shared.activate(ignoringOtherApps: true)
                 """
+            frameObservers = frameSidecarPath.map(frameObserverCode) ?? ""
         } else {
             // Headless spec or no spec: a borderless off-screen window used only to render at
             // the requested size, never shown or activated. Falls back to 400x600 with no spec.
@@ -366,6 +370,7 @@ public enum BridgeGenerator {
                                 created.setFrameOrigin(NSPoint(x: -10_000, y: -10_000))
                 """
             presentNewWindow = "window.orderFrontRegardless()"
+            frameObservers = ""
         }
         return """
             @_cdecl("renderPreviewToFile")
@@ -389,6 +394,7 @@ public enum BridgeGenerator {
                     window.contentView = hosting
                     if isNewWindow {
                         \(presentNewWindow)
+                        \(frameObservers)
                     } else {
                         window.orderFrontRegardless()
                     }
@@ -422,6 +428,35 @@ public enum BridgeGenerator {
                 }
             }
             """
+    }
+
+    /// Code (run once when the agent creates its visible window) that records the window's frame
+    /// to `sidecarPath` on every move/resize. A respawned agent reads it back so the user's
+    /// dragged/resized window is restored across non-leaf structural edits (#195). Reads the frame
+    /// off the notification's window so the `@Sendable` observer closure captures only the path.
+    private static func frameObserverCode(sidecarPath: String) -> String {
+        """
+        let __frameURL = URL(fileURLWithPath: "\(escapedForSwiftStringLiteral(sidecarPath))")
+                        let __recordFrame: @Sendable (Notification) -> Void = { __note in
+                            MainActor.assumeIsolated {
+                                guard let __win = __note.object as? NSWindow else { return }
+                                let __f = __win.frame
+                                let __dict: [String: Double] = [
+                                    "x": __f.origin.x, "y": __f.origin.y,
+                                    "width": __f.size.width, "height": __f.size.height,
+                                ]
+                                if let __data = try? JSONSerialization.data(withJSONObject: __dict) {
+                                    try? __data.write(to: __frameURL, options: .atomic)
+                                }
+                            }
+                        }
+                        NotificationCenter.default.addObserver(
+                            forName: NSWindow.didMoveNotification, object: window, queue: nil,
+                            using: __recordFrame)
+                        NotificationCenter.default.addObserver(
+                            forName: NSWindow.didResizeNotification, object: window, queue: nil,
+                            using: __recordFrame)
+        """
     }
 
     /// Generate the `@_cdecl("previewSetUp")` entry point that bridges async setUp.

--- a/Sources/PreviewsCore/PreviewSession.swift
+++ b/Sources/PreviewsCore/PreviewSession.swift
@@ -206,6 +206,25 @@ public actor PreviewSession {
         }
     }
 
+    /// Session-stable path the agent's bridge writes the live window frame to, so a respawned
+    /// agent can restore the user's dragged/resized window. Derived from the session id (not the
+    /// per-compile stem) so it survives across respawns within one session.
+    public nonisolated static func frameSidecarPath(for id: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-jit-frame-\(id).json")
+    }
+
+    /// The last window frame the agent recorded for this session, or nil when none was written.
+    public nonisolated static func storedWindowFrame(
+        for id: String
+    ) -> (x: Double, y: Double, width: Double, height: Double)? {
+        guard let data = try? Data(contentsOf: frameSidecarPath(for: id)),
+            let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Double],
+            let x = obj["x"], let y = obj["y"], let width = obj["width"], let height = obj["height"]
+        else { return nil }
+        return (x, y, width, height)
+    }
+
     /// Compile the preview for the JIT structural-reload path. Generates a render bridge
     /// with a baked PNG output path, compiles it to a `.o`, and returns the object plus the
     /// image path the agent will write.
@@ -261,7 +280,8 @@ public actor PreviewSession {
             renderOutputPath: imagePath.path,
             designTimeValuesPath: valuesPath.path,
             stableModuleImport: stable != nil ? splitContext?.0.moduleName : nil,
-            renderWindow: window
+            renderWindow: window,
+            frameSidecarPath: Self.frameSidecarPath(for: id).path
         )
 
         let objectPath: URL

--- a/Sources/PreviewsMacOS/HostApp.swift
+++ b/Sources/PreviewsMacOS/HostApp.swift
@@ -367,8 +367,21 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     @discardableResult
     public func jitStructuralReload(sessionID: String, session: PreviewSession) async throws -> URL? {
         guard agentBacked else { return nil }
+        restoreAgentWindowFrame(sessionID: sessionID, session: session)
         let build = try await session.compileObjectForJIT(window: agentWindowSpec(for: sessionID))
         return try await jitRender(sessionID: sessionID, build: build)
+    }
+
+    /// Before a structural reload, bake the agent's last recorded window frame into the session's
+    /// spec so a respawned agent restores the user's dragged/resized window instead of recentering
+    /// (#195). Only for visible sessions; absent sidecar keeps the stored spec unchanged.
+    private func restoreAgentWindowFrame(sessionID: String, session: PreviewSession) {
+        guard let spec = agentWindowSpecs[sessionID], !spec.headless,
+            let frame = PreviewSession.storedWindowFrame(for: session.id)
+        else { return }
+        agentWindowSpecs[sessionID] = JITRenderWindow(
+            x: frame.x, y: frame.y, width: frame.width, height: frame.height,
+            title: spec.title, headless: false)
     }
 
     /// Start a session with the agent as its surface from the first render: no

--- a/Tests/PreviewsCoreTests/BridgeGeneratorFrameHandoverTests.swift
+++ b/Tests/PreviewsCoreTests/BridgeGeneratorFrameHandoverTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+
+@testable import PreviewsCore
+
+@Suite("BridgeGenerator frame handover")
+struct BridgeGeneratorFrameHandoverTests {
+    static let source = """
+        import SwiftUI
+
+        struct TestView: View {
+            var body: some View {
+                Text("Hello")
+            }
+        }
+
+        #Preview { TestView() }
+        """
+
+    @Test("visible render window installs move/resize observers that write the frame sidecar")
+    func visibleInstallsFrameObservers() {
+        let generated = BridgeGenerator.generateCombinedSource(
+            originalSource: Self.source,
+            closureBody: "TestView()",
+            renderOutputPath: "/tmp/out.png",
+            renderWindow: JITRenderWindow(
+                x: 0, y: 0, width: 800, height: 1000, title: "t", headless: false),
+            frameSidecarPath: "/tmp/frame.json")
+        #expect(generated.source.contains("didMoveNotification"))
+        #expect(generated.source.contains("didResizeNotification"))
+        #expect(generated.source.contains("/tmp/frame.json"))
+    }
+
+    @Test("headless render window installs no frame observers")
+    func headlessInstallsNoFrameObservers() {
+        let generated = BridgeGenerator.generateCombinedSource(
+            originalSource: Self.source,
+            closureBody: "TestView()",
+            renderOutputPath: "/tmp/out.png",
+            renderWindow: JITRenderWindow(
+                x: 0, y: 0, width: 800, height: 1000, title: "t", headless: true),
+            frameSidecarPath: "/tmp/frame.json")
+        #expect(!generated.source.contains("didMoveNotification"))
+        #expect(!generated.source.contains("didResizeNotification"))
+    }
+}

--- a/Tests/PreviewsCoreTests/PreviewSessionFrameSidecarTests.swift
+++ b/Tests/PreviewsCoreTests/PreviewSessionFrameSidecarTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+
+@testable import PreviewsCore
+
+@Suite("PreviewSession frame sidecar")
+struct PreviewSessionFrameSidecarTests {
+    @Test("frame sidecar path is stable for a session id")
+    func pathIsStableForID() {
+        let a = PreviewSession.frameSidecarPath(for: "abc")
+        let b = PreviewSession.frameSidecarPath(for: "abc")
+        #expect(a == b)
+        #expect(a.lastPathComponent.contains("abc"))
+    }
+
+    @Test("stored window frame is nil when no sidecar exists")
+    func nilWhenAbsent() {
+        #expect(PreviewSession.storedWindowFrame(for: "no-such-session-\(UUID().uuidString)") == nil)
+    }
+
+    @Test("stored window frame round-trips a written sidecar")
+    func roundTrips() throws {
+        let id = "frame-test-\(UUID().uuidString)"
+        let url = PreviewSession.frameSidecarPath(for: id)
+        let dict: [String: Double] = ["x": 12, "y": 34, "width": 567, "height": 890]
+        try JSONSerialization.data(withJSONObject: dict).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let frame = PreviewSession.storedWindowFrame(for: id)
+        #expect(frame?.x == 12)
+        #expect(frame?.y == 34)
+        #expect(frame?.width == 567)
+        #expect(frame?.height == 890)
+    }
+}

--- a/Tests/PreviewsJITLinkTests/CappedPersistentTests.swift
+++ b/Tests/PreviewsJITLinkTests/CappedPersistentTests.swift
@@ -217,6 +217,67 @@ struct CappedPersistentTests {
         #expect(bits == 15, "bits=\(bits)")
     }
 
+    @Test func bridgeRecordsWindowFrameOnMoveAndResize() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("frame-record-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let sourceFile = dir.appendingPathComponent("ColorView.swift")
+        try """
+        import SwiftUI
+
+        #Preview {
+            Color.green.frame(width: 8, height: 8)
+        }
+        """.write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        let compiler = try await Compiler()
+        let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
+        let build = try await session.compileObjectForJIT(
+            window: JITRenderWindow(
+                x: -9000, y: -9000, width: 320, height: 240,
+                title: "Preview: ColorView.swift"))
+
+        let sidecar = PreviewSession.frameSidecarPath(for: session.id)
+        try? FileManager.default.removeItem(at: sidecar)
+        defer { try? FileManager.default.removeItem(at: sidecar) }
+
+        let probe = try await compiler.compileObject(
+            source: """
+                import AppKit
+
+                @_cdecl("preview_move_probe")
+                public func preview_move_probe() -> Int32 {
+                    MainActor.assumeIsolated {
+                        guard
+                            let window = NSApplication.shared.windows.first(where: {
+                                $0.identifier?.rawValue == "previewsmcp-preview"
+                            })
+                        else { return -1 }
+                        window.setFrame(
+                            NSRect(x: -8000, y: -7000, width: 321, height: 654), display: false)
+                        return 0
+                    }
+                }
+                """,
+            moduleName: "FrameMoveProbeFixture"
+        )
+
+        let agent = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
+        try agent.addObject(path: build.objectPath.path)
+        #expect(try agent.runOnMain(symbol: build.entrySymbol) == 0)
+        try agent.newGeneration()
+        try agent.addObject(path: probe.path)
+        #expect(try agent.runOnMain(symbol: "preview_move_probe") == 0)
+
+        let frame = try #require(PreviewSession.storedWindowFrame(for: session.id))
+        #expect(frame.width == 321)
+        #expect(frame.height == 654)
+        #expect(frame.x != -9000)
+        #expect(frame.y != -9000)
+    }
+
     @Test func reusesOneSessionAcrossFreshGenerations() async throws {
         let compiler = try await Compiler()
         let colors = [(1, 0, 0), (0, 1, 0), (0, 0, 1), (1, 0, 0), (0, 1, 0)]


### PR DESCRIPTION
Closes #195.

## Problem

Non-leaf structural edits respawn the agent (`requiresFreshAgent`). The replacement window was created from the compile-time spec (the original centered frame), so any drag or resize the user had done was lost. The window blinked and recentered on every non-leaf edit.

## Fix (frame handover)

- The generated bridge installs `didMove`/`didResize` observers on the **visible** window that write the live frame to a session-stable sidecar JSON (`previewsmcp-jit-frame-<sessionID>.json`).
- Before each structural reload the daemon reads that sidecar (`PreviewSession.storedWindowFrame`) and bakes the latest frame into the window spec, so a respawned agent restores the user's window. Absent sidecar keeps current behavior.
- The sidecar survives an agent crash, unlike querying a dying agent.
- Headless renders are unaffected: no observers are installed, and the restore is gated on `!headless`, so snapshot sizes are unchanged.

## Verification

- New red-green unit tests: `BridgeGeneratorFrameHandoverTests` (observers emitted for visible, not headless) and `PreviewSessionFrameSidecarTests` (path stability + sidecar round-trip).
- New JITLink e2e `bridgeRecordsWindowFrameOnMoveAndResize`: runs the real visible bridge through an agent, moves and resizes the window, and asserts the sidecar is written.
- Full local bar green: JIT 61, units 349, MCP 19, CLI 83.
- Manual: `previewsmcp run` a visible preview, drag/resize, make a non-leaf edit, window returns to the dragged frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)