### PR TITLE
Bazel: render previews for Apple bundle targets (exec app + framework)

### DIFF
--- a/Sources/PreviewsCLI/Handlers/PreviewStartHandler.swift
+++ b/Sources/PreviewsCLI/Handlers/PreviewStartHandler.swift
@@ -69,6 +69,13 @@ enum PreviewStartHandler: ToolHandler {
                         "Xcode scheme name (only used for .xcodeproj / .xcworkspace projects). Required when the project contains more than one scheme and none of them match the source file's directory."
                     ),
                 ]),
+                "buildSystem": .object([
+                    "type": .string("string"),
+                    "enum": .array(BuildSystemKind.allCases.map { .string($0.rawValue) }),
+                    "description": .string(
+                        "Force the build system instead of auto-detecting by project markers (spm, bazel, xcode). Useful when a project matches more than one, e.g. a rules_xcodeproj workspace that has both MODULE.bazel and a generated .xcodeproj."
+                    ),
+                ]),
                 "colorScheme": traitProperty(
                     enumValues: PreviewTraits.validColorSchemes,
                     description: "Color scheme override: 'light' or 'dark'"
@@ -373,13 +380,29 @@ private func detectBuildContext(
     let projectRootURL = extractOptionalString("projectPath", from: params)
         .map { Path.normalizeURL($0) }
     let scheme = extractOptionalString("scheme", from: params)
+    let buildSystem = try parseBuildSystemOverride(from: params)
     return try await detectAndBuild(
         for: fileURL,
         projectRoot: projectRootURL,
         platform: platform,
         scheme: scheme,
+        buildSystem: buildSystem,
         progress: progress
     )
+}
+
+private func parseBuildSystemOverride(
+    from params: CallTool.Parameters
+) throws -> BuildSystemKind? {
+    guard let raw = extractOptionalString("buildSystem", from: params) else { return nil }
+    guard let kind = BuildSystemKind(rawValue: raw) else {
+        throw BuildSystemError.buildSystemUnavailable(
+            kind: raw,
+            reason:
+                "unknown build system; valid values: \(BuildSystemKind.allCases.map(\.rawValue).joined(separator: ", "))"
+        )
+    }
+    return kind
 }
 
 private func startMacOSPreview(

--- a/Sources/PreviewsCLI/PreviewsMCPApp.swift
+++ b/Sources/PreviewsCLI/PreviewsMCPApp.swift
@@ -1,5 +1,6 @@
 import AppKit
 import ArgumentParser
+import PreviewsCore
 import PreviewsJITLink
 import PreviewsMacOS
 
@@ -8,6 +9,10 @@ enum CLIPlatform: String, ExpressibleByArgument, CaseIterable {
     case macos
     case ios
 }
+
+/// Let `--build-system` parse straight into the core enum so ArgumentParser
+/// validates the value and lists the choices in `--help`.
+extension BuildSystemKind: ExpressibleByArgument {}
 
 /// Wall-clock instant the process began. Captured at app entry (the first
 /// line of `PreviewsMCPApp.main`) so the `preview_build_info` MCP tool can

--- a/Sources/PreviewsCLI/RunCommand.swift
+++ b/Sources/PreviewsCLI/RunCommand.swift
@@ -42,6 +42,12 @@ struct RunCommand: AsyncParsableCommand {
     )
     var scheme: String?
 
+    @Option(
+        name: .long,
+        help: "Force build system: 'spm', 'bazel', or 'xcode' (overrides auto-detection)"
+    )
+    var buildSystem: String?
+
     @Option(name: .long, help: "Simulator device UDID (for ios; auto-selects if omitted)")
     var device: String?
 
@@ -185,6 +191,7 @@ struct RunCommand: AsyncParsableCommand {
         if let platform { args["platform"] = .string(platform.rawValue) }
         if let project { args["projectPath"] = .string(Path.normalize(project)) }
         if let scheme { args["scheme"] = .string(scheme) }
+        if let buildSystem { args["buildSystem"] = .string(buildSystem) }
         if let device { args["deviceUDID"] = .string(device) }
         if let colorScheme { args["colorScheme"] = .string(colorScheme) }
         if let dynamicTypeSize { args["dynamicTypeSize"] = .string(dynamicTypeSize) }

--- a/Sources/PreviewsCLI/RunCommand.swift
+++ b/Sources/PreviewsCLI/RunCommand.swift
@@ -42,11 +42,8 @@ struct RunCommand: AsyncParsableCommand {
     )
     var scheme: String?
 
-    @Option(
-        name: .long,
-        help: "Force build system: 'spm', 'bazel', or 'xcode' (overrides auto-detection)"
-    )
-    var buildSystem: String?
+    @Option(name: .long, help: "Force the build system, overriding auto-detection")
+    var buildSystem: BuildSystemKind?
 
     @Option(name: .long, help: "Simulator device UDID (for ios; auto-selects if omitted)")
     var device: String?
@@ -191,7 +188,7 @@ struct RunCommand: AsyncParsableCommand {
         if let platform { args["platform"] = .string(platform.rawValue) }
         if let project { args["projectPath"] = .string(Path.normalize(project)) }
         if let scheme { args["scheme"] = .string(scheme) }
-        if let buildSystem { args["buildSystem"] = .string(buildSystem) }
+        if let buildSystem { args["buildSystem"] = .string(buildSystem.rawValue) }
         if let device { args["deviceUDID"] = .string(device) }
         if let colorScheme { args["colorScheme"] = .string(colorScheme) }
         if let dynamicTypeSize { args["dynamicTypeSize"] = .string(dynamicTypeSize) }

--- a/Sources/PreviewsCLI/SnapshotCommand.swift
+++ b/Sources/PreviewsCLI/SnapshotCommand.swift
@@ -70,6 +70,12 @@ struct SnapshotCommand: AsyncParsableCommand {
     )
     var scheme: String?
 
+    @Option(
+        name: .long,
+        help: "Force build system: 'spm', 'bazel', or 'xcode' (overrides auto-detection)"
+    )
+    var buildSystem: String?
+
     @Option(name: .long, help: "Simulator device UDID (for ios; auto-selects if omitted)")
     var device: String?
 
@@ -216,6 +222,7 @@ struct SnapshotCommand: AsyncParsableCommand {
         ]
         if let project { startArgs["projectPath"] = .string(Path.normalize(project)) }
         if let scheme { startArgs["scheme"] = .string(scheme) }
+        if let buildSystem { startArgs["buildSystem"] = .string(buildSystem) }
         if let device { startArgs["deviceUDID"] = .string(device) }
         if let colorScheme { startArgs["colorScheme"] = .string(colorScheme) }
         if let dynamicTypeSize { startArgs["dynamicTypeSize"] = .string(dynamicTypeSize) }

--- a/Sources/PreviewsCLI/SnapshotCommand.swift
+++ b/Sources/PreviewsCLI/SnapshotCommand.swift
@@ -70,11 +70,8 @@ struct SnapshotCommand: AsyncParsableCommand {
     )
     var scheme: String?
 
-    @Option(
-        name: .long,
-        help: "Force build system: 'spm', 'bazel', or 'xcode' (overrides auto-detection)"
-    )
-    var buildSystem: String?
+    @Option(name: .long, help: "Force the build system, overriding auto-detection")
+    var buildSystem: BuildSystemKind?
 
     @Option(name: .long, help: "Simulator device UDID (for ios; auto-selects if omitted)")
     var device: String?
@@ -222,7 +219,7 @@ struct SnapshotCommand: AsyncParsableCommand {
         ]
         if let project { startArgs["projectPath"] = .string(Path.normalize(project)) }
         if let scheme { startArgs["scheme"] = .string(scheme) }
-        if let buildSystem { startArgs["buildSystem"] = .string(buildSystem) }
+        if let buildSystem { startArgs["buildSystem"] = .string(buildSystem.rawValue) }
         if let device { startArgs["deviceUDID"] = .string(device) }
         if let colorScheme { startArgs["colorScheme"] = .string(colorScheme) }
         if let dynamicTypeSize { startArgs["dynamicTypeSize"] = .string(dynamicTypeSize) }

--- a/Sources/PreviewsCLI/VariantsCommand.swift
+++ b/Sources/PreviewsCLI/VariantsCommand.swift
@@ -83,6 +83,12 @@ struct VariantsCommand: AsyncParsableCommand {
     )
     var scheme: String?
 
+    @Option(
+        name: .long,
+        help: "Force build system: 'spm', 'bazel', or 'xcode' (overrides auto-detection)"
+    )
+    var buildSystem: String?
+
     @Option(name: .long, help: "Simulator device UDID (for ios; auto-selects if omitted)")
     var device: String?
 
@@ -219,6 +225,7 @@ struct VariantsCommand: AsyncParsableCommand {
         ]
         if let project { startArgs["projectPath"] = .string(Path.normalize(project)) }
         if let scheme { startArgs["scheme"] = .string(scheme) }
+        if let buildSystem { startArgs["buildSystem"] = .string(buildSystem) }
         if let device { startArgs["deviceUDID"] = .string(device) }
         if let config { startArgs["config"] = .string(Path.normalize(config)) }
 

--- a/Sources/PreviewsCLI/VariantsCommand.swift
+++ b/Sources/PreviewsCLI/VariantsCommand.swift
@@ -83,11 +83,8 @@ struct VariantsCommand: AsyncParsableCommand {
     )
     var scheme: String?
 
-    @Option(
-        name: .long,
-        help: "Force build system: 'spm', 'bazel', or 'xcode' (overrides auto-detection)"
-    )
-    var buildSystem: String?
+    @Option(name: .long, help: "Force the build system, overriding auto-detection")
+    var buildSystem: BuildSystemKind?
 
     @Option(name: .long, help: "Simulator device UDID (for ios; auto-selects if omitted)")
     var device: String?
@@ -225,7 +222,7 @@ struct VariantsCommand: AsyncParsableCommand {
         ]
         if let project { startArgs["projectPath"] = .string(Path.normalize(project)) }
         if let scheme { startArgs["scheme"] = .string(scheme) }
-        if let buildSystem { startArgs["buildSystem"] = .string(buildSystem) }
+        if let buildSystem { startArgs["buildSystem"] = .string(buildSystem.rawValue) }
         if let device { startArgs["deviceUDID"] = .string(device) }
         if let config { startArgs["config"] = .string(Path.normalize(config)) }
 

--- a/Sources/PreviewsCore/BazelBuildSystem.swift
+++ b/Sources/PreviewsCore/BazelBuildSystem.swift
@@ -67,8 +67,21 @@ public actor BazelBuildSystem: BuildSystem {
         try await runBazelBuild(target: target, platform: platform)
 
         // 4. Locate the .swiftmodule
-        let compilerFlags = try await findCompilerFlags(
+        var compilerFlags = try await findCompilerFlags(
             target: target, moduleName: moduleName, platform: platform)
+
+        // 4b. Add dependency module search paths (swift_library deps and
+        //     objc_library module maps) from the target's SwiftCompile action,
+        //     so the bridge's `import <Dep>` resolves.
+        compilerFlags += try await findDependencyModuleFlags(
+            target: target, platform: platform)
+
+        // 4c. Add dependency archive link flags (`-L`/`-l`) for the target's
+        //     static-library deps, so the preview JIT link resolves their
+        //     cross-target symbols (`findDependencyModuleFlags` only covers the
+        //     compile-time module search).
+        compilerFlags += try await findDependencyArchiveFlags(
+            target: target, platform: platform)
 
         // 5. Collect source files for Tier 2
         let sourceFiles = try await collectSourceFiles(target: target)
@@ -220,6 +233,133 @@ public actor BazelBuildSystem: BuildSystem {
         return ["-I", moduleDir.path]
     }
 
+    /// Resolve a Bazel `cquery`/`aquery` output path (relative to the execroot,
+    /// or already absolute) to an absolute URL.
+    private func resolveExecrootPath(_ path: String) -> URL {
+        path.hasPrefix("/")
+            ? URL(fileURLWithPath: path)
+            : projectRoot.appendingPathComponent(path).standardizedFileURL
+    }
+
+    /// Extract dependency module-search flags from the target's `SwiftCompile`
+    /// action, so the bridge compile can import the target's dependency modules
+    /// (`swift_library` deps via `-I`, `objc_library` modules via
+    /// `-Xcc -fmodule-map-file=`). The target's own `-I` is added by
+    /// `findCompilerFlags`; this fills in everything its `import`s need.
+    ///
+    /// Reuses Bazel's own flags rather than reconstructing them per dependency,
+    /// because objc module maps live at non-obvious paths
+    /// (`<pkg>/<name>_modulemap/_/module.modulemap`) that are not in
+    /// `cquery --output=files`.
+    private func findDependencyModuleFlags(
+        target: String, platform: PreviewPlatform
+    ) async throws -> [String] {
+        var args = ["bazel", "aquery", "mnemonic(\"SwiftCompile\", \(target))"]
+        args += platformFlags(for: platform)
+        let output = (try? await runBazel(args, discardStderr: true)) ?? ""
+
+        func resolve(_ path: String) -> String { resolveExecrootPath(path).path }
+
+        let tokens =
+            output
+            .split(whereSeparator: { $0 == "\n" || $0 == " " || $0 == "\t" })
+            .map { $0.trimmingCharacters(in: CharacterSet(charactersIn: " \t\\'\"")) }
+            .filter { !$0.isEmpty }
+
+        var flags: [String] = []
+        var seen = Set<String>()
+        func add(_ items: [String], key: String) {
+            if seen.insert(key).inserted { flags += items }
+        }
+
+        var i = 0
+        while i < tokens.count {
+            let t = tokens[i]
+            if t.hasPrefix("-I"), t.count > 2 {
+                let p = resolve(String(t.dropFirst(2)))
+                add(["-I", p], key: "I:" + p)
+            } else if t.hasPrefix("-F"), t.count > 2 {
+                let p = resolve(String(t.dropFirst(2)))
+                add(["-F", p], key: "F:" + p)
+            } else if t == "-Xcc", i + 1 < tokens.count {
+                let next = tokens[i + 1]
+                if next.hasPrefix("-fmodule-map-file=") {
+                    let p = resolve(String(next.dropFirst("-fmodule-map-file=".count)))
+                    add(["-Xcc", "-fmodule-map-file=\(p)"], key: "mmap:" + p)
+                    i += 1
+                } else if next.hasPrefix("-I"), next.count > 2 {
+                    let p = resolve(String(next.dropFirst(2)))
+                    add(["-Xcc", "-I\(p)"], key: "XccI:" + p)
+                    i += 1
+                }
+            }
+            i += 1
+        }
+        return flags
+    }
+
+    /// Extract `-L <dir>` / `-l<name>` link flags for the target's dependency
+    /// static archives (`libSwiftLib.a`, `libObjCLib.a`), so the preview JIT
+    /// link resolves their cross-target symbols.
+    ///
+    /// Building `target` alone materializes its dependency swiftmodules but not
+    /// their static archives (a `swift_library` build has no link step), so this
+    /// first builds the dependency library targets to put their `.a` on disk.
+    ///
+    /// `deps(<target>)` also returns two kinds of archives that must NOT be
+    /// linked, filtered here:
+    ///   * Build tooling in the exec configuration (see `isExecConfigPath`,
+    ///     e.g. the rules_swift worker).
+    ///   * The target's own archive (`lib<target>.a`): it carries the preview
+    ///     file plus any `@main` object, both of which the JIT compiles fresh /
+    ///     must not link.
+    private func findDependencyArchiveFlags(
+        target: String, platform: PreviewPlatform
+    ) async throws -> [String] {
+        let platformArgs = platformFlags(for: platform)
+
+        let depLibs =
+            (try? await runBazelQuery(
+                "kind(\"(swift|objc)_library\", deps(\(target)))")) ?? ""
+        let labels = depLibs.split(separator: "\n").map(String.init)
+            .filter { $0.hasPrefix("//") }
+        if !labels.isEmpty {
+            try await runBazel(["bazel", "build"] + labels + platformArgs)
+        }
+
+        let output =
+            (try? await runBazel(
+                ["bazel", "cquery", "deps(\(target))", "--output=files"]
+                    + platformArgs, discardStderr: true)) ?? ""
+
+        let ownArchive = "lib\(target.split(separator: ":").last.map(String.init) ?? target).a"
+
+        var flags: [String] = []
+        var seenDir = Set<String>()
+        for line in output.split(separator: "\n").map(String.init) {
+            let path = line.trimmingCharacters(in: .whitespaces)
+            guard path.hasSuffix(".a") else { continue }
+            let base = URL(fileURLWithPath: path).lastPathComponent
+            guard base.hasPrefix("lib"), base != ownArchive else { continue }
+            if Self.isExecConfigPath(path) { continue }
+            let dir = resolveExecrootPath(path).deletingLastPathComponent().path
+            if seenDir.insert(dir).inserted { flags += ["-L", dir] }
+            flags += ["-l\(base.dropFirst(3).dropLast(2))"]
+        }
+        return flags
+    }
+
+    /// True if `path` is a Bazel output in an exec configuration (its
+    /// `bazel-out/<config>/...` config segment contains an `exec` mnemonic, e.g.
+    /// `darwin_arm64-opt-exec` or `darwin_arm64-opt-exec-ST-<hash>`). Such
+    /// outputs are build tooling, not runtime dependencies.
+    private static func isExecConfigPath(_ path: String) -> Bool {
+        let parts = path.split(separator: "/").map(String.init)
+        guard let i = parts.firstIndex(of: "bazel-out"), i + 1 < parts.count
+        else { return false }
+        return parts[i + 1].split(separator: "-").contains("exec")
+    }
+
     // MARK: - Private: Source Files (Tier 2)
 
     /// Collect all source files for the target, excluding the preview file.
@@ -251,12 +391,24 @@ public actor BazelBuildSystem: BuildSystem {
             guard let path = labelToPath(label) else { continue }
             let url = projectRoot.appendingPathComponent(path).standardizedFileURL
             // Exclude the preview file
-            if url.path != sourceFile.path {
-                sourceFiles.append(url)
-            }
+            if url.path == sourceFile.path { continue }
+            // Exclude `@main` entry-point files: their app-lifecycle entry
+            // symbol poisons the preview JIT link, and the preview never needs
+            // the app entry point.
+            if Self.declaresMainEntry(url) { continue }
+            sourceFiles.append(url)
         }
 
         return sourceFiles.isEmpty ? nil : sourceFiles
+    }
+
+    /// True if `file` declares an `@main` entry point at the start of a line.
+    private static func declaresMainEntry(_ file: URL) -> Bool {
+        guard let text = try? String(contentsOf: file, encoding: .utf8) else {
+            return false
+        }
+        return text.range(of: #"(?m)^[ \t]*@main\b"#, options: .regularExpression)
+            != nil
     }
 
     /// Convert a Bazel label like "//Sources/ToDo:Item.swift" to a relative path "Sources/ToDo/Item.swift".
@@ -288,10 +440,62 @@ public actor BazelBuildSystem: BuildSystem {
     private func platformFlags(for platform: PreviewPlatform) -> [String] {
         switch platform {
         case .macOS:
-            return []
+            // Pin the deployment target to match the bridge compile triple
+            // (`Platform.macOS` -> macosx14.0), so dependency modules built by
+            // Bazel do not come out at the SDK-default min (e.g. 26.2) and fail
+            // to load against the 14.0 bridge.
+            return ["--macos_minimum_os=14.0"]
         case .iOS:
-            return ["--platforms=@apple_support//platforms:ios_sim_arm64"]
+            // The real iOS-simulator transition needs `--platforms` (the legacy
+            // `--cpu`/`--apple_platform_type` flags name the output dir but do
+            // NOT apply the Apple SDK transition to a bare `swift_library`,
+            // leaving deps built against the macOS SDK). The platform lives in
+            // the apple_support repo, whose name varies per project (default
+            // `apple_support`, but e.g. the study uses `repo_name =
+            // "build_bazel_apple_support"`), so resolve it from MODULE.bazel.
+            // Pin the deployment target to match the bridge compile triple
+            // (`Platform.iOS` -> ios17.0): a bare swift_library otherwise gets
+            // the SDK-default min (e.g. 26.2), which fails to load against the
+            // 17.0 bridge ("module has a minimum deployment target of iOS 26.2").
+            return [
+                "--platforms=@\(appleSupportRepoName())//platforms:ios_sim_arm64",
+                "--ios_minimum_os=17.0",
+            ]
         }
+    }
+
+    /// Resolve the repo name the project exposes for the `apple_support` module,
+    /// so `--platforms=@<repo>//platforms:ios_sim_arm64` resolves. Reads the
+    /// `bazel_dep(name = "apple_support", ... repo_name = "...")` from
+    /// MODULE.bazel; defaults to `apple_support` (the module's own name).
+    private func appleSupportRepoName() -> String {
+        let moduleFile = projectRoot.appendingPathComponent("MODULE.bazel")
+        guard let text = try? String(contentsOf: moduleFile, encoding: .utf8) else {
+            return "apple_support"
+        }
+        // Match the `bazel_dep(...)` call that names apple_support, then its
+        // optional `repo_name`. The call may span multiple lines.
+        guard
+            let depRange = text.range(
+                of: #"bazel_dep\([^)]*name\s*=\s*"apple_support"[^)]*\)"#,
+                options: .regularExpression)
+        else {
+            return "apple_support"
+        }
+        let depCall = text[depRange]
+        if let rnRange = depCall.range(
+            of: #"repo_name\s*=\s*"([^"]+)""#, options: .regularExpression)
+        {
+            let match = depCall[rnRange]
+            if let q1 = match.range(of: "\""),
+                let q2 = match.range(
+                    of: "\"", options: .backwards,
+                    range: q1.upperBound..<match.endIndex)
+            {
+                return String(match[q1.upperBound..<q2.lowerBound])
+            }
+        }
+        return "apple_support"
     }
 
     // MARK: - Private: Process Execution

--- a/Sources/PreviewsCore/BuildSystem.swift
+++ b/Sources/PreviewsCore/BuildSystem.swift
@@ -38,12 +38,14 @@ public enum BuildSystemDetector {
         scheme: String? = nil,
         buildSystem: BuildSystemKind? = nil
     ) async throws -> (any BuildSystem)? {
+        // An explicit override wins over auto-detection and never falls through
+        // to the other systems.
+        if let buildSystem = buildSystem {
+            return try await forced(
+                buildSystem, for: sourceFile, projectRoot: projectRoot, scheme: scheme)
+        }
         // If an explicit project root is provided, detect which build system applies there
         if let projectRoot = projectRoot {
-            if let buildSystem = buildSystem {
-                return try forced(
-                    buildSystem, for: sourceFile, projectRoot: projectRoot, scheme: scheme)
-            }
             let fm = FileManager.default
             var isDir: ObjCBool = false
             if fm.fileExists(
@@ -71,18 +73,6 @@ public enum BuildSystemDetector {
             }
             return nil
         }
-        // Without an explicit root, an override honors the requested system only:
-        // it never falls through to the others.
-        if let buildSystem = buildSystem {
-            switch buildSystem {
-            case .spm:
-                return try await SPMBuildSystem.detect(for: sourceFile)
-            case .bazel:
-                return try await BazelBuildSystem.detect(for: sourceFile)
-            case .xcode:
-                return try await XcodeBuildSystem.detect(for: sourceFile, scheme: scheme)
-            }
-        }
         // SPM first (most common for Swift-only projects)
         if let spm = try await SPMBuildSystem.detect(for: sourceFile) {
             return spm
@@ -98,19 +88,31 @@ public enum BuildSystemDetector {
         return nil
     }
 
-    /// Construct the requested build system directly against an explicit project root.
+    /// Build the requested system for an explicit override. With a `projectRoot`
+    /// it constructs the system directly; without one it walks up from the source
+    /// file via that system's own `detect`. Either way it never falls through to
+    /// another build system.
     private static func forced(
         _ kind: BuildSystemKind,
         for sourceFile: URL,
-        projectRoot: URL,
+        projectRoot: URL?,
         scheme: String?
-    ) throws -> any BuildSystem {
+    ) async throws -> (any BuildSystem)? {
         switch kind {
         case .spm:
+            guard let projectRoot = projectRoot else {
+                return try await SPMBuildSystem.detect(for: sourceFile)
+            }
             return SPMBuildSystem(projectRoot: projectRoot, sourceFile: sourceFile)
         case .bazel:
+            guard let projectRoot = projectRoot else {
+                return try await BazelBuildSystem.detect(for: sourceFile)
+            }
             return BazelBuildSystem(projectRoot: projectRoot, sourceFile: sourceFile)
         case .xcode:
+            guard let projectRoot = projectRoot else {
+                return try await XcodeBuildSystem.detect(for: sourceFile, scheme: scheme)
+            }
             guard let projectFile = XcodeBuildSystem.findXcodeProject(in: projectRoot) else {
                 throw BuildSystemError.buildSystemUnavailable(
                     kind: kind.rawValue,

--- a/Sources/PreviewsCore/BuildSystem.swift
+++ b/Sources/PreviewsCore/BuildSystem.swift
@@ -14,6 +14,13 @@ public protocol BuildSystem: Sendable {
     var projectRoot: URL { get }
 }
 
+/// Explicitly selects a build system, bypassing marker-order auto-detection.
+public enum BuildSystemKind: String, Sendable, CaseIterable {
+    case spm
+    case bazel
+    case xcode
+}
+
 /// Tries registered build systems in order and returns the first match.
 public enum BuildSystemDetector {
     /// Detect the build system for a source file.
@@ -22,13 +29,21 @@ public enum BuildSystemDetector {
     ///   - projectRoot: If provided, use this as the project root instead of auto-detecting.
     ///   - scheme: Optional Xcode scheme name. Only used when the detected build
     ///     system is `XcodeBuildSystem`; ignored for SPM and Bazel.
+    ///   - buildSystem: Optional explicit override. When set, the marker order is
+    ///     skipped and the requested system is constructed directly. An override
+    ///     always wins over auto-detection.
     public static func detect(
         for sourceFile: URL,
         projectRoot: URL? = nil,
-        scheme: String? = nil
+        scheme: String? = nil,
+        buildSystem: BuildSystemKind? = nil
     ) async throws -> (any BuildSystem)? {
         // If an explicit project root is provided, detect which build system applies there
         if let projectRoot = projectRoot {
+            if let buildSystem = buildSystem {
+                return try forced(
+                    buildSystem, for: sourceFile, projectRoot: projectRoot, scheme: scheme)
+            }
             let fm = FileManager.default
             var isDir: ObjCBool = false
             if fm.fileExists(
@@ -56,6 +71,18 @@ public enum BuildSystemDetector {
             }
             return nil
         }
+        // Without an explicit root, an override honors the requested system only:
+        // it never falls through to the others.
+        if let buildSystem = buildSystem {
+            switch buildSystem {
+            case .spm:
+                return try await SPMBuildSystem.detect(for: sourceFile)
+            case .bazel:
+                return try await BazelBuildSystem.detect(for: sourceFile)
+            case .xcode:
+                return try await XcodeBuildSystem.detect(for: sourceFile, scheme: scheme)
+            }
+        }
         // SPM first (most common for Swift-only projects)
         if let spm = try await SPMBuildSystem.detect(for: sourceFile) {
             return spm
@@ -70,6 +97,32 @@ public enum BuildSystemDetector {
         }
         return nil
     }
+
+    /// Construct the requested build system directly against an explicit project root.
+    private static func forced(
+        _ kind: BuildSystemKind,
+        for sourceFile: URL,
+        projectRoot: URL,
+        scheme: String?
+    ) throws -> any BuildSystem {
+        switch kind {
+        case .spm:
+            return SPMBuildSystem(projectRoot: projectRoot, sourceFile: sourceFile)
+        case .bazel:
+            return BazelBuildSystem(projectRoot: projectRoot, sourceFile: sourceFile)
+        case .xcode:
+            guard let projectFile = XcodeBuildSystem.findXcodeProject(in: projectRoot) else {
+                throw BuildSystemError.buildSystemUnavailable(
+                    kind: kind.rawValue,
+                    reason: "no .xcodeproj or .xcworkspace found in \(projectRoot.path)")
+            }
+            return XcodeBuildSystem(
+                projectRoot: projectRoot,
+                sourceFile: sourceFile,
+                projectFile: projectFile,
+                requestedScheme: scheme)
+        }
+    }
 }
 
 /// Errors from build system operations.
@@ -79,6 +132,7 @@ public enum BuildSystemError: Error, LocalizedError {
     case missingArtifacts(String)
     case ambiguousTarget(sourceFile: String, candidates: [String])
     case unknownScheme(requested: String, candidates: [String])
+    case buildSystemUnavailable(kind: String, reason: String)
 
     public var errorDescription: String? {
         switch self {
@@ -94,6 +148,8 @@ public enum BuildSystemError: Error, LocalizedError {
         case .unknownScheme(let requested, let candidates):
             return
                 "Scheme '\(requested)' not found in project. Available schemes: \(candidates.joined(separator: ", "))"
+        case .buildSystemUnavailable(let kind, let reason):
+            return "Requested build system '\(kind)' is unavailable: \(reason)"
         }
     }
 }

--- a/Sources/PreviewsCore/PreviewSession.swift
+++ b/Sources/PreviewsCore/PreviewSession.swift
@@ -286,20 +286,22 @@ public actor PreviewSession {
 
         let objectPath: URL
         var supportObjectPaths: [URL] = []
-        var archivePaths: [URL] = []
-        var dylibPaths: [URL] = []
         var requiresFreshAgent = false
+
+        // The JIT links the target's dependency archives/dylibs regardless of
+        // which compile path runs (`splitContext.0` is `buildContext`, so the
+        // flags are the same in both branches).
+        let linkFlags = buildContext?.compilerFlags ?? []
+        var archivePaths = Self.dependencyArchives(in: linkFlags)
+        if let runtimeArchive = try await Toolchain.compilerRuntimeArchivePath() {
+            archivePaths.append(URL(fileURLWithPath: runtimeArchive))
+        }
+        var dylibPaths = Self.dependencyDylibs(in: linkFlags)
+        if let path = setupDylibPath, hasSetup {
+            dylibPaths.insert(path, at: 0)
+        }
+
         if let (ctx, bulk) = splitContext {
-            archivePaths = Self.dependencyArchives(in: ctx.compilerFlags)
-            if let runtimeArchive = try await Toolchain.compilerRuntimeArchivePath() {
-                archivePaths.append(URL(fileURLWithPath: runtimeArchive))
-            }
-            dylibPaths = Self.dependencyDylibs(in: ctx.compilerFlags)
-
-            if let path = setupDylibPath, hasSetup {
-                dylibPaths.insert(path, at: 0)
-            }
-
             if let stable {
                 supportObjectPaths = [stable.objectPath]
                 let mark = ContinuousClock.now
@@ -330,9 +332,13 @@ public actor PreviewSession {
                 requiresFreshAgent = true
             }
         } else {
+            // No Tier 2 bulk (e.g. an `@main` target whose only other source is
+            // the excluded entry-point file). Carry the build context's compiler
+            // flags so the lone preview compile still finds its dependency modules.
             objectPath = try await compiler.compileObject(
                 source: generated.source,
-                moduleName: "\(Self.moduleName(for: sourceFile))_\(Self.uniqueModuleToken())"
+                moduleName: "\(Self.moduleName(for: sourceFile))_\(Self.uniqueModuleToken())",
+                extraFlags: linkFlags
             )
         }
         try Self.writeDesignTimeValues(generated.literals, to: valuesPath)

--- a/Sources/PreviewsCore/XcodeBuildSystem.swift
+++ b/Sources/PreviewsCore/XcodeBuildSystem.swift
@@ -424,10 +424,14 @@ public actor XcodeBuildSystem: BuildSystem {
     }
 
     /// Collect dependency static-archive paths referenced by `OTHER_LDFLAGS`,
-    /// following an `@<file>` linker response file when present.
+    /// following an `@<file>` linker response file when present. Archives may
+    /// appear bare or behind a linker directive (`-force_load <path>`,
+    /// `-Wl,-force_load,<path>`), so each token is split on whitespace and any
+    /// `-Wl,`-style comma prefix is stripped before the `.a` check.
     static func collectDependencyArchives(fromOtherLDFlags value: String) -> [String] {
         var archives: [String] = []
-        func appendArchive(_ path: String) {
+        func appendArchive(_ token: String) {
+            let path = token.contains(",") ? String(token.split(separator: ",").last ?? "") : token
             if path.hasSuffix(".a"), FileManager.default.fileExists(atPath: path) {
                 archives.append(path)
             }
@@ -438,9 +442,7 @@ public actor XcodeBuildSystem: BuildSystem {
                 guard let content = try? String(contentsOfFile: file, encoding: .utf8) else {
                     continue
                 }
-                for line in content.split(separator: "\n").map(String.init) {
-                    appendArchive(line.trimmingCharacters(in: .whitespaces))
-                }
+                Self.tokenizeFlags(content).forEach(appendArchive)
             } else {
                 appendArchive(token)
             }
@@ -496,6 +498,14 @@ public actor XcodeBuildSystem: BuildSystem {
                     add(["-Xcc", arg, "-Xcc", value], key: "xcc:\(arg):\(value)")
                     i += 4
                     continue
+                }
+                // Most dropped -Xcc args are compile-only flags (-O0, -DDEBUG)
+                // and are expected. Warn only when an import-related flag arrives
+                // in an unhandled shape, so format drift is observable.
+                if clangValueFlags.contains(arg)
+                    || ["-iquote", "-isystem", "-working-directory"].contains(where: arg.hasPrefix)
+                {
+                    Log.warn("extractDependencyImportFlags: dropped import flag -Xcc \(arg)")
                 }
                 i += 2
                 continue

--- a/Sources/PreviewsCore/XcodeBuildSystem.swift
+++ b/Sources/PreviewsCore/XcodeBuildSystem.swift
@@ -415,21 +415,24 @@ public actor XcodeBuildSystem: BuildSystem {
         return flags
     }
 
+    /// Split a build-setting flag string into non-empty whitespace-separated tokens.
+    static func tokenizeFlags(_ value: String) -> [String] {
+        value
+            .split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "\n" })
+            .map(String.init)
+            .filter { !$0.isEmpty }
+    }
+
     /// Collect dependency static-archive paths referenced by `OTHER_LDFLAGS`,
     /// following an `@<file>` linker response file when present.
     static func collectDependencyArchives(fromOtherLDFlags value: String) -> [String] {
         var archives: [String] = []
-        let tokens =
-            value
-            .split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "\n" })
-            .map(String.init)
-            .filter { !$0.isEmpty }
         func appendArchive(_ path: String) {
             if path.hasSuffix(".a"), FileManager.default.fileExists(atPath: path) {
                 archives.append(path)
             }
         }
-        for token in tokens {
+        for token in Self.tokenizeFlags(value) {
             if token.hasPrefix("@") {
                 let file = String(token.dropFirst())
                 guard let content = try? String(contentsOfFile: file, encoding: .utf8) else {
@@ -470,12 +473,7 @@ public actor XcodeBuildSystem: BuildSystem {
     /// flags like `-emit-const-values-path`, `-static`, and `-enable-testing`
     /// are dropped.
     static func extractDependencyImportFlags(fromOtherSwiftFlags flags: String) -> [String] {
-        let tokens =
-            flags
-            .split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "\n" })
-            .map(String.init)
-            .filter { !$0.isEmpty }
-
+        let tokens = tokenizeFlags(flags)
         let clangValueFlags: Set<String> = ["-iquote", "-isystem", "-working-directory", "-I"]
         var result: [String] = []
         var seen = Set<String>()

--- a/Sources/PreviewsCore/XcodeBuildSystem.swift
+++ b/Sources/PreviewsCore/XcodeBuildSystem.swift
@@ -393,7 +393,123 @@ public actor XcodeBuildSystem: BuildSystem {
             }
         }
 
+        // Dependency module search paths from OTHER_SWIFT_FLAGS. rules_xcodeproj
+        // (Build-with-Bazel) puts dependency swiftmodules and objc module maps
+        // under bazel-out and exposes them here, not via the standard search
+        // path settings. Reuse those flags so the overlay recompile resolves
+        // `import SwiftLib` / `import ObjCLib`.
+        if let otherSwiftFlags = settings["OTHER_SWIFT_FLAGS"] {
+            flags += Self.extractDependencyImportFlags(fromOtherSwiftFlags: otherSwiftFlags)
+        }
+
+        // Dependency static archives from OTHER_LDFLAGS. The JIT resolves the
+        // overlay's cross-module symbols (e.g. SwiftLib/ObjCLib functions used
+        // by the preview) by linking these. Under rules_xcodeproj the linker
+        // inputs come via an `@<link.params>` response file; the target's own
+        // object is a `.lto.o`, so collecting the `.a` entries yields only deps.
+        if let ldFlags = settings["OTHER_LDFLAGS"] {
+            let archives = Self.collectDependencyArchives(fromOtherLDFlags: ldFlags)
+            flags += Self.archiveLinkFlags(archivePaths: archives, targetName: settings["TARGET_NAME"])
+        }
+
         return flags
+    }
+
+    /// Collect dependency static-archive paths referenced by `OTHER_LDFLAGS`,
+    /// following an `@<file>` linker response file when present.
+    static func collectDependencyArchives(fromOtherLDFlags value: String) -> [String] {
+        var archives: [String] = []
+        let tokens =
+            value
+            .split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "\n" })
+            .map(String.init)
+            .filter { !$0.isEmpty }
+        func appendArchive(_ path: String) {
+            if path.hasSuffix(".a"), FileManager.default.fileExists(atPath: path) {
+                archives.append(path)
+            }
+        }
+        for token in tokens {
+            if token.hasPrefix("@") {
+                let file = String(token.dropFirst())
+                guard let content = try? String(contentsOfFile: file, encoding: .utf8) else {
+                    continue
+                }
+                for line in content.split(separator: "\n").map(String.init) {
+                    appendArchive(line.trimmingCharacters(in: .whitespaces))
+                }
+            } else {
+                appendArchive(token)
+            }
+        }
+        return archives
+    }
+
+    /// Turn dependency archive paths into deduped `-L <dir>` / `-l<name>` pairs
+    /// (which `PreviewSession.dependencyArchives` resolves back to `lib<name>.a`),
+    /// excluding the target's own `lib<TargetName>.a` archive.
+    static func archiveLinkFlags(archivePaths: [String], targetName: String?) -> [String] {
+        let ownArchive = targetName.map { "lib\($0).a" }
+        var flags: [String] = []
+        var seen = Set<String>()
+        for path in archivePaths {
+            let name = (path as NSString).lastPathComponent
+            guard name.hasPrefix("lib"), name.hasSuffix(".a") else { continue }
+            if let ownArchive, name == ownArchive { continue }
+            let dir = (path as NSString).deletingLastPathComponent
+            let lib = String(name.dropFirst(3).dropLast(2))
+            if seen.insert("L:" + dir).inserted { flags += ["-L", dir] }
+            if seen.insert("l:" + lib).inserted { flags += ["-l" + lib] }
+        }
+        return flags
+    }
+
+    /// Extract dependency import flags from `OTHER_SWIFT_FLAGS`, keeping only the
+    /// search-path flags an overlay recompile needs (`-I`, `-F`, and the clang
+    /// `-Xcc` module-map / include / working-directory pairs). Compile-action
+    /// flags like `-emit-const-values-path`, `-static`, and `-enable-testing`
+    /// are dropped.
+    static func extractDependencyImportFlags(fromOtherSwiftFlags flags: String) -> [String] {
+        let tokens =
+            flags
+            .split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "\n" })
+            .map(String.init)
+            .filter { !$0.isEmpty }
+
+        let clangValueFlags: Set<String> = ["-iquote", "-isystem", "-working-directory", "-I"]
+        var result: [String] = []
+        var seen = Set<String>()
+        func add(_ items: [String], key: String) {
+            if seen.insert(key).inserted { result += items }
+        }
+
+        var i = 0
+        while i < tokens.count {
+            let t = tokens[i]
+            if t == "-Xcc", i + 1 < tokens.count {
+                let arg = tokens[i + 1]
+                if arg.hasPrefix("-fmodule-map-file=") || (arg.hasPrefix("-I") && arg.count > 2) {
+                    add(["-Xcc", arg], key: "xcc:" + arg)
+                    i += 2
+                    continue
+                }
+                if clangValueFlags.contains(arg), i + 3 < tokens.count, tokens[i + 2] == "-Xcc" {
+                    let value = tokens[i + 3]
+                    add(["-Xcc", arg, "-Xcc", value], key: "xcc:\(arg):\(value)")
+                    i += 4
+                    continue
+                }
+                i += 2
+                continue
+            }
+            if t.hasPrefix("-I"), t.count > 2 {
+                add(["-I", String(t.dropFirst(2))], key: "I:" + t)
+            } else if t.hasPrefix("-F"), t.count > 2 {
+                add(["-F", String(t.dropFirst(2))], key: "F:" + t)
+            }
+            i += 1
+        }
+        return result
     }
 
     /// Parse space-separated paths from xcodebuild, filtering out $(inherited) and quotes.

--- a/Sources/PreviewsEngine/BuildHelpers.swift
+++ b/Sources/PreviewsEngine/BuildHelpers.swift
@@ -55,12 +55,14 @@ public func detectAndBuild(
     projectRoot projectRootURL: URL?,
     platform: PreviewPlatform,
     scheme: String? = nil,
+    buildSystem buildSystemOverride: BuildSystemKind? = nil,
     progress: (any ProgressReporter)? = nil
 ) async throws -> BuildContext? {
     await progress?.report(.detectingProject, message: "Detecting project...")
     guard
         let buildSystem = try await BuildSystemDetector.detect(
-            for: fileURL, projectRoot: projectRootURL, scheme: scheme
+            for: fileURL, projectRoot: projectRootURL, scheme: scheme,
+            buildSystem: buildSystemOverride
         )
     else {
         return nil

--- a/Tests/PreviewsCoreTests/BuildSystemTests.swift
+++ b/Tests/PreviewsCoreTests/BuildSystemTests.swift
@@ -284,6 +284,76 @@ struct BuildSystemTests {
         #expect(buildSystem is BazelBuildSystem)
     }
 
+    // MARK: - BuildSystemDetector override
+
+    @Test("BuildSystemDetector override forces Xcode when Bazel markers would win")
+    func detectorOverrideForcesXcode() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+
+        // rules_xcodeproj shape: both a Bazel module and a generated .xcodeproj.
+        try "module(name = \"test\")".write(
+            to: tmpDir.appendingPathComponent("MODULE.bazel"), atomically: true, encoding: .utf8)
+        let xcodeproj = tmpDir.appendingPathComponent("MyApp.xcodeproj")
+        try FileManager.default.createDirectory(at: xcodeproj, withIntermediateDirectories: true)
+
+        let sourceFile = tmpDir.appendingPathComponent("main.swift")
+        try "import SwiftUI".write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        // Auto-detection picks Bazel (markers checked first).
+        let auto = try await BuildSystemDetector.detect(for: sourceFile, projectRoot: tmpDir)
+        #expect(auto is BazelBuildSystem)
+
+        // The override forces Xcode against the generated project.
+        let forced = try await BuildSystemDetector.detect(
+            for: sourceFile, projectRoot: tmpDir, buildSystem: .xcode)
+        #expect(forced is XcodeBuildSystem)
+    }
+
+    @Test("BuildSystemDetector override forces Bazel when SPM would win")
+    func detectorOverrideForcesBazel() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+
+        try "// swift-tools-version: 6.0".write(
+            to: tmpDir.appendingPathComponent("Package.swift"), atomically: true, encoding: .utf8)
+        try "module(name = \"test\")".write(
+            to: tmpDir.appendingPathComponent("MODULE.bazel"), atomically: true, encoding: .utf8)
+
+        let sourceFile = tmpDir.appendingPathComponent("main.swift")
+        try "import SwiftUI".write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let auto = try await BuildSystemDetector.detect(for: sourceFile, projectRoot: tmpDir)
+        #expect(auto is SPMBuildSystem)
+
+        let forced = try await BuildSystemDetector.detect(
+            for: sourceFile, projectRoot: tmpDir, buildSystem: .bazel)
+        #expect(forced is BazelBuildSystem)
+    }
+
+    @Test("BuildSystemDetector override throws when forced Xcode has no project")
+    func detectorOverrideXcodeWithoutProjectThrows() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+
+        let sourceFile = tmpDir.appendingPathComponent("main.swift")
+        try "import SwiftUI".write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        await #expect(throws: BuildSystemError.self) {
+            try await BuildSystemDetector.detect(
+                for: sourceFile, projectRoot: tmpDir, buildSystem: .xcode)
+        }
+    }
+
     // MARK: - BridgeGenerator
 
     @Test("BridgeGenerator.generateBridgeOnlySource produces correct output")

--- a/Tests/PreviewsCoreTests/BuildSystemTests.swift
+++ b/Tests/PreviewsCoreTests/BuildSystemTests.swift
@@ -839,6 +839,33 @@ struct BuildSystemTests {
         #expect(!flags.contains("-lMixedApp"))
     }
 
+    @Test("XcodeBuildSystem collects archives from an @link.params response file, including -force_load")
+    func collectDependencyArchivesFromResponseFile() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let bare = tmpDir.appendingPathComponent("libSwiftLib.a")
+        let forced = tmpDir.appendingPathComponent("libObjCLib.a")
+        try "".write(to: bare, atomically: true, encoding: .utf8)
+        try "".write(to: forced, atomically: true, encoding: .utf8)
+
+        // A bare archive line, a `-force_load <path>` directive, and a
+        // `-Wl,-force_load,<path>` comma-joined directive, plus a non-archive line.
+        let params = tmpDir.appendingPathComponent("link.params")
+        try """
+            \(bare.path)
+            -force_load \(forced.path)
+            -Wl,-add_ast_path,\(tmpDir.path)/SwiftLib.swiftmodule
+            """.write(to: params, atomically: true, encoding: .utf8)
+
+        let archives = XcodeBuildSystem.collectDependencyArchives(fromOtherLDFlags: "@\(params.path)")
+        #expect(archives.contains(bare.path))
+        #expect(archives.contains(forced.path))
+        #expect(archives.count == 2)
+    }
+
     // MARK: - XcodeBuildSystem source file collection
 
     @Test("XcodeBuildSystem collects source files from OutputFileMap")

--- a/Tests/PreviewsCoreTests/BuildSystemTests.swift
+++ b/Tests/PreviewsCoreTests/BuildSystemTests.swift
@@ -778,6 +778,67 @@ struct BuildSystemTests {
         #expect(paths == ["/path/to/libs", "/normal/path"])
     }
 
+    // MARK: - XcodeBuildSystem dependency import flags (rules_xcodeproj)
+
+    @Test("XcodeBuildSystem extracts dependency import flags from OTHER_SWIFT_FLAGS")
+    func extractDependencyImportFlags() {
+        // Representative of a rules_xcodeproj Build-with-Bazel OTHER_SWIFT_FLAGS:
+        // dep swiftmodule (-I), objc module map (-Xcc -fmodule-map-file=), and
+        // the clang -iquote / -working-directory pairs, mixed with compile-only
+        // flags that must be dropped.
+        let other = """
+            -Xcc -working-directory -Xcc /exec/_main -working-directory /exec/_main \
+            -enforce-exclusivity=checked \
+            -emit-const-values-path bazel-out/bin/App/Main.swiftconstvalues -DDEBUG -Onone \
+            -I/exec/_main/bazel-out/bin/mixed/SwiftLib \
+            -Xcc -iquote -Xcc /exec/_main \
+            -Xcc -iquote -Xcc /exec/_main/bazel-out/bin \
+            -Xcc -fmodule-map-file=/exec/_main/bazel-out/bin/mixed/ObjCLib/ObjCLib_modulemap/_/module.modulemap \
+            -enable-testing -static
+            """
+
+        let flags = XcodeBuildSystem.extractDependencyImportFlags(fromOtherSwiftFlags: other)
+
+        // Keeps the dep swiftmodule import path.
+        #expect(flags.contains("-I"))
+        #expect(flags.contains("/exec/_main/bazel-out/bin/mixed/SwiftLib"))
+        // Keeps the objc module map.
+        #expect(
+            flags.contains(
+                "-Xcc -fmodule-map-file=/exec/_main/bazel-out/bin/mixed/ObjCLib/ObjCLib_modulemap/_/module.modulemap"
+                    .replacingOccurrences(of: "-Xcc ", with: ""))
+        )
+        let joined = flags.joined(separator: " ")
+        #expect(joined.contains("-fmodule-map-file=/exec/_main/bazel-out/bin/mixed/ObjCLib"))
+        // Keeps the clang -iquote and -working-directory pairs.
+        #expect(joined.contains("-Xcc -iquote -Xcc /exec/_main/bazel-out/bin"))
+        #expect(joined.contains("-Xcc -working-directory -Xcc /exec/_main"))
+        // Drops compile-action flags.
+        #expect(!joined.contains("-emit-const-values-path"))
+        #expect(!joined.contains("-enable-testing"))
+        #expect(!joined.contains("-enforce-exclusivity"))
+        #expect(!flags.contains("-static"))
+    }
+
+    @Test("XcodeBuildSystem archiveLinkFlags emits -L/-l and excludes the own archive")
+    func archiveLinkFlags() {
+        let paths = [
+            "/exec/_main/bazel-out/bin/mixed/ObjCLib/libObjCLib.a",
+            "/exec/_main/bazel-out/bin/mixed/SwiftLib/libSwiftLib.a",
+            // The target's own archive must be excluded.
+            "/exec/_main/bazel-out/bin/mixed/App/libMixedApp.a",
+        ]
+        let flags = XcodeBuildSystem.archiveLinkFlags(archivePaths: paths, targetName: "MixedApp")
+
+        // -L/-l pairs are what PreviewSession.dependencyArchives resolves to
+        // lib<name>.a for the JIT link.
+        let joined = flags.joined(separator: " ")
+        #expect(joined.contains("-L /exec/_main/bazel-out/bin/mixed/ObjCLib -lObjCLib"))
+        #expect(joined.contains("-L /exec/_main/bazel-out/bin/mixed/SwiftLib -lSwiftLib"))
+        #expect(!joined.contains("MixedApp"))
+        #expect(!flags.contains("-lMixedApp"))
+    }
+
     // MARK: - XcodeBuildSystem source file collection
 
     @Test("XcodeBuildSystem collects source files from OutputFileMap")

--- a/examples/bazel/MODULE.bazel
+++ b/examples/bazel/MODULE.bazel
@@ -5,3 +5,5 @@ module(
 
 bazel_dep(name = "rules_swift", version = "3.5.0")
 bazel_dep(name = "apple_support", version = "2.3.0")
+bazel_dep(name = "rules_apple", version = "4.4.0")
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/examples/bazel/MODULE.bazel.lock
+++ b/examples/bazel/MODULE.bazel.lock
@@ -17,6 +17,7 @@
     "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
     "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
     "https://bcr.bazel.build/modules/apple_support/1.24.2/MODULE.bazel": "0e62471818affb9f0b26f128831d5c40b074d32e6dda5a0d3852847215a41ca4",
+    "https://bcr.bazel.build/modules/apple_support/2.2.0/MODULE.bazel": "5e32bc42e413a4544df7afee7fa4c7aff73e670a44e56e8e45ce1954332034ad",
     "https://bcr.bazel.build/modules/apple_support/2.3.0/MODULE.bazel": "d48f824ae8eeea5f837eb3038cef3615075d996d3e82eb9187192c2820605a81",
     "https://bcr.bazel.build/modules/apple_support/2.3.0/source.json": "d99b0a50918c4484856d773026b2fd60a694668c70fc0e19d592786dc7e5e469",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
@@ -31,7 +32,8 @@
     "https://bcr.bazel.build/modules/bazel_features/1.3.0/MODULE.bazel": "cdcafe83ec318cda34e02948e81d790aab8df7a929cec6f6969f13a489ccecd9",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.33.0/MODULE.bazel": "8b8dc9d2a4c88609409c3191165bccec0e4cb044cd7a72ccbe826583303459f6",
-    "https://bcr.bazel.build/modules/bazel_features/1.33.0/source.json": "13617db3930328c2cd2807a0f13d52ca870ac05f96db9668655113265147b2a6",
+    "https://bcr.bazel.build/modules/bazel_features/1.36.0/MODULE.bazel": "596cb62090b039caf1cad1d52a8bc35cf188ca9a4e279a828005e7ee49a1bec3",
+    "https://bcr.bazel.build/modules/bazel_features/1.36.0/source.json": "279625cafa5b63cc0a8ee8448d93bc5ac1431f6000c50414051173fd22a6df3c",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
@@ -46,6 +48,7 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
     "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/MODULE.bazel": "88ade7293becda963e0e3ea33e7d54d3425127e0a326e0d17da085a5f1f03ff6",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/MODULE.bazel": "69ad6927098316848b34a9142bcc975e018ba27f08c4ff403f50c1b6e646ca67",
     "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/MODULE.bazel": "72997b29dfd95c3fa0d0c48322d05590418edef451f8db8db5509c57875fb4b7",
     "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/source.json": "7ad77c1e8c1b84222d9b3f3cae016a76639435744c19330b0b37c0a3c9da7dc0",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
@@ -66,13 +69,14 @@
     "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/MODULE.bazel": "6f7b417dcc794d9add9e556673ad25cb3ba835224290f4f848f8e2db1e1fca74",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
     "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
-    "https://bcr.bazel.build/modules/platforms/0.0.11/source.json": "f7e188b79ebedebfe75e9e1d098b8845226c7992b307e28e1496f23112e8fc29",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
     "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
     "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
     "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
     "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
     "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel": "f05feb42b48f1b3c225e4ccf351f367be0371411a803198ec34a389fb22aa580",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/source.json": "f4ff1fd412e0246fd38c82328eb209130ead81d62dcd5a9e40910f867f733d96",
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
     "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
@@ -91,6 +95,8 @@
     "https://bcr.bazel.build/modules/re2/2024-07-02/MODULE.bazel": "0eadc4395959969297cbcf31a249ff457f2f1d456228c67719480205aa306daa",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
+    "https://bcr.bazel.build/modules/rules_apple/4.4.0/MODULE.bazel": "f89fc7eb7c68f9307d2f599abcba4e0fefa4af76765f55d0ba1514a1fe317f3d",
+    "https://bcr.bazel.build/modules/rules_apple/4.4.0/source.json": "635d4ca2721560bc17be8792fad91c81cccb6298b6b4897dd32f6997434cf826",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
     "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
     "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
@@ -103,9 +109,11 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.5/MODULE.bazel": "88dfc9361e8b5ae1008ac38f7cdfd45ad738e4fa676a3ad67d19204f045a1fd8",
     "https://bcr.bazel.build/modules/rules_cc/0.2.14/MODULE.bazel": "353c99ed148887ee89c54a17d4100ae7e7e436593d104b668476019023b58df8",
     "https://bcr.bazel.build/modules/rules_cc/0.2.15/MODULE.bazel": "6a0a4a75a57aa6dc888300d848053a58c6b12a29f89d4304e1c41448514ec6e8",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.15/source.json": "197965c6dcca5c98a9288f93849e2e1c69d622e71b0be8deb524e22d48c88e32",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.17/MODULE.bazel": "1849602c86cb60da8613d2de887f9566a6d354a6df6d7009f9d04a14402f9a84",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.17/source.json": "3832f45d145354049137c0090df04629d9c2b5493dc5c2bf46f1834040133a07",
     "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
@@ -157,10 +165,12 @@
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
     "https://bcr.bazel.build/modules/rules_python/0.40.0/MODULE.bazel": "9d1a3cd88ed7d8e39583d9ffe56ae8a244f67783ae89b60caafc9f5cf318ada7",
     "https://bcr.bazel.build/modules/rules_python/1.6.0/MODULE.bazel": "7e04ad8f8d5bea40451cf80b1bd8262552aa73f841415d20db96b7241bd027d8",
-    "https://bcr.bazel.build/modules/rules_python/1.6.0/source.json": "e980f654cf66ec4928672f41fc66c4102b5ea54286acf4aecd23256c84211be6",
+    "https://bcr.bazel.build/modules/rules_python/1.7.0/MODULE.bazel": "d01f995ecd137abf30238ad9ce97f8fc3ac57289c8b24bd0bf53324d937a14f8",
+    "https://bcr.bazel.build/modules/rules_python/1.7.0/source.json": "028a084b65dcf8f4dc4f82f8778dbe65df133f234b316828a82e060d81bdce32",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
     "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
-    "https://bcr.bazel.build/modules/rules_shell/0.3.0/source.json": "c55ed591aa5009401ddf80ded9762ac32c358d2517ee7820be981e2de9756cf3",
+    "https://bcr.bazel.build/modules/rules_shell/0.6.1/MODULE.bazel": "72e76b0eea4e81611ef5452aa82b3da34caca0c8b7b5c0c9584338aa93bae26b",
+    "https://bcr.bazel.build/modules/rules_shell/0.6.1/source.json": "20ec05cd5e592055e214b2da8ccb283c7f2a421ea0dc2acbf1aa792e11c03d0c",
     "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel": "4a09f199545a60d09895e8281362b1ff3bb08bbde69c6fc87aff5b92fcc916ca",
     "https://bcr.bazel.build/modules/rules_swift/3.5.0/MODULE.bazel": "e71b6024213df1cb5ed2f327b273f6f4a406611db1e2444f09a37a837eee941d",
     "https://bcr.bazel.build/modules/rules_swift/3.5.0/source.json": "265412f803895a90502e315b3318a8eaf4a6d535e0203862679f0b432a792aab",
@@ -245,10 +255,245 @@
         ]
       }
     },
+    "@@rules_python+//python/extensions:config.bzl%config": {
+      "general": {
+        "bzlTransitiveDigest": "9cZw51LLMu2V/jKcxvnA1pBg58ZgQEDuMni3CbNZSRg=",
+        "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "rules_python_internal": {
+            "repoRuleId": "@@rules_python+//python/private:internal_config_repo.bzl%internal_config_repo",
+            "attributes": {
+              "transition_setting_generators": {},
+              "transition_settings": []
+            }
+          },
+          "pypi__build": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/e2/03/f3c8ba0a6b6e30d7d18c40faab90807c9bb5e9a1e3b2fe2008af624a9c97/build-1.2.1-py3-none-any.whl",
+              "sha256": "75e10f767a433d9a86e50d83f418e83efc18ede923ee5ff7df93b6cb0306c5d4",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__click": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl",
+              "sha256": "ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__colorama": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl",
+              "sha256": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__importlib_metadata": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/2d/0a/679461c511447ffaf176567d5c496d1de27cbe34a87df6677d7171b2fbd4/importlib_metadata-7.1.0-py3-none-any.whl",
+              "sha256": "30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__installer": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/e5/ca/1172b6638d52f2d6caa2dd262ec4c811ba59eee96d54a7701930726bce18/installer-0.7.0-py3-none-any.whl",
+              "sha256": "05d1933f0a5ba7d8d6296bb6d5018e7c94fa473ceb10cf198a92ccea19c27b53",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__more_itertools": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/50/e2/8e10e465ee3987bb7c9ab69efb91d867d93959095f4807db102d07995d94/more_itertools-10.2.0-py3-none-any.whl",
+              "sha256": "686b06abe565edfab151cb8fd385a05651e1fdf8f0a14191e4439283421f8684",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__packaging": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl",
+              "sha256": "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pep517": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/25/6e/ca4a5434eb0e502210f591b97537d322546e4833dcb4d470a48c375c5540/pep517-0.13.1-py3-none-any.whl",
+              "sha256": "31b206f67165b3536dd577c5c3f1518e8fbaf38cbc57efff8369a392feff1721",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pip": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/8a/6a/19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b/pip-24.0-py3-none-any.whl",
+              "sha256": "ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pip_tools": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/0d/dc/38f4ce065e92c66f058ea7a368a9c5de4e702272b479c0992059f7693941/pip_tools-7.4.1-py3-none-any.whl",
+              "sha256": "4c690e5fbae2f21e87843e89c26191f0d9454f362d8acdbd695716493ec8b3a9",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pyproject_hooks": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/ae/f3/431b9d5fe7d14af7a32340792ef43b8a714e7726f1d7b69cc4e8e7a3f1d7/pyproject_hooks-1.1.0-py3-none-any.whl",
+              "sha256": "7ceeefe9aec63a1064c18d939bdc3adf2d8aa1988a510afec15151578b232aa2",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__setuptools": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/90/99/158ad0609729111163fc1f674a5a42f2605371a4cf036d0441070e2f7455/setuptools-78.1.1-py3-none-any.whl",
+              "sha256": "c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__tomli": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl",
+              "sha256": "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__wheel": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/7d/cd/d7460c9a869b16c3dd4e1e403cce337df165368c71d6af229a74699622ce/wheel-0.43.0-py3-none-any.whl",
+              "sha256": "55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__zipp": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/da/55/a03fd7240714916507e1fcf7ae355bd9d9ed2e6db492595f1a67f61681be/zipp-3.18.2-py3-none-any.whl",
+              "sha256": "dce197b859eb796242b0622af1b8beb0a722d52aa2f57133ead08edd5bf5374e",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_python+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_python+",
+            "pypi__build",
+            "rules_python++config+pypi__build"
+          ],
+          [
+            "rules_python+",
+            "pypi__click",
+            "rules_python++config+pypi__click"
+          ],
+          [
+            "rules_python+",
+            "pypi__colorama",
+            "rules_python++config+pypi__colorama"
+          ],
+          [
+            "rules_python+",
+            "pypi__importlib_metadata",
+            "rules_python++config+pypi__importlib_metadata"
+          ],
+          [
+            "rules_python+",
+            "pypi__installer",
+            "rules_python++config+pypi__installer"
+          ],
+          [
+            "rules_python+",
+            "pypi__more_itertools",
+            "rules_python++config+pypi__more_itertools"
+          ],
+          [
+            "rules_python+",
+            "pypi__packaging",
+            "rules_python++config+pypi__packaging"
+          ],
+          [
+            "rules_python+",
+            "pypi__pep517",
+            "rules_python++config+pypi__pep517"
+          ],
+          [
+            "rules_python+",
+            "pypi__pip",
+            "rules_python++config+pypi__pip"
+          ],
+          [
+            "rules_python+",
+            "pypi__pip_tools",
+            "rules_python++config+pypi__pip_tools"
+          ],
+          [
+            "rules_python+",
+            "pypi__pyproject_hooks",
+            "rules_python++config+pypi__pyproject_hooks"
+          ],
+          [
+            "rules_python+",
+            "pypi__setuptools",
+            "rules_python++config+pypi__setuptools"
+          ],
+          [
+            "rules_python+",
+            "pypi__tomli",
+            "rules_python++config+pypi__tomli"
+          ],
+          [
+            "rules_python+",
+            "pypi__wheel",
+            "rules_python++config+pypi__wheel"
+          ],
+          [
+            "rules_python+",
+            "pypi__zipp",
+            "rules_python++config+pypi__zipp"
+          ]
+        ]
+      }
+    },
     "@@rules_python+//python/uv:uv.bzl%uv": {
       "general": {
-        "bzlTransitiveDigest": "xfNZ/WmfkC9N/pNH0cmucTOrqBa966d9iMmmX54m1UM=",
-        "usagesDigest": "p80sy6cYQuWxx5jhV3fOTu+N9EyIUFG9+F7UC/nhXic=",
+        "bzlTransitiveDigest": "ijW9KS7qsIY+yBVvJ+Nr1mzwQox09j13DnE3iIwaeTM=",
+        "usagesDigest": "H8dQoNZcoqP+Mu0tHZTi4KHATzvNkM5ePuEqoQdklIU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/examples/bazel/README.md
+++ b/examples/bazel/README.md
@@ -1,20 +1,42 @@
 # Bazel Example Project
 
-A minimal SwiftUI library built with Bazel, with a cross-file type dependency, used to integration test PreviewsMCP's Bazel build system support.
+SwiftUI targets built with Bazel, used to integration test PreviewsMCP's Bazel build system support. It covers a plain `swift_library` (ToDo) plus the Apple bundle target types — an `ios_application` and an `ios_framework` — each with cross-module dependencies.
 
 ## Structure
 
 ```
-Sources/ToDo/
-├── BUILD.bazel                — swift_library target
-├── Item.swift                 — defines Item model (used by views)
-├── ToDoView.swift             — view + #Preview that references Item
-└── ToDoProviderPreview.swift  — PreviewProvider-based preview for integration testing
+Sources/
+├── ToDo/                       — swift_library
+│   ├── BUILD.bazel
+│   ├── Item.swift              — defines Item model (used by views)
+│   ├── ToDoView.swift          — view + #Preview that references Item
+│   └── ToDoProviderPreview.swift — PreviewProvider-based preview
+├── ObjCLib/                    — objc_library (PSGreeting.message())
+├── SwiftLib/                   — swift_library, depends on ObjCLib (GreetingBadge)
+├── App/                        — ios_application + its swift_library
+│   ├── BUILD.bazel             — MixedApp (ios_application) → MixedApp.library
+│   ├── MixedApp.swift          — @main App entry point
+│   └── ContentView.swift       — #Preview, imports ObjCLib + SwiftLib
+└── PreviewKit/                 — ios_framework + its swift_library
+    ├── BUILD.bazel             — PreviewKit (ios_framework) → PreviewKit.library
+    └── PreviewView.swift       — #Preview
 ```
+
+### ToDo (swift_library)
 
 The `#Preview` blocks in `ToDoView.swift` use `Item.samples` which is defined in `Item.swift`. This requires PreviewsMCP to detect the Bazel project, build it, and compile the preview against the target's build artifacts. The file has two previews: the default (with sample data) and "Empty State" (no items).
 
 The UI includes tappable item rows (toggle completion), a toggle switch, and a horizontally paged summary card section — suitable for testing tap, toggle, and swipe interactions.
+
+### Apple bundle targets and multiple targets
+
+`ContentView.swift` (the app) and `PreviewView.swift` (the framework) each render through the bundle's underlying `swift_library`, not the `ios_application` / `ios_framework` rule itself. PreviewsMCP resolves a preview by source **file**: it finds the nearest `BUILD`, then queries `kind("swift_library", rdeps(//<pkg>:all, //<pkg>:<File>.swift))` to find the `swift_library` in that package that owns the file. So multiple targets in different packages each route to their own library.
+
+These two files exercise the parts of the Bazel support that a plain `swift_library` does not:
+
+- **Cross-module dependencies.** `ContentView` imports the `objc_library` `ObjCLib` and the `swift_library` `SwiftLib`. PreviewsMCP pulls the dependency module search paths from the target's compile action and builds + links the dependency archives into the preview.
+- **`@main` app target.** `MixedApp.swift` carries the `@main` entry point. It is excluded from the preview compile (its app-lifecycle entry symbol would break the preview JIT link); the preview renders `ContentView()` on its own.
+- **iOS SDK transition.** On `--platform ios` the targets and their dependencies build through the real iOS-simulator platform transition.
 
 ## Prerequisites
 

--- a/examples/bazel/Sources/App/BUILD.bazel
+++ b/examples/bazel/Sources/App/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@rules_apple//apple:ios.bzl", "ios_application")
+load("@rules_swift//swift:swift.bzl", "swift_library")
+
+ios_application(
+    name = "MixedApp",
+    bundle_id = "io.previewsmcp.MixedApp",
+    families = ["iphone"],
+    infoplists = [":Info.plist"],
+    minimum_os_version = "17.0",
+    visibility = ["//visibility:public"],
+    deps = [":MixedApp.library"],
+)
+
+swift_library(
+    name = "MixedApp.library",
+    srcs = [
+        "ContentView.swift",
+        "MixedApp.swift",
+    ],
+    module_name = "MixedApp",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//Sources/ObjCLib",
+        "//Sources/SwiftLib",
+    ],
+)

--- a/examples/bazel/Sources/App/ContentView.swift
+++ b/examples/bazel/Sources/App/ContentView.swift
@@ -1,0 +1,21 @@
+import ObjCLib
+import SwiftLib
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack(spacing: 8) {
+            VStack {
+                Text("mixed app target")
+                Button("edit") {}
+            }
+            Text(PSGreeting.message())
+            GreetingBadge()
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/examples/bazel/Sources/App/Info.plist
+++ b/examples/bazel/Sources/App/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+</dict>
+</plist>

--- a/examples/bazel/Sources/App/MixedApp.swift
+++ b/examples/bazel/Sources/App/MixedApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct MixedApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/examples/bazel/Sources/ObjCLib/BUILD.bazel
+++ b/examples/bazel/Sources/ObjCLib/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
+
+objc_library(
+    name = "ObjCLib",
+    srcs = ["ObjCLib.m"],
+    hdrs = ["ObjCLib.h"],
+    module_name = "ObjCLib",
+    visibility = ["//visibility:public"],
+)

--- a/examples/bazel/Sources/ObjCLib/ObjCLib.h
+++ b/examples/bazel/Sources/ObjCLib/ObjCLib.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface PSGreeting : NSObject
++ (NSString *)message;
+@end

--- a/examples/bazel/Sources/ObjCLib/ObjCLib.m
+++ b/examples/bazel/Sources/ObjCLib/ObjCLib.m
@@ -1,0 +1,7 @@
+#import "ObjCLib.h"
+
+@implementation PSGreeting
++ (NSString *)message {
+    return @"from ObjCLib";
+}
+@end

--- a/examples/bazel/Sources/PreviewKit/BUILD.bazel
+++ b/examples/bazel/Sources/PreviewKit/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_apple//apple:ios.bzl", "ios_framework")
+load("@rules_swift//swift:swift.bzl", "swift_library")
+
+ios_framework(
+    name = "PreviewKit",
+    bundle_id = "io.previewsmcp.PreviewKit",
+    families = ["iphone"],
+    infoplists = [":Info.plist"],
+    minimum_os_version = "17.0",
+    visibility = ["//visibility:public"],
+    deps = [":PreviewKit.library"],
+)
+
+swift_library(
+    name = "PreviewKit.library",
+    srcs = ["PreviewView.swift"],
+    module_name = "PreviewKit",
+    visibility = ["//visibility:public"],
+)

--- a/examples/bazel/Sources/PreviewKit/Info.plist
+++ b/examples/bazel/Sources/PreviewKit/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+</dict>
+</plist>

--- a/examples/bazel/Sources/PreviewKit/PreviewView.swift
+++ b/examples/bazel/Sources/PreviewKit/PreviewView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+public struct PreviewView: View {
+    public init() {}
+
+    public var body: some View {
+        VStack(spacing: 8) {
+            Text("preview kit framework")
+            Image(systemName: "star.fill")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    PreviewView()
+}

--- a/examples/bazel/Sources/SwiftLib/BUILD.bazel
+++ b/examples/bazel/Sources/SwiftLib/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_swift//swift:swift.bzl", "swift_library")
+
+swift_library(
+    name = "SwiftLib",
+    srcs = ["GreetingBadge.swift"],
+    module_name = "SwiftLib",
+    visibility = ["//visibility:public"],
+    deps = ["//Sources/ObjCLib"],
+)

--- a/examples/bazel/Sources/SwiftLib/GreetingBadge.swift
+++ b/examples/bazel/Sources/SwiftLib/GreetingBadge.swift
@@ -1,0 +1,12 @@
+import ObjCLib
+import SwiftUI
+
+public struct GreetingBadge: View {
+    public init() {}
+
+    public var body: some View {
+        Label(PSGreeting.message(), systemImage: "tag")
+            .padding(6)
+            .background(.yellow, in: Capsule())
+    }
+}


### PR DESCRIPTION
## Summary

The Bazel build system rendered previews only for a plain `swift_library`. Apple bundle target types under rules_apple / rules_xcodeproj failed before reaching the canvas:

- an `ios_application`'s `@main` app target, and
- an `ios_framework`,

each broke at module resolution, the iOS SDK transition, or the preview JIT link. This makes both render via the standalone host on **macOS** and the **iOS simulator**, with zero changes to the project under test.

This PR also adds a `--build-system` override (#227) and, on the back of it, makes the **Xcode** build system render rules_xcodeproj Build-with-Bazel previews end to end.

## Changes

`BazelBuildSystem`:
- **`findDependencyModuleFlags`** pulls `-I` / `-F` / `-Xcc -fmodule-map-file=` from the target's `SwiftCompile` aquery so the bridge's `import <Dep>` resolves. (objc module maps live at non-obvious paths that `cquery --output=files` does not list.)
- **`platformFlags(.iOS)`** uses `--platforms` for the real iOS-sim SDK transition (the legacy `--cpu` / `--apple_platform_type` name the output dir but skip the transition for a bare `swift_library`), and resolves the `apple_support` repo name from `MODULE.bazel` instead of hardcoding it. Both platforms pin `--ios_minimum_os` / `--macos_minimum_os` to the bridge triple so deps do not come out at the SDK-default min.
- **`findDependencyArchiveFlags`** emits `-L`/`-l` for the target's dependency static archives so the JIT link resolves cross-target symbols, filtering out exec-config build tooling and the target's own archive.
- **`collectSourceFiles`** drops `@main` entry-point files, whose app-lifecycle entry symbol poisons the preview JIT link.

`PreviewSession`:
- The no-bulk path (reached when excluding `@main` empties the Tier 2 bulk) now carries the build context's compiler flags and links its dependency archives/dylibs into the JIT.

### Build-system override (#227)

- **`BuildSystemDetector.detect`** takes an optional `BuildSystemKind` (`spm` / `bazel` / `xcode`). When set it skips the marker order and constructs the requested system directly, still using `projectRoot` to find the `.xcodeproj` for the Xcode case. An explicit override wins; auto-detection stays the default.
- Surfaced as `--build-system` on `snapshot` / `run` / `variants` and as a `buildSystem` arg on the `preview_start` handler.
- Motivation: a rules_xcodeproj workspace ships both `MODULE.bazel` and a generated `.xcodeproj`. Markers are checked Bazel-first, so the Xcode path could never be exercised against it.

### Xcode path: Build-with-Bazel dependency resolution

Forcing `--build-system xcode` on a rules_xcodeproj project built, but the overlay recompile failed (`no such module 'ObjCLib'`), then the JIT could not materialize the dep symbols. The Xcode path forwarded only `-F` framework search paths, which suffices for native Xcode (deps are frameworks) but not Build-with-Bazel, where dep swiftmodules, objc module maps, and static archives live under `bazel-out`. `buildCompilerFlags` now also:

- forwards dependency import flags from **`OTHER_SWIFT_FLAGS`** (the dep swiftmodule `-I`, the objc `-Xcc -fmodule-map-file=`, and the clang `-iquote` / `-working-directory` pairs), dropping compile-action flags like `-emit-const-values-path`, `-static`, `-enable-testing`; and
- emits `-L`/`-l` for the dependency static archives listed in the **`OTHER_LDFLAGS`** `@link.params` response file (excluding the target's own archive), which `PreviewSession` links into the JIT.

This reuses Xcode's own build settings rather than re-deriving anything from Bazel.

## Testing

Snapshotted a mixed rules_xcodeproj study project (an `ios_application` with `ContentView` depending on an `objc_library` + a `swift_library`, plus an `ios_framework`):

- exec `@main` target, macOS: renders the real `ContentView` with both deps resolved.
- exec `@main` target, iOS simulator: same, in the sim.
- framework target, macOS: renders, no regression.
- **`--build-system xcode` on the same `Mixed.xcodeproj` (scheme `MixedApp`), iOS simulator:** renders the `ContentView` preview (ObjCLib text + SwiftLib `GreetingBadge`) identically to the Bazel path.

New unit tests cover the override precedence (force `xcode` where Bazel would win, force `bazel` where SPM would win, error when forced `xcode` has no project) and the `OTHER_SWIFT_FLAGS` / `OTHER_LDFLAGS` flag extraction.

Note: validating the iOS render, the first capture after a cold simulator can show the SpringBoard home screen from an IOSurface fallback race (not a render failure); a warm re-run renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Note for reviewers: behavior change beyond Bazel

The `PreviewSession` no-bulk path (the `else` after `splitContext`) now resolves and links the build context's dependency archives/dylibs plus the compiler runtime archive, where before it linked nothing. This path is reached whenever `sourceFiles == nil` (no Tier 2 bulk), which includes **non-Bazel** targets — e.g. a single-file SPM module. Those previews now link their dependency closure the same way the existing Tier 2 path already does, so it mirrors a proven configuration rather than a new one. It is not Bazel-specific. Flagging because it touches SPM/Xcode previews and has no test coverage.
