### PR TITLE
serve.log: bounded ring rotation for the daemon (#148)

### DIFF
--- a/Sources/PreviewsCLI/ServeCommand.swift
+++ b/Sources/PreviewsCLI/ServeCommand.swift
@@ -136,6 +136,7 @@ struct ServeCommand: ParsableCommand {
                 let host = Self.sharedHost!
                 _ = try await DaemonListener.start(host: host)
                 try DaemonLifecycle.register()
+                startLogRotation()
                 let startISO = ISO8601DateFormatter().string(from: ProcessStartup.time)
                 Log.info(
                     "daemon ready (pid \(ProcessInfo.processInfo.processIdentifier), started \(startISO))"
@@ -153,6 +154,25 @@ struct ServeCommand: ParsableCommand {
                 Log.error("daemon startup failed: \(error)")
                 DaemonLifecycle.unregister()
                 Darwin.exit(1)
+            }
+        }
+    }
+
+    /// Cap `serve.log` for the life of this daemon process. Daemon-only: stdio
+    /// mode never calls this, so fd 2 there (the parent's pipe) is untouched.
+    /// One rotator per process — never start this on the per-connection path or
+    /// concurrent cascades would corrupt the ring. The first check runs before
+    /// the first sleep so a large inherited log rotates promptly. Nothing
+    /// cancels the task; the `!Task.isCancelled` guard is a clean-stop
+    /// courtesy, and otherwise it ends when the process exits.
+    private func startLogRotation() {
+        let logFile = DaemonPaths.logFile
+        Task.detached {
+            while !Task.isCancelled {
+                LogRotation.rotateIfNeeded(
+                    logURL: logFile, fd: STDERR_FILENO,
+                    maxBytes: 5 * 1024 * 1024, keep: 3)
+                try? await Task.sleep(for: .seconds(60))
             }
         }
     }

--- a/Sources/PreviewsCore/LogRotation.swift
+++ b/Sources/PreviewsCore/LogRotation.swift
@@ -1,0 +1,62 @@
+import Darwin
+import Foundation
+
+/// Bounded ring rotation for the daemon's `serve.log`.
+///
+/// The daemon writes every diagnostic line to fd 2 (`Log`, `fputs(_, stderr)`,
+/// `write(STDERR_FILENO, …)`). Rotating at the file-descriptor level — rename
+/// the current log out of the way, open a fresh file, `dup2` it onto the live
+/// fd — transparently redirects all of those writers with no call-site change.
+///
+/// The ring keeps `serve.log` plus `serve.log.1 … serve.log.<keep>`. On each
+/// rotation the oldest is dropped and the rest shift up, so both the file count
+/// (`keep + 1`) and total disk (~`(keep + 1) * maxBytes`) stay bounded while
+/// the `.1 = newest history` convention `previewsmcp logs` relies on is kept.
+public enum LogRotation {
+
+    /// Rotate `logURL` if the file behind `fd` has reached `maxBytes`.
+    ///
+    /// Returns `true` when a rotation happened. Returns `false` (and does
+    /// nothing) when `fd` is not a regular file, is under the threshold, or the
+    /// reopen fails — in the failure case the live log is rolled back so `fd`
+    /// keeps writing to the path the reader tails.
+    @discardableResult
+    public static func rotateIfNeeded(
+        logURL: URL, fd: Int32, maxBytes: Int, keep: Int
+    ) -> Bool {
+        var st = stat()
+        guard fstat(fd, &st) == 0 else { return false }
+        // `S_ISREG` is a C function-like macro and is not imported into Swift,
+        // so compare the constants directly.
+        guard (st.st_mode & mode_t(S_IFMT)) == mode_t(S_IFREG) else { return false }
+        guard st.st_size >= off_t(maxBytes) else { return false }
+
+        let path = logURL.path
+        func ring(_ k: Int) -> String { "\(path).\(k)" }
+
+        // Cascade oldest-first so each destination slot is vacated before it is
+        // written, never clobbering a file we mean to keep.
+        unlink(ring(keep))
+        for k in stride(from: keep - 1, through: 1, by: -1) {
+            rename(ring(k), ring(k + 1))
+        }
+        // Never reach the truncating open below unless the live log was first
+        // moved aside — otherwise a failed move would let O_TRUNC wipe it.
+        guard rename(path, ring(1)) == 0 else { return false }
+
+        let newfd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0o600)
+        guard newfd >= 0 else {
+            rename(ring(1), path)
+            return false
+        }
+        if newfd != fd {
+            guard dup2(newfd, fd) >= 0 else {
+                close(newfd)
+                rename(ring(1), path)
+                return false
+            }
+            close(newfd)
+        }
+        return true
+    }
+}

