### PR TITLE
iOS previews over LLVM ORC JIT (remote-EPC, in-app executor)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .build/
+.build-iossim/
 .swiftpm/
 xcuserdata/
 DerivedData/

--- a/HostAppSource/HostApp.swift
+++ b/HostAppSource/HostApp.swift
@@ -29,27 +29,47 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
 
         let args = ProcessInfo.processInfo.arguments
 
-        guard let dylibIndex = args.firstIndex(of: "--dylib"),
-              dylibIndex + 1 < args.count else {
-            showError("Missing --dylib argument")
-            window.makeKeyAndVisible()
-            return true
+        // JIT mode runs the in-process ORC executor and links objects pushed by
+        // the daemon over the EPC socket — there is no preview dylib to load.
+        #if PREVIEWSMCP_IOS_JIT
+        var jitMode = false
+        if let jitPortIndex = args.firstIndex(of: "--jit-port"),
+           jitPortIndex + 1 < args.count,
+           let jitPort = UInt16(args[jitPortIndex + 1]) {
+            startJITExecutor(port: jitPort)
+            jitMode = true
         }
+        #else
+        let jitMode = false
+        #endif
 
-        let dylibPath = args[dylibIndex + 1]
+        if let dylibIndex = args.firstIndex(of: "--dylib"),
+           dylibIndex + 1 < args.count {
+            let dylibPath = args[dylibIndex + 1]
 
-        // Load setup dylib with RTLD_GLOBAL before any preview dylib so all
-        // preview dylibs share the same statics (issue #86).
-        if let setupIndex = args.firstIndex(of: "--setup-dylib"),
-           setupIndex + 1 < args.count {
-            let setupPath = args[setupIndex + 1]
-            if dlopen(setupPath, RTLD_NOW | RTLD_GLOBAL) == nil {
-                let err = String(cString: dlerror())
-                NSLog("PreviewHost: Failed to load setup dylib: \(err)")
+            // Load setup dylib with RTLD_GLOBAL before any preview dylib so all
+            // preview dylibs share the same statics (issue #86).
+            if let setupIndex = args.firstIndex(of: "--setup-dylib"),
+               setupIndex + 1 < args.count {
+                let setupPath = args[setupIndex + 1]
+                if dlopen(setupPath, RTLD_NOW | RTLD_GLOBAL) == nil {
+                    let err = String(cString: dlerror())
+                    NSLog("PreviewHost: Failed to load setup dylib: \(err)")
+                }
             }
+
+            loadPreview(dylibPath: dylibPath)
+        } else if !jitMode {
+            showError("Missing --dylib argument")
         }
 
-        loadPreview(dylibPath: dylibPath)
+        // JIT mode loads no dylib at launch, so the daemon's first render over EPC
+        // installs the real hosting controller. Until then, give the window a
+        // placeholder root view controller so UIKit's end-of-launch assertion
+        // ("windows are expected to have a root view controller") doesn't abort.
+        if jitMode, window.rootViewController == nil {
+            window.rootViewController = UIViewController()
+        }
 
         initTouchInjection()
         activateAccessibility()
@@ -63,6 +83,45 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
         window.makeKeyAndVisible()
         return true
     }
+
+    #if PREVIEWSMCP_IOS_JIT
+    // Connect back to the daemon's EPC listener and run the in-process ORC
+    // executor. Runs on a detached thread so the SimpleRemoteEPCServer can
+    // block on the socket while the UIApplication run loop stays live on main
+    // (run_on_main dispatches to it).
+    private func startJITExecutor(port: UInt16) {
+        Thread.detachNewThread {
+            let fd = Self.connectLoopback(port: port)
+            guard fd >= 0 else {
+                NSLog("PreviewHost: JIT executor failed to connect on port \(port)")
+                return
+            }
+            _ = previewsmcp_ios_executor_start(fd, fd)
+        }
+    }
+
+    private static func connectLoopback(port: UInt16) -> Int32 {
+        let fd = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { return -1 }
+
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = port.bigEndian
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+
+        let result = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                Darwin.connect(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard result == 0 else {
+            Darwin.close(fd)
+            return -1
+        }
+        return fd
+    }
+    #endif
 
     private func loadPreview(dylibPath: String) {
         guard let handle = dlopen(dylibPath, RTLD_NOW | RTLD_GLOBAL) else {

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,21 @@ let jitEnabled =
 let jitCLIDependencies: [Target.Dependency] = jitEnabled ? ["PreviewsJITLink"] : []
 let jitCLISwiftSettings: [SwiftSetting] = jitEnabled ? [.define("PREVIEWSMCP_JIT")] : []
 
+// iOS-simulator JIT: the in-app ORC executor needs the cross-built iossim
+// TargetProcess libs and the iossim orc runtime. Gated separately from macOS
+// JIT because those artifacts come from `scripts/build-jit-llvm-iossim.sh` and
+// may be absent on a macOS-only checkout. When present, the BundleIOSSimJIT
+// plugin stages them into PreviewsIOS resources for IOSHostBuilder.
+let llvmBuildIOSSim = "\(packageDir)/third_party/llvm-build-iossim/lib/libLLVMOrcTargetProcess.a"
+let orcRuntimeIOSSim = "\(packageDir)/third_party/llvm-build-rt/lib/darwin/liborc_rt_iossim.a"
+
+let iosJitEnabled =
+    FileManager.default.fileExists(atPath: llvmBuildIOSSim)
+    && FileManager.default.fileExists(atPath: orcRuntimeIOSSim)
+
+let iosJitSwiftSettings: [SwiftSetting] = iosJitEnabled ? [.define("PREVIEWSMCP_IOS_JIT")] : []
+let iosJitPlugins: [Target.PluginUsage] = iosJitEnabled ? [.plugin(name: "BundleIOSSimJIT")] : []
+
 var targets: [Target] = [
     .target(
         name: "SimulatorBridge",
@@ -44,7 +59,8 @@ var targets: [Target] = [
     .target(
         name: "PreviewsIOS",
         dependencies: ["PreviewsCore", "SimulatorBridge"],
-        plugins: [.plugin(name: "EmbedHostAppSource")]
+        swiftSettings: iosJitSwiftSettings,
+        plugins: [.plugin(name: "EmbedHostAppSource")] + iosJitPlugins
     ),
     .target(
         name: "PreviewsEngine",
@@ -60,7 +76,7 @@ var targets: [Target] = [
             .product(name: "ArgumentParser", package: "swift-argument-parser"),
             .product(name: "MCP", package: "swift-sdk"),
         ] + jitCLIDependencies,
-        swiftSettings: jitCLISwiftSettings,
+        swiftSettings: jitCLISwiftSettings + iosJitSwiftSettings,
         plugins: [.plugin(name: "GenerateVersion")]
     ),
     .executableTarget(
@@ -120,6 +136,15 @@ var targets: [Target] = [
     ),
 ]
 
+if iosJitEnabled {
+    targets += [
+        .plugin(
+            name: "BundleIOSSimJIT",
+            capability: .buildTool()
+        )
+    ]
+}
+
 if jitEnabled {
     targets += [
         .target(
@@ -170,8 +195,9 @@ if jitEnabled {
         ),
         .testTarget(
             name: "PreviewsJITLinkTests",
-            dependencies: ["PreviewsJITLink", "PreviewsCore", "PreviewAgent"],
-            exclude: ["Fixtures"]
+            dependencies: ["PreviewsJITLink", "PreviewsCore", "PreviewAgent", "PreviewsIOS"],
+            exclude: ["Fixtures"],
+            swiftSettings: iosJitSwiftSettings
         ),
     ]
 }

--- a/Plugins/BundleIOSSimJIT/BundleIOSSimJIT.swift
+++ b/Plugins/BundleIOSSimJIT/BundleIOSSimJIT.swift
@@ -1,0 +1,27 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct BundleIOSSimJIT: BuildToolPlugin {
+    func createBuildCommands(
+        context: PluginContext,
+        target: Target
+    ) throws -> [Command] {
+        let script = context.package.directoryURL
+            .appending(path: "scripts/bundle-iossim-jit.sh")
+        let outputDir = context.pluginWorkDirectoryURL
+
+        return [
+            .prebuildCommand(
+                displayName: "Bundle iossim JIT executor artifacts",
+                executable: URL(fileURLWithPath: "/bin/bash"),
+                arguments: [
+                    script.path(),
+                    context.package.directoryURL.path(),
+                    outputDir.path(),
+                ],
+                outputFilesDirectory: outputDir
+            )
+        ]
+    }
+}

--- a/Sources/PreviewsCLI/Handlers/PreviewStartHandler.swift
+++ b/Sources/PreviewsCLI/Handlers/PreviewStartHandler.swift
@@ -6,6 +6,22 @@ import PreviewsEngine
 import PreviewsIOS
 import PreviewsMacOS
 
+#if PREVIEWSMCP_JIT
+import PreviewsJITLink
+#endif
+
+/// Builds the iOS JIT reloader from the accepted EPC fd, or nil when the JIT build is
+/// absent so iOS stays on the dylib path. Mirrors the macOS `host.makeStructuralReloader`
+/// injection in `PreviewsMCPApp`. Active only when both the JIT link library
+/// (`PREVIEWSMCP_JIT`) and the bundled iossim runtime (`PREVIEWSMCP_IOS_JIT`) are present.
+private let iosJITReloaderFactory: IOSPreviewSession.MakeJITReloader? = {
+    #if PREVIEWSMCP_JIT && PREVIEWSMCP_IOS_JIT
+    return { fd, orcPath in try IOSJITStructuralReloader(remoteFD: fd, orcRuntimePath: orcPath) }
+    #else
+    return nil
+    #endif
+}()
+
 enum PreviewStartHandler: ToolHandler {
     static let name: ToolName = .previewStart
 
@@ -287,7 +303,8 @@ private func handleIOSPreviewStart(
         setupCompilerFlags: setupResult?.compilerFlags ?? [],
         setupSDKPath: setupResult?.sdkPath,
         setupDylibPath: setupResult?.dylibPath,
-        progress: progress
+        progress: progress,
+        makeJITReloader: iosJITReloaderFactory
     )
 
     stage("session.start begin")

--- a/Sources/PreviewsCore/BridgeGenerator.swift
+++ b/Sources/PreviewsCore/BridgeGenerator.swift
@@ -82,10 +82,15 @@ public enum BridgeGenerator {
 
         let bodyKindEntry = bodyKindEntryPoint(closureBody: transformedClosureBody)
         let renderEntry =
-            renderOutputPath.map {
-                renderToFileEntryPoint(
-                    viewCode: viewCode, path: $0, valuesPath: designTimeValuesPath,
-                    window: renderWindow, frameSidecarPath: frameSidecarPath)
+            renderOutputPath.map { path -> String in
+                switch platform {
+                case .macOS:
+                    return renderToFileEntryPoint(
+                        viewCode: viewCode, path: path, valuesPath: designTimeValuesPath,
+                        window: renderWindow, frameSidecarPath: frameSidecarPath)
+                case .iOS:
+                    return iosRenderEntryPoint(viewCode: viewCode, valuesPath: designTimeValuesPath)
+                }
             } ?? ""
         let bridgeCode: String
         switch platform {
@@ -118,6 +123,8 @@ public enum BridgeGenerator {
                 }
 
                 \(bodyKindEntry)
+
+                \(renderEntry)
                 """
         }
 
@@ -308,6 +315,21 @@ public enum BridgeGenerator {
         """
     }
 
+    /// Generated code (run at the top of a render entry) that re-seeds `DesignTimeStore`
+    /// from the values JSON the daemon rewrites per literal edit. Empty when no path.
+    private static func designTimeSeed(_ valuesPath: String?) -> String {
+        valuesPath.map {
+            """
+            if let __dtData = try? Data(contentsOf: URL(fileURLWithPath: "\(escapedForSwiftStringLiteral($0))")),
+                let __dtValues = try? JSONSerialization.jsonObject(with: __dtData)
+                    as? [String: Any]
+            {
+                DesignTimeStore.shared.values = __dtValues
+            }
+            """
+        } ?? ""
+    }
+
     /// Generate the `@_cdecl("renderPreviewToFile")` entry point (macOS, model-A JIT path).
     /// Builds the same preview view as `createPreviewView`, hosts it in a borderless
     /// `NSWindow` positioned off-screen via `NSHostingView` (AppKit-backed views like
@@ -324,17 +346,7 @@ public enum BridgeGenerator {
         viewCode: String, path: String, valuesPath: String?, window: JITRenderWindow?,
         frameSidecarPath: String?
     ) -> String {
-        let seed =
-            valuesPath.map {
-                """
-                if let __dtData = try? Data(contentsOf: URL(fileURLWithPath: "\(escapedForSwiftStringLiteral($0))")),
-                    let __dtValues = try? JSONSerialization.jsonObject(with: __dtData)
-                        as? [String: Any]
-                {
-                    DesignTimeStore.shared.values = __dtValues
-                }
-                """
-            } ?? ""
+        let seed = designTimeSeed(valuesPath)
         let createWindow: String
         let presentNewWindow: String
         let frameObservers: String
@@ -424,6 +436,33 @@ public enum BridgeGenerator {
                     } catch {
                         return Int32(-3)
                     }
+                    return 0
+                }
+            }
+            """
+    }
+
+    /// Generate the `@_cdecl("renderPreviewToFile")` entry point (iOS JIT path). Builds the
+    /// same preview view as `createPreviewView`, hosts it in a `UIHostingController`, and sets
+    /// it as the live host app's key-window `rootViewController` on the main actor. Unlike the
+    /// macOS entry it does not raster a PNG: the daemon captures the simulator screen via
+    /// `simctl`, so the baked render path is unused here. Nullary and run over the agent's
+    /// `runOnMain` surface; re-running it after a literal edit re-seeds DesignTimeStore.
+    private static func iosRenderEntryPoint(viewCode: String, valuesPath: String?) -> String {
+        let seed = designTimeSeed(valuesPath)
+        return """
+            @_cdecl("renderPreviewToFile")
+            public func renderPreviewToFile() -> Int32 {
+                MainActor.assumeIsolated {
+                    \(seed)
+                    let view = \(viewCode)
+                    let hosting = UIHostingController(rootView: view)
+                    let windows = UIApplication.shared.connectedScenes
+                        .compactMap { $0 as? UIWindowScene }
+                        .flatMap { $0.windows }
+                    guard let window = windows.first(where: { $0.isKeyWindow }) ?? windows.first
+                    else { return Int32(-1) }
+                    window.rootViewController = hosting
                     return 0
                 }
             }

--- a/Sources/PreviewsCore/IOSStructuralReloader.swift
+++ b/Sources/PreviewsCore/IOSStructuralReloader.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Daemon-side handle for the in-app iOS ORC executor reached over the EPC socket.
+///
+/// The iOS analogue of `StructuralReloader`: it links a freshly compiled object into
+/// the live host app over the EPC connection and runs its render entry on the app's
+/// main thread, which hosts the preview view on the key window. Unlike the macOS path
+/// it does not raster a PNG; the daemon captures the simulator screen via `simctl`.
+///
+/// Defined here, JIT-free, so `IOSPreviewSession` can hold the connection without
+/// depending on the gated JIT target: `PreviewsJITLink` provides the implementation and
+/// the executable injects a factory only when the JIT build is present.
+public protocol IOSStructuralReloader: Sendable {
+    /// Link and render `build`'s entry over the EPC connection, first linking the target's
+    /// dependency `dylibPaths` / `archivePaths` / `supportObjectPaths` (all empty for the
+    /// standalone path, where `objectPath` is self-contained).
+    func render(_ build: JITRenderBuild) async throws
+}

--- a/Sources/PreviewsIOS/IOSHostBuilder.swift
+++ b/Sources/PreviewsIOS/IOSHostBuilder.swift
@@ -76,7 +76,7 @@ public actor IOSHostBuilder {
         try IOSHostAppSource.code.write(to: sourceFile, atomically: true, encoding: .utf8)
 
         // Compile
-        try await run(
+        var compileArgs = [
             swiftcPath,
             "-emit-executable",
             "-parse-as-library",
@@ -87,8 +87,36 @@ public actor IOSHostBuilder {
             "-gnone",
             "-module-cache-path", moduleCachePath.path,
             "-o", binaryPath.path,
-            sourceFile.path
-        )
+        ]
+
+        #if PREVIEWSMCP_IOS_JIT
+        // Link the in-app ORC executor so the host can JIT-link objects pushed
+        // by the daemon over the second (EPC) socket. server.o references the
+        // LLVM symbols, so it must precede the archives; the orc runtime is NOT
+        // linked here — the daemon injects it remotely.
+        let jit = try Self.jitArtifacts()
+        let bridgingHeader = workDir.appendingPathComponent("previewsmcp_ios_executor.h")
+        try Self.bridgingHeaderSource.write(to: bridgingHeader, atomically: true, encoding: .utf8)
+        compileArgs += [
+            "-D", "PREVIEWSMCP_IOS_JIT",
+            "-import-objc-header", bridgingHeader.path,
+        ]
+        compileArgs.append(sourceFile.path)
+        compileArgs.append(jit.serverObject.path)
+        compileArgs += [
+            "-L", jit.libDir.path,
+            "-lLLVMOrcTargetProcess",
+            "-lLLVMOrcShared",
+            "-lLLVMSupport",
+            "-lLLVMTargetParser",
+            "-lLLVMDemangle",
+            "-lc++",
+        ]
+        #else
+        compileArgs.append(sourceFile.path)
+        #endif
+
+        try await run(compileArgs)
 
         // Create .app bundle
         try FileManager.default.createDirectory(at: appDir, withIntermediateDirectories: true)
@@ -120,6 +148,11 @@ public actor IOSHostBuilder {
 
     @discardableResult
     private func run(_ args: String...) async throws -> String {
+        try await run(args)
+    }
+
+    @discardableResult
+    private func run(_ args: [String]) async throws -> String {
         let output = try await runAsync(args[0], arguments: Array(args.dropFirst()))
         guard output.exitCode == 0 else {
             throw IOSHostBuildError.compilationFailed(
@@ -130,6 +163,38 @@ public actor IOSHostBuilder {
     }
 
 }
+
+#if PREVIEWSMCP_IOS_JIT
+extension IOSHostBuilder {
+    struct JITArtifacts {
+        let serverObject: URL
+        let libDir: URL
+    }
+
+    /// Locate the iossim JIT executor artifacts staged into PreviewsIOS
+    /// resources by the BundleIOSSimJIT plugin. `server.o` and the LLVM
+    /// archives share the bundle's resource directory.
+    static func jitArtifacts() throws -> JITArtifacts {
+        guard let serverObject = Bundle.module.url(forResource: "server", withExtension: "o") else {
+            throw IOSHostBuildError.compilationFailed(
+                "iOS JIT build requested but server.o is missing from the PreviewsIOS resource bundle"
+            )
+        }
+        return JITArtifacts(
+            serverObject: serverObject,
+            libDir: serverObject.deletingLastPathComponent()
+        )
+    }
+
+    static let bridgingHeaderSource = "int previewsmcp_ios_executor_start(int in_fd, int out_fd);\n"
+
+    /// Path to the iossim orc runtime archive the daemon injects remotely via
+    /// `JITSession(remoteFD:orcRuntimePath:)`. Not linked into the host app.
+    public static var jitOrcRuntimePath: String? {
+        Bundle.module.url(forResource: "liborc_rt_iossim", withExtension: "a")?.path
+    }
+}
+#endif
 
 public enum IOSHostBuildError: Error, LocalizedError, CustomStringConvertible {
     case compilationFailed(String)

--- a/Sources/PreviewsIOS/IOSPreviewSession.swift
+++ b/Sources/PreviewsIOS/IOSPreviewSession.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import PreviewsCore
 
@@ -33,6 +34,15 @@ public actor IOSPreviewSession {
     /// per-session and torn down by `stop()`.
     private let channel = IOSHostChannel()
 
+    /// Builds the JIT reloader from the accepted EPC socket and the bundled
+    /// iossim orc runtime path. Injected by the composition root behind the JIT
+    /// flag; `nil` keeps the session on the dylib path.
+    public typealias MakeJITReloader =
+        @Sendable (_ epcFD: Int32, _ orcRuntimePath: String) throws -> any IOSStructuralReloader
+    private let makeJITReloader: MakeJITReloader?
+    private var jitReloader: (any IOSStructuralReloader)?
+    private var jitListenFD: Int32 = -1
+
     /// Outermost body kind of the currently-loaded preview. Reported by the host
     /// after each dylib load (initial `init` handshake + every `reloadAck`).
     /// Defaults to `.uiView` so a stale or legacy host that never reports a kind
@@ -62,7 +72,8 @@ public actor IOSPreviewSession {
         setupCompilerFlags: [String] = [],
         setupSDKPath: String? = nil,
         setupDylibPath: URL? = nil,
-        progress: (any ProgressReporter)? = nil
+        progress: (any ProgressReporter)? = nil,
+        makeJITReloader: MakeJITReloader? = nil
     ) {
         self.id = UUID().uuidString
         self.sourceFile = sourceFile
@@ -80,6 +91,7 @@ public actor IOSPreviewSession {
         self.setupSDKPath = setupSDKPath
         self.setupDylibPath = setupDylibPath
         self.progress = progress
+        self.makeJITReloader = makeJITReloader
     }
 
     // MARK: - Lifecycle
@@ -96,8 +108,15 @@ public actor IOSPreviewSession {
             Log.info("iOS preview: \(s) [\(deviceUDID.prefix(8))]")
         }
 
-        // 1. Compile preview dylib for iOS simulator
-        stage("compiling dylib")
+        var jitMode = false
+        #if PREVIEWSMCP_IOS_JIT
+        jitMode = makeJITReloader != nil
+        #endif
+
+        // 1. Compile the preview. The dylib path links a dylib now and loads it via
+        // the host's `--dylib` argv; the JIT path skips the dylib and renders over the
+        // EPC connection once the in-app executor is up (step 8).
+        stage(jitMode ? "compiling (JIT)" : "compiling dylib")
         await progress?.report(.compilingBridge, message: "Compiling \(sourceFile.lastPathComponent)...")
         let previewSession = PreviewSession(
             sourceFile: sourceFile,
@@ -112,7 +131,7 @@ public actor IOSPreviewSession {
             setupSDKPath: setupSDKPath
         )
         self.session = previewSession
-        let compileResult = try await previewSession.compile()
+        let dylibPath = jitMode ? nil : try await previewSession.compile().dylibPath
 
         // 2. Build host app.
         stage("building host app")
@@ -122,6 +141,16 @@ public actor IOSPreviewSession {
 
         // 4. Create TCP server on loopback, bind to ephemeral port
         let port = try await channel.bindAndListen()
+
+        // 4b. JIT mode: bind a second loopback listener for the EPC channel the
+        // in-app ORC executor connects back on. The JSON channel above still
+        // serves elements / touch / screenshot.
+        var jitPort: Int?
+        #if PREVIEWSMCP_IOS_JIT
+        if makeJITReloader != nil {
+            jitPort = try bindJITListener()
+        }
+        #endif
 
         // 5. Boot + install + launch with retry. The whole sequence is
         // retried because PR #141 CI has shown the iOS simulator
@@ -135,12 +164,15 @@ public actor IOSPreviewSession {
         await progress?.report(.installingApp, message: "Installing host app...")
         await progress?.report(.launchingApp, message: "Launching host app...")
 
-        var launchArgs = [
-            "--dylib", compileResult.dylibPath.path,
-            "--port", String(port),
-        ]
+        var launchArgs = ["--port", String(port)]
+        if let dylibPath {
+            launchArgs += ["--dylib", dylibPath.path]
+        }
         if let setupPath = setupDylibPath {
             launchArgs += ["--setup-dylib", setupPath.path]
+        }
+        if let jitPort {
+            launchArgs += ["--jit-port", String(jitPort)]
         }
 
         var launchedPid: Int?
@@ -236,6 +268,26 @@ public actor IOSPreviewSession {
             )
         }
 
+        #if PREVIEWSMCP_IOS_JIT
+        // 8. JIT mode: accept the executor's EPC connection and stand up the
+        // remote session over it. The host connects --port and --jit-port
+        // independently, so this accept is ordered after the JSON connect but
+        // either may arrive first (the listen backlog holds the other).
+        if let make = makeJITReloader {
+            guard let orcPath = IOSHostBuilder.jitOrcRuntimePath else {
+                throw IOSPreviewSessionError.jitRuntimeMissing
+            }
+            stage("awaiting JIT executor connection")
+            let epcFD = try acceptJIT(timeoutSeconds: 10)
+            let reloader = try make(epcFD, orcPath)
+            jitReloader = reloader
+            stage("JIT executor connected; rendering initial preview")
+            let build = try await previewSession.compileObjectForJIT()
+            try await reloader.render(build)
+            stage("initial JIT render complete")
+        }
+        #endif
+
         stage("connected; start complete (bodyKind=\(lastBodyKind))")
 
         return pid
@@ -245,6 +297,70 @@ public actor IOSPreviewSession {
     /// `IOSHostChannel.close()` is safe to call when nothing was opened.
     public func stop() async {
         await channel.close()
+        jitReloader = nil
+        if jitListenFD >= 0 {
+            Darwin.close(jitListenFD)
+            jitListenFD = -1
+        }
+    }
+
+    // MARK: - JIT EPC socket
+
+    /// Bind a second loopback listener for the in-app ORC executor's EPC
+    /// connection and return the assigned port. The accepted fd is owned by the
+    /// JIT session built from it; `stop()` closes the listen fd.
+    private func bindJITListener() throws -> Int {
+        let fd = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw IOSPreviewSessionError.socketCreateFailed }
+        var reuse: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size))
+
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = 0
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+
+        let bound = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                Darwin.bind(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bound == 0, Darwin.listen(fd, 1) == 0 else {
+            Darwin.close(fd)
+            throw IOSPreviewSessionError.socketCreateFailed
+        }
+
+        var name = sockaddr_in()
+        var len = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let named = withUnsafeMutablePointer(to: &name) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                getsockname(fd, sockPtr, &len)
+            }
+        }
+        guard named == 0 else {
+            Darwin.close(fd)
+            throw IOSPreviewSessionError.socketCreateFailed
+        }
+        jitListenFD = fd
+        return Int(UInt16(bigEndian: name.sin_port))
+    }
+
+    /// Accept the executor's EPC connection (up to `timeoutSeconds`) and close
+    /// the listen fd. Returns the connected fd, which the JIT session owns.
+    private func acceptJIT(timeoutSeconds: Int32) throws -> Int32 {
+        var pfd = pollfd(fd: jitListenFD, events: Int16(POLLIN), revents: 0)
+        let ready = poll(&pfd, 1, timeoutSeconds * 1000)
+        guard ready > 0 else {
+            throw IOSPreviewSessionError.socketAcceptTimeout
+        }
+        let conn = Darwin.accept(jitListenFD, nil, nil)
+        Darwin.close(jitListenFD)
+        jitListenFD = -1
+        guard conn >= 0 else {
+            throw IOSPreviewSessionError.socketAcceptFailed
+        }
+        return conn
     }
 
     // MARK: - Communication
@@ -269,6 +385,17 @@ public actor IOSPreviewSession {
             setupSDKPath: setupSDKPath
         )
         self.session = previewSession
+
+        #if PREVIEWSMCP_IOS_JIT
+        // JIT path: link the freshly compiled object into the live host over EPC and
+        // re-run its render entry. No dylib, no `reload` round-trip over the JSON channel.
+        if let jitReloader {
+            let build = try await previewSession.compileObjectForJIT()
+            try await jitReloader.render(build)
+            return
+        }
+        #endif
+
         let compileResult = try await previewSession.compile()
 
         let requestID = UUID().uuidString
@@ -474,6 +601,7 @@ public enum IOSPreviewSessionError: Error, LocalizedError, CustomStringConvertib
     case socketCreateFailed
     case socketAcceptFailed
     case socketAcceptTimeout
+    case jitRuntimeMissing
     case socketResponseTimeout(String)
     case connectionLost
     /// JSON parse or shape mismatch on a host-app response. Distinct
@@ -487,6 +615,7 @@ public enum IOSPreviewSessionError: Error, LocalizedError, CustomStringConvertib
         case .socketCreateFailed: return "Failed to create TCP server socket"
         case .socketAcceptFailed: return "Failed to accept connection from host app"
         case .socketAcceptTimeout: return "Timed out waiting for host app to connect"
+        case .jitRuntimeMissing: return "Bundled iossim orc runtime archive not found"
         case .socketResponseTimeout(let id): return "Timed out waiting for response (id: \(id))"
         case .connectionLost: return "Connection to host app lost"
         case .responseDecodeFailed(let operation):

--- a/Sources/PreviewsJITLink/IOSJITStructuralReloader.swift
+++ b/Sources/PreviewsJITLink/IOSJITStructuralReloader.swift
@@ -1,0 +1,62 @@
+import Foundation
+import PreviewsCore
+
+/// `IOSStructuralReloader` backed by the in-app ORC executor reached over an EPC socket.
+///
+/// Unlike `JITStructuralReloader`, the iOS reloader cannot respawn its executor: the
+/// executor lives inside the long-running simulator host app, reached over a single
+/// accepted EPC fd. So one `JITSession` serves every edit for the session's lifetime,
+/// linking each structural edit into a fresh `JITDylib` (`newGeneration`). A full host
+/// restart, when needed to bound leaked `__swift5_*` metadata, is driven by the daemon
+/// via `simctl`, not from here.
+public actor IOSJITStructuralReloader: IOSStructuralReloader {
+    private let session: JITSession
+    private var generation = 0
+    private var didRunSetUp = false
+
+    public init(remoteFD fd: Int32, orcRuntimePath: String) throws {
+        session = try JITSession(remoteFD: fd, orcRuntimePath: orcRuntimePath)
+    }
+
+    public func render(_ build: JITRenderBuild) async throws {
+        // Each call links a freshly compiled object (compileObjectForJIT mints a new
+        // objectPath every time) into a fresh generation. iOS has no literal-only re-seed
+        // path yet, so there is no same-object fast path to short-circuit here.
+        if generation > 0 {
+            try session.newGeneration()
+        }
+        generation += 1
+
+        for dylib in build.dylibPaths {
+            try session.addDylib(path: dylib.path)
+        }
+        for archive in build.archivePaths {
+            try session.addArchive(path: archive.path)
+        }
+        for support in build.supportObjectPaths {
+            try session.addObject(path: support.path)
+        }
+        try session.addObject(path: build.objectPath.path)
+
+        if let setupEntry = build.setupEntrySymbol, !didRunSetUp {
+            _ = try session.runOnMain(symbol: setupEntry)
+            didRunSetUp = true
+        }
+        try await runEntry(build.entrySymbol)
+    }
+
+    /// Run the render entry, re-running it (no relink) on the iOS entry's `-1` "no key
+    /// window yet" status. The host installs a placeholder root controller at launch, but
+    /// the first render can race window attachment on a cold simulator; a few short retries
+    /// cover that without failing `start()`. Any other non-zero status fails immediately.
+    private func runEntry(_ entrySymbol: String) async throws {
+        for attempt in 1...5 {
+            let status = try session.runOnMain(symbol: entrySymbol)
+            if status == 0 { return }
+            guard status == -1, attempt < 5 else {
+                throw JITReloadError.renderFailed(status: status)
+            }
+            try await Task.sleep(for: .milliseconds(200))
+        }
+    }
+}

--- a/Sources/PreviewsJITLink/PreviewsJITLink.swift
+++ b/Sources/PreviewsJITLink/PreviewsJITLink.swift
@@ -49,6 +49,17 @@ public final class JITSession {
         handle = session
     }
 
+    public init(remoteFD fd: Int32, orcRuntimePath: String) throws {
+        var session: OpaquePointer?
+        if let error = previewsmcp_jit_remote_session_create_from_fd(&session, fd, orcRuntimePath) {
+            throw JITLinkError.failed(error.string())
+        }
+        guard let session else {
+            throw JITLinkError.failed("no session returned")
+        }
+        handle = session
+    }
+
     public func runMain(symbol: String) throws -> Int32 {
         var result: Int32 = 0
         if let error = previewsmcp_jit_session_run_main(handle, symbol, &result) {

--- a/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
+++ b/Sources/PreviewsJITLinkCxx/PreviewsJITLinkCxx.cpp
@@ -356,38 +356,9 @@ previewsmcp_jit_session_create(previewsmcp_jit_session **out_session,
   return nullptr;
 }
 
-const char *
-previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
-                                      const char *agent_path,
-                                      const char *orc_rt_path) {
-  initNativeTargetOnce();
-
-  int sv[2];
-  if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) {
-    return strdup(
-        ("socketpair failed: " + std::string(strerror(errno))).c_str());
-  }
-  fcntl(sv[0], F_SETFD, FD_CLOEXEC);
-  fcntl(sv[1], F_SETFD, FD_CLOEXEC);
-
-  int childFd = (sv[0] > sv[1] ? sv[0] : sv[1]) + 1;
-  posix_spawn_file_actions_t actions;
-  posix_spawn_file_actions_init(&actions);
-  posix_spawn_file_actions_adddup2(&actions, sv[1], childFd);
-  std::string fdArg =
-      "filedescs=" + std::to_string(childFd) + "," + std::to_string(childFd);
-  char *const argv[] = {const_cast<char *>(agent_path),
-                        const_cast<char *>(fdArg.c_str()), nullptr};
-  pid_t pid = 0;
-  int rc =
-      posix_spawn(&pid, agent_path, &actions, nullptr, argv, *_NSGetEnviron());
-  posix_spawn_file_actions_destroy(&actions);
-  close(sv[1]);
-  if (rc != 0) {
-    close(sv[0]);
-    return strdup(("posix_spawn failed: " + std::string(strerror(rc))).c_str());
-  }
-
+static const char *
+createRemoteSessionFromFDs(previewsmcp_jit_session **out_session, int inFd,
+                           int outFd, const char *orc_rt_path, pid_t pid) {
   llvm::orc::SimpleRemoteEPC::Setup setup;
   setup.CreateMemoryAccess = [](llvm::orc::SimpleRemoteEPC &epc)
       -> llvm::Expected<
@@ -406,7 +377,7 @@ previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
       llvm::orc::SimpleRemoteEPC::Create<llvm::orc::FDSimpleRemoteEPCTransport>(
           std::make_unique<llvm::orc::DynamicThreadPoolTaskDispatcher>(
               std::nullopt),
-          std::move(setup), sv[0], sv[0]);
+          std::move(setup), inFd, outFd);
   if (!epc) {
     killAgent(pid);
     return toCStr(epc.takeError());
@@ -476,6 +447,47 @@ previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
   session->jd = &*jd;
   *out_session = session;
   return nullptr;
+}
+
+const char *
+previewsmcp_jit_remote_session_create(previewsmcp_jit_session **out_session,
+                                      const char *agent_path,
+                                      const char *orc_rt_path) {
+  initNativeTargetOnce();
+
+  int sv[2];
+  if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) {
+    return strdup(
+        ("socketpair failed: " + std::string(strerror(errno))).c_str());
+  }
+  fcntl(sv[0], F_SETFD, FD_CLOEXEC);
+  fcntl(sv[1], F_SETFD, FD_CLOEXEC);
+
+  int childFd = (sv[0] > sv[1] ? sv[0] : sv[1]) + 1;
+  posix_spawn_file_actions_t actions;
+  posix_spawn_file_actions_init(&actions);
+  posix_spawn_file_actions_adddup2(&actions, sv[1], childFd);
+  std::string fdArg =
+      "filedescs=" + std::to_string(childFd) + "," + std::to_string(childFd);
+  char *const argv[] = {const_cast<char *>(agent_path),
+                        const_cast<char *>(fdArg.c_str()), nullptr};
+  pid_t pid = 0;
+  int rc =
+      posix_spawn(&pid, agent_path, &actions, nullptr, argv, *_NSGetEnviron());
+  posix_spawn_file_actions_destroy(&actions);
+  close(sv[1]);
+  if (rc != 0) {
+    close(sv[0]);
+    return strdup(("posix_spawn failed: " + std::string(strerror(rc))).c_str());
+  }
+
+  return createRemoteSessionFromFDs(out_session, sv[0], sv[0], orc_rt_path, pid);
+}
+
+const char *previewsmcp_jit_remote_session_create_from_fd(
+    previewsmcp_jit_session **out_session, int fd, const char *orc_rt_path) {
+  initNativeTargetOnce();
+  return createRemoteSessionFromFDs(out_session, fd, fd, orc_rt_path, 0);
 }
 
 const char *previewsmcp_jit_session_run_main(previewsmcp_jit_session *session,

--- a/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
+++ b/Sources/PreviewsJITLinkCxx/include/PreviewsJITLinkCxx.h
@@ -25,6 +25,10 @@ const char *_Nullable previewsmcp_jit_remote_session_create(
     previewsmcp_jit_session *_Nullable *_Nonnull out_session,
     const char *agent_path, const char *orc_rt_path);
 
+const char *_Nullable previewsmcp_jit_remote_session_create_from_fd(
+    previewsmcp_jit_session *_Nullable *_Nonnull out_session, int fd,
+    const char *orc_rt_path);
+
 const char *_Nullable previewsmcp_jit_session_run_main(
     previewsmcp_jit_session *session, const char *symbol_name,
     int32_t *out_result);

--- a/Tests/PreviewsCoreTests/BridgeGeneratorIOSRenderTests.swift
+++ b/Tests/PreviewsCoreTests/BridgeGeneratorIOSRenderTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+
+@testable import PreviewsCore
+
+@Suite("BridgeGenerator iOS render entry")
+struct BridgeGeneratorIOSRenderTests {
+    static let source = """
+        import SwiftUI
+
+        struct TestView: View {
+            var body: some View {
+                Text("Hello")
+            }
+        }
+
+        #Preview { TestView() }
+        """
+
+    @Test("iOS JIT source emits a renderPreviewToFile entry that hosts the view on the key window")
+    func iosEmitsRenderEntry() {
+        let generated = BridgeGenerator.generateCombinedSource(
+            originalSource: Self.source,
+            closureBody: "TestView()",
+            platform: .iOS,
+            renderOutputPath: "/tmp/out.png",
+            designTimeValuesPath: "/tmp/out.json")
+        #expect(generated.source.contains("@_cdecl(\"renderPreviewToFile\")"))
+        #expect(generated.source.contains("UIHostingController(rootView: view)"))
+        #expect(generated.source.contains("rootViewController"))
+        #expect(generated.source.contains("MainActor.assumeIsolated"))
+        #expect(generated.source.contains("isKeyWindow"))
+        #expect(!generated.source.contains("NSHostingView"))
+        #expect(!generated.source.contains("NSWindow"))
+    }
+
+    @Test("iOS render entry re-seeds DesignTimeStore from the values JSON")
+    func iosRenderEntrySeedsValues() {
+        let generated = BridgeGenerator.generateCombinedSource(
+            originalSource: Self.source,
+            closureBody: "TestView()",
+            platform: .iOS,
+            renderOutputPath: "/tmp/out.png",
+            designTimeValuesPath: "/tmp/out.json")
+        #expect(generated.source.contains("DesignTimeStore.shared.values = __dtValues"))
+    }
+
+    @Test("iOS source without a render path emits no render entry (dylib path)")
+    func iosWithoutRenderPathHasNoEntry() {
+        let generated = BridgeGenerator.generateCombinedSource(
+            originalSource: Self.source,
+            closureBody: "TestView()",
+            platform: .iOS)
+        #expect(!generated.source.contains("renderPreviewToFile"))
+    }
+}

--- a/Tests/PreviewsCoreTests/IOSCompileObjectForJITTests.swift
+++ b/Tests/PreviewsCoreTests/IOSCompileObjectForJITTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+
+@testable import PreviewsCore
+
+@Suite("iOS compileObjectForJIT")
+struct IOSCompileObjectForJITTests {
+    @Test("compiles an iOS-triple object carrying the renderPreviewToFile entry")
+    func compilesIOSObjectWithRenderEntry() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ios-jit-object-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let sourceFile = dir.appendingPathComponent("Preview.swift")
+        try """
+            import SwiftUI
+
+            struct TestView: View {
+                var body: some View {
+                    Text("Hello")
+                }
+            }
+
+            #Preview { TestView() }
+            """.write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        let compiler = try await Compiler(platform: .iOS)
+        let session = PreviewSession(sourceFile: sourceFile, compiler: compiler, platform: .iOS)
+        let build = try await session.compileObjectForJIT()
+
+        #expect(build.entrySymbol == "renderPreviewToFile")
+        #expect(FileManager.default.fileExists(atPath: build.objectPath.path))
+
+        let symbols = try await runAsync("/usr/bin/nm", arguments: [build.objectPath.path])
+        #expect(symbols.stdout.contains("renderPreviewToFile"))
+    }
+}

--- a/Tests/PreviewsIOSTests/IOSHostBuilderHashTests.swift
+++ b/Tests/PreviewsIOSTests/IOSHostBuilderHashTests.swift
@@ -32,7 +32,13 @@ struct IOSHostBuilderHashTests {
         // (and the change should land in the same PR as the edit).
         // Updated 2026-05-06 for #160: HostApp.swift gained body-kind probe
         // dlsym + reloadAck/init handshake reporting.
-        let expected = "3230e348b2f22a14bcf3ec18e7a7675e2ed51f850bef33c75d81d2c60f98090e"
+        // Updated 2026-06-15 for iOS JIT: HostApp.swift gained the
+        // PREVIEWSMCP_IOS_JIT --jit-port branch that starts the in-app ORC
+        // executor, and the dylib-arg guard no longer fails in JIT mode.
+        // Updated 2026-06-15 for iOS JIT render: JIT mode installs a placeholder
+        // root view controller at launch so UIKit's end-of-launch assertion
+        // doesn't abort before the first render over EPC.
+        let expected = "532971b3df24de106c6f761c2b27fbe6efa3f7af37a7a6b19ad0a182b6f2e115"
         #expect(hash == expected, "host-app artifact hash drifted (was \(expected), now \(hash))")
     }
 }

--- a/Tests/PreviewsJITLinkTests/Fixtures/ios_hosting_probe.swift
+++ b/Tests/PreviewsJITLinkTests/Fixtures/ios_hosting_probe.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+import UIKit
+
+struct IOSHostingProbeView: View {
+    var body: some View {
+        Text("hi").padding()
+    }
+}
+
+@_cdecl("ios_hosting_probe_value")
+public func ios_hosting_probe_value() -> Int32 {
+    MainActor.assumeIsolated {
+        let host = UIHostingController(rootView: IOSHostingProbeView())
+        host.loadViewIfNeeded()
+        let size = host.sizeThatFits(in: CGSize(width: 1000, height: 1000))
+        return size.width > 0 ? 1 : 0
+    }
+}

--- a/Tests/PreviewsJITLinkTests/Fixtures/ios_render_probe.swift
+++ b/Tests/PreviewsJITLinkTests/Fixtures/ios_render_probe.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import UIKit
+
+@_cdecl("ios_render_probe_value")
+public func ios_render_probe_value() -> Int32 {
+    MainActor.assumeIsolated {
+        let content = Color(red: 1, green: 0, blue: 0).frame(width: 8, height: 8)
+        let renderer = ImageRenderer(content: content)
+        renderer.scale = 1
+        guard let cgImage = renderer.cgImage else {
+            return Int32(-1)
+        }
+        var pixel = [UInt8](repeating: 0, count: 4)
+        let space = CGColorSpaceCreateDeviceRGB()
+        guard
+            let ctx = CGContext(
+                data: &pixel, width: 1, height: 1, bitsPerComponent: 8,
+                bytesPerRow: 4, space: space,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        else {
+            return Int32(-2)
+        }
+        let w = CGFloat(cgImage.width)
+        let h = CGFloat(cgImage.height)
+        ctx.draw(cgImage, in: CGRect(x: -w / 2, y: -h / 2, width: w, height: h))
+        let r = Int32(pixel[0])
+        let g = Int32(pixel[1])
+        let b = Int32(pixel[2])
+        return (r << 16) | (g << 8) | b
+    }
+}

--- a/Tests/PreviewsJITLinkTests/Fixtures/main_thread_probe.swift
+++ b/Tests/PreviewsJITLinkTests/Fixtures/main_thread_probe.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+@_cdecl("main_thread_probe")
+public func main_thread_probe() -> Int32 {
+    Thread.isMainThread ? 1 : 0
+}

--- a/Tests/PreviewsJITLinkTests/IOSSimSpikeTests.swift
+++ b/Tests/PreviewsJITLinkTests/IOSSimSpikeTests.swift
@@ -1,0 +1,448 @@
+import Foundation
+import PreviewsJITLink
+import Testing
+
+#if PREVIEWSMCP_IOS_JIT
+import PreviewsCore
+import PreviewsIOS
+#endif
+
+/// Phase 0 spike: prove the macOS daemon can drive an ORC executor running
+/// inside an iOS simulator process and link + run an object there. The executor
+/// (`.build-iossim/iossim-executor`, built by scripts/build-iossim-executor.sh)
+/// connects back over TCP loopback, which the simulator shares with the host,
+/// and the daemon builds the remote session over that fd. Gated on the iossim
+/// artifacts so the macOS bar is unaffected when they are absent.
+struct IOSSimSpikeTests {
+    static let packageRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+
+    static var executor: URL {
+        packageRoot.appendingPathComponent(".build-iossim/iossim-executor")
+    }
+
+    static var orcRuntime: URL {
+        packageRoot.appendingPathComponent(
+            "third_party/llvm-build-rt/lib/darwin/liborc_rt_iossim.a")
+    }
+
+    static var artifactsPresent: Bool {
+        FileManager.default.isExecutableFile(atPath: executor.path)
+            && FileManager.default.fileExists(atPath: orcRuntime.path)
+    }
+
+    static var jitHostApp: URL {
+        packageRoot.appendingPathComponent(".build-iossim/PreviewsMCPJITHost.app")
+    }
+
+    static let jitHostBundleID = "com.previewsmcp.jithost"
+
+    static var jitHostPresent: Bool {
+        FileManager.default.fileExists(atPath: jitHostApp.path)
+            && FileManager.default.fileExists(atPath: orcRuntime.path)
+    }
+
+    @Test(.enabled(if: artifactsPresent), .timeLimit(.minutes(5)))
+    func linksCObjectRemotelyIntoSimulator() throws {
+        try SimSpikeSupport.withRemoteSession(fixture: "answer.c") { session in
+            let result = try session.runMain(symbol: "answer")
+            #expect(result == 42)
+        }
+    }
+
+    @Test(.enabled(if: artifactsPresent), .timeLimit(.minutes(5)))
+    func linksSwiftObjectRemotelyIntoSimulator() throws {
+        try SimSpikeSupport.withRemoteSession(fixture: "swift_answer.swift") { session in
+            let result = try session.runMain(symbol: "swift_answer")
+            #expect(result == 42)
+        }
+    }
+
+    @Test(.enabled(if: artifactsPresent), .timeLimit(.minutes(5)))
+    func runsOnMainThreadInSimulator() throws {
+        try SimSpikeSupport.withRemoteSession(fixture: "main_thread_probe.swift") { session in
+            let offMain = try session.runMain(symbol: "main_thread_probe")
+            #expect(offMain == 0)
+            let onMain = try session.runOnMain(symbol: "main_thread_probe")
+            #expect(onMain == 1)
+        }
+    }
+
+    @Test(.enabled(if: artifactsPresent), .timeLimit(.minutes(5)))
+    func buildsUIHostingControllerInSimulator() throws {
+        try SimSpikeSupport.withRemoteSession(fixture: "ios_hosting_probe.swift") { session in
+            let result = try session.runOnMain(symbol: "ios_hosting_probe_value")
+            #expect(result == 1)
+        }
+    }
+
+    @Test(.enabled(if: artifactsPresent), .timeLimit(.minutes(5)))
+    func rendersSwiftUIContentInSimulator() throws {
+        try SimSpikeSupport.withRemoteSession(fixture: "ios_render_probe.swift") { session in
+            let packed = try session.runOnMain(symbol: "ios_render_probe_value")
+            #expect(packed >= 0)
+            let r = (packed >> 16) & 0xFF
+            let g = (packed >> 8) & 0xFF
+            let b = packed & 0xFF
+            #expect(r > 200 && g < 60 && b < 60)
+        }
+    }
+
+    @Test(.enabled(if: jitHostPresent), .timeLimit(.minutes(5)))
+    func hostsRemoteSessionInSimulatorApp() throws {
+        let udid = try SimSpikeSupport.bootSimulator()
+        let object = try SimSpikeSupport.compileForIOSSim("answer.c")
+        try SimSpikeSupport.installApp(udid: udid, appPath: Self.jitHostApp.path)
+
+        let listener = try SimSpikeSupport.openLoopbackListener()
+        defer { close(listener.fd) }
+
+        try SimSpikeSupport.launchApp(
+            udid: udid, bundleID: Self.jitHostBundleID,
+            args: ["--jit-port", "\(listener.port)"])
+        defer { SimSpikeSupport.terminateApp(udid: udid, bundleID: Self.jitHostBundleID) }
+
+        let conn = try SimSpikeSupport.acceptOne(listenFD: listener.fd, timeoutSeconds: 60)
+        let session = try JITSession(remoteFD: conn, orcRuntimePath: Self.orcRuntime.path)
+        try session.addObject(path: object.path)
+        let result = try session.runMain(symbol: "answer")
+        #expect(result == 42)
+    }
+
+    #if PREVIEWSMCP_IOS_JIT
+    /// Phase 2 fold: the REAL production host app (built by IOSHostBuilder with
+    /// the executor linked from PreviewsIOS resources) hosts the ORC executor
+    /// and the daemon links + runs an object inside it over the EPC socket. JIT
+    /// mode needs no preview dylib, so the app launches with `--jit-port` alone.
+    @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
+    func hostsRemoteSessionInRealHostApp() async throws {
+        let udid = try SimSpikeSupport.bootSimulator()
+        let object = try SimSpikeSupport.compileForIOSSim("answer.c")
+        let appPath = try await IOSHostBuilder().ensureHostApp()
+        try SimSpikeSupport.installApp(udid: udid, appPath: appPath.path)
+
+        let listener = try SimSpikeSupport.openLoopbackListener()
+        defer { close(listener.fd) }
+
+        try SimSpikeSupport.launchApp(
+            udid: udid, bundleID: IOSPreviewSession.hostBundleID,
+            args: ["--jit-port", "\(listener.port)"])
+        defer {
+            SimSpikeSupport.terminateApp(udid: udid, bundleID: IOSPreviewSession.hostBundleID)
+        }
+
+        let conn = try SimSpikeSupport.acceptOne(listenFD: listener.fd, timeoutSeconds: 60)
+        guard let orcPath = IOSHostBuilder.jitOrcRuntimePath else {
+            throw SimSpikeSupport.SpikeError.message("bundled iossim orc runtime missing")
+        }
+        let session = try JITSession(remoteFD: conn, orcRuntimePath: orcPath)
+        try session.addObject(path: object.path)
+        let result = try session.runMain(symbol: "answer")
+        #expect(result == 42)
+    }
+
+    /// Chunk 4: the PRODUCTION IOSPreviewSession.start() stands up the EPC
+    /// session over the second socket. It compiles + launches the real preview
+    /// host (dylib + JSON channel as today) AND, given an injected JIT factory,
+    /// binds a second listener, passes --jit-port, accepts the executor, and
+    /// builds the remote session — proving the factory receives a live fd
+    /// (it links answer.c and runs 42 inside the closure).
+    @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
+    func productionSessionEstablishesJITOverSecondSocket() async throws {
+        let udid = try SimSpikeSupport.bootSimulator()
+        let object = try SimSpikeSupport.compileForIOSSim("answer.c")
+
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-ios-jit-prod-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let sourceFile = tempDir.appendingPathComponent("HelloView.swift")
+        try Self.helloViewSource.write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        let compiler = try await Compiler(platform: .iOS)
+        let hostBuilder = try await IOSHostBuilder()
+        let simulatorManager = SimulatorManager()
+
+        let linked = ResultBox()
+        let session = IOSPreviewSession(
+            sourceFile: sourceFile,
+            deviceUDID: udid,
+            compiler: compiler,
+            hostBuilder: hostBuilder,
+            simulatorManager: simulatorManager,
+            makeJITReloader: { fd, orcPath in
+                let s = try JITSession(remoteFD: fd, orcRuntimePath: orcPath)
+                try s.addObject(path: object.path)
+                linked.set(try s.runMain(symbol: "answer"))
+                return CapturingReloader(session: s)
+            }
+        )
+        defer {
+            SimSpikeSupport.terminateApp(udid: udid, bundleID: IOSPreviewSession.hostBundleID)
+        }
+
+        let pid = try await session.start()
+        #expect(pid > 0)
+        #expect(linked.get() == 42)
+        await session.stop()
+    }
+
+    /// End-to-end iOS JIT render: drives the REAL production `IOSPreviewSession.start()`
+    /// with the production `IOSJITStructuralReloader` factory. start() compiles the preview
+    /// to an object, injects it over EPC, and runs `renderPreviewToFile`, which hosts the
+    /// SwiftUI view on the key window. The accessibility tree fetched over the JSON channel
+    /// must then contain the rendered text — proving the preview renders over JIT, not dylib.
+    @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
+    func endToEndRendersOverJIT() async throws {
+        let udid = try SimSpikeSupport.bootSimulator()
+
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-ios-jit-e2e-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let sourceFile = tempDir.appendingPathComponent("HelloView.swift")
+        try Self.helloViewSource.write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        let compiler = try await Compiler(platform: .iOS)
+        let hostBuilder = try await IOSHostBuilder()
+        let simulatorManager = SimulatorManager()
+
+        let session = IOSPreviewSession(
+            sourceFile: sourceFile,
+            deviceUDID: udid,
+            compiler: compiler,
+            hostBuilder: hostBuilder,
+            simulatorManager: simulatorManager,
+            makeJITReloader: { fd, orcPath in
+                try IOSJITStructuralReloader(remoteFD: fd, orcRuntimePath: orcPath)
+            }
+        )
+        defer {
+            SimSpikeSupport.terminateApp(udid: udid, bundleID: IOSPreviewSession.hostBundleID)
+        }
+
+        let pid = try await session.start()
+        #expect(pid > 0)
+
+        let elements = try await session.fetchElements()
+        #expect(elements.contains("Hello from iOS JIT!"))
+        await session.stop()
+    }
+
+    static var jitOrcRuntimePresent: Bool {
+        IOSHostBuilder.jitOrcRuntimePath != nil
+    }
+
+    static let helloViewSource = """
+        import SwiftUI
+
+        struct HelloView: View {
+            var body: some View {
+                Text("Hello from iOS JIT!")
+                    .font(.largeTitle)
+                    .padding()
+            }
+        }
+
+        #Preview {
+            HelloView()
+        }
+        """
+    #endif
+}
+
+#if PREVIEWSMCP_IOS_JIT
+/// Holds the remote JIT session for the lifetime of the preview session, mirroring
+/// how the real reloader will retain it to drive renders.
+private final class CapturingReloader: IOSStructuralReloader, @unchecked Sendable {
+    let session: JITSession
+    init(session: JITSession) { self.session = session }
+    func render(_ build: JITRenderBuild) async throws {}
+}
+
+/// Thread-safe box so the @Sendable factory closure can report the linked result.
+private final class ResultBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Int32?
+    func set(_ v: Int32) { lock.lock(); value = v; lock.unlock() }
+    func get() -> Int32? { lock.lock(); defer { lock.unlock() }; return value }
+}
+#endif
+
+enum SimSpikeSupport {
+    enum SpikeError: Error, CustomStringConvertible {
+        case message(String)
+        var description: String {
+            switch self {
+            case let .message(m): return m
+            }
+        }
+    }
+
+    static func withRemoteSession(
+        fixture: String, _ body: (JITSession) throws -> Void
+    ) throws {
+        let udid = try bootSimulator()
+        let object = try compileForIOSSim(fixture)
+
+        let listener = try openLoopbackListener()
+        defer { close(listener.fd) }
+
+        let proc = try spawnExecutor(
+            udid: udid, executor: IOSSimSpikeTests.executor, port: listener.port)
+        defer { proc.terminate() }
+
+        let conn = try acceptOne(listenFD: listener.fd, timeoutSeconds: 60)
+        let session = try JITSession(
+            remoteFD: conn, orcRuntimePath: IOSSimSpikeTests.orcRuntime.path)
+        try session.addObject(path: object.path)
+        try body(session)
+    }
+
+    static func compileForIOSSim(_ source: String) throws -> URL {
+        let input = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures", isDirectory: true)
+            .appendingPathComponent(source)
+        let outDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PreviewsJITLinkIOSSimFixtures", isDirectory: true)
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+        let output = outDir.appendingPathComponent(
+            (source as NSString).deletingPathExtension + ".o")
+
+        let sdk = try run("/usr/bin/xcrun", ["--sdk", "iphonesimulator", "--show-sdk-path"])
+            .output.trimmingCharacters(in: .whitespacesAndNewlines)
+        let target = "arm64-apple-ios16.0-simulator"
+        let arguments: [String]
+        if input.pathExtension == "swift" {
+            arguments = [
+                "swiftc", "-c", "-parse-as-library", "-module-name", "Fixtures",
+                "-target", target, "-sdk", sdk, input.path, "-o", output.path,
+            ]
+        } else {
+            arguments = [
+                "clang", "-target", target, "-isysroot", sdk,
+                "-c", input.path, "-o", output.path,
+            ]
+        }
+        let result = try run("/usr/bin/xcrun", arguments)
+        guard result.status == 0 else {
+            throw SpikeError.message("compiling \(source) for iossim failed:\n\(result.output)")
+        }
+        return output
+    }
+
+    static func bootSimulator() throws -> String {
+        if let udid = firstUDID(in: try run(
+            "/usr/bin/xcrun", ["simctl", "list", "devices", "booted"]).output) {
+            return udid
+        }
+        guard let udid = firstUDID(in: try run(
+            "/usr/bin/xcrun", ["simctl", "list", "devices", "available"]).output,
+            onLinesMatching: "iPhone") else {
+            throw SpikeError.message("no available iPhone simulator to boot")
+        }
+        _ = try run("/usr/bin/xcrun", ["simctl", "boot", udid])
+        _ = try run("/usr/bin/xcrun", ["simctl", "bootstatus", udid, "-b"])
+        return udid
+    }
+
+    static func installApp(udid: String, appPath: String) throws {
+        let result = try run("/usr/bin/xcrun", ["simctl", "install", udid, appPath])
+        guard result.status == 0 else {
+            throw SpikeError.message("simctl install failed:\n\(result.output)")
+        }
+    }
+
+    static func launchApp(udid: String, bundleID: String, args: [String]) throws {
+        let result = try run(
+            "/usr/bin/xcrun",
+            ["simctl", "launch", "--terminate-running-process", udid, bundleID] + args)
+        guard result.status == 0 else {
+            throw SpikeError.message("simctl launch failed:\n\(result.output)")
+        }
+    }
+
+    static func terminateApp(udid: String, bundleID: String) {
+        _ = try? run("/usr/bin/xcrun", ["simctl", "terminate", udid, bundleID])
+    }
+
+    static func spawnExecutor(udid: String, executor: URL, port: UInt16) throws -> Process {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+        p.arguments = ["simctl", "spawn", udid, executor.path, "port=\(port)"]
+        try p.run()
+        return p
+    }
+
+    static func openLoopbackListener() throws -> (fd: Int32, port: UInt16) {
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw SpikeError.message("socket failed") }
+        var yes: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, socklen_t(MemoryLayout<Int32>.size))
+
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_addr.s_addr = (0x7f00_0001 as in_addr_t).bigEndian
+        addr.sin_port = 0
+        let bound = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bound == 0 else { close(fd); throw SpikeError.message("bind failed") }
+        guard listen(fd, 1) == 0 else { close(fd); throw SpikeError.message("listen failed") }
+
+        var name = sockaddr_in()
+        var len = socklen_t(MemoryLayout<sockaddr_in>.size)
+        _ = withUnsafeMutablePointer(to: &name) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(fd, $0, &len)
+            }
+        }
+        return (fd, UInt16(bigEndian: name.sin_port))
+    }
+
+    static func acceptOne(listenFD: Int32, timeoutSeconds: Int32) throws -> Int32 {
+        var pfd = pollfd(fd: listenFD, events: Int16(POLLIN), revents: 0)
+        let ready = poll(&pfd, 1, timeoutSeconds * 1000)
+        guard ready > 0 else {
+            throw SpikeError.message("timed out waiting for executor to connect")
+        }
+        let conn = accept(listenFD, nil, nil)
+        guard conn >= 0 else { throw SpikeError.message("accept failed") }
+        return conn
+    }
+
+    private static func firstUDID(in text: String, onLinesMatching needle: String? = nil)
+        -> String?
+    {
+        for line in text.split(separator: "\n") {
+            if let needle, !line.contains(needle) { continue }
+            guard let open = line.firstIndex(of: "("), line[open...].count >= 38 else { continue }
+            let start = line.index(after: open)
+            let candidate = line[start...].prefix(36)
+            if candidate.count == 36, candidate.allSatisfy({ $0.isHexDigit || $0 == "-" }) {
+                return String(candidate)
+            }
+        }
+        return nil
+    }
+
+    private static func run(_ executable: String, _ arguments: [String]) throws
+        -> (status: Int32, output: String)
+    {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (process.terminationStatus, String(decoding: data, as: UTF8.self))
+    }
+}

--- a/iossim-executor/main.cpp
+++ b/iossim-executor/main.cpp
@@ -1,0 +1,76 @@
+// Minimal ORC executor for the iOS simulator: the standalone analog of the
+// in-app iOS JIT host. Runs a SimpleRemoteEPCServer (see server.cpp) so the
+// macOS daemon can link and run objects remotely inside a simulator process.
+// Unlike the macOS agent it cannot inherit a socketpair fd (simctl spawn
+// launches it in the simulator's process domain), so it connects out over TCP
+// loopback, which the simulator shares with the host.
+
+#include "server.h"
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <arpa/inet.h>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <dlfcn.h>
+#include <netinet/in.h>
+#include <string>
+#include <sys/socket.h>
+#include <thread>
+#include <unistd.h>
+
+static void printErrorAndExit(const char *msg) {
+  fprintf(stderr, "iossim-executor error: %s\n\nUsage:\n  iossim-executor port=<tcp-port>\n",
+          msg);
+  exit(1);
+}
+
+static int connectLoopback(int port) {
+  int fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0)
+    printErrorAndExit("socket failed");
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(static_cast<uint16_t>(port));
+  if (inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr) != 1)
+    printErrorAndExit("inet_pton failed");
+  if (connect(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) != 0)
+    printErrorAndExit("connect failed");
+  return fd;
+}
+
+int main(int argc, char *argv[]) {
+  dlopen("/usr/lib/swift/libswiftCore.dylib", RTLD_NOW | RTLD_GLOBAL);
+  dlopen("/usr/lib/swift/libswift_Concurrency.dylib", RTLD_NOW | RTLD_GLOBAL);
+  dlopen("/usr/lib/swift/libswiftFoundation.dylib", RTLD_NOW | RTLD_GLOBAL);
+  dlopen("/usr/lib/swift/libswiftDispatch.dylib", RTLD_NOW | RTLD_GLOBAL);
+  dlopen("/System/Library/Frameworks/UIKit.framework/UIKit",
+         RTLD_NOW | RTLD_GLOBAL);
+  dlopen("/System/Library/Frameworks/SwiftUI.framework/SwiftUI",
+         RTLD_NOW | RTLD_GLOBAL);
+
+  if (argc != 2)
+    printErrorAndExit("expected exactly one argument");
+
+  const char *arg = argv[1];
+  const char *eq = strchr(arg, '=');
+  if (!eq || strncmp(arg, "port", static_cast<size_t>(eq - arg)) != 0)
+    printErrorAndExit("expected port=<tcp-port>");
+  int Port = atoi(eq + 1);
+  if (Port <= 0)
+    printErrorAndExit("invalid port");
+
+  int FD = connectLoopback(Port);
+
+  std::thread ServerThread([FD] {
+    previewsmcp_ios_executor_start(FD, FD);
+    std::_Exit(0);
+  });
+  ServerThread.detach();
+
+  // Drain the main run loop (and with it the main dispatch queue) so
+  // run_on_main's dispatch_sync target executes, mirroring PreviewAgent.
+  while (true)
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.25, false);
+}

--- a/iossim-executor/server.cpp
+++ b/iossim-executor/server.cpp
@@ -1,0 +1,257 @@
+#include "server.h"
+
+#include "llvm/ExecutionEngine/Orc/Shared/AllocationActions.h"
+#include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/ExecutionEngine/Orc/Shared/MemoryFlags.h"
+#include "llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h"
+#include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
+#include "llvm/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.h"
+#include "llvm/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.h"
+#include "llvm/ExecutionEngine/Orc/TargetProcess/RegisterEHFrames.h"
+#include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.h"
+#include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.h"
+#include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/Memory.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstring>
+#include <dispatch/dispatch.h>
+#include <dlfcn.h>
+#include <map>
+#include <mutex>
+#include <vector>
+
+using namespace llvm;
+using namespace llvm::orc;
+
+LLVM_ATTRIBUTE_USED void linkComponents() {
+  errs() << (void *)&llvm_orc_registerEHFrameSectionWrapper
+         << (void *)&llvm_orc_deregisterEHFrameSectionWrapper
+         << (void *)&llvm_orc_registerJITLoaderGDBWrapper
+         << (void *)&llvm_orc_registerJITLoaderGDBAllocAction;
+}
+
+using namespace llvm::orc::shared;
+
+namespace {
+
+llvm::Error registerSwiftSection(const char *Symbol,
+                                 llvm::orc::ExecutorAddrRange R) {
+  using Fn = void (*)(const void *, const void *);
+  auto *fn = reinterpret_cast<Fn>(dlsym(RTLD_DEFAULT, Symbol));
+  if (!fn)
+    return llvm::make_error<llvm::StringError>(
+        std::string("iossim-executor: Swift runtime symbol not found: ") +
+            Symbol,
+        llvm::inconvertibleErrorCode());
+  fn(R.Start.toPtr<const void *>(), R.End.toPtr<const void *>());
+  return llvm::Error::success();
+}
+
+CWrapperFunctionResult previewsmcp_register_conformances(const char *ArgData,
+                                                         size_t ArgSize) {
+  return WrapperFunction<SPSError(SPSExecutorAddrRange)>::handle(
+             ArgData, ArgSize,
+             [](llvm::orc::ExecutorAddrRange R) {
+               return registerSwiftSection("swift_registerProtocolConformances",
+                                           R);
+             })
+      .release();
+}
+
+CWrapperFunctionResult previewsmcp_register_types(const char *ArgData,
+                                                  size_t ArgSize) {
+  return WrapperFunction<SPSError(SPSExecutorAddrRange)>::handle(
+             ArgData, ArgSize,
+             [](llvm::orc::ExecutorAddrRange R) {
+               return registerSwiftSection("swift_registerTypeMetadataRecords",
+                                           R);
+             })
+      .release();
+}
+
+struct MainThreadCall {
+  int32_t (*Fn)();
+  int32_t Result;
+};
+
+void invokeOnMain(void *Ctx) {
+  auto *Call = static_cast<MainThreadCall *>(Ctx);
+  Call->Result = Call->Fn();
+}
+
+CWrapperFunctionResult previewsmcp_run_on_main(const char *ArgData,
+                                               size_t ArgSize) {
+  return WrapperFunction<int32_t(SPSExecutorAddr)>::handle(
+             ArgData, ArgSize,
+             [](llvm::orc::ExecutorAddr FnAddr) -> int32_t {
+               MainThreadCall Call{FnAddr.toPtr<int32_t (*)()>(), 0};
+               dispatch_sync_f(dispatch_get_main_queue(), &Call, invokeOnMain);
+               return Call.Result;
+             })
+      .release();
+}
+
+struct AnonAllocation {
+  size_t Size;
+  std::vector<WrapperFunctionCall> DeallocActions;
+};
+
+std::mutex AnonMapperMutex;
+std::map<void *, size_t> AnonReservations;
+std::map<llvm::orc::ExecutorAddr, AnonAllocation> AnonAllocations;
+
+CWrapperFunctionResult previewsmcp_anon_reserve(const char *ArgData,
+                                                size_t ArgSize) {
+  return WrapperFunction<SPSExpected<SPSExecutorAddr>(uint64_t)>::handle(
+             ArgData, ArgSize,
+             [](uint64_t Size) -> Expected<llvm::orc::ExecutorAddr> {
+               std::error_code EC;
+               auto MB = sys::Memory::allocateMappedMemory(
+                   Size, nullptr, sys::Memory::MF_READ | sys::Memory::MF_WRITE,
+                   EC);
+               if (EC)
+                 return errorCodeToError(EC);
+               std::lock_guard<std::mutex> Lock(AnonMapperMutex);
+               AnonReservations[MB.base()] = Size;
+               return llvm::orc::ExecutorAddr::fromPtr(MB.base());
+             })
+      .release();
+}
+
+CWrapperFunctionResult previewsmcp_anon_initialize(const char *ArgData,
+                                                   size_t ArgSize) {
+  using namespace llvm::orc::tpctypes;
+  return WrapperFunction<SPSExpected<SPSExecutorAddr>(SPSFinalizeRequest)>::
+      handle(ArgData, ArgSize,
+             [](FinalizeRequest FR) -> Expected<llvm::orc::ExecutorAddr> {
+               llvm::orc::ExecutorAddr Base(~0ULL);
+               llvm::orc::ExecutorAddr End(0);
+               for (auto &Seg : FR.Segments) {
+                 Base = std::min(Base, Seg.Addr);
+                 End = std::max(End, Seg.Addr + Seg.Size);
+               }
+               for (auto &Seg : FR.Segments) {
+                 char *Mem = Seg.Addr.toPtr<char *>();
+                 if (!Seg.Content.empty())
+                   memcpy(Mem, Seg.Content.data(), Seg.Content.size());
+                 memset(Mem + Seg.Content.size(), 0,
+                        Seg.Size - Seg.Content.size());
+                 sys::MemoryBlock MB(Mem, Seg.Size);
+                 if (auto EC = sys::Memory::protectMappedMemory(
+                         MB, toSysMemoryProtectionFlags(Seg.RAG.Prot)))
+                   return errorCodeToError(EC);
+                 if ((Seg.RAG.Prot & MemProt::Exec) == MemProt::Exec)
+                   sys::Memory::InvalidateInstructionCache(Mem, Seg.Size);
+               }
+               auto Dealloc = runFinalizeActions(FR.Actions);
+               if (!Dealloc)
+                 return Dealloc.takeError();
+               std::lock_guard<std::mutex> Lock(AnonMapperMutex);
+               AnonAllocations[Base] = {End - Base, std::move(*Dealloc)};
+               return Base;
+             })
+          .release();
+}
+
+CWrapperFunctionResult previewsmcp_anon_deinitialize(const char *ArgData,
+                                                     size_t ArgSize) {
+  return WrapperFunction<SPSError(SPSSequence<SPSExecutorAddr>)>::handle(
+             ArgData, ArgSize,
+             [](std::vector<llvm::orc::ExecutorAddr> Bases) -> Error {
+               Error Err = Error::success();
+               std::lock_guard<std::mutex> Lock(AnonMapperMutex);
+               for (auto B : llvm::reverse(Bases)) {
+                 auto I = AnonAllocations.find(B);
+                 if (I == AnonAllocations.end())
+                   continue;
+                 if (auto E = runDeallocActions(I->second.DeallocActions))
+                   Err = joinErrors(std::move(Err), std::move(E));
+                 sys::MemoryBlock MB(B.toPtr<void *>(), I->second.Size);
+                 if (auto EC = sys::Memory::protectMappedMemory(
+                         MB, sys::Memory::MF_READ | sys::Memory::MF_WRITE))
+                   Err = joinErrors(std::move(Err), errorCodeToError(EC));
+                 AnonAllocations.erase(I);
+               }
+               return Err;
+             })
+      .release();
+}
+
+CWrapperFunctionResult previewsmcp_anon_release(const char *ArgData,
+                                                size_t ArgSize) {
+  return WrapperFunction<SPSError(SPSSequence<SPSExecutorAddr>)>::handle(
+             ArgData, ArgSize,
+             [](std::vector<llvm::orc::ExecutorAddr> Bases) -> Error {
+               Error Err = Error::success();
+               std::lock_guard<std::mutex> Lock(AnonMapperMutex);
+               for (auto B : Bases) {
+                 auto I = AnonReservations.find(B.toPtr<void *>());
+                 if (I == AnonReservations.end())
+                   continue;
+                 sys::MemoryBlock MB(I->first, I->second);
+                 if (auto EC = sys::Memory::releaseMappedMemory(MB))
+                   Err = joinErrors(std::move(Err), errorCodeToError(EC));
+                 AnonReservations.erase(I);
+               }
+               return Err;
+             })
+      .release();
+}
+
+CWrapperFunctionResult previewsmcp_write_pointers(const char *ArgData,
+                                                  size_t ArgSize) {
+  using namespace llvm::orc::tpctypes;
+  return WrapperFunction<void(SPSSequence<SPSMemoryAccessPointerWrite>)>::
+      handle(ArgData, ArgSize,
+             [](std::vector<PointerWrite> Ws) {
+               for (auto &W : Ws)
+                 *W.Addr.toPtr<void **>() = W.Value.toPtr<void *>();
+             })
+          .release();
+}
+
+} // namespace
+
+int previewsmcp_ios_executor_start(int in_fd, int out_fd) {
+  auto Server = SimpleRemoteEPCServer::Create<FDSimpleRemoteEPCTransport>(
+      [](SimpleRemoteEPCServer::Setup &S) -> Error {
+        S.setDispatcher(
+            std::make_unique<SimpleRemoteEPCServer::ThreadDispatcher>());
+        S.bootstrapSymbols() = SimpleRemoteEPCServer::defaultBootstrapSymbols();
+        S.bootstrapSymbols()["__previewsmcp_register_conformances"] =
+            llvm::orc::ExecutorAddr::fromPtr(&previewsmcp_register_conformances);
+        S.bootstrapSymbols()["__previewsmcp_register_types"] =
+            llvm::orc::ExecutorAddr::fromPtr(&previewsmcp_register_types);
+        S.bootstrapSymbols()["__previewsmcp_write_pointers"] =
+            llvm::orc::ExecutorAddr::fromPtr(&previewsmcp_write_pointers);
+        S.bootstrapSymbols()["__previewsmcp_run_on_main"] =
+            llvm::orc::ExecutorAddr::fromPtr(&previewsmcp_run_on_main);
+        S.bootstrapSymbols()["__previewsmcp_anon_reserve"] =
+            llvm::orc::ExecutorAddr::fromPtr(&previewsmcp_anon_reserve);
+        S.bootstrapSymbols()["__previewsmcp_anon_initialize"] =
+            llvm::orc::ExecutorAddr::fromPtr(&previewsmcp_anon_initialize);
+        S.bootstrapSymbols()["__previewsmcp_anon_deinitialize"] =
+            llvm::orc::ExecutorAddr::fromPtr(&previewsmcp_anon_deinitialize);
+        S.bootstrapSymbols()["__previewsmcp_anon_release"] =
+            llvm::orc::ExecutorAddr::fromPtr(&previewsmcp_anon_release);
+        S.services().push_back(
+            std::make_unique<rt_bootstrap::SimpleExecutorDylibManager>());
+        S.services().push_back(
+            std::make_unique<rt_bootstrap::SimpleExecutorMemoryManager>());
+        S.services().push_back(
+            std::make_unique<rt_bootstrap::ExecutorSharedMemoryMapperService>());
+        return Error::success();
+      },
+      in_fd, out_fd);
+  if (!Server) {
+    logAllUnhandledErrors(Server.takeError(), errs(), "iossim-executor: ");
+    return 1;
+  }
+  if (auto Err = (*Server)->waitForDisconnect()) {
+    logAllUnhandledErrors(std::move(Err), errs(), "iossim-executor: ");
+    return 2;
+  }
+  return 0;
+}

--- a/iossim-executor/server.h
+++ b/iossim-executor/server.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Runs an ORC SimpleRemoteEPCServer over the given file descriptors, blocking
+// until the daemon disconnects. Used by both the standalone iossim-executor and
+// the in-app iOS JIT host. The Swift runtime and an event loop (for
+// run_on_main) must already be available in the host process. Returns 0 on a
+// clean disconnect, nonzero on error.
+int previewsmcp_ios_executor_start(int in_fd, int out_fd);
+
+#ifdef __cplusplus
+}
+#endif

--- a/iossim-jit-host/App.swift
+++ b/iossim-jit-host/App.swift
@@ -1,0 +1,53 @@
+import Darwin
+import UIKit
+
+@main
+final class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        let root = UIViewController()
+        root.view.backgroundColor = .white
+        window.rootViewController = root
+        self.window = window
+        window.makeKeyAndVisible()
+
+        let args = ProcessInfo.processInfo.arguments
+        if let i = args.firstIndex(of: "--jit-port"), i + 1 < args.count,
+            let port = UInt16(args[i + 1])
+        {
+            Thread.detachNewThread {
+                let fd = Self.connectLoopback(port: port)
+                guard fd >= 0 else {
+                    NSLog("jit-host: failed to connect on port \(port)")
+                    return
+                }
+                _ = previewsmcp_ios_executor_start(fd, fd)
+            }
+        }
+        return true
+    }
+
+    private static func connectLoopback(port: UInt16) -> Int32 {
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { return -1 }
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = port.bigEndian
+        addr.sin_addr.s_addr = (0x7f00_0001 as in_addr_t).bigEndian
+        let ok = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                connect(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        if ok != 0 {
+            close(fd)
+            return -1
+        }
+        return fd
+    }
+}

--- a/iossim-jit-host/Info.plist
+++ b/iossim-jit-host/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.previewsmcp.jithost</string>
+    <key>CFBundleExecutable</key>
+    <string>PreviewsMCPJITHost</string>
+    <key>CFBundleName</key>
+    <string>PreviewsMCPJITHost</string>
+    <key>CFBundleDisplayName</key>
+    <string>PreviewsMCPJITHost</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>UILaunchStoryboardName</key>
+    <string></string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+</dict>
+</plist>

--- a/iossim-jit-host/bridging.h
+++ b/iossim-jit-host/bridging.h
@@ -1,0 +1,2 @@
+#pragma once
+int previewsmcp_ios_executor_start(int in_fd, int out_fd);

--- a/scripts/build-iossim-executor.sh
+++ b/scripts/build-iossim-executor.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Builds the minimal iOS-simulator ORC executor (iossim-executor/main.cpp),
+# linking the iossim LLVM TargetProcess static libs + the iossim orc runtime.
+# Requires scripts/build-jit-llvm-iossim.sh to have run first.
+#
+# Usage: scripts/build-iossim-executor.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC_INC="$ROOT/third_party/llvm-project/llvm/include"
+GEN_INC="$ROOT/third_party/llvm-build-iossim/include"
+LIBDIR="$ROOT/third_party/llvm-build-iossim/lib"
+OUT="$ROOT/.build-iossim/iossim-executor"
+
+[ -e "$LIBDIR/libLLVMOrcTargetProcess.a" ] || { echo "error: run scripts/build-jit-llvm-iossim.sh first"; exit 1; }
+
+SDK="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+CLANGXX="$(xcrun -f clang++)"
+mkdir -p "$(dirname "$OUT")"
+
+echo "==> compiling + linking iossim-executor"
+"$CLANGXX" \
+  -target arm64-apple-ios14.0-simulator \
+  -isysroot "$SDK" \
+  -std=c++17 -fno-rtti -O2 \
+  -I"$SRC_INC" -I"$GEN_INC" \
+  "$ROOT/iossim-executor/server.cpp" \
+  "$ROOT/iossim-executor/main.cpp" \
+  -L"$LIBDIR" \
+  -lLLVMOrcTargetProcess -lLLVMOrcShared -lLLVMSupport -lLLVMTargetParser \
+  -lLLVMDemangle \
+  -framework CoreFoundation \
+  -o "$OUT"
+
+echo "==> ad-hoc codesigning"
+codesign -s - -f "$OUT"
+
+echo "==> done: $OUT"
+file "$OUT"

--- a/scripts/build-iossim-jit-host.sh
+++ b/scripts/build-iossim-jit-host.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Builds a minimal iOS-simulator .app that hosts the ORC executor in-process
+# (iossim-jit-host/App.swift calls previewsmcp_ios_executor_start). Proves a
+# Swift-built app can link the iossim LLVM TargetProcess libs + the server glue
+# and run the EPC server as a real UIApplication. Requires
+# scripts/build-jit-llvm-iossim.sh first.
+#
+# Usage: scripts/build-iossim-jit-host.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC_INC="$ROOT/third_party/llvm-project/llvm/include"
+GEN_INC="$ROOT/third_party/llvm-build-iossim/include"
+LIBDIR="$ROOT/third_party/llvm-build-iossim/lib"
+SRC="$ROOT/iossim-jit-host"
+OUT="$ROOT/.build-iossim/PreviewsMCPJITHost.app"
+
+[ -e "$LIBDIR/libLLVMOrcTargetProcess.a" ] || { echo "error: run scripts/build-jit-llvm-iossim.sh first"; exit 1; }
+
+SDK="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+CLANGXX="$(xcrun -f clang++)"
+SWIFTC="$(xcrun -f swiftc)"
+TARGET="arm64-apple-ios16.0-simulator"
+BUILD="$ROOT/.build-iossim"
+mkdir -p "$BUILD"
+
+echo "==> compiling server glue (iossim)"
+"$CLANGXX" \
+  -target "$TARGET" -isysroot "$SDK" \
+  -std=c++17 -fno-rtti -O2 \
+  -I"$SRC_INC" -I"$GEN_INC" \
+  -c "$ROOT/iossim-executor/server.cpp" -o "$BUILD/server.o"
+
+echo "==> compiling + linking app binary"
+"$SWIFTC" \
+  -emit-executable \
+  -parse-as-library \
+  -target "$TARGET" \
+  -sdk "$SDK" \
+  -module-name PreviewsMCPJITHost \
+  -import-objc-header "$SRC/bridging.h" \
+  -Onone -gnone \
+  "$SRC/App.swift" \
+  "$BUILD/server.o" \
+  -L"$LIBDIR" \
+  -lLLVMOrcTargetProcess -lLLVMOrcShared -lLLVMSupport -lLLVMTargetParser \
+  -lLLVMDemangle \
+  -lc++ \
+  -o "$BUILD/PreviewsMCPJITHost"
+
+echo "==> packaging .app"
+rm -rf "$OUT"
+mkdir -p "$OUT"
+cp "$BUILD/PreviewsMCPJITHost" "$OUT/PreviewsMCPJITHost"
+cp "$SRC/Info.plist" "$OUT/Info.plist"
+codesign -s - -f "$OUT"
+
+echo "==> done: $OUT"

--- a/scripts/build-jit-llvm-iossim.sh
+++ b/scripts/build-jit-llvm-iossim.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Cross-builds the LLVM ORC TargetProcess executor libraries for the iOS
+# simulator, so the in-app JIT host (the iOS analog of PreviewAgent) can run a
+# SimpleRemoteEPCServer in-process. Only the executor-side libs are needed
+# (OrcTargetProcess + OrcShared + Support + TargetParser); the heavy ORC
+# controller stays on the macOS daemon and links the existing host libLLVM.
+#
+# Reuses the host llvm-tblgen from the macOS build (third_party/llvm-build), so
+# scripts/build-jit-llvm.sh must have been run first. Uses a dedicated build dir
+# (third_party/llvm-build-iossim) that the macOS build never touches, so the
+# CMakeCache path-baking gotcha does not apply.
+#
+# Usage: scripts/build-jit-llvm-iossim.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="$ROOT/third_party/llvm-project"
+HOST_BUILD="$ROOT/third_party/llvm-build"
+BUILD="$ROOT/third_party/llvm-build-iossim"
+
+command -v cmake >/dev/null || { echo "error: cmake not found"; exit 1; }
+command -v ninja >/dev/null || { echo "error: ninja not found"; exit 1; }
+[ -e "$SRC/.git" ] || { echo "error: run scripts/build-jit-llvm.sh first (no llvm source)"; exit 1; }
+[ -x "$HOST_BUILD/bin/llvm-tblgen" ] || { echo "error: run scripts/build-jit-llvm.sh first (no host llvm-tblgen)"; exit 1; }
+
+SDK="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+echo "==> iphonesimulator sdk: $SDK"
+
+echo "==> [1/2] configuring llvm (iossim cross, executor libs only)"
+cmake -G Ninja -S "$SRC/llvm" -B "$BUILD" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DCMAKE_SYSTEM_NAME=iOS \
+  -DCMAKE_CROSSCOMPILING=TRUE \
+  -DCMAKE_MACOSX_BUNDLE=OFF \
+  -DCMAKE_OSX_SYSROOT="$SDK" \
+  -DCMAKE_OSX_ARCHITECTURES=arm64 \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
+  -DLLVM_TARGETS_TO_BUILD="AArch64;X86" \
+  -DLLVM_TABLEGEN="$HOST_BUILD/bin/llvm-tblgen" \
+  -DLLVM_NATIVE_TOOL_DIR="$HOST_BUILD/bin" \
+  -DLLVM_BUILD_LLVM_DYLIB=OFF \
+  -DLLVM_LINK_LLVM_DYLIB=OFF \
+  -DLLVM_ENABLE_PROJECTS="" \
+  -DLLVM_ENABLE_RUNTIMES="" \
+  -DLLVM_BUILD_TOOLS=OFF \
+  -DLLVM_BUILD_UTILS=OFF \
+  -DLLVM_BUILD_RUNTIME=OFF \
+  -DLLVM_INCLUDE_TESTS=OFF \
+  -DLLVM_INCLUDE_BENCHMARKS=OFF \
+  -DLLVM_INCLUDE_EXAMPLES=OFF \
+  -DLLVM_INCLUDE_UTILS=OFF \
+  -DLLVM_INCLUDE_TOOLS=OFF
+
+echo "==> [2/2] building LLVMOrcTargetProcess (+ deps)"
+ninja -C "$BUILD" LLVMOrcTargetProcess
+
+echo "==> done"
+find "$BUILD/lib" -name "libLLVMOrcTargetProcess.a" -o -name "libLLVMOrcShared.a" \
+  -o -name "libLLVMSupport.a" -o -name "libLLVMTargetParser.a" | sort

--- a/scripts/bundle-iossim-jit.sh
+++ b/scripts/bundle-iossim-jit.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Compiles the iOS-simulator ORC executor glue (iossim-executor/server.cpp ->
+# server.o) and copies it, the iossim LLVM TargetProcess libs, the iossim orc
+# runtime, and the C bridging header into an output directory. The
+# BundleIOSSimJIT build-tool plugin invokes this so the artifacts land in
+# PreviewsIOS's resource bundle, where IOSHostBuilder finds them via
+# Bundle.module to link the in-app JIT executor into the iOS host app.
+#
+# Usage: bundle-iossim-jit.sh <packageRoot> <outDir>
+set -euo pipefail
+
+ROOT="$1"
+OUT="$2"
+
+SRC_INC="$ROOT/third_party/llvm-project/llvm/include"
+GEN_INC="$ROOT/third_party/llvm-build-iossim/include"
+LIBDIR="$ROOT/third_party/llvm-build-iossim/lib"
+RT="$ROOT/third_party/llvm-build-rt/lib/darwin/liborc_rt_iossim.a"
+SERVER_CPP="$ROOT/iossim-executor/server.cpp"
+SERVER_H="$ROOT/iossim-executor/server.h"
+
+mkdir -p "$OUT"
+
+SDK="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+TARGET="arm64-apple-ios16.0-simulator"
+SERVER_O="$OUT/server.o"
+
+if [ ! -e "$SERVER_O" ] || [ "$SERVER_CPP" -nt "$SERVER_O" ] || [ "$SERVER_H" -nt "$SERVER_O" ]; then
+  xcrun clang++ \
+    -target "$TARGET" -isysroot "$SDK" \
+    -std=c++17 -fno-rtti -O2 \
+    -I"$SRC_INC" -I"$GEN_INC" \
+    -c "$SERVER_CPP" -o "$SERVER_O"
+fi
+
+cp "$RT" "$OUT/liborc_rt_iossim.a"
+for lib in libLLVMOrcTargetProcess libLLVMOrcShared libLLVMSupport libLLVMTargetParser libLLVMDemangle; do
+  cp "$LIBDIR/$lib.a" "$OUT/$lib.a"
+done


### PR DESCRIPTION
## Summary

Migrates iOS simulator previews from dylib hot-reload to **LLVM ORC JIT**, mirroring the macOS remote-EPC model: the daemon keeps the ORC controller, the simulator host app runs the executor (SimpleRemoteEPCServer + orc_rt) in-process, and the daemon links compiled objects into it remotely over a dedicated EPC socket alongside the existing JSON channel. This is the full feature (Phases 0-2 / chunks 1-5); nothing was committed before, so it lands as one squash PR.

## What's here

- **Packaging** — `BundleIOSSimJIT` prebuild plugin compiles the iossim executor glue (`server.cpp` → `server.o`) and stages the iossim LLVM TargetProcess libs + `liborc_rt_iossim.a` into `PreviewsIOS` resources. Gated on `iosJitEnabled` (`PREVIEWSMCP_IOS_JIT`).
- **Host app** — `--jit-port` branch starts the in-app ORC executor on a detached thread and connects back over loopback; dylib-arg guard no longer hard-requires `--dylib`; JIT mode installs a placeholder root VC at launch so UIKit does not abort before the first render.
- **Render path** — `BridgeGenerator` emits an iOS `renderPreviewToFile` entry that hosts a `UIHostingController` as the key window's root VC on the main actor (screenshot stays simctl). `IOSJITStructuralReloader` holds one long-lived `JITSession` over the EPC fd (no respawn). `IOSPreviewSession` routes `start()`/`reload()` through `compileObjectForJIT` + the reloader when injected, skipping the dylib; the CLI injects the factory behind `PREVIEWSMCP_JIT && PREVIEWSMCP_IOS_JIT`.

## Verification

- `endToEndRendersOverJIT` drives the real production session and asserts the accessibility tree contains the rendered text.
- Live simulator screenshot confirmed ("Hello from iOS JIT!").
- Full `PreviewsJITLinkTests` suite **70 green**, no macOS regression. `/simplify` + `/code-review` (high) pass.

## Known follow-ups (not in this PR)

- Retire the superseded spike (`iossim-jit-host/`, `build-iossim-jit-host.sh`, `hostsRemoteSessionInSimulatorApp`).
- Literal-edit-over-JIT (today every iOS JIT edit full-relinks; metadata growth bounded only by host restart).
- dylib Phase B (retire the iOS dylib path now that JIT is default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)