### PR TITLE
Regenerate stale ListTools schema snapshot (#243)

### DIFF
--- a/Tests/PreviewsCLITests/list_tools_snapshot.json
+++ b/Tests/PreviewsCLITests/list_tools_snapshot.json
@@ -19,6 +19,15 @@
     "description" : "Compile and launch a live SwiftUI preview. Returns a session ID. Supports macOS (default) and iOS simulator.",
     "inputSchema" : {
       "properties" : {
+        "buildSystem" : {
+          "description" : "Force the build system instead of auto-detecting by project markers (spm, bazel, xcode). Useful when a project matches more than one, e.g. a rules_xcodeproj workspace that has both MODULE.bazel and a generated .xcodeproj.",
+          "enum" : [
+            "spm",
+            "bazel",
+            "xcode"
+          ],
+          "type" : "string"
+        },
         "colorScheme" : {
           "description" : "Color scheme override: 'light' or 'dark'",
           "enum" : [


### PR DESCRIPTION
## Summary
`ListToolsSnapshotTests` has been red on `main` since #239, which added a `buildSystem` enum parameter to `preview_start` without re-blessing the schema fixture. This regenerates `Tests/PreviewsCLITests/list_tools_snapshot.json` via the test's documented bless path.

The only delta is a 9-line `buildSystem` property (`enum: [spm, bazel, xcode]`) on `preview_start`. The tool list is unchanged — confirmed with a structural `jq` diff of the old vs regenerated fixture.

## Verification
- `swift test --filter ListToolsSnapshotTests` now passes (was failing on `main`).
- Fixture-only change, no source code touched, so no broader suite run is needed.

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)