### PR TITLE
iOS: make the JIT flags mandatory, retire the PREVIEWSMCP_IOS_JIT scaffolding

### DIFF
--- a/HostAppSource/HostApp.swift
+++ b/HostAppSource/HostApp.swift
@@ -1,5 +1,5 @@
-import UIKit
 import SwiftUI
+import UIKit
 
 @main
 class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
@@ -22,13 +22,12 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
 
         // The in-process ORC executor links objects pushed by the daemon over the
         // EPC socket — there is no preview dylib to load.
-        #if PREVIEWSMCP_IOS_JIT
         if let jitPortIndex = args.firstIndex(of: "--jit-port"),
-           jitPortIndex + 1 < args.count,
-           let jitPort = UInt16(args[jitPortIndex + 1]) {
+            jitPortIndex + 1 < args.count,
+            let jitPort = UInt16(args[jitPortIndex + 1])
+        {
             startJITExecutor(port: jitPort)
         }
-        #endif
 
         // No preview is loaded at launch; the daemon's first render over EPC
         // installs the real hosting controller. Until then, give the window a
@@ -40,8 +39,9 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
         activateAccessibility()
 
         if let portIndex = args.firstIndex(of: "--port"),
-           portIndex + 1 < args.count,
-           let port = UInt16(args[portIndex + 1]) {
+            portIndex + 1 < args.count,
+            let port = UInt16(args[portIndex + 1])
+        {
             connectToServer(port: port)
         }
 
@@ -49,7 +49,6 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    #if PREVIEWSMCP_IOS_JIT
     // Connect back to the daemon's EPC listener and run the in-process ORC
     // executor. Runs on a detached thread so the SimpleRemoteEPCServer can
     // block on the socket while the UIApplication run loop stays live on main
@@ -86,7 +85,6 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
         }
         return fd
     }
-    #endif
 
     // MARK: - TCP Socket Client
 
@@ -149,7 +147,8 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
             socketReadBuffer = Data(socketReadBuffer[(newlineIndex + 1)...])
 
             guard let message = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
-                  let type = message["type"] as? String else { continue }
+                let type = message["type"] as? String
+            else { continue }
 
             handleMessage(message, type: type)
         }