--- a/Tests/PreviewsCoreTests/LogRotationTests.swift
+++ b/Tests/PreviewsCoreTests/LogRotationTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Testing
+
+@testable import PreviewsCore
+
+/// Each test opens its own private fd to a temp `serve.log` and passes that fd
+/// to `rotateIfNeeded`, so the `dup2` inside rotation only retargets the test's
+/// fd — never the process-global fd 2 that `LogTests.captureStderr` must
+/// serialize around. That keeps this suite parallel-safe.
+@Suite("LogRotation")
+struct LogRotationTests {
+
+    private func tempDir() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("logrot-\(UUID().uuidString)", isDirectory: true)
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func read(_ url: URL) -> String? {
+        try? String(contentsOf: url, encoding: .utf8)
+    }
+
+    @Test("under threshold is a no-op")
+    func underThreshold() {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let log = dir.appendingPathComponent("serve.log")
+        try! Data("small".utf8).write(to: log)
+        let fd = open(log.path, O_WRONLY)
+        defer { close(fd) }
+
+        let rotated = LogRotation.rotateIfNeeded(
+            logURL: log, fd: fd, maxBytes: 1024, keep: 3)
+
+        #expect(rotated == false)
+        #expect(!FileManager.default.fileExists(atPath: dir.appendingPathComponent("serve.log.1").path))
+    }
+
+    @Test("rotates and reopens over threshold")
+    func rotateReopen() {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let log = dir.appendingPathComponent("serve.log")
+        let dot1 = dir.appendingPathComponent("serve.log.1")
+        let old = String(repeating: "x", count: 2048)
+        try! Data(old.utf8).write(to: log)
+        let fd = open(log.path, O_WRONLY)
+        defer { close(fd) }
+
+        let rotated = LogRotation.rotateIfNeeded(
+            logURL: log, fd: fd, maxBytes: 1024, keep: 3)
+
+        #expect(rotated)
+        #expect(read(dot1) == old)
+        #expect(read(log) == "")
+
+        let msg = "new line\n"
+        let n = msg.withCString { write(fd, $0, strlen($0)) }
+        #expect(n == msg.utf8.count)
+        #expect(read(log) == msg)
+        #expect(read(dot1) == old)
+    }
+
+    @Test("ring caps and drops the oldest")
+    func ringCap() {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        func f(_ name: String) -> URL { dir.appendingPathComponent(name) }
+        let log = f("serve.log")
+        try! Data("C".utf8).write(to: f("serve.log.3"))
+        try! Data("B".utf8).write(to: f("serve.log.2"))
+        try! Data("A".utf8).write(to: f("serve.log.1"))
+        try! Data(String(repeating: "D", count: 2048).utf8).write(to: log)
+        let fd = open(log.path, O_WRONLY)
+        defer { close(fd) }
+
+        let rotated = LogRotation.rotateIfNeeded(
+            logURL: log, fd: fd, maxBytes: 1024, keep: 3)
+
+        #expect(rotated)
+        #expect(read(f("serve.log.1")) == String(repeating: "D", count: 2048))
+        #expect(read(f("serve.log.2")) == "A")
+        #expect(read(f("serve.log.3")) == "B")
+        #expect(!FileManager.default.fileExists(atPath: f("serve.log.4").path))
+    }
+
+    @Test("filesystem failure rolls back without losing the live log")
+    func failureRollback() {
+        let dir = tempDir()
+        let log = dir.appendingPathComponent("serve.log")
+        let payload = String(repeating: "D", count: 2048)
+        try! Data(payload.utf8).write(to: log)
+        let fd = open(log.path, O_WRONLY)
+        defer {
+            close(fd)
+            chmod(dir.path, 0o700)
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        // Strip the inherited ACL that macOS temp dirs carry (mode bits alone
+        // don't restrict access otherwise), then drop write so the rename of
+        // the live log fails. Rotation must bail without touching `serve.log`.
+        stripACL(dir)
+        chmod(dir.path, 0o500)
+        let rotated = LogRotation.rotateIfNeeded(
+            logURL: log, fd: fd, maxBytes: 1024, keep: 3)
+
+        #expect(rotated == false)
+        let survived =
+            read(log) == payload
+            || read(dir.appendingPathComponent("serve.log.1")) == payload
+        #expect(survived)
+        let n = "x".withCString { write(fd, $0, 1) }
+        #expect(n == 1)
+    }
+
+    private func stripACL(_ url: URL) {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/bin/chmod")
+        p.arguments = ["-N", url.path]
+        try? p.run()
+        p.waitUntilExit()
+    }
+}


### PR DESCRIPTION
## Summary

The daemon redirected stderr to `~/.previewsmcp/serve.log` and appended forever, with no rotation or size cap (#148). This adds a JetBrains-style bounded ring: `serve.log` plus `serve.log.1..N`, oldest dropped, so both file count and total disk stay bounded (~`(keep+1) * threshold`).

- `LogRotation.rotateIfNeeded` (new, in `PreviewsCore`) `fstat`s the live fd and, over threshold, runs an oldest-first rename cascade then reopens a fresh `serve.log` and `dup2`s it onto the fd. This transparently redirects every stderr writer (`Log`, `fputs(stderr)`, `write(STDERR_FILENO)`).
- A failed rename or reopen rolls back so the live log is never stranded or truncated.
- A single daemon-only timer in `runDaemon` drives it (5 MB threshold, keep 3, 60s check). Stdio mode is untouched.

## Verification

New `LogRotationTests` (4 cases, swift-testing): no-op under threshold, rotate+reopen, ring cap drops oldest, filesystem-failure rollback with no data loss. `swift build`, `swift test --filter LogRotation`, and `swift-format lint --strict` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)