### PR TITLE
iOS: surface in-app JIT executor failures to the daemon (#217)

### DIFF
--- a/Sources/PreviewsIOS/IOSHostChannel.swift
+++ b/Sources/PreviewsIOS/IOSHostChannel.swift
@@ -2,6 +2,15 @@ import Darwin
 import Foundation
 import PreviewsCore
 
+/// An in-app JIT executor failure the host reported over its `jitError`
+/// breadcrumb. `stage` is `connect` (the EPC socket never connected) or
+/// `executor` (the ORC server failed to start after connecting); `code` is the
+/// host-side return value when one is available.
+public struct IOSHostJITError: Sendable, Equatable {
+    public let stage: String
+    public let code: Int?
+}
+
 /// TCP loopback transport between `IOSPreviewSession` and the iOS host
 /// app. Owns all socket state (listen FD, connected FD, read source,
 /// pending response continuations) and the line-delimited JSON protocol
@@ -46,6 +55,14 @@ public actor IOSHostChannel {
     /// a shell-hosted agent must never report `active`.
     private var latestApplicationStateValue: String?
     public var latestApplicationState: String? { latestApplicationStateValue }
+
+    /// Last in-app JIT executor failure the host reported over its `jitError`
+    /// message. Set when `connectLoopback`/`previewsmcp_ios_executor_start` fail
+    /// inside the agent — a host-side fault the daemon would otherwise see only
+    /// as a generic `acceptJIT` timeout or a confusing downstream link error.
+    /// Sticky across disconnect so the start flow can enrich its thrown error.
+    private var latestJITErrorValue: IOSHostJITError?
+    public var latestJITError: IOSHostJITError? { latestJITErrorValue }
 
     public init() {}
 
@@ -336,6 +353,14 @@ public actor IOSHostChannel {
             // Unsolicited lifecycle breadcrumb (no id) — record and move on.
             if message["type"] as? String == "lifecycle", let state = message["state"] as? String {
                 latestApplicationStateValue = state
+                continue
+            }
+
+            // Unsolicited in-app JIT failure breadcrumb (no id) — record and move on.
+            if message["type"] as? String == "jitError" {
+                latestJITErrorValue = IOSHostJITError(
+                    stage: message["stage"] as? String ?? "unknown",
+                    code: message["code"] as? Int)
                 continue
             }
 

--- a/Sources/PreviewsIOS/IOSPreviewSession.swift
+++ b/Sources/PreviewsIOS/IOSPreviewSession.swift
@@ -275,22 +275,26 @@ public actor IOSPreviewSession {
         // accept is ordered after the JSON connect but either may arrive first
         // (the listen backlog holds the other).
         stage("awaiting JIT executor connection")
-        let epcFD = try acceptJIT(timeoutSeconds: 10)
-        let reloader = try makeJITReloader(epcFD, orcPath)
-        jitReloader = reloader
-        stage("JIT executor connected; compiling initial preview")
-        let build = try await previewSession.compileObjectForJIT()
+        do {
+            let epcFD = try acceptJIT(timeoutSeconds: 10)
+            let reloader = try makeJITReloader(epcFD, orcPath)
+            jitReloader = reloader
+            stage("JIT executor connected; compiling initial preview")
+            let build = try await previewSession.compileObjectForJIT()
 
-        // The render entry installs the SwiftUI hosting controller into the
-        // agent's key window, which only exists once the shell completes the
-        // hosting handshake and the agent's scene connects. Wait for the agent's
-        // sceneReady signal so the render targets a real window deterministically.
-        // The agent is a SwiftUI App; the render hands its controller to a store
-        // the WindowGroup observes, so the render can run before the hosted
-        // scene attaches (the store buffers it until SwiftUI's window is up).
-        stage("rendering initial preview")
-        try await reloader.render(build)
-        stage("initial JIT render complete")
+            // The render entry installs the SwiftUI hosting controller into the
+            // agent's key window, which only exists once the shell completes the
+            // hosting handshake and the agent's scene connects. Wait for the agent's
+            // sceneReady signal so the render targets a real window deterministically.
+            // The agent is a SwiftUI App; the render hands its controller to a store
+            // the WindowGroup observes, so the render can run before the hosted
+            // scene attaches (the store buffers it until SwiftUI's window is up).
+            stage("rendering initial preview")
+            try await reloader.render(build)
+            stage("initial JIT render complete")
+        } catch {
+            throw await enrichedJITFailure(error)
+        }
 
         stage("connected; start complete")
 
@@ -367,6 +371,18 @@ public actor IOSPreviewSession {
             throw IOSPreviewSessionError.socketAcceptFailed
         }
         return conn
+    }
+
+    /// If the host reported an in-app JIT failure over the JSON channel, return
+    /// that as the error so the caller sees the host-side cause instead of a
+    /// generic accept timeout or downstream link error; otherwise pass `fallback`
+    /// through unchanged. See issue #217.
+    private func enrichedJITFailure(_ fallback: Error) async -> Error {
+        if let jitError = await channel.latestJITError {
+            return IOSPreviewSessionError.jitExecutorFailed(
+                stage: jitError.stage, code: jitError.code)
+        }
+        return fallback
     }
 
     /// Build a fresh `PreviewSession` for the current source, index, and traits.
@@ -506,14 +522,18 @@ public actor IOSPreviewSession {
         // (its agent-UDS EOFs), holds its cached frame + spinner, then reconnects
         // to the same stable sock path the new agent rebinds and re-hosts. No
         // shell relaunch, so the device display never blanks.
-        let epcFD = try acceptJIT(timeoutSeconds: 10)
-        let reloader = try makeJITReloader(epcFD, orcPath)
-        self.jitReloader = reloader
+        do {
+            let epcFD = try acceptJIT(timeoutSeconds: 10)
+            let reloader = try makeJITReloader(epcFD, orcPath)
+            self.jitReloader = reloader
 
-        let previewSession = makePreviewSession()
-        self.session = previewSession
-        let build = try await previewSession.compileObjectForJIT()
-        try await reloader.render(build)
+            let previewSession = makePreviewSession()
+            self.session = previewSession
+            let build = try await previewSession.compileObjectForJIT()
+            try await reloader.render(build)
+        } catch {
+            throw await enrichedJITFailure(error)
+        }
         baselineRSS = nil
         relaunchCount += 1
         return pid
@@ -682,6 +702,11 @@ public enum IOSPreviewSessionError: Error, LocalizedError, CustomStringConvertib
     /// from `socketResponseTimeout` so callers and operators can tell
     /// "host app didn't respond" from "host app responded with garbage."
     case responseDecodeFailed(operation: String)
+    /// The in-app ORC executor reported a failure over the JSON channel
+    /// (`connect` = EPC socket never connected; `executor` = ORC server failed
+    /// to start). Replaces the generic accept timeout / downstream link error
+    /// with the host-side cause. See issue #217.
+    case jitExecutorFailed(stage: String, code: Int?)
 
     public var description: String {
         switch self {
@@ -694,6 +719,9 @@ public enum IOSPreviewSessionError: Error, LocalizedError, CustomStringConvertib
         case .connectionLost: return "Connection to host app lost"
         case .responseDecodeFailed(let operation):
             return "Failed to decode host app response (operation: \(operation))"
+        case .jitExecutorFailed(let stage, let code):
+            let suffix = code.map { " (code \($0))" } ?? ""
+            return "In-app JIT executor failed during \(stage)\(suffix)"
         }
     }
 

--- a/Tests/PreviewsIOSTests/IOSHostBuilderHashTests.swift
+++ b/Tests/PreviewsIOSTests/IOSHostBuilderHashTests.swift
@@ -59,7 +59,9 @@ struct IOSHostBuilderHashTests {
         // Updated 2026-06-21 for agent->shell redirect: HostApp.swift bounces a
         // direct foreground to the shell via the private LSApplicationWorkspace
         // (silent), gated so the hosted-launch transient .active does not bounce.
-        let expected = "89bc57661ae627bacf9c1b94247cd53999efc53adc8f3318be25045372d42ef8"
+        // Updated 2026-06-21 for #217: HostApp.swift reports an in-app JIT executor
+        // failure (connect/executor) to the daemon over the JSON channel.
+        let expected = "b76d69511202dabeb5f22ce52b1cd2d2e929d31b455c255f23b118011377d403"
         #expect(hash == expected, "host-app artifact hash drifted (was \(expected), now \(hash))")
     }
 }

--- a/Tests/PreviewsIOSTests/IOSHostChannelTests.swift
+++ b/Tests/PreviewsIOSTests/IOSHostChannelTests.swift
@@ -92,6 +92,30 @@ struct IOSHostChannelTests {
         #expect(elapsed < 2.0, "pending continuation should be failed by disconnect well before the 10s timeout")
     }
 
+    @Test("jitError breadcrumb from the host is recorded")
+    func recordsJITError() async throws {
+        let channel = IOSHostChannel()
+        defer { Task { await channel.close() } }
+
+        let port = try await channel.bindAndListen()
+        async let connect: Void = channel.awaitConnect(timeout: .seconds(5))
+        let clientFD = try connectClient(port: port)
+        try await connect
+
+        let line = #"{"type":"jitError","stage":"connect","code":-1}"# + "\n"
+        _ = line.withCString { Darwin.write(clientFD, $0, strlen($0)) }
+
+        let deadline = Date().addingTimeInterval(2.0)
+        while Date() < deadline, await channel.latestJITError == nil {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        let recorded = await channel.latestJITError
+        #expect(recorded?.stage == "connect")
+        #expect(recorded?.code == -1)
+
+        Darwin.close(clientFD)
+    }
+
     @Test("close() is idempotent after a successful connect")
     func closeIsIdempotent() async throws {
         let channel = IOSHostChannel()

--- a/ios-host/app/HostApp.swift
+++ b/ios-host/app/HostApp.swift
@@ -171,14 +171,44 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
     // block on the socket while the UIApplication run loop stays live on main
     // (run_on_main dispatches to it).
     private func startJITExecutor(port: UInt16) {
-        Thread.detachNewThread {
+        Thread.detachNewThread { [weak self] in
             let fd = Self.connectLoopback(port: port)
             guard fd >= 0 else {
                 NSLog("PreviewHost: JIT executor failed to connect on port \(port)")
+                self?.reportJITError(stage: "connect", code: -1)
                 return
             }
-            _ = previewsmcp_ios_executor_start(fd, fd)
+            let rc = previewsmcp_ios_executor_start(fd, fd)
+            // rc == 1 is an ORC server setup failure (the fd connected but the
+            // executor never came up). rc == 2 / 0 fire on disconnect during
+            // normal teardown, so reporting them would be a false positive.
+            if rc == 1 {
+                NSLog("PreviewHost: JIT executor setup failed (rc=\(rc))")
+                self?.reportJITError(stage: "executor", code: rc)
+            }
         }
+    }
+
+    // Report an in-app JIT failure to the daemon over the JSON channel. The
+    // executor thread can fail before `connectToServer` binds the socket, so
+    // stash the breadcrumb and flush it once the channel is up.
+    private var pendingJITError: [String: Any]?
+
+    private func reportJITError(stage: String, code: Int32) {
+        DispatchQueue.main.async {
+            let msg: [String: Any] = ["type": "jitError", "stage": stage, "code": Int(code)]
+            if self.socketFD >= 0 {
+                self.sendResponse(msg)
+            } else {
+                self.pendingJITError = msg
+            }
+        }
+    }
+
+    private func flushPendingJITError() {
+        guard let pending = pendingJITError else { return }
+        pendingJITError = nil
+        sendResponse(pending)
     }
 
     private static func connectLoopback(port: UInt16) -> Int32 {
@@ -234,6 +264,7 @@ class PreviewHostAppDelegate: UIResponder, UIApplicationDelegate {
         NSLog("PreviewHost: Connected to server on port \(port)")
         startReadLoop()
         startMemoryReporting()
+        flushPendingJITError()
     }
 
     // MARK: - Hosted-scene handshake socket


### PR DESCRIPTION
## Summary
When the in-app ORC executor failed to connect back to the daemon's EPC listener, the only signal was an `NSLog` line on the device. The daemon saw a generic 10s `acceptJIT` timeout, and a post-connect executor setup failure surfaced later as a confusing downstream link error.

This adds a structured `jitError` breadcrumb over the existing JSON channel (the same channel that already carries `memory` / `lifecycle`), and surfaces it daemon-side.

## Design
Chose the **structured JSON signal** over an on-device error view. Under shell-owns-agent the shell composites the display, so the agent's own window is not reliably on screen, and the shell already owns overlay escalation. Pushing the failure out as data is the right layering.

- **Agent (`HostApp.swift`):** sends `{"type":"jitError","stage":...,"code":...}`. `stage:"connect"` when `connectLoopback` fails; `stage:"executor"` when `previewsmcp_ios_executor_start` returns `1` (ORC setup failed after the fd connected). Returns `2`/`0` fire on normal teardown disconnect, so they are deliberately **not** reported. The executor thread can fail before the JSON socket binds, so the breadcrumb is stashed and flushed once `connectToServer` succeeds.
- **Daemon (`IOSHostChannel`):** records the latest `jitError` (new `IOSHostJITError`), mirroring the existing `latestRSS` / `latestApplicationState` pattern.
- **Daemon (`IOSPreviewSession`):** the `start()` and `_relaunch()` JIT critical sections wrap accept+link+render in a catch that rethrows as `IOSPreviewSessionError.jitExecutorFailed(stage:code:)` when a host breadcrumb is present. The enrichment only substitutes when a breadcrumb exists, so unrelated render errors pass through unchanged.

## Verification
- New `IOSHostChannelTests.recordsJITError` (deterministic, no simulator) plus the existing channel race tests pass.
- Host-app hash test re-pinned (`HostApp.swift` is embedded source).
- `swift build` green; `HostApp.swift` syntax-parsed against the iphonesimulator SDK (it compiles on-device, not under `swift build`).
- The full sim-driving E2E was not run: it needs a simulator and would collide with active streaming work on the dev sim. The on-device send path is exercised only at runtime, so a manual bad-`--jit-port` check is a reasonable follow-up.

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)