@@ -174,8 +173,9 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
 
     private func sendResponse(_ dict: [String: Any]) {
         guard socketFD >= 0,
-              var data = try? JSONSerialization.data(withJSONObject: dict) else { return }
-        data.append(0x0A) // newline
+            var data = try? JSONSerialization.data(withJSONObject: dict)
+        else { return }
+        data.append(0x0A)  // newline
         let fd = socketFD
         data.withUnsafeBytes { buf in
             guard let base = buf.baseAddress else { return }
@@ -198,35 +198,42 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
     // Based on Lyft's Hammer (github.com/lyft/Hammer).
 
     // Function pointer types
-    private typealias CreateDigitizerEventFn = @convention(c) (
-        CFAllocator?, UInt64, UInt32, UInt32, UInt32, UInt32, UInt32,
-        Double, Double, Double, Double, Double, Bool, Bool, UInt32
-    ) -> UnsafeMutableRawPointer?
+    private typealias CreateDigitizerEventFn =
+        @convention(c) (
+            CFAllocator?, UInt64, UInt32, UInt32, UInt32, UInt32, UInt32,
+            Double, Double, Double, Double, Double, Bool, Bool, UInt32
+        ) -> UnsafeMutableRawPointer?
 
-    private typealias CreateDigitizerFingerEventFn = @convention(c) (
-        CFAllocator?, UInt64, UInt32, UInt32, UInt32,
-        Double, Double, Double, Double, Double, Bool, Bool, UInt32
-    ) -> UnsafeMutableRawPointer?
+    private typealias CreateDigitizerFingerEventFn =
+        @convention(c) (
+            CFAllocator?, UInt64, UInt32, UInt32, UInt32,
+            Double, Double, Double, Double, Double, Bool, Bool, UInt32
+        ) -> UnsafeMutableRawPointer?
 
-    private typealias AppendEventFn = @convention(c) (
-        UnsafeMutableRawPointer, UnsafeMutableRawPointer, UInt32
-    ) -> Void
+    private typealias AppendEventFn =
+        @convention(c) (
+            UnsafeMutableRawPointer, UnsafeMutableRawPointer, UInt32
+        ) -> Void
 
-    private typealias SetIntegerValueFn = @convention(c) (
-        UnsafeMutableRawPointer, UInt32, Int32
-    ) -> Void
+    private typealias SetIntegerValueFn =
+        @convention(c) (
+            UnsafeMutableRawPointer, UInt32, Int32
+        ) -> Void
 
-    private typealias SetFloatValueFn = @convention(c) (
-        UnsafeMutableRawPointer, UInt32, Double
-    ) -> Void
+    private typealias SetFloatValueFn =
+        @convention(c) (
+            UnsafeMutableRawPointer, UInt32, Double
+        ) -> Void
 
-    private typealias SetSenderIDFn = @convention(c) (
-        UnsafeMutableRawPointer, UInt64
-    ) -> Void
+    private typealias SetSenderIDFn =
+        @convention(c) (
+            UnsafeMutableRawPointer, UInt64
+        ) -> Void
 
-    private typealias BKSSetDigitizerInfoFn = @convention(c) (
-        UnsafeMutableRawPointer, UInt32, Bool, Bool, CFString?, Double, Float
-    ) -> Void
+    private typealias BKSSetDigitizerInfoFn =
+        @convention(c) (
+            UnsafeMutableRawPointer, UInt32, Bool, Bool, CFString?, Double, Float
+        ) -> Void
 
     private var createDigitizerEvent: CreateDigitizerEventFn?
     private var createDigitizerFingerEvent: CreateDigitizerFingerEventFn?
@@ -241,20 +248,26 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
         guard let iokit = dlopen("/System/Library/Frameworks/IOKit.framework/IOKit", RTLD_NOW) else {
             NSLog("PreviewHost: Failed to load IOKit"); return
         }
-        guard let bbs = dlopen("/System/Library/PrivateFrameworks/BackBoardServices.framework/BackBoardServices", RTLD_NOW) else {
+        guard
+            let bbs = dlopen(
+                "/System/Library/PrivateFrameworks/BackBoardServices.framework/BackBoardServices", RTLD_NOW)
+        else {
             NSLog("PreviewHost: Failed to load BackBoardServices"); return
         }
 
-        createDigitizerEvent = unsafeBitCast(dlsym(iokit, "IOHIDEventCreateDigitizerEvent"), to: CreateDigitizerEventFn?.self)
-        createDigitizerFingerEvent = unsafeBitCast(dlsym(iokit, "IOHIDEventCreateDigitizerFingerEvent"), to: CreateDigitizerFingerEventFn?.self)
+        createDigitizerEvent = unsafeBitCast(
+            dlsym(iokit, "IOHIDEventCreateDigitizerEvent"), to: CreateDigitizerEventFn?.self)
+        createDigitizerFingerEvent = unsafeBitCast(
+            dlsym(iokit, "IOHIDEventCreateDigitizerFingerEvent"), to: CreateDigitizerFingerEventFn?.self)
         appendEvent = unsafeBitCast(dlsym(iokit, "IOHIDEventAppendEvent"), to: AppendEventFn?.self)
         setIntegerValue = unsafeBitCast(dlsym(iokit, "IOHIDEventSetIntegerValue"), to: SetIntegerValueFn?.self)
         setFloatValue = unsafeBitCast(dlsym(iokit, "IOHIDEventSetFloatValue"), to: SetFloatValueFn?.self)
         setSenderID = unsafeBitCast(dlsym(iokit, "IOHIDEventSetSenderID"), to: SetSenderIDFn?.self)
         bksSetDigitizerInfo = unsafeBitCast(dlsym(bbs, "BKSHIDEventSetDigitizerInfo"), to: BKSSetDigitizerInfoFn?.self)
 
-        touchReady = (createDigitizerEvent != nil && createDigitizerFingerEvent != nil &&
-                      appendEvent != nil && setIntegerValue != nil && bksSetDigitizerInfo != nil)
+        touchReady =
+            (createDigitizerEvent != nil && createDigitizerFingerEvent != nil && appendEvent != nil
+                && setIntegerValue != nil && bksSetDigitizerInfo != nil)
 
         NSLog("PreviewHost: Touch injection \(touchReady ? "ready" : "FAILED")")
     }
@@ -265,17 +278,20 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
         switch action {
         case "tap":
             guard let x = command["x"] as? Double,
-                  let y = command["y"] as? Double else { return }
+                let y = command["y"] as? Double
+            else { return }
             sendTap(x: x, y: y)
         case "swipe":
             guard let fromX = command["fromX"] as? Double,
-                  let fromY = command["fromY"] as? Double,
-                  let toX = command["toX"] as? Double,
-                  let toY = command["toY"] as? Double else { return }
+                let fromY = command["fromY"] as? Double,
+                let toX = command["toX"] as? Double,
+                let toY = command["toY"] as? Double
+            else { return }
             let duration = command["duration"] as? Double ?? 0.3
             let steps = command["steps"] as? Int ?? 10
-            sendSwipe(fromX: fromX, fromY: fromY, toX: toX, toY: toY,
-                      duration: duration, steps: steps)
+            sendSwipe(
+                fromX: fromX, fromY: fromY, toX: toX, toY: toY,
+                duration: duration, steps: steps)
         default:
             break
         }
@@ -288,9 +304,11 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
 
-    private func sendSwipe(fromX: Double, fromY: Double,
-                            toX: Double, toY: Double,
-                            duration: Double, steps: Int) {
+    private func sendSwipe(
+        fromX: Double, fromY: Double,
+        toX: Double, toY: Double,
+        duration: Double, steps: Int
+    ) {
         let stepCount = max(steps, 2)
         let interval = duration / Double(stepCount)
 
@@ -317,11 +335,12 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
 
     private func sendTouchEvent(x: Double, y: Double, phase: TouchPhase) {
         guard touchReady,
-              let createParent = createDigitizerEvent,
-              let createFinger = createDigitizerFingerEvent,
-              let append = appendEvent,
-              let setInt = setIntegerValue,
-              let setBKS = bksSetDigitizerInfo else { return }
+            let createParent = createDigitizerEvent,
+            let createFinger = createDigitizerFingerEvent,
+            let append = appendEvent,
+            let setInt = setIntegerValue,
+            let setBKS = bksSetDigitizerInfo
+        else { return }
 
         let timestamp = mach_absolute_time()
         let isTouching = (phase != .ended)
@@ -331,13 +350,15 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
         // began/ended: .touch | .range (0x03)
         // moved: .position (0x04)
         let fingerMask: UInt32 = (phase == .moved) ? 0x04 : 0x03
-        let parentMask: UInt32 = 0x02 // .touch
+        let parentMask: UInt32 = 0x02  // .touch
 
         // Parent event (hand, transducerType=3)
-        guard let parent = createParent(
-            nil, timestamp, 3, 0, 0, parentMask, 0,
-            0, 0, 0, 0, 0, false, isTouching, 0
-        ) else { return }
+        guard
+            let parent = createParent(
+                nil, timestamp, 3, 0, 0, parentMask, 0,
+                0, 0, 0, 0, 0, false, isTouching, 0
+            )
+        else { return }
 
         // Set isDisplayIntegrated
         setInt(parent, 0xB0019, 1)
@@ -346,11 +367,13 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
         setSenderID?(parent, 0x0000000123456789)
 
         // Child finger event
-        guard let finger = createFinger(
-            nil, timestamp, 1, 1, fingerMask,
-            x, y, 0, pressure, 0,
-            isTouching, isTouching, 0
-        ) else { return }
+        guard
+            let finger = createFinger(
+                nil, timestamp, 1, 1, fingerMask,
+                x, y, 0, pressure, 0,
+                isTouching, isTouching, 0
+            )
+        else { return }
 
         // Set radius on finger
         setFloatValue?(finger, 0xB0014, 5.0)  // majorRadius
@@ -363,8 +386,9 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
         if let w = self.window {
             let sel = NSSelectorFromString("_contextId")
             if w.responds(to: sel) {
-                contextId = UInt32(truncatingIfNeeded:
-                    Int(bitPattern: w.perform(sel)?.toOpaque()))
+                contextId = UInt32(
+                    truncatingIfNeeded:
+                        Int(bitPattern: w.perform(sel)?.toOpaque()))
             }
         }
 
@@ -437,7 +461,7 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
                 "x": Int(frame.origin.x),
                 "y": Int(frame.origin.y),
                 "width": Int(frame.size.width),
-                "height": Int(frame.size.height)
+                "height": Int(frame.size.height),
             ]
         }
         node["children"] = children
@@ -454,7 +478,7 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
                 "x": Int(frame.origin.x),
                 "y": Int(frame.origin.y),
                 "width": Int(frame.size.width),
-                "height": Int(frame.size.height)
+                "height": Int(frame.size.height),
             ]
         } else if let accElement = element as? NSObject {
             // accessibilityFrame is in screen coordinates — convert to window
@@ -464,7 +488,7 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
                 "x": Int(windowFrame.origin.x),
                 "y": Int(windowFrame.origin.y),
                 "width": Int(windowFrame.size.width),
-                "height": Int(windowFrame.size.height)
+                "height": Int(windowFrame.size.height),
             ]
         }
 
