### PR TITLE
chore: drop the write-only lastLiterals field

### DIFF
--- a/Sources/PreviewsCore/PreviewSession.swift
+++ b/Sources/PreviewsCore/PreviewSession.swift
@@ -70,7 +70,6 @@ public actor PreviewSession {
     private let setupSDKPath: String?
     private let setupDylibPath: URL?
     private var lastOriginalSource: String?
-    private var lastLiterals: [LiteralEntry]?
     private var lastJITBuild: JITRenderBuild?
     private var cachedStableModule: (key: [String: Date], module: Compiler.StableModule)?
 
@@ -241,7 +240,6 @@ public actor PreviewSession {
         try Self.writeDesignTimeValues(generated.literals, to: valuesPath)
 
         lastOriginalSource = source
-        lastLiterals = generated.literals
 
         let build = JITRenderBuild(
             objectPath: objectPath,


### PR DESCRIPTION
`PreviewSession.lastLiterals` was assigned in `compileObjectForJIT` but read nowhere (confirmed repo-wide). The literal fast path uses `lastOriginalSource` (structural diff) + the design-time-values JSON at `build.valuesPath` (rewritten by `applyLiteralValuesForJIT`); this field was a leftover from when literal values were held in memory.

Removes the declaration and its single write. PreviewsCore builds, swift-format `--strict` clean, 305 PreviewsCoreTests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)