### PR TITLE
Port CLI ergonomics from early Previews prototype

### DIFF
--- a/Sources/PreviewsCLI/ListCommand.swift
+++ b/Sources/PreviewsCLI/ListCommand.swift
@@ -5,41 +5,124 @@ import PreviewsCore
 struct ListCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "list",
-        abstract: "List #Preview blocks in a Swift source file"
+        abstract: "List #Preview blocks in a Swift source file or directory"
     )
 
-    @Argument(help: "Path to Swift source file")
-    var file: String
+    @Argument(
+        help: "Path to a Swift source file or directory to scan",
+        transform: Path.normalize
+    )
+    var path: String
 
     @Flag(
         name: .long,
-        help: "Emit preview info as a JSON document on stdout"
+        help: "Stream one JSON object per preview (NDJSON) on stdout"
     )
     var json: Bool = false
 
-    mutating func run() throws {
-        let fileURL = Path.normalizeURL(file)
-        let previews = try PreviewParser.parse(fileAt: fileURL)
+    func validate() throws {
+        guard !path.isEmpty else {
+            throw ValidationError("path must not be empty")
+        }
+        guard FileManager.default.fileExists(atPath: path) else {
+            throw ValidationError("path does not exist: \(path)")
+        }
+    }
 
-        if json {
-            let payload = DaemonProtocol.PreviewListResult(
-                file: fileURL.path,
-                previews: previews.map {
-                    DaemonProtocol.PreviewInfoDTO(from: $0, activeIndex: -1)
+    func run() throws {
+        var isDirectory: ObjCBool = false
+        FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+        let files = isDirectory.boolValue ? swiftFiles(in: path) : [path]
+
+        var total = 0
+        var failures = 0
+        for file in files {
+            let previews: [PreviewInfo]
+            do {
+                previews = try PreviewParser.parse(fileAt: URL(fileURLWithPath: file))
+            } catch {
+                warn("warning: skipping \(file): \(error.localizedDescription)")
+                failures += 1
+                continue
+            }
+
+            if json {
+                for preview in previews {
+                    try emitJSONLine(PreviewLine(from: preview, file: file))
                 }
+            } else if isDirectory.boolValue {
+                guard !previews.isEmpty else { continue }
+                print(file)
+                for preview in previews {
+                    print("  " + humanLine(preview))
+                }
+            } else if previews.isEmpty {
+                print("No #Preview blocks found in \(URL(fileURLWithPath: file).lastPathComponent)")
+            } else {
+                for preview in previews {
+                    print(humanLine(preview))
+                }
+            }
+            total += previews.count
+        }
+
+        if isDirectory.boolValue {
+            warn("scanned \(files.count) files, \(failures) failures, \(total) previews")
+        }
+        if failures > 0 {
+            throw ExitCode.failure
+        }
+    }
+}
+
+private struct PreviewLine: Encodable {
+    let file: String
+    let index: Int
+    let name: String?
+    let line: Int
+    let snippet: String
+
+    init(from preview: PreviewInfo, file: String) {
+        self.file = file
+        self.index = preview.index
+        self.name = preview.name
+        self.line = preview.line
+        self.snippet = preview.snippet
+    }
+}
+
+private extension ListCommand {
+    func swiftFiles(in path: String) -> [String] {
+        let url = URL(fileURLWithPath: path)
+        guard
+            let enumerator = FileManager.default.enumerator(
+                at: url,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles]
             )
-            try emitJSON(payload)
-            return
-        }
+        else { return [] }
+        return
+            enumerator
+            .compactMap { $0 as? URL }
+            .filter { $0.pathExtension == "swift" }
+            .map(\.path)
+            .sorted()
+    }
 
-        if previews.isEmpty {
-            print("No #Preview blocks found in \(fileURL.lastPathComponent)")
-            return
-        }
+    func humanLine(_ preview: PreviewInfo) -> String {
+        let name = preview.name ?? "Preview"
+        return "[\(preview.index)] \(name) (line \(preview.line)): \(preview.snippet)"
+    }
 
-        for preview in previews {
-            let name = preview.name ?? "Preview"
-            print("[\(preview.index)] \(name) (line \(preview.line)): \(preview.snippet)")
-        }
+    func emitJSONLine(_ record: PreviewLine) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        var data = try encoder.encode(record)
+        data.append(0x0A)
+        FileHandle.standardOutput.write(data)
+    }
+
+    func warn(_ message: String) {
+        FileHandle.standardError.write(Data((message + "\n").utf8))
     }
 }

