### PR TITLE
macOS: retire the dylib preview path, make PREVIEWSMCP_JIT mandatory (Phase A)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,15 +7,20 @@ let llvmBuild = "\(packageDir)/third_party/llvm-build"
 let llvmSrcInclude = "\(packageDir)/third_party/llvm-project/llvm/include"
 let orcRuntimeArchive = "\(packageDir)/third_party/llvm-build-rt/lib/darwin/liborc_rt_osx.a"
 
-let jitEnabled =
+// JIT is mandatory on macOS: the dylib preview path has been retired, so the
+// prebuilt LLVM artifacts must be present. Fail fast with a build-script hint
+// rather than later at link time with an opaque missing-symbol error.
+guard
     FileManager.default.fileExists(atPath: llvmBuild)
-    && FileManager.default.fileExists(atPath: orcRuntimeArchive)
+        && FileManager.default.fileExists(atPath: orcRuntimeArchive)
+else {
+    fatalError(
+        "PreviewsMCP requires the prebuilt LLVM JIT artifacts. Run scripts/build-jit-llvm.sh first.")
+}
 
-// Composition-root wiring for the JIT structural-reload path. Only the executable
-// references the gated PreviewsJITLink, behind one `#if PREVIEWSMCP_JIT`; the daemon
-// logic depends solely on the JIT-free `StructuralReloader` protocol in PreviewsCore.
-let jitCLIDependencies: [Target.Dependency] = jitEnabled ? ["PreviewsJITLink"] : []
-let jitCLISwiftSettings: [SwiftSetting] = jitEnabled ? [.define("PREVIEWSMCP_JIT")] : []
+// Composition-root wiring for the JIT structural-reload path.
+let jitCLIDependencies: [Target.Dependency] = ["PreviewsJITLink"]
+let jitCLISwiftSettings: [SwiftSetting] = [.define("PREVIEWSMCP_JIT")]
 
 // iOS-simulator JIT: the in-app ORC executor needs the cross-built iossim
 // TargetProcess libs and the iossim orc runtime. Gated separately from macOS
@@ -145,62 +150,60 @@ if iosJitEnabled {
     ]
 }
 
