### PR TITLE
chore: fix swift-format --strict indentation debt

### DIFF
--- a/Tests/PreviewsCoreTests/BuildSystemTests.swift
+++ b/Tests/PreviewsCoreTests/BuildSystemTests.swift
@@ -853,10 +853,10 @@ struct BuildSystemTests {
         // `-Wl,-force_load,<path>` comma-joined directive, plus a non-archive line.
         let params = tmpDir.appendingPathComponent("link.params")
         try """
-            \(bare.path)
-            -force_load \(forced.path)
-            -Wl,-add_ast_path,\(tmpDir.path)/SwiftLib.swiftmodule
-            """.write(to: params, atomically: true, encoding: .utf8)
+        \(bare.path)
+        -force_load \(forced.path)
+        -Wl,-add_ast_path,\(tmpDir.path)/SwiftLib.swiftmodule
+        """.write(to: params, atomically: true, encoding: .utf8)
 
         let archives = XcodeBuildSystem.collectDependencyArchives(fromOtherLDFlags: "@\(params.path)")
         #expect(archives.contains(bare.path))

--- a/Tests/PreviewsCoreTests/IOSCompileObjectForJITTests.swift
+++ b/Tests/PreviewsCoreTests/IOSCompileObjectForJITTests.swift
@@ -14,16 +14,16 @@ struct IOSCompileObjectForJITTests {
 
         let sourceFile = dir.appendingPathComponent("Preview.swift")
         try """
-            import SwiftUI
+        import SwiftUI
 
-            struct TestView: View {
-                var body: some View {
-                    Text("Hello")
-                }
+        struct TestView: View {
+            var body: some View {
+                Text("Hello")
             }
+        }
 
-            #Preview { TestView() }
-            """.write(to: sourceFile, atomically: true, encoding: .utf8)
+        #Preview { TestView() }
+        """.write(to: sourceFile, atomically: true, encoding: .utf8)
 
         let compiler = try await Compiler(platform: .iOS)
         let session = PreviewSession(sourceFile: sourceFile, compiler: compiler, platform: .iOS)


### PR DESCRIPTION
Repo-wide swift-format `--strict` sweep. There were 12 `[Indentation]` violations, all in the interior of multi-line string literals (embedded Swift/link-param snippets) in `IOSCompileObjectForJITTests.swift` (×8) and `BuildSystemTests.swift` (×4). CI is off, so the formatter never ran on them.

`swift-format format -i` left-shifts each literal block uniformly (content lines + closing delimiter), so the string values are byte-identical and the embedded snippets are unchanged. Verified: the 77 tests across both suites pass, and `swift-format lint --strict --recursive Sources Tests` now reports 0 errors.

Whitespace-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)