### PR TITLE
JIT: tighten reloader injection and post-mandatory types (#218)

### DIFF
--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -85,8 +85,7 @@ public struct PreviewsMCPApp {
         // `serve` is the only command that runs AppKit in-process — every
         // other subcommand is now a daemon client.
         let app = NSApplication.shared
-        let host = PreviewHost()
-        host.makeStructuralReloader = { JITStructuralReloader() }
+        let host = PreviewHost(makeStructuralReloader: { JITStructuralReloader() })
         ServeCommand.sharedHost = host
         app.delegate = host
 

--- a/Sources/PreviewsIOS/IOSPreviewSession.swift
+++ b/Sources/PreviewsIOS/IOSPreviewSession.swift
@@ -36,12 +36,11 @@ public actor IOSPreviewSession {
     private let channel = IOSHostChannel()
 
     /// Builds the JIT reloader from the accepted EPC socket and the bundled
-    /// iossim orc runtime path. Injected by the composition root; left optional
-    /// only so tests can supply their own factory. `nil` makes `start()` throw
-    /// `jitRequired`.
+    /// iossim orc runtime path. Injected by the composition root so every
+    /// session has a reloader; tests supply their own factory.
     public typealias MakeJITReloader =
         @Sendable (_ epcFD: Int32, _ orcRuntimePath: String) throws -> any IOSStructuralReloader
-    private let makeJITReloader: MakeJITReloader?
+    private let makeJITReloader: MakeJITReloader
     private var jitReloader: (any IOSStructuralReloader)?
     private var jitListenFD: Int32 = -1
 
@@ -63,7 +62,7 @@ public actor IOSPreviewSession {
         setupSDKPath: String? = nil,
         setupDylibPath: URL? = nil,
         progress: (any ProgressReporter)? = nil,
-        makeJITReloader: MakeJITReloader? = nil
+        makeJITReloader: @escaping MakeJITReloader
     ) {
         self.id = UUID().uuidString
         self.sourceFile = sourceFile
@@ -89,9 +88,6 @@ public actor IOSPreviewSession {
     /// Start the iOS preview: compile, boot sim, install host, launch, connect socket.
     /// Returns the PID of the launched host app.
     public func start() async throws -> Int {
-        guard let makeJITReloader else {
-            throw IOSPreviewSessionError.jitRequired
-        }
         guard let orcPath = IOSHostBuilder.jitOrcRuntimePath else {
             throw IOSPreviewSessionError.jitRuntimeMissing
         }
@@ -332,15 +328,9 @@ public actor IOSPreviewSession {
     }
 
     /// Handle a source file change by recompiling and re-linking over JIT.
-    /// Returns `false`: iOS JIT has no literal fast path yet, so every edit
-    /// is a full structural reload.
-    @discardableResult
-    public func handleSourceChange() async throws -> Bool {
-        guard await channel.isConnected else {
-            throw IOSPreviewSessionError.notStarted
-        }
+    /// iOS JIT has no literal fast path yet, so every edit is a full structural reload.
+    public func handleSourceChange() async throws {
         try await reload()
-        return false
     }
 
     /// Switch to a different preview index and recompile. Traits are preserved. @State is lost.
@@ -478,7 +468,6 @@ public enum IOSPreviewSessionError: Error, LocalizedError, CustomStringConvertib
     case socketAcceptFailed
     case socketAcceptTimeout
     case jitRuntimeMissing
-    case jitRequired
     case socketResponseTimeout(String)
     case connectionLost
     /// JSON parse or shape mismatch on a host-app response. Distinct
@@ -493,8 +482,6 @@ public enum IOSPreviewSessionError: Error, LocalizedError, CustomStringConvertib
         case .socketAcceptFailed: return "Failed to accept connection from host app"
         case .socketAcceptTimeout: return "Timed out waiting for host app to connect"
         case .jitRuntimeMissing: return "Bundled iossim orc runtime archive not found"
-        case .jitRequired:
-            return "iOS previews require a JIT reloader, but none was injected"
         case .socketResponseTimeout(let id): return "Timed out waiting for response (id: \(id))"
         case .connectionLost: return "Connection to host app lost"
         case .responseDecodeFailed(let operation):

--- a/Sources/PreviewsMacOS/HostApp.swift
+++ b/Sources/PreviewsMacOS/HostApp.swift
@@ -25,7 +25,7 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     /// composition root. Each session gets its own reloader — its own agent
     /// process and window — so respawns, crashes, setup state, and window
     /// lifetime stay contained to one session.
-    public var makeStructuralReloader: (@MainActor () -> any StructuralReloader)?
+    private let makeStructuralReloader: @MainActor () -> any StructuralReloader
     /// Per-session reloaders. Removing a session's entry releases its agent
     /// process, which closes the agent-hosted window.
     private var reloaders: [String: any StructuralReloader] = [:]
@@ -47,7 +47,8 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     /// queue and persist the older snapshot last.
     private var lastPublishTask: Task<Void, Never>?
 
-    public override init() {
+    public init(makeStructuralReloader: @escaping @MainActor () -> any StructuralReloader) {
+        self.makeStructuralReloader = makeStructuralReloader
         super.init()
     }
 
@@ -179,7 +180,7 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     /// so the agent shows its own live window there — the agent window is the
     /// session's interactive surface.
     @discardableResult
-    public func jitStructuralReload(sessionID: String, session: PreviewSession) async throws -> URL? {
+    public func jitStructuralReload(sessionID: String, session: PreviewSession) async throws -> URL {
         restoreAgentWindowFrame(sessionID: sessionID, session: session)
         let build = try await session.compileObjectForJIT(window: agentWindowSpec(for: sessionID))
         return try await jitRender(sessionID: sessionID, build: build)
@@ -233,7 +234,8 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     /// still in flight when its session closes cannot resurrect an agent.
     private func reloader(for sessionID: String) -> (any StructuralReloader)? {
         if let existing = reloaders[sessionID] { return existing }
-        guard sessions[sessionID] != nil, let made = makeStructuralReloader?() else { return nil }
+        guard sessions[sessionID] != nil else { return nil }
+        let made = makeStructuralReloader()
         reloaders[sessionID] = made
         return made
     }

--- a/Tests/PreviewsEngineTests/MacOSPreviewHandleAgentSnapshotTests.swift
+++ b/Tests/PreviewsEngineTests/MacOSPreviewHandleAgentSnapshotTests.swift
@@ -40,12 +40,10 @@ struct MacOSPreviewHandleAgentSnapshotTests {
 
         let compiler = try await Compiler()
         let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
-        let host = PreviewHost()
-        host.makeStructuralReloader = { RecordingReloader() }
+        let host = PreviewHost(makeStructuralReloader: { RecordingReloader() })
         host.watchFile(sessionID: "s1", session: session, filePath: sourceFile.path, compiler: compiler)
 
-        let imagePath = try await host.jitStructuralReload(sessionID: "s1", session: session)
-        let imageURL = try #require(imagePath)
+        let imageURL = try await host.jitStructuralReload(sessionID: "s1", session: session)
         try Self.greenPNG().write(to: imageURL)
 
         let handle = MacOSPreviewHandle(id: "s1", session: session, host: host)
@@ -82,9 +80,8 @@ struct MacOSPreviewHandleAgentSnapshotTests {
 
         let compiler = try await Compiler()
         let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
-        let host = PreviewHost()
         let reloader = RecordingReloader()
-        host.makeStructuralReloader = { reloader }
+        let host = PreviewHost(makeStructuralReloader: { reloader })
         host.watchFile(sessionID: "s1", session: session, filePath: sourceFile.path, compiler: compiler)
 
         _ = try await host.jitStructuralReload(sessionID: "s1", session: session)

--- a/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
+++ b/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
@@ -39,13 +39,11 @@ struct PreviewHostJITReloadTests {
         let compiler = try await Compiler()
         let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
 
-        let host = PreviewHost()
         let reloader = RecordingReloader()
-        host.makeStructuralReloader = { reloader }
+        let host = PreviewHost(makeStructuralReloader: { reloader })
         host.watchFile(sessionID: "s1", session: session, filePath: sourceFile.path, compiler: compiler)
 
         let imagePath = try await host.jitStructuralReload(sessionID: "s1", session: session)
-        #expect(imagePath != nil)
         #expect(host.agentSnapshotPath(for: "s1") == imagePath)
         #expect(reloader.calls.count == 1)
         #expect(reloader.calls.first?.entrySymbol == "renderPreviewToFile")
@@ -69,13 +67,12 @@ struct PreviewHostJITReloadTests {
         let compiler = try await Compiler()
         let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
 
-        let host = PreviewHost()
         var made: [RecordingReloader] = []
-        host.makeStructuralReloader = {
+        let host = PreviewHost(makeStructuralReloader: {
             let reloader = RecordingReloader()
             made.append(reloader)
             return reloader
-        }
+        })
         host.watchFile(sessionID: "a", session: session, filePath: sourceFile.path, compiler: compiler)
         host.watchFile(sessionID: "b", session: session, filePath: sourceFile.path, compiler: compiler)
 
@@ -123,8 +120,7 @@ struct PreviewHostJITReloadTests {
         let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
         let build = try await session.compileObjectForJIT()
 
-        let host = PreviewHost()
-        host.makeStructuralReloader = { RecordingReloader() }
+        let host = PreviewHost(makeStructuralReloader: { RecordingReloader() })
         host.watchFile(sessionID: "s1", session: session, filePath: sourceFile.path, compiler: compiler)
 
         let stringLiteral = try #require(
@@ -163,8 +159,7 @@ struct PreviewHostJITReloadTests {
         let compiler = try await Compiler()
         let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
 
-        let host = PreviewHost()
-        host.makeStructuralReloader = { RecordingReloader() }
+        let host = PreviewHost(makeStructuralReloader: { RecordingReloader() })
 
         try await host.jitStart(
             sessionID: "visible", session: session,
@@ -207,12 +202,11 @@ struct PreviewHostJITReloadTests {
         let compiler = try await Compiler()
         let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
 
-        let host = PreviewHost()
         var madeCount = 0
-        host.makeStructuralReloader = {
+        let host = PreviewHost(makeStructuralReloader: {
             madeCount += 1
             return RecordingReloader()
-        }
+        })
 
         try await host.jitStart(
             sessionID: "s", session: session,

--- a/Tests/PreviewsMacOSTests/PreviewHostTests.swift
+++ b/Tests/PreviewsMacOSTests/PreviewHostTests.swift
@@ -8,6 +8,12 @@ import Testing
 @Suite("PreviewHost")
 struct PreviewHostTests {
 
+    /// This suite never triggers a reload, so the injected factory just needs to
+    /// satisfy the now-required constructor parameter.
+    final class StubReloader: StructuralReloader, @unchecked Sendable {
+        func render(_ build: JITRenderBuild) async throws {}
+    }
+
     /// Regression guard for the iOS `run` hot-reload bug.
     ///
     /// `FileWatcher` callbacks dereference `self` via an unretained pointer,
@@ -19,7 +25,7 @@ struct PreviewHostTests {
     /// alive — if that mechanism breaks, this test should go red.
     @Test("retainFileWatcher keeps a watcher alive past the creating scope")
     func retainFileWatcherKeepsWatcherAlive() async throws {
-        let host = PreviewHost()
+        let host = PreviewHost(makeStructuralReloader: { StubReloader() })
 
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("preview-host-test-\(UUID().uuidString)")


### PR DESCRIPTION
Fixes #218.

Three cleanups deferred from making JIT mandatory (#213/#214):

- **`IOSPreviewSession.handleSourceChange`** dropped its dead `@discardableResult Bool` (always `false`) and the redundant `isConnected` guard that `reload()` already enforces.
- **`PreviewHost.jitStructuralReload`** now returns `URL` instead of `URL?`; it always returned `jitRender`'s non-optional `URL` once the `agentBacked` guard was removed.
- **`makeStructuralReloader`** (macOS) and **`makeJITReloader`** (iOS) are now required constructor parameters instead of optional vars set post-init, so the type enforces "a host always has a reloader." Removed the now-unreachable `IOSPreviewSessionError.jitRequired`.

## Verification
Full local bar green: units 337, JIT 70, CLI 14, macOS MCP 8, iOS 13. Merge gate clean (`/simplify` no changes, `/code-review` high 0 findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)