--- a/Sources/PreviewsCLI/RunCommand.swift
+++ b/Sources/PreviewsCLI/RunCommand.swift
@@ -18,7 +18,7 @@ struct RunCommand: AsyncParsableCommand {
             """
     )
 
-    @Argument(help: "Path to Swift source file containing #Preview")
+    @Argument(help: "Path to Swift source file containing #Preview", transform: Path.normalize)
     var file: String
 
     @Option(name: .long, help: "Which preview to show (0-based index)")
@@ -33,7 +33,11 @@ struct RunCommand: AsyncParsableCommand {
     @Option(name: .long, help: "Target platform: 'macos' or 'ios' (auto-detected if omitted)")
     var platform: CLIPlatform?
 
-    @Option(name: .long, help: "Project root path (auto-detected if omitted)")
+    @Option(
+        name: .long,
+        help: "Project root path (auto-detected if omitted)",
+        transform: Path.normalize
+    )
     var project: String?
 
     @Option(
@@ -66,7 +70,11 @@ struct RunCommand: AsyncParsableCommand {
     @Flag(name: .long, help: "Hide Simulator.app GUI (iOS only)")
     var headless: Bool = false
 
-    @Option(name: .long, help: "Path to .previewsmcp.json config file (auto-discovered if omitted)")
+    @Option(
+        name: .long,
+        help: "Path to .previewsmcp.json config file (auto-discovered if omitted)",
+        transform: Path.normalize
+    )
     var config: String?
 
     @Flag(
@@ -81,11 +89,13 @@ struct RunCommand: AsyncParsableCommand {
     )
     var json: Bool = false
 
-    mutating func run() async throws {
-        guard FileManager.default.fileExists(atPath: Path.normalize(file)) else {
+    func validate() throws {
+        guard FileManager.default.fileExists(atPath: file) else {
             throw ValidationError("File not found: \(file)")
         }
+    }
 
+    mutating func run() async throws {
         // Local trait validation — fail fast before reaching the daemon.
         do {
             _ = try PreviewTraits.validated(
@@ -180,13 +190,13 @@ struct RunCommand: AsyncParsableCommand {
         // re-normalizes on receipt (idempotent for already-canonical
         // paths) to also cover non-CLI MCP clients.
         var args: [String: Value] = [
-            "filePath": .string(Path.normalize(file)),
+            "filePath": .string(file),
             "previewIndex": .int(preview),
             "width": .int(width),
             "height": .int(height),
         ]
         if let platform { args["platform"] = .string(platform.rawValue) }
-        if let project { args["projectPath"] = .string(Path.normalize(project)) }
+        if let project { args["projectPath"] = .string(project) }
         if let scheme { args["scheme"] = .string(scheme) }
         if let buildSystem { args["buildSystem"] = .string(buildSystem.rawValue) }
         if let device { args["deviceUDID"] = .string(device) }
@@ -195,7 +205,7 @@ struct RunCommand: AsyncParsableCommand {
         if let locale { args["locale"] = .string(locale) }
         if let layoutDirection { args["layoutDirection"] = .string(layoutDirection) }
         if let legibilityWeight { args["legibilityWeight"] = .string(legibilityWeight) }
-        if let config { args["config"] = .string(Path.normalize(config)) }
+        if let config { args["config"] = .string(config) }
         // Always send headless — both the macOS and iOS daemon paths default
         // `extractOptionalBool("headless") ?? true` when the key is absent, so
         // dropping the key on `--headless=false` would silently force a headless

--- a/Sources/PreviewsCLI/SnapshotCommand.swift
+++ b/Sources/PreviewsCLI/SnapshotCommand.swift
@@ -31,7 +31,7 @@ struct SnapshotCommand: AsyncParsableCommand {
             """
     )
 
