### PR TITLE
iOS: wire the setup dylib into JIT previews (#215)

### DIFF
--- a/Sources/PreviewsCLI/Handlers/PreviewStartHandler.swift
+++ b/Sources/PreviewsCLI/Handlers/PreviewStartHandler.swift
@@ -293,6 +293,7 @@ private func handleIOSPreviewStart(
         setupType: setupResult?.typeName,
         setupCompilerFlags: setupResult?.compilerFlags ?? [],
         setupSDKPath: setupResult?.sdkPath,
+        setupDylibPath: setupResult?.dylibPath,
         progress: progress,
         makeJITReloader: iosJITReloaderFactory
     )

--- a/Sources/PreviewsIOS/IOSPreviewSession.swift
+++ b/Sources/PreviewsIOS/IOSPreviewSession.swift
@@ -27,6 +27,7 @@ public actor IOSPreviewSession {
     private let setupType: String?
     private let setupCompilerFlags: [String]
     private let setupSDKPath: String?
+    private let setupDylibPath: URL?
     public var currentTraits: PreviewTraits { traits }
 
     /// Transport to the iOS host app. Owns all socket state — bind,
@@ -60,6 +61,7 @@ public actor IOSPreviewSession {
         setupType: String? = nil,
         setupCompilerFlags: [String] = [],
         setupSDKPath: String? = nil,
+        setupDylibPath: URL? = nil,
         progress: (any ProgressReporter)? = nil,
         makeJITReloader: MakeJITReloader? = nil
     ) {
@@ -77,6 +79,7 @@ public actor IOSPreviewSession {
         self.setupType = setupType
         self.setupCompilerFlags = setupCompilerFlags
         self.setupSDKPath = setupSDKPath
+        self.setupDylibPath = setupDylibPath
         self.progress = progress
         self.makeJITReloader = makeJITReloader
     }
@@ -302,7 +305,8 @@ public actor IOSPreviewSession {
             setupModule: setupModule,
             setupType: setupType,
             setupCompilerFlags: setupCompilerFlags,
-            setupSDKPath: setupSDKPath
+            setupSDKPath: setupSDKPath,
+            setupDylibPath: setupDylibPath
         )
     }
 

--- a/Tests/PreviewsJITLinkTests/IOSSimSpikeTests.swift
+++ b/Tests/PreviewsJITLinkTests/IOSSimSpikeTests.swift
@@ -201,6 +201,62 @@ struct IOSSimSpikeTests {
         await session.stop()
     }
 
+    /// End-to-end iOS JIT render WITH a setup plugin, over a real project build context
+    /// (setup only applies when `splitContext` is non-nil, which needs a `buildContext`).
+    /// The setup dylib (`ToDoPreviewSetup` built for the iOS sim) must be threaded into the
+    /// JIT link so `previewSetUp` resolves and `wrap()` overlays its banner. Red before #215:
+    /// `IOSPreviewSession` dropped `setupDylibPath`, so the setup symbols never linked.
+    /// After the fix the banner's `dev@example.com` appears in the a11y tree.
+    @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
+    func endToEndRendersSetupWrappedOverJIT() async throws {
+        let udid = try SimSpikeSupport.bootSimulator()
+
+        let hot = Self.packageRoot
+            .appendingPathComponent("examples/spm/Sources/ToDo/Summary.swift")
+        guard let spm = try await SPMBuildSystem.detect(for: hot) else {
+            Issue.record("no SPM build system detected for \(hot.path)")
+            return
+        }
+        let buildContext = try await spm.build(platform: .iOS)
+
+        let configResult = try #require(
+            ProjectConfigLoader.find(from: hot.deletingLastPathComponent()))
+        let setupConfig = try #require(configResult.config.setup)
+        let setup = try await SetupBuilder.build(
+            config: setupConfig, configDirectory: configResult.directory, platform: .iOS)
+
+        let compiler = try await Compiler(platform: .iOS)
+        let hostBuilder = try await IOSHostBuilder()
+        let simulatorManager = SimulatorManager()
+
+        let session = IOSPreviewSession(
+            sourceFile: hot,
+            deviceUDID: udid,
+            compiler: compiler,
+            hostBuilder: hostBuilder,
+            simulatorManager: simulatorManager,
+            buildContext: buildContext,
+            setupModule: setup.moduleName,
+            setupType: setup.typeName,
+            setupCompilerFlags: setup.compilerFlags,
+            setupSDKPath: setup.sdkPath,
+            setupDylibPath: setup.dylibPath,
+            makeJITReloader: { fd, orcPath in
+                try IOSJITStructuralReloader(remoteFD: fd, orcRuntimePath: orcPath)
+            }
+        )
+        defer {
+            SimSpikeSupport.terminateApp(udid: udid, bundleID: IOSPreviewSession.hostBundleID)
+        }
+
+        let pid = try await session.start()
+        #expect(pid > 0)
+
+        let elements = try await session.fetchElements()
+        #expect(elements.contains("dev@example.com"))
+        await session.stop()
+    }
+
     static var jitOrcRuntimePresent: Bool {
         IOSHostBuilder.jitOrcRuntimePath != nil
     }


### PR DESCRIPTION
Fixes #215.

## Problem
iOS previews with a setup plugin were silently broken under JIT. `IOSPreviewSession` passed `setupModule`/`setupType`/`setupCompilerFlags`/`setupSDKPath` into the `PreviewSession` used by `compileObjectForJIT`, but never threaded `setupDylibPath`. So the setup dylib was absent from the JIT link and the `previewSetUp`/`wrap` symbols failed to resolve.

## Fix
Thread `setupDylibPath` through `IOSPreviewSession` (init param + stored + forwarded in `makePreviewSession()`), mirroring the macOS path, and pass `setupResult?.dylibPath` in `handleIOSPreviewStart`.

## Verification
New iOS-sim e2e test `endToEndRendersSetupWrappedOverJIT` builds `examples/spm` for iOS with the `ToDoPreviewSetup` plugin and asserts the setup banner text appears in the accessibility tree. Red-green confirmed: red was `Symbols not found: previewSetUp/wrap/setUp`, green renders the banner. Full local bar green: units 337, JIT 70, CLI 14, macOS MCP 8, iOS 13. Merge gate clean (`/simplify` no changes, `/code-review` high 0 findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)