### PR TITLE
iOS JIT: relaunch host on memory pressure to reclaim leaked metadata (#221)

### DIFF
--- a/HostAppSource/HostApp.swift
+++ b/HostAppSource/HostApp.swift
@@ -116,6 +116,36 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
         socketFD = fd
         NSLog("PreviewHost: Connected to server on port \(port)")
         startReadLoop()
+        startMemoryReporting()
+    }
+
+    // Report resident memory to the daemon once a second over the JSON channel.
+    // The daemon gates host relaunch (to reclaim leaked JIT'd `__swift5_*`/ObjC
+    // metadata it cannot free in-process) on this value. Sends run on the main
+    // queue so they never interleave with response writes on the same socket.
+    private var memoryTimer: DispatchSourceTimer?
+
+    private func startMemoryReporting() {
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now() + 1, repeating: 1)
+        timer.setEventHandler { [weak self] in
+            guard let self else { return }
+            self.sendResponse(["type": "memory", "rss": Int(self.currentRSSBytes())])
+        }
+        timer.resume()
+        memoryTimer = timer
+    }
+
+    private func currentRSSBytes() -> UInt64 {
+        var info = mach_task_basic_info()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<mach_task_basic_info>.size / MemoryLayout<natural_t>.size)
+        let result = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+            }
+        }
+        return result == KERN_SUCCESS ? info.resident_size : 0
     }
 
     private func startReadLoop() {

--- a/Sources/PreviewsIOS/IOSHostChannel.swift
+++ b/Sources/PreviewsIOS/IOSHostChannel.swift
@@ -35,6 +35,11 @@ public actor IOSHostChannel {
     /// Data-typed continuations for Sendable compliance across task boundaries.
     private var pendingDataResponses: [String: CheckedContinuation<Data, Error>] = [:]
 
+    /// Latest resident-memory reading (bytes) pushed by the host app's `memory`
+    /// message. Zero until the first report arrives or after a disconnect.
+    private var latestRSSBytes: UInt64 = 0
+    public var latestRSS: UInt64 { latestRSSBytes }
+
     public init() {}
 
     /// Whether the channel has an established connection to the host
@@ -310,10 +315,19 @@ public actor IOSHostChannel {
             let lineData = Data(readBuffer[readBuffer.startIndex..<newlineIndex])
             readBuffer = Data(readBuffer[(newlineIndex + 1)...])
 
-            // Parse just enough to extract the id for routing
-            guard let message = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
-                let id = message["id"] as? String
+            guard let message = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any]
             else {
+                continue
+            }
+
+            // Unsolicited memory report (no id) — record and move on.
+            if message["type"] as? String == "memory", let rss = message["rss"] as? Int {
+                latestRSSBytes = UInt64(max(0, rss))
+                continue
+            }
+
+            // Everything else is a response routed by id.
+            guard let id = message["id"] as? String else {
                 continue
             }
 
@@ -327,6 +341,7 @@ public actor IOSHostChannel {
     /// Handle host app disconnect.
     private func handleDisconnect() {
         connectedFD = -1
+        latestRSSBytes = 0
         for (_, continuation) in pendingDataResponses {
             continuation.resume(throwing: IOSPreviewSessionError.connectionLost)
         }

--- a/Sources/PreviewsIOS/IOSPreviewSession.swift
+++ b/Sources/PreviewsIOS/IOSPreviewSession.swift
@@ -62,6 +62,7 @@ public actor IOSPreviewSession {
         setupSDKPath: String? = nil,
         setupDylibPath: URL? = nil,
         progress: (any ProgressReporter)? = nil,
+        memoryRelaunchThresholdBytes: UInt64 = 150 * 1024 * 1024,
         makeJITReloader: @escaping MakeJITReloader
     ) {
         self.id = UUID().uuidString
@@ -80,7 +81,40 @@ public actor IOSPreviewSession {
         self.setupSDKPath = setupSDKPath
         self.setupDylibPath = setupDylibPath
         self.progress = progress
+        self.memoryRelaunchThresholdBytes = memoryRelaunchThresholdBytes
         self.makeJITReloader = makeJITReloader
+    }
+
+    /// Relaunch the host once its reported RSS grows this many bytes past the
+    /// post-start baseline, reclaiming leaked JIT'd metadata. Checked before every
+    /// render that mints a new generation (structural edit or reload), so memory
+    /// stays bounded by baseline + threshold + one generation.
+    private let memoryRelaunchThresholdBytes: UInt64
+    private var baselineRSS: UInt64?
+
+    /// Number of memory-triggered host relaunches this session has performed.
+    public private(set) var relaunchCount = 0
+
+    /// Serializes the mutating render entry points (`reload`, `handleSourceChange`). The file
+    /// watcher fires a Task per change, so without this two edits could interleave at an
+    /// `await` and one could render or relaunch while the other has the channel torn down.
+    private var renderBusy = false
+    private var renderWaiters: [CheckedContinuation<Void, Never>] = []
+
+    private func acquireRenderLock() async {
+        if !renderBusy {
+            renderBusy = true
+            return
+        }
+        await withCheckedContinuation { renderWaiters.append($0) }
+    }
+
+    private func releaseRenderLock() {
+        if renderWaiters.isEmpty {
+            renderBusy = false
+        } else {
+            renderWaiters.removeFirst().resume()
+        }
     }
 
     // MARK: - Lifecycle
@@ -306,17 +340,30 @@ public actor IOSPreviewSession {
         )
     }
 
+    /// Latest resident memory (bytes) the host app reported over the JSON channel.
+    /// Zero before the first report or after a disconnect.
+    public var hostRSS: UInt64 {
+        get async { await channel.latestRSS }
+    }
+
     // MARK: - Communication
 
     /// Recompile the preview to an object and re-link it into the live host over
     /// the EPC connection, re-running its render entry.
     public func reload() async throws {
+        await acquireRenderLock()
+        defer { releaseRenderLock() }
+
         guard await channel.isConnected else {
             throw IOSPreviewSessionError.notStarted
         }
         guard let jitReloader else {
             throw IOSPreviewSessionError.notStarted
         }
+
+        // A reload mints a fresh object, so it links a new generation and grows the
+        // leak just like a structural edit. Reclaim first if over threshold.
+        if try await relaunchIfMemoryPressure() { return }
 
         let previewSession = makePreviewSession()
         self.session = previewSession
@@ -332,6 +379,9 @@ public actor IOSPreviewSession {
     /// mirroring the macOS path. Otherwise fall back to a structural reload that reuses the
     /// persistent session so its stable-module cache and literal baseline carry forward.
     public func handleSourceChange() async throws {
+        await acquireRenderLock()
+        defer { releaseRenderLock() }
+
         guard await channel.isConnected, let jitReloader, let session else {
             throw IOSPreviewSessionError.notStarted
         }
@@ -344,8 +394,88 @@ public actor IOSPreviewSession {
             return
         }
 
+        // Structural edit grows leaked metadata. Reclaim by relaunching if over
+        // threshold, instead of relinking a new generation.
+        if try await relaunchIfMemoryPressure() { return }
+
         let build = try await session.compileObjectForJIT()
         try await jitReloader.render(build)
+    }
+
+    /// Relaunch the whole host app to reclaim leaked `__swift5_*`/ObjC metadata that the
+    /// Swift runtime cannot unregister in-process. Tears down both sockets, terminates and
+    /// relaunches the host, re-accepts the JSON and EPC channels, rebuilds the reloader, and
+    /// re-renders the current source. Costs a full-screen flash and `@State` loss, so callers
+    /// gate this on memory pressure and prefer a structural-edit boundary.
+    @discardableResult
+    public func relaunch() async throws -> Int {
+        await acquireRenderLock()
+        defer { releaseRenderLock() }
+        return try await _relaunch()
+    }
+
+    /// Lock-free relaunch body. The internal memory-pressure path calls this directly,
+    /// since it already holds the render lock; the public `relaunch()` wraps it in the lock.
+    @discardableResult
+    private func _relaunch() async throws -> Int {
+        guard await channel.isConnected else {
+            throw IOSPreviewSessionError.notStarted
+        }
+        guard let orcPath = IOSHostBuilder.jitOrcRuntimePath else {
+            throw IOSPreviewSessionError.jitRuntimeMissing
+        }
+
+        await channel.close()
+        self.jitReloader = nil
+        if jitListenFD >= 0 {
+            Darwin.close(jitListenFD)
+            jitListenFD = -1
+        }
+
+        let port = try await channel.bindAndListen()
+        let jitPort = try bindJITListener()
+
+        await simulatorManager.terminateAppIfRunning(udid: deviceUDID, bundleID: Self.hostBundleID)
+        let pid = try await simulatorManager.launchApp(
+            udid: deviceUDID,
+            bundleID: Self.hostBundleID,
+            arguments: ["--port", String(port), "--jit-port", String(jitPort)]
+        )
+
+        try await channel.awaitConnect(timeout: .seconds(10))
+        let epcFD = try acceptJIT(timeoutSeconds: 10)
+        let reloader = try makeJITReloader(epcFD, orcPath)
+        self.jitReloader = reloader
+
+        let previewSession = makePreviewSession()
+        self.session = previewSession
+        let build = try await previewSession.compileObjectForJIT()
+        try await reloader.render(build)
+        baselineRSS = nil
+        relaunchCount += 1
+        return pid
+    }
+
+    /// Whether the host's reported RSS has grown past the relaunch threshold.
+    /// The first non-zero reading seeds the baseline (and never triggers).
+    private func shouldRelaunchForMemory() async -> Bool {
+        let rss = await channel.latestRSS
+        guard rss > 0 else { return false }
+        guard let baseline = baselineRSS else {
+            baselineRSS = rss
+            return false
+        }
+        return rss >= baseline + memoryRelaunchThresholdBytes
+    }
+
+    /// If the host has crossed the memory threshold, relaunch (which recompiles and
+    /// renders the current source in a fresh process) and return true. Callers that
+    /// mint a new generation route through this first and return when it relaunches,
+    /// since the relaunch has already rendered.
+    private func relaunchIfMemoryPressure() async throws -> Bool {
+        guard await shouldRelaunchForMemory() else { return false }
+        try await _relaunch()
+        return true
     }
 
     /// Switch to a different preview index and recompile. Traits are preserved. @State is lost.

--- a/Tests/PreviewsIOSTests/IOSHostBuilderHashTests.swift
+++ b/Tests/PreviewsIOSTests/IOSHostBuilderHashTests.swift
@@ -43,7 +43,9 @@ struct IOSHostBuilderHashTests {
         // --dylib/--setup-dylib args, and the reload/init/literals handlers).
         // Updated 2026-06-16 for iOS JIT mandatory: the --jit-port branch and the
         // startJITExecutor/connectLoopback helpers are no longer behind #if.
-        let expected = "5b900b18a768b57caf614f60ef988436716efa2ecaa12043d5485c8c08b6d03d"
+        // Updated 2026-06-17 for #221 reclaim: HostApp.swift reports resident memory
+        // to the daemon once a second over the JSON channel (startMemoryReporting).
+        let expected = "5f3fbe7f95701c93b4e8c4cc626bf89ef0ca5c0ddea7673f678253fba51735ad"
         #expect(hash == expected, "host-app artifact hash drifted (was \(expected), now \(hash))")
     }
 }

--- a/Tests/PreviewsJITLinkTests/IOSSimSpikeTests.swift
+++ b/Tests/PreviewsJITLinkTests/IOSSimSpikeTests.swift
@@ -201,6 +201,235 @@ struct IOSSimSpikeTests {
         await session.stop()
     }
 
+    /// Keystone for #221 reclaim: `relaunch()` must terminate and relaunch the host, re-accept
+    /// both the JSON and EPC channels, rebuild the reloader, and re-render the current source.
+    /// After the relaunch the accessibility tree fetched over the (re-established) JSON channel
+    /// must still contain the rendered text — proving the whole round-trip survives a host
+    /// restart, which is how leaked `__swift5_*`/ObjC metadata is reclaimed.
+    @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
+    func relaunchReRendersCurrentPreview() async throws {
+        let udid = try SimSpikeSupport.bootSimulator()
+
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-ios-jit-relaunch-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let sourceFile = tempDir.appendingPathComponent("HelloView.swift")
+        try Self.helloViewSource.write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        let compiler = try await Compiler(platform: .iOS)
+        let hostBuilder = try await IOSHostBuilder()
+        let simulatorManager = SimulatorManager()
+
+        let session = IOSPreviewSession(
+            sourceFile: sourceFile,
+            deviceUDID: udid,
+            compiler: compiler,
+            hostBuilder: hostBuilder,
+            simulatorManager: simulatorManager,
+            makeJITReloader: { fd, orcPath in
+                try IOSJITStructuralReloader(remoteFD: fd, orcRuntimePath: orcPath)
+            }
+        )
+        defer {
+            SimSpikeSupport.terminateApp(udid: udid, bundleID: IOSPreviewSession.hostBundleID)
+        }
+
+        let pid = try await session.start()
+        #expect(pid > 0)
+        let before = try await session.fetchElements()
+        #expect(before.contains("Hello from iOS JIT!"))
+
+        // The host reports RSS once a second over the JSON channel; allow one tick.
+        try await Task.sleep(for: .seconds(2))
+        let reportedRSS = await session.hostRSS
+        #expect(reportedRSS > 0)
+
+        let newPid = try await session.relaunch()
+        #expect(newPid > 0)
+        #expect(newPid != pid)
+
+        let after = try await session.fetchElements()
+        #expect(after.contains("Hello from iOS JIT!"))
+        await session.stop()
+    }
+
+    /// Chunk 3 gating: a structural edit past the memory threshold relaunches the host
+    /// instead of relinking in place. With the threshold forced to 0, the first structural
+    /// edit seeds the RSS baseline (no relaunch) and the second crosses it, so `relaunchCount`
+    /// becomes 1 and the latest edit must still render — proving the gate fires at the edit
+    /// boundary and the fresh process shows the current source.
+    @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
+    func structuralEditPastThresholdRelaunches() async throws {
+        func structuralSource(rows: Int) -> String {
+            let extra = (0..<rows).map { "                    Text(\"row \($0)\")" }.joined(separator: "\n")
+            return """
+                import SwiftUI
+
+                struct HelloView: View {
+                    var body: some View {
+                        VStack {
+                            Text("Hello from iOS JIT!")
+                \(extra)
+                        }
+                    }
+                }
+
+                #Preview {
+                    HelloView()
+                }
+                """
+        }
+
+        let udid = try SimSpikeSupport.bootSimulator()
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-ios-jit-gate-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let sourceFile = tempDir.appendingPathComponent("HelloView.swift")
+        try structuralSource(rows: 0).write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        let compiler = try await Compiler(platform: .iOS)
+        let hostBuilder = try await IOSHostBuilder()
+        let simulatorManager = SimulatorManager()
+
+        let session = IOSPreviewSession(
+            sourceFile: sourceFile,
+            deviceUDID: udid,
+            compiler: compiler,
+            hostBuilder: hostBuilder,
+            simulatorManager: simulatorManager,
+            memoryRelaunchThresholdBytes: 0,
+            makeJITReloader: { fd, orcPath in
+                try IOSJITStructuralReloader(remoteFD: fd, orcRuntimePath: orcPath)
+            }
+        )
+        defer {
+            SimSpikeSupport.terminateApp(udid: udid, bundleID: IOSPreviewSession.hostBundleID)
+        }
+
+        _ = try await session.start()
+        try await Task.sleep(for: .seconds(2))  // let the first RSS report arrive
+
+        // First structural edit seeds the baseline — no relaunch yet.
+        try structuralSource(rows: 1).write(to: sourceFile, atomically: true, encoding: .utf8)
+        try await session.handleSourceChange()
+        let countAfterFirst = await session.relaunchCount
+        #expect(countAfterFirst == 0)
+
+        // Second structural edit crosses baseline + 0 — relaunch fires here.
+        try structuralSource(rows: 2).write(to: sourceFile, atomically: true, encoding: .utf8)
+        try await session.handleSourceChange()
+        let countAfterSecond = await session.relaunchCount
+        #expect(countAfterSecond == 1)
+
+        let elements = try await session.fetchElements()
+        #expect(elements.contains("row 1"))
+        await session.stop()
+    }
+
+    /// Gate covers the reload path too: `reload()` (used by switchPreview/reconfigure/
+    /// setTraits) mints a fresh object, so it links a new generation and grows the leak
+    /// like a structural edit. With the threshold forced to 0, the first reload seeds the
+    /// baseline and the second crosses it, so a relaunch must fire (relaunchCount == 1).
+    @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
+    func reloadPastThresholdRelaunches() async throws {
+        let udid = try SimSpikeSupport.bootSimulator()
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-ios-jit-reloadgate-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let sourceFile = tempDir.appendingPathComponent("HelloView.swift")
+        try Self.helloViewSource.write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        let compiler = try await Compiler(platform: .iOS)
+        let hostBuilder = try await IOSHostBuilder()
+        let simulatorManager = SimulatorManager()
+
+        let session = IOSPreviewSession(
+            sourceFile: sourceFile,
+            deviceUDID: udid,
+            compiler: compiler,
+            hostBuilder: hostBuilder,
+            simulatorManager: simulatorManager,
+            memoryRelaunchThresholdBytes: 0,
+            makeJITReloader: { fd, orcPath in
+                try IOSJITStructuralReloader(remoteFD: fd, orcRuntimePath: orcPath)
+            }
+        )
+        defer {
+            SimSpikeSupport.terminateApp(udid: udid, bundleID: IOSPreviewSession.hostBundleID)
+        }
+
+        _ = try await session.start()
+        try await Task.sleep(for: .seconds(2))  // let the first RSS report arrive
+
+        try await session.reload()
+        let countAfterFirst = await session.relaunchCount
+        #expect(countAfterFirst == 0)
+
+        try await session.reload()
+        let countAfterSecond = await session.relaunchCount
+        #expect(countAfterSecond == 1)
+
+        let elements = try await session.fetchElements()
+        #expect(elements.contains("Hello from iOS JIT!"))
+        await session.stop()
+    }
+
+    /// Concurrency: the file watcher fires a Task per change, so several reloads can race on
+    /// the actor. handleSourceChange/reload must serialize so a second edit never interleaves
+    /// with another's render or relaunch (which tears down and rebinds both sockets). A
+    /// tracking reloader asserts no two renders overlap when many edits fire at once.
+    @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
+    func concurrentEditsSerialize() async throws {
+        let udid = try SimSpikeSupport.bootSimulator()
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-ios-jit-serialize-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let sourceFile = tempDir.appendingPathComponent("HelloView.swift")
+        try Self.helloViewSource.write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        let compiler = try await Compiler(platform: .iOS)
+        let hostBuilder = try await IOSHostBuilder()
+        let simulatorManager = SimulatorManager()
+
+        let trackerBox = TrackerBox()
+        let session = IOSPreviewSession(
+            sourceFile: sourceFile,
+            deviceUDID: udid,
+            compiler: compiler,
+            hostBuilder: hostBuilder,
+            simulatorManager: simulatorManager,
+            makeJITReloader: { fd, orcPath in
+                let tracker = ConcurrencyTrackingReloader(
+                    inner: try IOSJITStructuralReloader(remoteFD: fd, orcRuntimePath: orcPath))
+                trackerBox.set(tracker)
+                return tracker
+            }
+        )
+        defer {
+            SimSpikeSupport.terminateApp(udid: udid, bundleID: IOSPreviewSession.hostBundleID)
+        }
+
+        _ = try await session.start()
+
+        // Fire several reloads at once; serialized renders must never overlap.
+        await withThrowingTaskGroup(of: Void.self) { group in
+            for _ in 0..<5 {
+                group.addTask { try await session.reload() }
+            }
+            try? await group.waitForAll()
+        }
+
+        let maxActive = trackerBox.get()?.maxActive ?? 0
+        #expect(maxActive == 1)
+        let elements = try await session.fetchElements()
+        #expect(elements.contains("Hello from iOS JIT!"))
+        await session.stop()
+    }
+
     /// Literal-only edit over iOS JIT (#216): after the initial render, a change that
     /// touches only a `Text` string must re-seed the DesignTimeStore and re-run the SAME
     /// linked object — no recompile, no new generation — mirroring the macOS literal path.
@@ -361,6 +590,32 @@ private final class RecordingReloader: IOSStructuralReloader, @unchecked Sendabl
     var objectPaths: [String] {
         lock.withLock { paths }
     }
+}
+
+/// Wraps a real reloader and tracks how many `render` calls are in flight at once, so a test
+/// can assert the session serializes its render entry points (max concurrency 1).
+private final class ConcurrencyTrackingReloader: IOSStructuralReloader, @unchecked Sendable {
+    let inner: any IOSStructuralReloader
+    private let lock = NSLock()
+    private var active = 0
+    private(set) var maxActive = 0
+    init(inner: any IOSStructuralReloader) { self.inner = inner }
+    func render(_ build: JITRenderBuild) async throws {
+        lock.withLock {
+            active += 1
+            maxActive = max(maxActive, active)
+        }
+        defer { lock.withLock { active -= 1 } }
+        try await inner.render(build)
+    }
+}
+
+/// Thread-safe box handing a `ConcurrencyTrackingReloader` back from the @Sendable factory.
+private final class TrackerBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: ConcurrencyTrackingReloader?
+    func set(_ v: ConcurrencyTrackingReloader) { lock.withLock { value = v } }
+    func get() -> ConcurrencyTrackingReloader? { lock.withLock { value } }
 }
 
 /// Thread-safe box so the @Sendable factory closure can hand the recorder back to the test.


### PR DESCRIPTION
## Problem

iOS structural edits JIT-link a fresh generation each time, and the Swift runtime cannot unregister the resulting `__swift5_proto`/`__swift5_types` (or ObjC class) metadata. Resident memory grows ~1.4 MB per structural edit and is never reclaimed in-process.

A standalone experiment proved in-process reclaim is impossible:
- Removing a generation's `JITDylib` frees the memory but crashes in `_objc_map_images` on the next link (dangling runtime pointers into freed JIT memory).
- The iOS 26.2 `libswiftCore` exports **no** unregister/deregister symbol at any visibility, and the registered records point at descriptors in the generation's `__TEXT`/`__const`, so those pages can never be freed.

A fresh process is the only safe reclaim (this is what Apple does too).

## Approach

Reclaim by relaunching the whole sim host app, gated on memory pressure:

- **RSS reporting** — the host self-measures RSS via `task_info` and reports it once a second over the JSON channel; the daemon records the latest value (`IOSHostChannel.latestRSS`).
- **Relaunch** — `IOSPreviewSession.relaunch()` terminates and relaunches the host, re-accepts the JSON and EPC channels, rebuilds the reloader, and re-renders the current source.
- **Gate** — fires at the next new-generation render (`handleSourceChange`'s structural path and `reload()`, used by `switchPreview`/`reconfigure`/`setTraits`) once RSS crosses `baseline + 150 MB`. Normal edits keep the fast in-process relink; the relaunch flash is masked by the edit (which already resets `@State`, same as Xcode).
- **Serialization** — `reload()` and `handleSourceChange()` run under an async render lock so a second edit cannot interleave with another's render or relaunch.

## Verification

- Full iOS JIT suite green: relaunch keystone, RSS plumbing, gating on both edit and reload paths, concurrent-edit serialization, plus existing e2e.
- Red-green verified on the gate (reload path) and the serialization lock.
- Live run confirmed the RSS sawtooth (climb to ~442 MB, relaunch, drop to ~291 MB) and that the preview stays interactive after a relaunch.

## Follow-ups (not in this PR)

- Rapid edits queue rather than coalesce (fine at human edit pace).
- The render lock uses `CheckedContinuation` without prompt cancellation handling (matches existing `IOSHostChannel` convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)