### PR TITLE
Tests: assert rendered content in preview e2e

### DIFF
--- a/Sources/PreviewsCLI/DaemonProtocol.swift
+++ b/Sources/PreviewsCLI/DaemonProtocol.swift
@@ -144,7 +144,7 @@ enum DaemonProtocol {
     }
 
     // Elements doesn't get a Codable DTO — the accessibility tree is
-    // arbitrary nested JSON from WDA. The daemon encodes it directly
+    // arbitrary nested JSON built in-app by the simulator host. The daemon encodes it directly
     // into a `Value.object(["sessionID": ..., "elements": <tree>])`
     // and the CLI's `--json` passthrough serializes it back verbatim.
 }

--- a/Sources/PreviewsCLI/Handlers/PreviewElementsHandler.swift
+++ b/Sources/PreviewsCLI/Handlers/PreviewElementsHandler.swift
@@ -58,7 +58,7 @@ enum PreviewElementsHandler: ToolHandler {
 
         let elementsJSON = try await iosSession.fetchElements(filter: filter)
 
-        // Parse WDA's JSON into a `Value` so the structured payload carries
+        // Parse the host's accessibility-tree JSON into a `Value` so the structured payload carries
         // the tree natively rather than as an opaque string. The text block
         // keeps the raw JSON for agents that don't consume
         // `structuredContent`.

--- a/Tests/MCPIntegrationTests/MCPTestServer.swift
+++ b/Tests/MCPIntegrationTests/MCPTestServer.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import MCP
 import System
@@ -363,6 +364,30 @@ final class MCPTestServer: @unchecked Sendable {
         } else if mimeType == "image/jpeg" {
             #expect(data[0] == 0xFF && data[1] == 0xD8, "Expected JPEG header")
         }
+    }
+
+    static func assertNotBlank(_ content: [Tool.Content]) throws {
+        let (data, _) = try extractImageData(from: content)
+        guard let rep = NSBitmapImageRep(data: data) else {
+            Issue.record("Snapshot did not decode as an image")
+            return
+        }
+        let stepX = max(1, rep.pixelsWide / 20)
+        let stepY = max(1, rep.pixelsHigh / 20)
+        var reference: NSColor?
+        for y in stride(from: 0, to: rep.pixelsHigh, by: stepY) {
+            for x in stride(from: 0, to: rep.pixelsWide, by: stepX) {
+                guard let c = rep.colorAt(x: x, y: y)?.usingColorSpace(.deviceRGB) else { continue }
+                guard let ref = reference else { reference = c; continue }
+                if abs(c.redComponent - ref.redComponent) > 0.05
+                    || abs(c.greenComponent - ref.greenComponent) > 0.05
+                    || abs(c.blueComponent - ref.blueComponent) > 0.05
+                {
+                    return
+                }
+            }
+        }
+        Issue.record("Snapshot appears blank (uniform color) — nothing rendered")
     }
 
     /// Extract all image content items from a tool result.

--- a/Tests/MCPIntegrationTests/MacOSMCPTests.swift
+++ b/Tests/MCPIntegrationTests/MacOSMCPTests.swift
@@ -57,6 +57,7 @@ struct MacOSMCPTests {
         try MCPTestServer.assertValidImage(
             pngContent, expectedMimeType: "image/png",
             minSize: 10_000, expectedWidth: 400, expectedHeight: 600)
+        try MCPTestServer.assertNotBlank(pngContent)
         let (data0, _) = try MCPTestServer.extractImageData(from: jpegContent)
 
         // --- preview_switch to valid index ---

--- a/Tests/PreviewsIOSTests/IOSPreviewSessionTests.swift
+++ b/Tests/PreviewsIOSTests/IOSPreviewSessionTests.swift
@@ -100,6 +100,11 @@ struct IOSPreviewSessionTests {
             let screenshotPath = tempDir.appendingPathComponent("ios_preview.png")
             try pngData.write(to: screenshotPath)
             print("Saved to: \(screenshotPath.path)")
+
+            let elements = try await session.fetchElements()
+            #expect(
+                elements.contains("Hello from iOS Simulator!"),
+                "Element tree should contain the rendered text; got: \(elements)")
         } catch {
             testError = error
         }


### PR DESCRIPTION
## What

The macOS and iOS preview e2e tests only checked that a valid, big-enough image came back, so a blank or wrong render would still pass. This adds content-based assertions.

- **iOS** `endToEnd` now asserts the accessibility tree contains the rendered text via `fetchElements` (this is the CI-running iOS test, which previously checked only image magic bytes).
- **macOS** `fullMacOSWorkflow` gains `MCPTestServer.assertNotBlank`, a pixel probe that fails when the snapshot is a single flat color.

Also fixes two stale comments that called the in-app accessibility tree "WDA" — we do not use WebDriverAgent; the tree is built in-app from UIKit accessibility.

## Verification

Both assertions are red-green verified locally:
- iOS `endToEnd` green (33s); fails on a bogus expected string.
- macOS `fullMacOSWorkflow` green (23s); fails when the not-blank expectation is inverted.

Ran `/simplify` (flattened `assertNotBlank`) and `/code-review` high (no blocking bugs; low-severity flake/robustness notes accepted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)