-if jitEnabled {
-    targets += [
-        .target(
-            name: "PreviewsJITLink",
-            dependencies: ["PreviewsJITLinkCxx", "PreviewsCore"],
-            plugins: [.plugin(name: "BundleOrcRuntime")]
-        ),
-        .target(
-            // TODO: bundle libLLVM (U3); links the third_party build for now.
-            name: "PreviewsJITLinkCxx",
-            cxxSettings: [
-                .unsafeFlags([
-                    "-I\(llvmSrcInclude)",
-                    "-I\(llvmBuild)/include",
-                    "-fno-rtti",
-                ])
-            ],
-            linkerSettings: [
-                .unsafeFlags([
-                    "-L\(llvmBuild)/lib",
-                    "-lLLVM",
-                    "-Xlinker", "-rpath",
-                    "-Xlinker", "\(llvmBuild)/lib",
-                ])
-            ]
-        ),
-        .plugin(
-            name: "BundleOrcRuntime",
-            capability: .buildTool()
-        ),
-        .executableTarget(
-            name: "PreviewAgent",
-            cxxSettings: [
-                .unsafeFlags([
-                    "-I\(llvmSrcInclude)",
-                    "-I\(llvmBuild)/include",
-                    "-fno-rtti",
-                ])
-            ],
-            linkerSettings: [
-                .unsafeFlags([
-                    "-L\(llvmBuild)/lib",
-                    "-lLLVM",
-                    "-Xlinker", "-rpath",
-                    "-Xlinker", "\(llvmBuild)/lib",
-                ])
-            ]
-        ),
-        .testTarget(
-            name: "PreviewsJITLinkTests",
-            dependencies: ["PreviewsJITLink", "PreviewsCore", "PreviewAgent", "PreviewsIOS"],
-            exclude: ["Fixtures"],
-            swiftSettings: iosJitSwiftSettings
-        ),
-    ]
-}
+targets += [
+    .target(
+        name: "PreviewsJITLink",
+        dependencies: ["PreviewsJITLinkCxx", "PreviewsCore"],
+        plugins: [.plugin(name: "BundleOrcRuntime")]
+    ),
+    .target(
+        // TODO: bundle libLLVM (U3); links the third_party build for now.
+        name: "PreviewsJITLinkCxx",
+        cxxSettings: [
+            .unsafeFlags([
+                "-I\(llvmSrcInclude)",
+                "-I\(llvmBuild)/include",
+                "-fno-rtti",
+            ])
+        ],
+        linkerSettings: [
+            .unsafeFlags([
+                "-L\(llvmBuild)/lib",
+                "-lLLVM",
+                "-Xlinker", "-rpath",
+                "-Xlinker", "\(llvmBuild)/lib",
+            ])
+        ]
+    ),
+    .plugin(
+        name: "BundleOrcRuntime",
+        capability: .buildTool()
+    ),
+    .executableTarget(
+        name: "PreviewAgent",
+        cxxSettings: [
+            .unsafeFlags([
+                "-I\(llvmSrcInclude)",
+                "-I\(llvmBuild)/include",
+                "-fno-rtti",
+            ])
+        ],
+        linkerSettings: [
+            .unsafeFlags([
+                "-L\(llvmBuild)/lib",
+                "-lLLVM",
+                "-Xlinker", "-rpath",
+                "-Xlinker", "\(llvmBuild)/lib",
+            ])
+        ]
+    ),
+    .testTarget(
+        name: "PreviewsJITLinkTests",
+        dependencies: ["PreviewsJITLink", "PreviewsCore", "PreviewAgent", "PreviewsIOS"],
+        exclude: ["Fixtures"],
+        swiftSettings: iosJitSwiftSettings
+    ),
+]
 
 let package = Package(
     name: "PreviewsMCP",

--- a/Sources/PreviewsCLI/Handlers/PreviewStartHandler.swift
+++ b/Sources/PreviewsCLI/Handlers/PreviewStartHandler.swift
@@ -4,19 +4,15 @@ import MCP
 import PreviewsCore
 import PreviewsEngine
 import PreviewsIOS
+import PreviewsJITLink
 import PreviewsMacOS
 
-#if PREVIEWSMCP_JIT
-import PreviewsJITLink
-#endif
-
-/// Builds the iOS JIT reloader from the accepted EPC fd, or nil when the JIT build is
-/// absent — in which case iOS previews are unavailable and `start()` throws `jitRequired`.
-/// Mirrors the macOS `host.makeStructuralReloader` injection in `PreviewsMCPApp`. Active
-/// only when both the JIT link library (`PREVIEWSMCP_JIT`) and the bundled iossim runtime
-/// (`PREVIEWSMCP_IOS_JIT`) are present.
+/// Builds the iOS JIT reloader from the accepted EPC fd, or nil when the bundled iossim
+/// runtime is absent — in which case iOS previews are unavailable and `start()` throws
+/// `jitRequired`. Mirrors the macOS `host.makeStructuralReloader` injection in
+/// `PreviewsMCPApp`. Active only when the iossim runtime (`PREVIEWSMCP_IOS_JIT`) is present.
 private let iosJITReloaderFactory: IOSPreviewSession.MakeJITReloader? = {
-    #if PREVIEWSMCP_JIT && PREVIEWSMCP_IOS_JIT
+    #if PREVIEWSMCP_IOS_JIT
     return { fd, orcPath in try IOSJITStructuralReloader(remoteFD: fd, orcRuntimePath: orcPath) }
     #else
     return nil
@@ -415,7 +411,6 @@ private func startMacOSPreview(
 
     let sessionID = session.id
 
-    #if PREVIEWSMCP_JIT
     try await host.jitStart(
         sessionID: sessionID, session: session,
         title: title, size: NSSize(width: width, height: height),
@@ -431,33 +426,6 @@ private func startMacOSPreview(
             buildContext: buildContext
         )
     }
-    #else
-    let compileResult = try await session.compile()
-    let setupDylibPath = setupResult?.dylibPath
-
-    await MainActor.run {
-        do {
-            try host.loadPreview(
-                sessionID: sessionID,
-                dylibPath: compileResult.dylibPath,
-                title: title,
-                size: NSSize(width: width, height: height),
-                headless: headless,
-                setupDylibPath: setupDylibPath
-            )
-            host.watchFile(
-                sessionID: sessionID,
-                session: session,
-                filePath: fileURL.path,
-                compiler: compiler,
-                additionalPaths: buildContext?.sourceFiles?.map(\.path) ?? [],
-                buildContext: buildContext
-            )
-        } catch {
-            Log.error("MCP: Failed to load preview: \(error)")
-        }
-    }
-    #endif
 
     return sessionID
 }

--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -1,10 +1,7 @@
 import AppKit
 import ArgumentParser
-import PreviewsMacOS
-
-#if PREVIEWSMCP_JIT
 import PreviewsJITLink
-#endif
+import PreviewsMacOS
 
 /// Target platform for CLI commands.
 enum CLIPlatform: String, ExpressibleByArgument, CaseIterable {
@@ -89,9 +86,7 @@ public struct PreviewsMCPApp {
         // other subcommand is now a daemon client.
         let app = NSApplication.shared
         let host = PreviewHost()
-        #if PREVIEWSMCP_JIT
         host.makeStructuralReloader = { JITStructuralReloader() }
-        #endif
         ServeCommand.sharedHost = host
         app.delegate = host
 

--- a/Sources/PreviewsCore/BridgeGenerator.swift
+++ b/Sources/PreviewsCore/BridgeGenerator.swift
@@ -334,7 +334,7 @@ public enum BridgeGenerator {
     /// Builds the same preview view as `createPreviewView`, hosts it in a borderless
     /// `NSWindow` positioned off-screen via `NSHostingView` (AppKit-backed views like
     /// `List` need a real window's backing hierarchy — `ImageRenderer` returns nil or a
-    /// blank raster for them), captures at a deterministic 1x like `Snapshot.capture`,
+    /// blank raster for them), captures at a deterministic 1x,
     /// and writes a PNG to `path`. Nullary so it runs over the agent's `runOnMain`
     /// surface; the path is baked in (the daemon recompiles per structural edit).
     ///

--- a/Sources/PreviewsCore/PreviewSessionHandle.swift
+++ b/Sources/PreviewsCore/PreviewSessionHandle.swift
@@ -4,9 +4,8 @@ import Foundation
 /// tool handlers that need to operate on a session without branching on
 /// iOS vs macOS. Backends (`MacOSPreviewHandle`, `IOSPreviewHandle`) live
 /// in `PreviewsEngine` and encapsulate platform-specific work — the
-/// 300ms layout-settle and `host.loadPreview` after `setTraits` on macOS,
-/// the iOS host-app socket protocol on iOS — so the call site sees one
-/// shape.
+/// 300ms layout-settle after `setTraits` on macOS, the iOS host-app
+/// socket protocol on iOS — so the call site sees one shape.
 public protocol PreviewSessionHandle: Sendable {
     nonisolated var id: String { get }
     nonisolated var sourceFile: URL { get }
@@ -21,20 +20,20 @@ public protocol PreviewSessionHandle: Sendable {
     var isRegistered: Bool { get async }
 
     /// Replace traits absolutely (no merge) and recompile. Used by
-    /// `preview_variants`. macOS implementations also reload the dylib
-    /// into the host window. Callers planning an immediate snapshot
-    /// should call `awaitLayoutSettle()` afterward — the 300ms macOS
-    /// settle is not folded into `setTraits` because the variants
-    /// restore step does not snapshot and pays no settle cost.
+    /// `preview_variants`. macOS implementations re-render in the session's
+    /// agent. Callers planning an immediate snapshot should call
+    /// `awaitLayoutSettle()` afterward — the 300ms macOS settle is not folded
+    /// into `setTraits` because the variants restore step does not snapshot
+    /// and pays no settle cost.
     func setTraits(_ traits: PreviewTraits) async throws
 
     /// Merge traits into the current set and clear the named fields, then
-    /// recompile. Used by `preview_configure`. macOS implementations also
-    /// reload the dylib into the host window.
+    /// recompile. Used by `preview_configure`. macOS implementations re-render
+    /// in the session's agent.
     func reconfigure(traits: PreviewTraits, clearing: Set<PreviewTraits.Field>) async throws
 
     /// Switch to a different `#Preview` index and recompile. Traits are
-    /// preserved. macOS implementations also reload the dylib.
+    /// preserved. macOS implementations re-render in the session's agent.
     func switchPreview(to index: Int) async throws
 
     /// Capture a screenshot. `quality >= 1.0` requests PNG output where
@@ -42,12 +41,11 @@ public protocol PreviewSessionHandle: Sendable {
     ///
     /// If a preceding `setTraits` / `switchPreview` / `reconfigure` call
     /// changed the rendered view, call `awaitLayoutSettle()` first. On
-    /// macOS the snapshot will otherwise capture a pre-layout frame —
-    /// `cacheDisplay` forces layout synchronously but does not recover
-    /// from a fresh `loadPreview` swap on its own.
+    /// macOS the snapshot will otherwise capture a pre-layout frame from
+    /// the agent before its new view tree has settled.
     func snapshot(quality: Double) async throws -> Data
 
-    /// Wait for SwiftUI layout to settle after a fresh dylib load. macOS
+    /// Wait for SwiftUI layout to settle after a structural reload. macOS
     /// pauses 300ms; iOS no-ops (the host-app reload-ack already implies
     /// the new view tree is mounted). Called between `setTraits` /
     /// `switchPreview` / `reconfigure` and a subsequent `snapshot` to

--- a/Sources/PreviewsEngine/MacOSPreviewHandle.swift
+++ b/Sources/PreviewsEngine/MacOSPreviewHandle.swift
@@ -4,7 +4,7 @@ import PreviewsCore
 import PreviewsMacOS
 
 /// macOS adapter for `PreviewSessionHandle`. Bundles the
-/// `PreviewSession + PreviewHost.window/loadPreview/closePreview` plus
+/// `PreviewSession + PreviewHost.jitRender/closePreview` plus
 /// the 300ms post-`setTraits` layout-settle pause that the SwiftUI
 /// hosting view needs before a snapshot. Encapsulating the pause here
 /// keeps it out of MCP tool handlers.
@@ -40,50 +40,27 @@ public actor MacOSPreviewHandle: PreviewSessionHandle {
     /// and is what tipped CI's `preview_variants` test over its 60s
     /// callTool budget.
     public func setTraits(_ traits: PreviewTraits) async throws {
-        try await reload(
-            jit: { try await self.session.setTraitsForJIT(traits, window: $0) },
-            dylib: { try await self.session.setTraits(traits) })
+        try await reload { try await self.session.setTraitsForJIT(traits, window: $0) }
     }
 
     public func reconfigure(traits: PreviewTraits, clearing: Set<PreviewTraits.Field>) async throws {
-        try await reload(
-            jit: { try await self.session.reconfigureForJIT(traits: traits, clearing: clearing, window: $0) },
-            dylib: { try await self.session.reconfigure(traits: traits, clearing: clearing) })
+        try await reload {
+            try await self.session.reconfigureForJIT(traits: traits, clearing: clearing, window: $0)
+        }
     }
 
     public func switchPreview(to index: Int) async throws {
-        try await reload(
-            jit: { try await self.session.switchPreviewForJIT(to: index, window: $0) },
-            dylib: { try await self.session.switchPreview(to: index) })
+        try await reload { try await self.session.switchPreviewForJIT(to: index, window: $0) }
     }
 
-    /// The single routing seam for every mutating reload. In a JIT build every
-    /// session re-renders in its agent; in a non-JIT build every session reloads
-    /// a dylib into its daemon window. The split is per-build, never per-session.
+    /// Shared window-spec + render plumbing for every mutating reload. Every
+    /// session re-renders in its agent over JIT.
     private func reload(
-        jit: (JITRenderWindow?) async throws -> JITRenderBuild,
-        dylib: () async throws -> CompileResult
+        _ jit: (JITRenderWindow?) async throws -> JITRenderBuild
     ) async throws {
-        enum Surface {
-            case agent(JITRenderWindow?)
-            case daemonWindow
-        }
-        let surface: Surface = await MainActor.run {
-            guard host.agentBacked else {
-                return .daemonWindow
-            }
-            return .agent(host.agentWindowSpec(for: id))
-        }
-        switch surface {
-        case .agent(let window):
-            let build = try await jit(window)
-            try await host.jitRender(sessionID: id, build: build)
-        case .daemonWindow:
-            let result = try await dylib()
-            try await MainActor.run {
-                try host.loadPreview(sessionID: id, dylibPath: result.dylibPath)
-            }
-        }
+        let window = await MainActor.run { host.agentWindowSpec(for: id) }
+        let build = try await jit(window)
+        try await host.jitRender(sessionID: id, build: build)
     }
 
     public func snapshot(quality: Double) async throws -> Data {
@@ -91,24 +68,18 @@ public actor MacOSPreviewHandle: PreviewSessionHandle {
         let sessionID = id
         let colorScheme = await session.currentTraits.colorScheme
         return try await MainActor.run {
-            if host.agentBacked {
-                guard let imagePath = host.agentSnapshotPath(for: sessionID) else {
-                    throw SnapshotError.captureFailed
-                }
-                let named: NSAppearance? =
-                    switch colorScheme {
-                    case "dark": NSAppearance(named: .darkAqua)
-                    case "light": NSAppearance(named: .aqua)
-                    default: nil
-                    }
-                let appearance = named ?? NSApplication.shared.effectiveAppearance
-                return try Snapshot.encode(
-                    imageAt: imagePath, format: format, flattenedWith: appearance)
-            }
-            guard let window = host.window(for: sessionID) else {
+            guard let imagePath = host.agentSnapshotPath(for: sessionID) else {
                 throw SnapshotError.captureFailed
             }
-            return try Snapshot.capture(window: window, format: format)
+            let named: NSAppearance? =
+                switch colorScheme {
+                case "dark": NSAppearance(named: .darkAqua)
+                case "light": NSAppearance(named: .aqua)
+                default: nil
+                }
+            let appearance = named ?? NSApplication.shared.effectiveAppearance
+            return try Snapshot.encode(
+                imageAt: imagePath, format: format, flattenedWith: appearance)
         }
     }
 

--- a/Sources/PreviewsMacOS/HostApp.swift
+++ b/Sources/PreviewsMacOS/HostApp.swift
@@ -2,45 +2,30 @@ import AppKit
 import PreviewsCore
 import SwiftUI
 
-/// Manages preview windows. Loads compiled dylibs and displays views in NSWindows.
+/// Manages preview sessions. Each session renders in its own agent process over
+/// JIT; the daemon tracks session state and serves the agent-rendered snapshots.
 ///
 /// Only one runtime shape remains since the CLI/MCP parity migration:
 /// `serve` is the sole subcommand that ever constructs a PreviewHost, and
-/// it always wants headless windows plus a daemon that stays alive after
-/// the last window closes. Earlier `.interactive` and `.snapshot` modes
-/// were removed once every non-`serve` CLI command moved to the daemon
-/// client path.
+/// it always wants a daemon that stays alive after the last session closes.
+/// Earlier `.interactive` and `.snapshot` modes were removed once every
+/// non-`serve` CLI command moved to the daemon client path.
 @MainActor
 public class PreviewHost: NSObject, NSApplicationDelegate {
 
-    private var windows: [String: NSWindow] = [:]
-    private var loaders: [String: DylibLoader] = [:]
     private var sessions: [String: PreviewSession] = [:]
     /// Latest agent-rendered PNG per session. Set once a session goes through the
-    /// JIT structural-reload path; `preview_snapshot` serves this instead of the
-    /// in-daemon window for those sessions.
+    /// JIT structural-reload path; `preview_snapshot` serves this for the session.
     private var agentImagePaths: [String: URL] = [:]
-    // Keep old loaders and views alive so their dylib types remain valid.
-    private var retainedLoaders: [DylibLoader] = []
-    private var retainedViews: [NSView] = []
-    private var hasCalledSetUp = false
-    /// Retains the setup dylib loaded with RTLD_GLOBAL so all preview dylibs share its statics.
-    private var setupDylibLoader: DylibLoader?
-    /// Remembered so the watchFile reload path can pass it to loadPreview.
-    private var setupDylibPath: URL?
 
     /// Callback invoked after NSApplication finishes launching.
     public var onLaunch: (@MainActor () -> Void)?
 
     /// Makes the structural-reload strategy for the JIT path. Injected at the
-    /// composition root, non-nil only in JIT builds. Each session gets its own
-    /// reloader — its own agent process and window — so respawns, crashes, setup
-    /// state, and window lifetime stay contained to one session.
+    /// composition root. Each session gets its own reloader — its own agent
+    /// process and window — so respawns, crashes, setup state, and window
+    /// lifetime stay contained to one session.
     public var makeStructuralReloader: (@MainActor () -> any StructuralReloader)?
-    /// Whether sessions render in agent processes. In a JIT build every macOS
-    /// session is agent-backed from its first render until close; in a non-JIT
-    /// build none ever is, so routing is per-build, not per-session.
-    public var agentBacked: Bool { makeStructuralReloader != nil }
     /// Per-session reloaders. Removing a session's entry releases its agent
     /// process, which closes the agent-hosted window.
     private var reloaders: [String: any StructuralReloader] = [:]
@@ -92,86 +77,6 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         return false
     }
 
-    /// Load a dylib and display its preview view in a window.
-    /// If a window already exists for this session, reuses it (swaps content view).
-    /// - Parameter headless: If provided, overrides the instance-level default for this window.
-    /// - Parameter setupDylibPath: Path to the setup dynamic library. Loaded once with RTLD_GLOBAL
-    ///   so all preview dylibs share the same statics (see issue #86).
-    public func loadPreview(
-        sessionID: String,
-        dylibPath: URL,
-        entryPoint: String = "createPreviewView",
-        title: String = "Preview",
-        size: NSSize = NSSize(width: 400, height: 600),
-        headless: Bool? = nil,
-        setupDylibPath: URL? = nil
-    ) throws {
-        let headless = headless ?? self.headless
-
-        // Load the setup dylib once before any preview dylib. RTLD_GLOBAL ensures
-        // all preview dylibs resolve setup symbols from this shared image.
-        if let path = setupDylibPath {
-            self.setupDylibPath = path
-        }
-        if let path = self.setupDylibPath, setupDylibLoader == nil {
-            setupDylibLoader = try DylibLoader(path: path.path)
-        }
-
-        let loader = try DylibLoader(path: dylibPath.path)
-
-        // Call setUp exactly once on first dylib load
-        if !hasCalledSetUp {
-            hasCalledSetUp = true
-            typealias SetUpFunc = @convention(c) () -> Void
-            if let setUpFn: SetUpFunc = try? loader.symbol(name: "previewSetUp") {
-                setUpFn()
-            }
-        }
-
-        typealias CreateFunc = @convention(c) () -> UnsafeMutableRawPointer
-        let createView: CreateFunc = try loader.symbol(name: entryPoint)
-
-        // Retire the old loader (keep it alive, don't dlclose)
-        if let oldLoader = loaders.removeValue(forKey: sessionID) {
-            retainedLoaders.append(oldLoader)
-        }
-        loaders[sessionID] = loader
-
-        // Create the view
-        let rawPtr = createView()
-        let hostingView = Unmanaged<NSView>.fromOpaque(rawPtr).takeRetainedValue()
-
-        if let existingWindow = windows[sessionID] {
-            // Retain old content view before swapping
-            if let oldView = existingWindow.contentView {
-                retainedViews.append(oldView)
-            }
-            existingWindow.contentView = hostingView
-            existingWindow.title = title
-        } else {
-            // Create new window
-            let window = NSWindow(
-                contentRect: NSRect(origin: .zero, size: size),
-                styleMask: headless
-                    ? .borderless : [.titled, .closable, .resizable, .miniaturizable],
-                backing: .buffered,
-                defer: false
-            )
-            window.title = title
-            window.contentView = hostingView
-            if headless {
-                window.setFrameOrigin(NSPoint(x: -10000, y: -10000))
-                window.orderFrontRegardless()
-            } else {
-                window.center()
-                window.makeKeyAndOrderFront(nil)
-                NSApp.setActivationPolicy(.regular)
-                NSApp.activate(ignoringOtherApps: true)
-            }
-            windows[sessionID] = window
-        }
-    }
-
     /// Start watching source files and reload the preview on changes.
     /// Uses the fast path (literal-only update via DesignTimeStore) when possible.
     /// When `additionalPaths` is provided, watches all target files for cross-file changes.
@@ -201,34 +106,27 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
                     return
                 }
 
-                // Fast path: try literal-only update. An agent-backed session re-renders
-                // in the agent (rewrite the design-time values JSON, re-run the same
-                // object — no recompile); otherwise the in-daemon DesignTimeStore path.
-                let agentBacked = await MainActor.run { self.agentBacked }
+                // Fast path: try literal-only update. The agent re-renders in place
+                // (rewrite the design-time values JSON, re-run the same object — no
+                // recompile).
                 if let currentSession = await MainActor.run(body: { self.sessions[sessionID] }),
                     let changes = await currentSession.tryLiteralUpdate(newSource: newSource),
                     !changes.isEmpty
                 {
                     fputs("Literal-only change: \(changes.count) value(s)\n", stderr)
-                    if agentBacked {
-                        do {
-                            try await self.jitLiteralReload(
-                                sessionID: sessionID, session: currentSession, changes: changes)
-                            fputs("Literal re-rendered in agent (no recompile)\n", stderr)
-                        } catch {
-                            fputs("JIT literal reload failed: \(error)\n", stderr)
-                        }
-                        return
-                    }
-                    await MainActor.run {
-                        self.applyLiteralChanges(sessionID: sessionID, changes: changes)
+                    do {
+                        try await self.jitLiteralReload(
+                            sessionID: sessionID, session: currentSession, changes: changes)
+                        fputs("Literal re-rendered in agent (no recompile)\n", stderr)
+                    } catch {
+                        fputs("JIT literal reload failed: \(error)\n", stderr)
                     }
                     return
                 }
 
                 // Slow path: structural change, full recompile.
                 // Reuse the existing session so traits set via preview_configure are
-                // preserved without a race — compile() re-reads the source file and
+                // preserved without a race — the reload re-reads the source file and
                 // uses the session's stored traits, which live inside the actor.
                 fputs("Structural change, recompiling...\n", stderr)
                 do {
@@ -241,34 +139,9 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
                         return
                     }
 
-                    if try await self.jitStructuralReload(
-                        sessionID: sessionID, session: existingSession
-                    ) != nil {
-                        fputs("Reloaded (JIT agent)!\n", stderr); fflush(stderr)
-                        return
-                    }
-
-                    let compileResult = try await existingSession.compile()
-                    fputs("Compiled: \(compileResult.dylibPath.lastPathComponent)\n", stderr)
-
-                    await MainActor.run {
-                        do {
-                            let existingFrame = self.windows[sessionID]?.frame
-                            try self.loadPreview(
-                                sessionID: sessionID,
-                                dylibPath: compileResult.dylibPath,
-                                title: "Preview: \(fileURL.lastPathComponent)",
-                                size: existingFrame?.size ?? NSSize(width: 400, height: 600),
-                                setupDylibPath: self.setupDylibPath
-                            )
-                            if let frame = existingFrame {
-                                self.windows[sessionID]?.setFrameOrigin(frame.origin)
-                            }
-                            fputs("Reloaded!\n", stderr); fflush(stderr)
-                        } catch {
-                            fputs("Reload failed: \(error)\n", stderr); fflush(stderr)
-                        }
-                    }
+                    _ = try await self.jitStructuralReload(
+                        sessionID: sessionID, session: existingSession)
+                    fputs("Reloaded (JIT agent)!\n", stderr); fflush(stderr)
                 } catch {
                     fputs("Recompilation failed: \(error)\n", stderr)
                 }
@@ -276,49 +149,7 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// Apply literal-only changes by calling DesignTimeStore setters via dlsym.
-    /// The @Observable DesignTimeStore triggers SwiftUI re-render automatically.
-    @MainActor
-    private func applyLiteralChanges(
-        sessionID: String,
-        changes: [(id: String, newValue: LiteralValue)]
-    ) {
-        guard let loader = loaders[sessionID] else {
-            fputs("No loader for session \(sessionID)\n", stderr)
-            return
-        }
-
-        for (id, value) in changes {
-            do {
-                switch value {
-                case .string(let s):
-                    typealias Setter = @convention(c) (UnsafePointer<CChar>, UnsafePointer<CChar>) -> Void
-                    let fn: Setter = try loader.symbol(name: "designTimeSetString")
-                    id.withCString { idPtr in s.withCString { valPtr in fn(idPtr, valPtr) } }
-
-                case .integer(let n):
-                    typealias Setter = @convention(c) (UnsafePointer<CChar>, Int) -> Void
-                    let fn: Setter = try loader.symbol(name: "designTimeSetInteger")
-                    id.withCString { idPtr in fn(idPtr, n) }
-
-                case .float(let d):
-                    typealias Setter = @convention(c) (UnsafePointer<CChar>, Double) -> Void
-                    let fn: Setter = try loader.symbol(name: "designTimeSetFloat")
-                    id.withCString { idPtr in fn(idPtr, d) }
-
-                case .boolean(let b):
-                    typealias Setter = @convention(c) (UnsafePointer<CChar>, Bool) -> Void
-                    let fn: Setter = try loader.symbol(name: "designTimeSetBoolean")
-                    id.withCString { idPtr in fn(idPtr, b) }
-                }
-            } catch {
-                fputs("Failed to set design-time value \(id): \(error)\n", stderr)
-            }
-        }
-        fputs("Applied \(changes.count) literal change(s) — @State preserved\n", stderr)
-    }
-
-    /// Close and clean up a preview window. Dropping the session's reloader kills
+    /// Close and clean up a preview session. Dropping the session's reloader kills
     /// its agent process, closing the agent-hosted window with it.
     public func closePreview(sessionID: String) {
         fileWatchers[sessionID]?.stop()
@@ -328,18 +159,6 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         reloaders.removeValue(forKey: sessionID)
         agentWindowSpecs.removeValue(forKey: sessionID)
         notifySessionsChanged()
-
-        if let window = windows.removeValue(forKey: sessionID) {
-            if let oldView = window.contentView {
-                retainedViews.append(oldView)
-            }
-            window.contentView = nil
-            window.orderOut(nil)
-        }
-
-        if let loader = loaders.removeValue(forKey: sessionID) {
-            retainedLoaders.append(loader)
-        }
     }
 
     /// Get the session for a session ID (for reconfiguration).
@@ -352,21 +171,15 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     /// that matches the target source file).
     public var allSessions: [String: PreviewSession] { sessions }
 
-    /// Get the window for a session (for snapshotting).
-    public func window(for sessionID: String) -> NSWindow? {
-        windows[sessionID]
-    }
-
     /// Structural reload via the JIT path: compile the preview to a render-bridge
     /// object, render it in the agent, and record the agent's PNG for snapshots.
-    /// Returns the image path, or nil if no reloader is injected (non-JIT build).
+    /// Returns the agent's image path.
     ///
     /// For a visible session the session's window spec is baked into the bridge
     /// so the agent shows its own live window there — the agent window is the
     /// session's interactive surface.
     @discardableResult
     public func jitStructuralReload(sessionID: String, session: PreviewSession) async throws -> URL? {
-        guard agentBacked else { return nil }
         restoreAgentWindowFrame(sessionID: sessionID, session: session)
         let build = try await session.compileObjectForJIT(window: agentWindowSpec(for: sessionID))
         return try await jitRender(sessionID: sessionID, build: build)

--- a/Sources/PreviewsMacOS/Snapshot.swift
+++ b/Sources/PreviewsMacOS/Snapshot.swift
@@ -1,7 +1,7 @@
 import AppKit
 import Foundation
 
-/// Captures the contents of an NSWindow as image data.
+/// Encodes agent-rendered preview images as output image data.
 @MainActor
 public enum Snapshot {
 
@@ -9,40 +9,6 @@ public enum Snapshot {
     public enum ImageFormat: Sendable {
         case jpeg(quality: Double)
         case png
-    }
-
-    /// Capture the current contents of a window's content view.
-    /// Uses `cacheDisplay` to render directly from the view hierarchy, which works
-    /// regardless of window position (including off-screen/headless) and captures
-    /// only the SwiftUI content without the title bar.
-    /// - Parameters:
-    ///   - window: The window to capture.
-    ///   - format: Output format (default: JPEG at 0.85 quality).
-    public static func capture(window: NSWindow, format: ImageFormat = .jpeg(quality: 0.85)) throws -> Data {
-        guard let contentView = window.contentView else {
-            throw SnapshotError.captureFailed
-        }
-        let bounds = contentView.bounds
-        guard bounds.width > 0, bounds.height > 0 else {
-            throw SnapshotError.captureFailed
-        }
-        // Pin the raster to a deterministic 1x (one pixel per point). bitmapImageRepForCachingDisplay
-        // inherits the host window's backingScaleFactor — 2x on a Retina display — which made the
-        // snapshot's pixel dimensions depend on which machine the daemon ran on. Building the rep
-        // manually with pixel dimensions equal to the point bounds keeps output reproducible.
-        guard let bitmapRep = makeRep(pixelsWide: Int(bounds.width.rounded()), pixelsHigh: Int(bounds.height.rounded()))
-        else {
-            throw SnapshotError.captureFailed
-        }
-        bitmapRep.size = bounds.size
-        contentView.cacheDisplay(in: bounds, to: bitmapRep)
-        return try data(from: bitmapRep, format: format)
-    }
-
-    /// Capture and write to a file.
-    public static func capture(window: NSWindow, format: ImageFormat = .jpeg(quality: 0.85), to path: URL) throws {
-        let data = try capture(window: window, format: format)
-        try data.write(to: path)
     }
 
     /// Re-encode an agent-rendered image file (PNG) to the requested output format,

--- a/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
+++ b/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
@@ -170,7 +170,6 @@ struct PreviewHostJITReloadTests {
             sessionID: "visible", session: session,
             title: "Preview: ColorView.swift",
             size: NSSize(width: 320, height: 240), headless: false)
-        #expect(host.window(for: "visible") == nil)
         #expect(host.agentSnapshotPath(for: "visible") != nil)
         let spec = try #require(host.agentWindowSpec(for: "visible"))
         #expect(spec.title == "Preview: ColorView.swift")
@@ -230,22 +229,5 @@ struct PreviewHostJITReloadTests {
         let literal = try await host.jitLiteralReload(sessionID: "s", session: session, changes: [])
         #expect(literal == nil)
         #expect(madeCount == 1)
-    }
-
-    @Test func noReloaderFallsThrough() async throws {
-        let host = PreviewHost()
-        let dir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("p34ci3a-nil-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: dir) }
-        let sourceFile = dir.appendingPathComponent("Empty.swift")
-        try "import SwiftUI\n".write(to: sourceFile, atomically: true, encoding: .utf8)
-
-        let compiler = try await Compiler()
-        let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
-
-        let imagePath = try await host.jitStructuralReload(sessionID: "s2", session: session)
-        #expect(imagePath == nil)
-        #expect(host.agentSnapshotPath(for: "s2") == nil)
     }
 }


### PR DESCRIPTION
## Summary

macOS previews are now JIT-only. The dylib preview path is retired and
`PREVIEWSMCP_JIT` is made mandatory: the build fails fast with a build-script
hint if the prebuilt LLVM artifacts are missing.

This is the macOS analog of the iOS dylib Phase B (#212). It is the first of two
related PRs; the second hardens the iOS JIT flags the same way.

## What changed

- **PreviewHost**: drop `loadPreview`, `applyLiteralChanges`, the dylib loader
  caches, the non-JIT branches in `watchFile`, and the now-dead in-daemon window
  subsystem they fed (`windows`, `window(for:)`, `retainedViews`, the
  `closePreview` window teardown) plus the always-true `agentBacked` boolean.
- **Snapshot**: drop the unused `capture(window:)` overloads; only the agent
  image re-encode (`encode`) remains.
- **MacOSPreviewHandle**: collapse the per-build reload/snapshot routing seam to
  the JIT/agent surface only.
- **PreviewStartHandler / PreviewsMCPApp**: un-gate the `PreviewsJITLink` import
  and the `makeStructuralReloader` injection; the iOS factory gate simplifies to
  `#if PREVIEWSMCP_IOS_JIT`.
- **Package.swift**: `PREVIEWSMCP_JIT` is unconditional; a missing-artifact guard
  fails the manifest with a clear hint.

## Kept on purpose

The dylib compile primitives (`PreviewSession.compile`, `Compiler.compileCombined`,
`DylibLoader`) stay — they remain load-bearing test infrastructure for bridge and
trait verification.

## Verification

Local bar green on the final code: build `--build-tests`, units 337, JIT 69
(`--no-parallel`), CLI 14, macOS MCP e2e 8 (incl. headless render + content
asserts). Merge gate (`/simplify` + `/code-review` high) run in-session:
`/code-review` found 0 correctness bugs; macOS setup-under-JIT verified still
wired (`setupDylibPath` → `compileObjectForJIT` → `previewSetUp` via
`didRunSetUp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)