### PR TITLE
iOS JIT: literal edits re-seed without recompile (#216)

### DIFF
--- a/Sources/PreviewsIOS/IOSPreviewSession.swift
+++ b/Sources/PreviewsIOS/IOSPreviewSession.swift
@@ -327,10 +327,25 @@ public actor IOSPreviewSession {
         try await jitReloader.render(build)
     }
 
-    /// Handle a source file change by recompiling and re-linking over JIT.
-    /// iOS JIT has no literal fast path yet, so every edit is a full structural reload.
+    /// Handle a source file change. Fast path: a literal-only edit rewrites the design-time
+    /// values JSON and re-runs the same linked object over EPC (no recompile, no relink),
+    /// mirroring the macOS path. Otherwise fall back to a structural reload that reuses the
+    /// persistent session so its stable-module cache and literal baseline carry forward.
     public func handleSourceChange() async throws {
-        try await reload()
+        guard await channel.isConnected, let jitReloader, let session else {
+            throw IOSPreviewSessionError.notStarted
+        }
+
+        let newSource = try String(contentsOf: sourceFile, encoding: .utf8)
+        if let changes = await session.tryLiteralUpdate(newSource: newSource), !changes.isEmpty,
+            let build = try await session.applyLiteralValuesForJIT(changes)
+        {
+            try await jitReloader.render(build)
+            return
+        }
+
+        let build = try await session.compileObjectForJIT()
+        try await jitReloader.render(build)
     }
 
     /// Switch to a different preview index and recompile. Traits are preserved. @State is lost.

--- a/Sources/PreviewsJITLink/IOSJITStructuralReloader.swift
+++ b/Sources/PreviewsJITLink/IOSJITStructuralReloader.swift
@@ -12,6 +12,7 @@ import PreviewsCore
 public actor IOSJITStructuralReloader: IOSStructuralReloader {
     private let session: JITSession
     private var generation = 0
+    private var lastObjectPath: URL?
     private var didRunSetUp = false
 
     public init(remoteFD fd: Int32, orcRuntimePath: String) throws {
@@ -19,9 +20,16 @@ public actor IOSJITStructuralReloader: IOSStructuralReloader {
     }
 
     public func render(_ build: JITRenderBuild) async throws {
-        // Each call links a freshly compiled object (compileObjectForJIT mints a new
-        // objectPath every time) into a fresh generation. iOS has no literal-only re-seed
-        // path yet, so there is no same-object fast path to short-circuit here.
+        // Literal re-render: the same object is already linked in the live generation, so just
+        // re-run its entry. It re-seeds DesignTimeStore from the (rewritten) values JSON, with
+        // no new JITDylib and no re-link (which would re-register the object's classes).
+        if let lastObjectPath, build.objectPath == lastObjectPath {
+            try await runEntry(build.entrySymbol)
+            return
+        }
+
+        // Structural edit: compileObjectForJIT minted a new objectPath, so link it into a
+        // fresh generation.
         if generation > 0 {
             try session.newGeneration()
         }
@@ -37,6 +45,7 @@ public actor IOSJITStructuralReloader: IOSStructuralReloader {
             try session.addObject(path: support.path)
         }
         try session.addObject(path: build.objectPath.path)
+        lastObjectPath = build.objectPath
 
         if let setupEntry = build.setupEntrySymbol, !didRunSetUp {
             _ = try session.runOnMain(symbol: setupEntry)

--- a/Tests/PreviewsJITLinkTests/IOSSimSpikeTests.swift
+++ b/Tests/PreviewsJITLinkTests/IOSSimSpikeTests.swift
@@ -201,6 +201,66 @@ struct IOSSimSpikeTests {
         await session.stop()
     }
 
+    /// Literal-only edit over iOS JIT (#216): after the initial render, a change that
+    /// touches only a `Text` string must re-seed the DesignTimeStore and re-run the SAME
+    /// linked object — no recompile, no new generation — mirroring the macOS literal path.
+    /// A `RecordingReloader` wraps the real reloader and captures each rendered object path.
+    /// Red before the fix: `handleSourceChange` rebuilt the session and recompiled, so the
+    /// second render carried a fresh object path.
+    @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
+    func literalEditReSeedsSameObjectWithoutRecompile() async throws {
+        let udid = try SimSpikeSupport.bootSimulator()
+
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-ios-jit-literal-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let sourceFile = tempDir.appendingPathComponent("HelloView.swift")
+        try Self.helloViewSource.write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        let compiler = try await Compiler(platform: .iOS)
+        let hostBuilder = try await IOSHostBuilder()
+        let simulatorManager = SimulatorManager()
+
+        let recorderBox = RecorderBox()
+        let session = IOSPreviewSession(
+            sourceFile: sourceFile,
+            deviceUDID: udid,
+            compiler: compiler,
+            hostBuilder: hostBuilder,
+            simulatorManager: simulatorManager,
+            makeJITReloader: { fd, orcPath in
+                let recorder = RecordingReloader(
+                    inner: try IOSJITStructuralReloader(remoteFD: fd, orcRuntimePath: orcPath))
+                recorderBox.set(recorder)
+                return recorder
+            }
+        )
+        defer {
+            SimSpikeSupport.terminateApp(udid: udid, bundleID: IOSPreviewSession.hostBundleID)
+        }
+
+        let pid = try await session.start()
+        #expect(pid > 0)
+        let before = try await session.fetchElements()
+        #expect(before.contains("Hello from iOS JIT!"))
+
+        let edited = Self.helloViewSource.replacingOccurrences(
+            of: "Hello from iOS JIT!", with: "Hello from literal edit!")
+        try edited.write(to: sourceFile, atomically: true, encoding: .utf8)
+        try await session.handleSourceChange()
+
+        let after = try await session.fetchElements()
+        #expect(after.contains("Hello from literal edit!"))
+
+        let paths = recorderBox.get()?.objectPaths ?? []
+        #expect(paths.count == 2)
+        #expect(
+            paths.first == paths.last,
+            "literal edit must re-render the same object (no recompile)")
+        await session.stop()
+    }
+
     /// End-to-end iOS JIT render WITH a setup plugin, over a real project build context
     /// (setup only applies when `splitContext` is non-nil, which needs a `buildContext`).
     /// The setup dylib (`ToDoPreviewSetup` built for the iOS sim) must be threaded into the
@@ -284,6 +344,31 @@ private final class CapturingReloader: IOSStructuralReloader, @unchecked Sendabl
     let session: JITSession
     init(session: JITSession) { self.session = session }
     func render(_ build: JITRenderBuild) async throws {}
+}
+
+/// Wraps a real reloader and records the object path of every rendered build, so a test
+/// can assert a literal re-render reused the same object (no recompile) while the inner
+/// reloader still drives the real EPC render.
+private final class RecordingReloader: IOSStructuralReloader, @unchecked Sendable {
+    let inner: any IOSStructuralReloader
+    private let lock = NSLock()
+    private var paths: [String] = []
+    init(inner: any IOSStructuralReloader) { self.inner = inner }
+    func render(_ build: JITRenderBuild) async throws {
+        lock.withLock { paths.append(build.objectPath.path) }
+        try await inner.render(build)
+    }
+    var objectPaths: [String] {
+        lock.withLock { paths }
+    }
+}
+
+/// Thread-safe box so the @Sendable factory closure can hand the recorder back to the test.
+private final class RecorderBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: RecordingReloader?
+    func set(_ v: RecordingReloader) { lock.withLock { value = v } }
+    func get() -> RecordingReloader? { lock.withLock { value } }
 }
 
 /// Thread-safe box so the @Sendable factory closure can report the linked result.


### PR DESCRIPTION
## Summary

Closes #216. Brings the macOS literal-edit-over-JIT fast path to iOS. A literal-only source edit now rewrites the design-time values JSON and re-runs the **same** linked object over the EPC connection, instead of a full structural recompile + relink. This reduces respawn frequency and matches macOS behavior.

- `IOSPreviewSession.handleSourceChange` tries `tryLiteralUpdate` first; on a literal-only edit it calls `applyLiteralValuesForJIT` and re-renders the existing build. Otherwise it falls back to a structural reload that **reuses the persistent session** (preserving its stable-module cache and literal baseline), mirroring macOS `jitStructuralReload`.
- `IOSJITStructuralReloader.render` restores the `objectPath == lastObjectPath` fast path: re-run the entry only, no new generation, no relink (which would re-register the object's classes).

The `!changes.isEmpty` guard is load-bearing: the iOS `FileWatcher` watches bulk files too, and a bulk-only edit makes `LiteralDiffer` return `.literalOnly([])` for the unchanged hot file; the guard forces the structural recompile so the bulk change is not dropped.

## Verification

Added a sim-gated integration test (`IOSSimSpikeTests.literalEditReSeedsSameObjectWithoutRecompile`). It renders `HelloView`, edits only the `Text` string, calls `handleSourceChange()`, then asserts the a11y tree shows the new string **and** the reloader rendered the same objectPath twice (proof of no recompile). Confirmed RED before the fix (`_1.o` vs `_2.o`) and GREEN after. The full `IOSSimSpikeTests` suite passes serially.

Gates: `/simplify` and `/code-review high` both run; no must-fix findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)