@@ -480,7 +504,8 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
         if let identifiable = element as? UIView,
-           let identifier = identifiable.accessibilityIdentifier, !identifier.isEmpty {
+            let identifier = identifiable.accessibilityIdentifier, !identifier.isEmpty
+        {
             node["identifier"] = identifier
         }
 

--- a/Package.swift
+++ b/Package.swift
@@ -22,20 +22,24 @@ else {
 let jitCLIDependencies: [Target.Dependency] = ["PreviewsJITLink"]
 let jitCLISwiftSettings: [SwiftSetting] = [.define("PREVIEWSMCP_JIT")]
 
-// iOS-simulator JIT: the in-app ORC executor needs the cross-built iossim
-// TargetProcess libs and the iossim orc runtime. Gated separately from macOS
-// JIT because those artifacts come from `scripts/build-jit-llvm-iossim.sh` and
-// may be absent on a macOS-only checkout. When present, the BundleIOSSimJIT
-// plugin stages them into PreviewsIOS resources for IOSHostBuilder.
+// iOS-simulator JIT is mandatory like macOS: the in-app ORC executor needs the
+// cross-built iossim TargetProcess libs and the iossim orc runtime, staged into
+// PreviewsIOS resources by the BundleIOSSimJIT plugin. The artifacts come from
+// `scripts/build-jit-llvm-iossim.sh`; fail fast with a build-script hint if they
+// are missing rather than later in the plugin's copy step.
 let llvmBuildIOSSim = "\(packageDir)/third_party/llvm-build-iossim/lib/libLLVMOrcTargetProcess.a"
 let orcRuntimeIOSSim = "\(packageDir)/third_party/llvm-build-rt/lib/darwin/liborc_rt_iossim.a"
 
-let iosJitEnabled =
+guard
     FileManager.default.fileExists(atPath: llvmBuildIOSSim)
-    && FileManager.default.fileExists(atPath: orcRuntimeIOSSim)
+        && FileManager.default.fileExists(atPath: orcRuntimeIOSSim)
+else {
+    fatalError(
+        "PreviewsMCP requires the prebuilt iossim JIT artifacts. Run scripts/build-jit-llvm-iossim.sh first."
+    )
+}
 
-let iosJitSwiftSettings: [SwiftSetting] = iosJitEnabled ? [.define("PREVIEWSMCP_IOS_JIT")] : []
-let iosJitPlugins: [Target.PluginUsage] = iosJitEnabled ? [.plugin(name: "BundleIOSSimJIT")] : []
+let iosJitPlugins: [Target.PluginUsage] = [.plugin(name: "BundleIOSSimJIT")]
 
 var targets: [Target] = [
     .target(
@@ -64,7 +68,6 @@ var targets: [Target] = [
     .target(
         name: "PreviewsIOS",
         dependencies: ["PreviewsCore", "SimulatorBridge"],
-        swiftSettings: iosJitSwiftSettings,
         plugins: [.plugin(name: "EmbedHostAppSource")] + iosJitPlugins
     ),
     .target(
@@ -81,7 +84,7 @@ var targets: [Target] = [
             .product(name: "ArgumentParser", package: "swift-argument-parser"),
             .product(name: "MCP", package: "swift-sdk"),
         ] + jitCLIDependencies,
-        swiftSettings: jitCLISwiftSettings + iosJitSwiftSettings,
+        swiftSettings: jitCLISwiftSettings,
         plugins: [.plugin(name: "GenerateVersion")]
     ),
     .executableTarget(
@@ -141,16 +144,11 @@ var targets: [Target] = [
     ),
 ]
 
-if iosJitEnabled {
-    targets += [
-        .plugin(
-            name: "BundleIOSSimJIT",
-            capability: .buildTool()
-        )
-    ]
-}
-
 targets += [
+    .plugin(
+        name: "BundleIOSSimJIT",
+        capability: .buildTool()
+    ),
     .target(
         name: "PreviewsJITLink",
         dependencies: ["PreviewsJITLinkCxx", "PreviewsCore"],
@@ -200,8 +198,7 @@ targets += [
     .testTarget(
         name: "PreviewsJITLinkTests",
         dependencies: ["PreviewsJITLink", "PreviewsCore", "PreviewAgent", "PreviewsIOS"],
-        exclude: ["Fixtures"],
-        swiftSettings: iosJitSwiftSettings
+        exclude: ["Fixtures"]
     ),
 ]
 

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,6 @@ else {
 
 // Composition-root wiring for the JIT structural-reload path.
 let jitCLIDependencies: [Target.Dependency] = ["PreviewsJITLink"]
-let jitCLISwiftSettings: [SwiftSetting] = [.define("PREVIEWSMCP_JIT")]
 
 // iOS-simulator JIT is mandatory like macOS: the in-app ORC executor needs the
 // cross-built iossim TargetProcess libs and the iossim orc runtime, staged into
@@ -84,7 +83,6 @@ var targets: [Target] = [
             .product(name: "ArgumentParser", package: "swift-argument-parser"),
             .product(name: "MCP", package: "swift-sdk"),
         ] + jitCLIDependencies,
-        swiftSettings: jitCLISwiftSettings,
         plugins: [.plugin(name: "GenerateVersion")]
     ),
     .executableTarget(

--- a/Sources/PreviewsCLI/Handlers/PreviewStartHandler.swift
+++ b/Sources/PreviewsCLI/Handlers/PreviewStartHandler.swift
@@ -7,17 +7,11 @@ import PreviewsIOS
 import PreviewsJITLink
 import PreviewsMacOS
 
-/// Builds the iOS JIT reloader from the accepted EPC fd, or nil when the bundled iossim
-/// runtime is absent — in which case iOS previews are unavailable and `start()` throws
-/// `jitRequired`. Mirrors the macOS `host.makeStructuralReloader` injection in
-/// `PreviewsMCPApp`. Active only when the iossim runtime (`PREVIEWSMCP_IOS_JIT`) is present.
-private let iosJITReloaderFactory: IOSPreviewSession.MakeJITReloader? = {
-    #if PREVIEWSMCP_IOS_JIT
-    return { fd, orcPath in try IOSJITStructuralReloader(remoteFD: fd, orcRuntimePath: orcPath) }
-    #else
-    return nil
-    #endif
-}()
+/// Builds the iOS JIT reloader from the accepted EPC fd. Mirrors the macOS
+/// `host.makeStructuralReloader` injection in `PreviewsMCPApp`.
+private let iosJITReloaderFactory: IOSPreviewSession.MakeJITReloader = { fd, orcPath in
+    try IOSJITStructuralReloader(remoteFD: fd, orcRuntimePath: orcPath)
+}
 
 enum PreviewStartHandler: ToolHandler {
     static let name: ToolName = .previewStart

--- a/Sources/PreviewsIOS/IOSHostBuilder.swift
+++ b/Sources/PreviewsIOS/IOSHostBuilder.swift
@@ -89,7 +89,6 @@ public actor IOSHostBuilder {
             "-o", binaryPath.path,
         ]
 
-        #if PREVIEWSMCP_IOS_JIT
         // Link the in-app ORC executor so the host can JIT-link objects pushed
         // by the daemon over the second (EPC) socket. server.o references the
         // LLVM symbols, so it must precede the archives; the orc runtime is NOT
@@ -98,7 +97,6 @@ public actor IOSHostBuilder {
         let bridgingHeader = workDir.appendingPathComponent("previewsmcp_ios_executor.h")
         try Self.bridgingHeaderSource.write(to: bridgingHeader, atomically: true, encoding: .utf8)
         compileArgs += [
-            "-D", "PREVIEWSMCP_IOS_JIT",
             "-import-objc-header", bridgingHeader.path,
         ]
         compileArgs.append(sourceFile.path)
@@ -112,9 +110,6 @@ public actor IOSHostBuilder {
             "-lLLVMDemangle",
             "-lc++",
         ]
-        #else
-        compileArgs.append(sourceFile.path)
-        #endif
 
         try await run(compileArgs)
 
@@ -164,7 +159,6 @@ public actor IOSHostBuilder {
 
 }
 
-#if PREVIEWSMCP_IOS_JIT
 extension IOSHostBuilder {
     struct JITArtifacts {
         let serverObject: URL
@@ -194,7 +188,6 @@ extension IOSHostBuilder {
         Bundle.module.url(forResource: "liborc_rt_iossim", withExtension: "a")?.path
     }
 }
-#endif
 
 public enum IOSHostBuildError: Error, LocalizedError, CustomStringConvertible {
     case compilationFailed(String)

--- a/Sources/PreviewsIOS/IOSPreviewSession.swift
+++ b/Sources/PreviewsIOS/IOSPreviewSession.swift
@@ -35,8 +35,9 @@ public actor IOSPreviewSession {
     private let channel = IOSHostChannel()
 
     /// Builds the JIT reloader from the accepted EPC socket and the bundled
-    /// iossim orc runtime path. Injected by the composition root behind the JIT
-    /// flag. iOS previews require JIT; `nil` makes `start()` throw `jitRequired`.
+    /// iossim orc runtime path. Injected by the composition root; left optional
+    /// only so tests can supply their own factory. `nil` makes `start()` throw
+    /// `jitRequired`.
     public typealias MakeJITReloader =
         @Sendable (_ epcFD: Int32, _ orcRuntimePath: String) throws -> any IOSStructuralReloader
     private let makeJITReloader: MakeJITReloader?
@@ -85,7 +86,6 @@ public actor IOSPreviewSession {
     /// Start the iOS preview: compile, boot sim, install host, launch, connect socket.
     /// Returns the PID of the launched host app.
     public func start() async throws -> Int {
-        #if PREVIEWSMCP_IOS_JIT
         guard let makeJITReloader else {
             throw IOSPreviewSessionError.jitRequired
         }
@@ -217,9 +217,6 @@ public actor IOSPreviewSession {
         stage("connected; start complete")
 
         return pid
-        #else
-        throw IOSPreviewSessionError.jitRequired
-        #endif
     }
 
     /// Close the socket connection and clean up resources. Idempotent —
@@ -493,7 +490,7 @@ public enum IOSPreviewSessionError: Error, LocalizedError, CustomStringConvertib
         case .socketAcceptTimeout: return "Timed out waiting for host app to connect"
         case .jitRuntimeMissing: return "Bundled iossim orc runtime archive not found"
         case .jitRequired:
-            return "iOS previews require the JIT build (PREVIEWSMCP_IOS_JIT with the iossim runtime)"
+            return "iOS previews require a JIT reloader, but none was injected"
         case .socketResponseTimeout(let id): return "Timed out waiting for response (id: \(id))"
         case .connectionLost: return "Connection to host app lost"
         case .responseDecodeFailed(let operation):

--- a/Tests/PreviewsIOSTests/IOSHostBuilderHashTests.swift
+++ b/Tests/PreviewsIOSTests/IOSHostBuilderHashTests.swift
@@ -41,7 +41,9 @@ struct IOSHostBuilderHashTests {
         // Updated 2026-06-15 for dylib Phase B: iOS is JIT-only now, so HostApp.swift
         // dropped all dylib loading (loadPreview/showError/applyLiterals, the
         // --dylib/--setup-dylib args, and the reload/init/literals handlers).
-        let expected = "ad5032b60eb337cf2a0920272262688ea3da36fd4cae9ecd0c3976fe1d3c8133"
+        // Updated 2026-06-16 for iOS JIT mandatory: the --jit-port branch and the
+        // startJITExecutor/connectLoopback helpers are no longer behind #if.
+        let expected = "5b900b18a768b57caf614f60ef988436716efa2ecaa12043d5485c8c08b6d03d"
         #expect(hash == expected, "host-app artifact hash drifted (was \(expected), now \(hash))")
     }
 }

--- a/Tests/PreviewsIOSTests/IOSHostBuilderTests.swift
+++ b/Tests/PreviewsIOSTests/IOSHostBuilderTests.swift
@@ -40,15 +40,14 @@ struct IOSHostBuilderTests {
         #expect(output.contains("arm64"))
 
         // Guard against silent mis-escaping in the embedded `"""…"""` host-app
-        // source: the error screen's title should survive round-tripping into
-        // the compiled binary as a literal string. If someone double-escapes
-        // or drops a character, the byte search misses and the test fails
-        // before a user hits a broken error screen in the simulator.
+        // source: a known literal string should survive round-tripping into the
+        // compiled binary verbatim. If someone double-escapes or drops a
+        // character, the byte search misses.
         let binaryData = try Data(contentsOf: binaryPath)
-        let title = Data("Preview host error".utf8)
+        let marker = Data("PreviewHost: Failed to create socket".utf8)
         #expect(
-            binaryData.range(of: title) != nil,
-            "compiled host binary should embed the error-screen title verbatim"
+            binaryData.range(of: marker) != nil,
+            "compiled host binary should embed the host-app log string verbatim"
         )
 
         print("Built iOS host app at: \(appPath.path)")

--- a/Tests/PreviewsJITLinkTests/IOSSimSpikeTests.swift
+++ b/Tests/PreviewsJITLinkTests/IOSSimSpikeTests.swift
@@ -1,11 +1,8 @@
 import Foundation
-import PreviewsJITLink
-import Testing
-
-#if PREVIEWSMCP_IOS_JIT
 import PreviewsCore
 import PreviewsIOS
-#endif
+import PreviewsJITLink
+import Testing
 
 /// Phase 0 spike: prove the macOS daemon can drive an ORC executor running
 /// inside an iOS simulator process and link + run an object there. The executor
@@ -79,7 +76,6 @@ struct IOSSimSpikeTests {
         }
     }
 
-    #if PREVIEWSMCP_IOS_JIT
     /// Phase 2 fold: the REAL production host app (built by IOSHostBuilder with
     /// the executor linked from PreviewsIOS resources) hosts the ORC executor
     /// and the daemon links + runs an object inside it over the EPC socket. JIT
@@ -224,10 +220,8 @@ struct IOSSimSpikeTests {
             HelloView()
         }
         """
-    #endif
 }
 
-#if PREVIEWSMCP_IOS_JIT
 /// Holds the remote JIT session for the lifetime of the preview session, mirroring
 /// how the real reloader will retain it to drive renders.
 private final class CapturingReloader: IOSStructuralReloader, @unchecked Sendable {
@@ -243,7 +237,6 @@ private final class ResultBox: @unchecked Sendable {
     func set(_ v: Int32) { lock.lock(); value = v; lock.unlock() }
     func get() -> Int32? { lock.lock(); defer { lock.unlock() }; return value }
 }
-#endif
 
 enum SimSpikeSupport {
     enum SpikeError: Error, CustomStringConvertible {
@@ -309,13 +302,20 @@ enum SimSpikeSupport {
     }
 
     static func bootSimulator() throws -> String {
-        if let udid = firstUDID(in: try run(
-            "/usr/bin/xcrun", ["simctl", "list", "devices", "booted"]).output) {
+        if let udid = firstUDID(
+            in: try run(
+                "/usr/bin/xcrun", ["simctl", "list", "devices", "booted"]
+            ).output)
+        {
             return udid
         }
-        guard let udid = firstUDID(in: try run(
-            "/usr/bin/xcrun", ["simctl", "list", "devices", "available"]).output,
-            onLinesMatching: "iPhone") else {
+        guard
+            let udid = firstUDID(
+                in: try run(
+                    "/usr/bin/xcrun", ["simctl", "list", "devices", "available"]
+                ).output,
+                onLinesMatching: "iPhone")
+        else {
             throw SpikeError.message("no available iPhone simulator to boot")
         }
         _ = try run("/usr/bin/xcrun", ["simctl", "boot", udid])


### PR DESCRIPTION
## Summary

iOS previews have been JIT-only since dylib Phase B (#212). This makes the iOS
JIT build unconditional like macOS (Phase A, #213) and deletes the
`#if PREVIEWSMCP_IOS_JIT` scaffolding so the flag no longer exists. Second of the
two related PRs.

## What changed

- **IOSPreviewSession.start()**: drop the `#else throw jitRequired` wrapper; the
  body is unconditional. The runtime `guard let makeJITReloader else { throw
  jitRequired }` stays as the test-injection seam.
- **IOSHostBuilder**: the JIT link path (server.o + iossim LLVM archives) and the
  `jitArtifacts`/`jitOrcRuntimePath` extension are unconditional; dropped the dead
  non-JIT `#else` and the now-needless `-D PREVIEWSMCP_IOS_JIT` host-app define.
- **HostAppSource/HostApp.swift**: the `--jit-port` branch and
  `startJITExecutor`/`connectLoopback` are no longer gated. Hash → `5b900b18…`.
- **PreviewStartHandler**: the iOS reloader factory is now a non-optional constant.
- **IOSSimSpikeTests**: the iOS JIT tests/imports/helpers are no longer gated.
- **Package.swift**: the `PREVIEWSMCP_IOS_JIT` define is dropped (no references
  left); the `BundleIOSSimJIT` plugin and the iossim-artifact requirement are
  mandatory, failing fast with a build-script hint if the artifacts are missing.

## Drive-by fix

`IOSHostBuilderTests` searched the compiled host binary for "Preview host error",
a string #212 removed with the host error screen — so that test was **red on main**
since #212. Repointed the escaping guard at a stable host-app log literal that
still exists.

## Verification

Local bar green: build `--build-tests`; PreviewsIOSTests 13 (hash + host-app build
+ escaping guard); PreviewsJITLinkTests 69 incl. the three iOS sim e2e tests
(`hostsRemoteSessionInRealHostApp`, `productionSessionEstablishesJITOverSecondSocket`,
`endToEndRendersOverJIT`) now un-gated and rendering on a booted simulator; units
337; CLI 14; macOS MCP 8. Merge gate (`/simplify` + `/code-review` high) run
in-session: `/code-review` found 0 correctness bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)