-    @Argument(help: "Path to Swift source file containing #Preview")
+    @Argument(help: "Path to Swift source file containing #Preview", transform: Path.normalize)
     var file: String?
 
     @Option(name: .shortAndLong, help: "Output image file path (.jpg or .png)")
@@ -61,7 +61,11 @@ struct SnapshotCommand: AsyncParsableCommand {
     @Option(name: .long, help: "Target platform: 'macos' or 'ios' (auto-detected if omitted)")
     var platform: CLIPlatform?
 
-    @Option(name: .long, help: "Project root path (auto-detected if omitted)")
+    @Option(
+        name: .long,
+        help: "Project root path (auto-detected if omitted)",
+        transform: Path.normalize
+    )
     var project: String?
 
     @Option(
@@ -92,7 +96,11 @@ struct SnapshotCommand: AsyncParsableCommand {
     @Option(name: .long, help: "Legibility weight: 'regular' or 'bold'")
     var legibilityWeight: String?
 
-    @Option(name: .long, help: "Path to .previewsmcp.json config file (auto-discovered if omitted)")
+    @Option(
+        name: .long,
+        help: "Path to .previewsmcp.json config file (auto-discovered if omitted)",
+        transform: Path.normalize
+    )
     var config: String?
 
     @Flag(
@@ -122,7 +130,7 @@ struct SnapshotCommand: AsyncParsableCommand {
         }
 
         if let file {
-            guard FileManager.default.fileExists(atPath: Path.normalize(file)) else {
+            guard FileManager.default.fileExists(atPath: file) else {
                 throw ValidationError("File not found: \(file)")
             }
         }
@@ -191,11 +199,11 @@ struct SnapshotCommand: AsyncParsableCommand {
     /// Create an ephemeral session for the target file, capture, tear down.
     /// Trait flags are applied at start.
     private func snapshotEphemeral(file: String, client: Client) async throws {
-        // Normalize locally — used for client-side helpers (config
-        // discovery, platform inference) and sent to the daemon, which
-        // runs in its own process and does not share our CWD. The daemon
-        // re-normalizes on receipt for non-CLI MCP clients.
-        let fileURL = Path.normalizeURL(file)
+        // `file` is canonicalized at the argument boundary. The absolute
+        // path is sent to the daemon, which runs in its own process and
+        // does not share our CWD; the daemon re-normalizes on receipt for
+        // non-CLI MCP clients.
+        let fileURL = URL(fileURLWithPath: file)
         let configResult = loadProjectConfig(explicit: config, fileURL: fileURL)
         let resolvedPlatform = Self.resolvePlatform(
             explicit: platform,
@@ -217,7 +225,7 @@ struct SnapshotCommand: AsyncParsableCommand {
             // root and hang resolving the main package.
             "platform": .string(resolvedPlatform.rawValue),
         ]
-        if let project { startArgs["projectPath"] = .string(Path.normalize(project)) }
+        if let project { startArgs["projectPath"] = .string(project) }
         if let scheme { startArgs["scheme"] = .string(scheme) }
         if let buildSystem { startArgs["buildSystem"] = .string(buildSystem.rawValue) }
         if let device { startArgs["deviceUDID"] = .string(device) }
@@ -226,7 +234,7 @@ struct SnapshotCommand: AsyncParsableCommand {
         if let locale { startArgs["locale"] = .string(locale) }
         if let layoutDirection { startArgs["layoutDirection"] = .string(layoutDirection) }
         if let legibilityWeight { startArgs["legibilityWeight"] = .string(legibilityWeight) }
-        if let config { startArgs["config"] = .string(Path.normalize(config)) }
+        if let config { startArgs["config"] = .string(config) }
 
         let startResponse = try await client.callToolStructured(
             name: "preview_start", arguments: startArgs

--- a/Sources/PreviewsCLI/VariantsCommand.swift
+++ b/Sources/PreviewsCLI/VariantsCommand.swift
@@ -37,7 +37,7 @@ struct VariantsCommand: AsyncParsableCommand {
             """
     )
 
-    @Argument(help: "Path to Swift source file containing #Preview")
+    @Argument(help: "Path to Swift source file containing #Preview", transform: Path.normalize)
     var file: String?
 
     @Option(
@@ -74,7 +74,11 @@ struct VariantsCommand: AsyncParsableCommand {
     @Option(name: .long, help: "Target platform: 'macos' or 'ios' (auto-detected if omitted)")
     var platform: CLIPlatform?
 
-    @Option(name: .long, help: "Project root path (auto-detected if omitted)")
+    @Option(
+        name: .long,
+        help: "Project root path (auto-detected if omitted)",
+        transform: Path.normalize
+    )
     var project: String?
 
     @Option(
@@ -95,7 +99,11 @@ struct VariantsCommand: AsyncParsableCommand {
     )
     var session: String?
 
-    @Option(name: .long, help: "Path to .previewsmcp.json config file (auto-discovered if omitted)")
+    @Option(
+        name: .long,
+        help: "Path to .previewsmcp.json config file (auto-discovered if omitted)",
+        transform: Path.normalize
+    )
     var config: String?
 
     @Flag(
@@ -127,7 +135,7 @@ struct VariantsCommand: AsyncParsableCommand {
             )
         }
         if let file {
-            guard FileManager.default.fileExists(atPath: Path.normalize(file)) else {
+            guard FileManager.default.fileExists(atPath: file) else {
                 throw ValidationError("File not found: \(file)")
             }
         }
@@ -198,11 +206,11 @@ struct VariantsCommand: AsyncParsableCommand {
         outputDir: URL,
         client: Client
     ) async throws -> Int32 {
-        // Normalize locally — used for client-side helpers (config
-        // discovery, platform inference) and sent to the daemon, which
-        // runs in its own process and does not share our CWD. The daemon
-        // re-normalizes on receipt for non-CLI MCP clients.
-        let fileURL = Path.normalizeURL(file)
+        // `file` is canonicalized at the argument boundary. The absolute
+        // path is sent to the daemon, which runs in its own process and
+        // does not share our CWD; the daemon re-normalizes on receipt for
+        // non-CLI MCP clients.
+        let fileURL = URL(fileURLWithPath: file)
         let configResult = loadProjectConfig(explicit: config, fileURL: fileURL)
         let resolvedPlatform = SnapshotCommand.resolvePlatform(
             explicit: platform,
@@ -220,11 +228,11 @@ struct VariantsCommand: AsyncParsableCommand {
             "headless": .bool(true),
             "platform": .string(resolvedPlatform.rawValue),
         ]
-        if let project { startArgs["projectPath"] = .string(Path.normalize(project)) }
+        if let project { startArgs["projectPath"] = .string(project) }
         if let scheme { startArgs["scheme"] = .string(scheme) }
         if let buildSystem { startArgs["buildSystem"] = .string(buildSystem.rawValue) }
         if let device { startArgs["deviceUDID"] = .string(device) }
-        if let config { startArgs["config"] = .string(Path.normalize(config)) }
+        if let config { startArgs["config"] = .string(config) }
 
         let startResponse = try await client.callToolStructured(
             name: "preview_start", arguments: startArgs

--- a/Sources/PreviewsCore/PreviewParser.swift
+++ b/Sources/PreviewsCore/PreviewParser.swift
@@ -116,11 +116,31 @@ private final class PreviewVisitor: SyntaxVisitor {
     // MARK: - PreviewProvider support
 
     override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        visitPreviewProvider(node)
+    }
+
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        visitPreviewProvider(node)
+    }
+
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+        visitPreviewProvider(node)
+    }
+
+    override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+        visitPreviewProvider(node)
+    }
+
+    override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+        visitPreviewProvider(node)
+    }
+
+    private func visitPreviewProvider(_ node: some DeclGroupSyntax) -> SyntaxVisitorContinueKind {
         guard conformsToPreviewProvider(node) else {
-            return .skipChildren
+            return .visitChildren
         }
         guard let body = findPreviewsBody(in: node) else {
-            return .skipChildren
+            return .visitChildren
         }
 
         // Collect static computed properties for cross-property reference resolution
@@ -293,7 +313,7 @@ private final class PreviewVisitor: SyntaxVisitor {
 
     /// Collect all static computed properties (other than `previews`) from the struct.
     /// Returns a dictionary of property name → body source text.
-    private func collectStaticProperties(in node: StructDeclSyntax) -> [String: String] {
+    private func collectStaticProperties(in node: some DeclGroupSyntax) -> [String: String] {
         var props: [String: String] = [:]
         for member in node.memberBlock.members {
             guard let varDecl = member.decl.as(VariableDeclSyntax.self),
@@ -323,16 +343,16 @@ private final class PreviewVisitor: SyntaxVisitor {
     }
 
     /// Check if struct has `PreviewProvider` in its inheritance clause.
-    private func conformsToPreviewProvider(_ node: StructDeclSyntax) -> Bool {
+    private func conformsToPreviewProvider(_ node: some DeclGroupSyntax) -> Bool {
         guard let inheritanceClause = node.inheritanceClause else { return false }
         return inheritanceClause.inheritedTypes.contains { inherited in
-            let name = inherited.type.description.trimmed
+            let name = inherited.type.trimmedDescription
             return name == "PreviewProvider" || name == "SwiftUI.PreviewProvider"
         }
     }
 
     /// Find `static var previews: some View { ... }` and return its code block.
-    private func findPreviewsBody(in node: StructDeclSyntax) -> CodeBlockItemListSyntax? {
+    private func findPreviewsBody(in node: some DeclGroupSyntax) -> CodeBlockItemListSyntax? {
         for member in node.memberBlock.members {
             guard let varDecl = member.decl.as(VariableDeclSyntax.self),
                 varDecl.modifiers.contains(where: { $0.name.text == "static" }),

--- a/Tests/CLIIntegrationTests/ListCommandTests.swift
+++ b/Tests/CLIIntegrationTests/ListCommandTests.swift
@@ -50,7 +50,7 @@ struct ListCommandTests {
         #expect(result.exitCode != 0)
     }
 
-    @Test("--json emits a JSON document with file and previews array")
+    @Test("--json emits one self-contained JSON object per preview (NDJSON)")
     func listJSON() async throws {
         let file = CLIRunner.spmExampleRoot
             .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
@@ -58,20 +58,66 @@ struct ListCommandTests {
         let result = try await CLIRunner.run("list", arguments: [file, "--json"])
 
         #expect(result.exitCode == 0, "stderr: \(result.stderr)")
-        let stdout = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let data = stdout.data(using: .utf8) else {
-            Issue.record("stdout was not UTF-8")
-            return
+        let lines = ndjsonLines(result.stdout)
+        #expect(lines.count == 2, "ToDoView has 2 previews, one NDJSON line each")
+
+        var indices: [Int] = []
+        for line in lines {
+            let obj = try #require(
+                try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any],
+                "each line must be a standalone JSON object: \(line)"
+            )
+            #expect((obj["file"] as? String)?.hasSuffix("ToDoView.swift") == true)
+            indices.append(try #require(obj["index"] as? Int))
+            #expect(obj["line"] is Int)
         }
-        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        #expect(parsed != nil, "stdout should be a JSON object")
-        #expect(
-            (parsed?["file"] as? String)?.hasSuffix("ToDoView.swift") == true,
-            "should contain 'file' field"
-        )
-        let previews = parsed?["previews"] as? [[String: Any]]
-        #expect(previews != nil, "should contain 'previews' array")
-        #expect(previews?.count == 2, "ToDoView has 2 previews")
-        #expect(previews?.first?["index"] as? Int == 0, "first preview index should be 0")
+        #expect(indices.sorted() == [0, 1], "per-file indices start at 0")
     }
+
+    @Test("Scans a directory recursively for previews")
+    func listDirectory() async throws {
+        let dir = CLIRunner.spmExampleRoot.appendingPathComponent("Sources/ToDo").path
+
+        let result = try await CLIRunner.run("list", arguments: [dir])
+
+        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+        #expect(result.stdout.contains("ToDoView.swift"))
+        #expect(result.stdout.contains("UIKitPreview.swift"))
+        #expect(result.stdout.contains("Empty State"))
+        #expect(result.stderr.contains("previews"), "summary goes to stderr")
+    }
+
+    @Test("--json over a directory streams NDJSON aggregated across files")
+    func listDirectoryJSON() async throws {
+        let dir = CLIRunner.spmExampleRoot.appendingPathComponent("Sources/ToDo").path
+
+        let result = try await CLIRunner.run("list", arguments: [dir, "--json"])
+
+        #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+        let lines = ndjsonLines(result.stdout)
+        #expect(lines.count >= 5, "the ToDo dir aggregates previews from several files")
+
+        var files: Set<String> = []
+        for line in lines {
+            let obj = try #require(
+                try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any],
+                "each line must be a standalone JSON object: \(line)"
+            )
+            let file = try #require(obj["file"] as? String)
+            #expect(file.hasSuffix(".swift"))
+            files.insert(file)
+        }
+        #expect(files.count >= 2, "should aggregate across multiple files")
+        #expect(
+            !files.contains { $0.hasSuffix("Item.swift") },
+            "files with no previews emit no NDJSON lines"
+        )
+    }
+}
+
+private func ndjsonLines(_ stdout: String) -> [String] {
+    stdout
+        .split(separator: "\n")
+        .map { $0.trimmingCharacters(in: .whitespaces) }
+        .filter { !$0.isEmpty }
 }

--- a/Tests/PreviewsCLITests/PathNormalizationTests.swift
+++ b/Tests/PreviewsCLITests/PathNormalizationTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+
+@testable import PreviewsCLI
+
+@Suite("CLI path normalization at the argument boundary")
+struct PathNormalizationTests {
+
+    private static let home = FileManager.default.homeDirectoryForCurrentUser.path
+
+    private static let repoRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+
+    private static let existingFile =
+        repoRoot
+        .appendingPathComponent("examples/spm/Sources/ToDo/ToDoView.swift").path
+
+    @Test("run expands tilde in project and config and resolves the file")
+    func runNormalizesPaths() throws {
+        let cmd = try RunCommand.parse([
+            Self.existingFile, "--project", "~/proj", "--config", "~/c.json",
+        ])
+        #expect(cmd.file.hasPrefix("/"))
+        #expect(cmd.file.hasSuffix("examples/spm/Sources/ToDo/ToDoView.swift"))
+        #expect(cmd.project == "\(Self.home)/proj")
+        #expect(cmd.config == "\(Self.home)/c.json")
+    }
+
+    @Test("snapshot expands tilde in file, project, and config")
+    func snapshotNormalizesPaths() throws {
+        let cmd = try SnapshotCommand.parse([
+            "~/a.swift", "--project", "~/proj", "--config", "~/c.json",
+        ])
+        #expect(cmd.file == "\(Self.home)/a.swift")
+        #expect(cmd.project == "\(Self.home)/proj")
+        #expect(cmd.config == "\(Self.home)/c.json")
+    }
+
+    @Test("variants expands tilde in file, project, and config")
+    func variantsNormalizesPaths() throws {
+        let cmd = try VariantsCommand.parse([
+            "~/a.swift", "--variant", "dark", "--project", "~/proj", "--config", "~/c.json",
+        ])
+        #expect(cmd.file == "\(Self.home)/a.swift")
+        #expect(cmd.project == "\(Self.home)/proj")
+        #expect(cmd.config == "\(Self.home)/c.json")
+    }
+}

--- a/Tests/PreviewsCoreTests/PreviewParserTests.swift
+++ b/Tests/PreviewsCoreTests/PreviewParserTests.swift
@@ -601,4 +601,42 @@ struct PreviewParserTests {
         #expect(secondParse.count == 1)
         #expect(secondParse[0].closureBody.contains("MyView()"))
     }
+
+    @Test("PreviewProvider conformance on an extension is detected")
+    func previewProviderOnExtension() {
+        let source = """
+            import SwiftUI
+
+            struct MyView: View {
+                var body: some View { Text("Hello") }
+            }
+
+            extension MyView_Previews: PreviewProvider {
+                static var previews: some View {
+                    MyView()
+                }
+            }
+            """
+
+        let previews = PreviewParser.parse(source: source)
+        #expect(previews.count == 1)
+        #expect(previews[0].closureBody.contains("MyView()"))
+    }
+
+    @Test("PreviewProvider conformance on a class is detected")
+    func previewProviderOnClass() {
+        let source = """
+            import SwiftUI
+
+            final class MyView_Previews: PreviewProvider {
+                static var previews: some View {
+                    MyView()
+                }
+            }
+            """
+
+        let previews = PreviewParser.parse(source: source)
+        #expect(previews.count == 1)
+        #expect(previews[0].closureBody.contains("MyView()"))
+    }
 }


### PR DESCRIPTION
Reviews an early `Previews` rewrite and ports its better CLI and path ideas into our CLI. None of the prototype's project-specific bits were ported (its `open` command and config conventions stayed out).

## What changed

1. **`list` streams NDJSON and scans directories** (`4db2dfa`)
   - `list` now accepts a directory and scans `.swift` files recursively.
   - `--json` streams NDJSON, one self-contained record per preview, so large directory scans are consumable iteratively instead of waiting for one document at the end.
   - Path is normalized at the ArgumentParser boundary; emptiness and existence move into `validate()`.
   - Per-file warnings and the scan summary go to stderr, keeping stdout a clean data stream.
   - The MCP `PreviewListResult` contract is unchanged; only the standalone CLI `list --json` output shape changed.

2. **Parser detects `PreviewProvider` on more decl kinds** (`6d5f9ea`)
   - Generalize provider detection from struct-only to any `DeclGroupSyntax`, so a provider declared as a class, enum, actor, or extension is found.
   - Non-providers now return `.visitChildren`, so a `#Preview` nested inside a non-provider type is also discovered.
   - Swap the custom `.description.trimmed` for SwiftSyntax's `trimmedDescription`.

3. **Path normalization at the argument boundary** (`62555cc`)
   - Apply `transform: Path.normalize` to the file, project, and config inputs of `run`, `snapshot`, and `variants`, dropping the redundant `Path.normalize(...)` calls scattered through each command.
   - Move `run`'s file-existence check into `validate()`.
   - `outputDir` (variants) and `output` (snapshot) keep use-site normalization, since both have a default that `transform` does not run on.

## Verification

- `PreviewParser` suite: 27 tests pass, including new `extension` and `class` provider cases.
- `list` CLI suite: 7 tests pass, including NDJSON and directory cases.
- New fast unit tests parse `run`/`snapshot`/`variants` with `~`-prefixed paths and assert the stored values are tilde-expanded.
- `run --detach` macOS integration test passes, so the normalization refactor is behavior-preserving.
- `swift-format lint --strict` clean on all touched files.

Not run: the heavier iOS `variants`/`snapshot` integration suites (need a simulator); covered by the unit tests plus the shared identical pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)