### PR TITLE
iOS app interface: IndigoHID input + MJPEG stream over a per-session loopback server

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -67,6 +67,7 @@ var targets: [Target] = [
     .target(
         name: "PreviewsIOS",
         dependencies: ["PreviewsCore", "SimulatorBridge"],
+        resources: [.embedInCode("Resources/client.html")],
         plugins: [.plugin(name: "EmbedHostAppSource")] + iosJitPlugins
     ),
     .target(

--- a/Sources/PreviewsCLI/DaemonProtocol.swift
+++ b/Sources/PreviewsCLI/DaemonProtocol.swift
@@ -66,6 +66,7 @@ enum DaemonProtocol {
         let previews: [PreviewInfoDTO]
         let activeIndex: Int
         let setupWarning: String?
+        let appServerPort: Int?
     }
 
     struct VariantOutcomeDTO: Codable, Sendable, Equatable {

--- a/Sources/PreviewsCLI/Handlers/PreviewStartHandler.swift
+++ b/Sources/PreviewsCLI/Handlers/PreviewStartHandler.swift
@@ -220,7 +220,8 @@ enum PreviewStartHandler: ToolHandler {
                 DaemonProtocol.PreviewInfoDTO(from: $0, activeIndex: previewIndex)
             },
             activeIndex: previewIndex,
-            setupWarning: standaloneSetupWarning.isEmpty ? nil : standaloneSetupWarning
+            setupWarning: standaloneSetupWarning.isEmpty ? nil : standaloneSetupWarning,
+            appServerPort: nil
         )
         return try CallTool.Result(
             content: [
@@ -347,7 +348,8 @@ private func handleIOSPreviewStart(
             DaemonProtocol.PreviewInfoDTO(from: $0, activeIndex: previewIndex)
         },
         activeIndex: previewIndex,
-        setupWarning: nil
+        setupWarning: nil,
+        appServerPort: (await session.appServerPort).map(Int.init)
     )
     return try CallTool.Result(
         content: [

--- a/Sources/PreviewsIOS/AVCCVideoStream.swift
+++ b/Sources/PreviewsIOS/AVCCVideoStream.swift
@@ -1,0 +1,127 @@
+import CoreVideo
+import Foundation
+import IOSurface
+import os
+
+/// Bytes that wrap each chunk on the `/stream.avcc` wire. Every chunk is a
+/// 4-byte big-endian length (covering the tag byte plus payload) followed by a
+/// one-byte tag and the payload:
+///
+/// - `0x01` description — avcC parameter-set blob (SPS/PPS); configures the
+///   decoder. Emitted once per encoder session and replayed to late joiners.
+/// - `0x02` keyframe — IDR (decoder can start here).
+/// - `0x03` delta — non-IDR P-frame (depends on prior frames).
+/// - `0x04` seed — a JPEG painted immediately on connect so the viewer sees the
+///   current screen before the first IDR decodes.
+enum AVCCEnvelope {
+    static let descriptionTag: UInt8 = 0x01
+    static let keyframeTag: UInt8 = 0x02
+    static let deltaTag: UInt8 = 0x03
+    static let seedTag: UInt8 = 0x04
+
+    static func description(avcc: Data) -> Data { wrap(tag: descriptionTag, payload: avcc) }
+    static func keyframe(avcc: Data) -> Data { wrap(tag: keyframeTag, payload: avcc) }
+    static func delta(avcc: Data) -> Data { wrap(tag: deltaTag, payload: avcc) }
+    static func seed(jpeg: Data) -> Data { wrap(tag: seedTag, payload: jpeg) }
+
+    static func wrap(tag: UInt8, payload: Data) -> Data {
+        let length = UInt32(payload.count + 1)
+        var out = Data(capacity: 5 + payload.count)
+        withUnsafeBytes(of: length.bigEndian) { out.append(contentsOf: $0) }
+        out.append(tag)
+        out.append(payload)
+        return out
+    }
+}
+
+/// The H.264 side of the app interface. It owns an `H264Encoder`, fans the
+/// encoded chunks out to every `/stream.avcc` subscriber, and gates encoding on
+/// having at least one subscriber so an MJPEG-only session pays no H.264 cost.
+///
+/// `feed(surface:)` is called from the framebuffer streamer's capture queue with
+/// a live IOSurface; encoder output and subscriber writes happen on this type's
+/// own queue. Late joiners get the cached avcC description replayed and a forced
+/// keyframe so an IDR follows promptly. Encoding is event-driven, so on a fully
+/// static screen the forced IDR only lands once the screen next changes; the
+/// JPEG seed (sent by the endpoint) covers that gap by painting the current
+/// frame immediately.
+public final class AVCCVideoStream: @unchecked Sendable {
+    private let encoder: H264Encoder
+    private let queue = DispatchQueue(label: "com.previewsmcp.avcc")
+    private var subscribers: [ObjectIdentifier: (Data) -> Void] = [:]
+    private var cachedDescription: Data?
+    private var pendingKeyframe = false
+    /// Mirrors `!subscribers.isEmpty` for a lock-cheap fast path in `feed`, so an
+    /// MJPEG-only session skips the per-frame queue hop entirely.
+    private let hasSubscribers = OSAllocatedUnfairLock(initialState: false)
+
+    public init() {
+        encoder = H264Encoder()
+        encoder.onEncoded = { [weak self] encoded in self?.handleEncoded(encoded) }
+    }
+
+    /// Feed one captured frame. No-op when no subscriber is consuming the H.264
+    /// stream. Wraps the surface zero-copy; the encoder deep-copies before its
+    /// async encode, so the surface need not outlive this call.
+    func feed(surface: IOSurfaceRef) {
+        guard hasSubscribers.withLock({ $0 }) else { return }
+        let force: Bool? = queue.sync {
+            if subscribers.isEmpty { return nil }
+            let f = pendingKeyframe
+            pendingKeyframe = false
+            return f
+        }
+        guard let force else { return }
+
+        var unmanaged: Unmanaged<CVPixelBuffer>?
+        let attrs = [kCVPixelBufferIOSurfacePropertiesKey as String: [:]] as CFDictionary
+        guard
+            CVPixelBufferCreateWithIOSurface(kCFAllocatorDefault, surface, attrs, &unmanaged)
+                == kCVReturnSuccess, let pixelBuffer = unmanaged?.takeRetainedValue()
+        else { return }
+        encoder.encode(pixelBuffer, forceKeyframe: force)
+    }
+
+    /// Register a subscriber. Replays the cached decoder description and arms a
+    /// forced keyframe so the new client decodes promptly. `send` is invoked on
+    /// this type's queue with each enveloped chunk.
+    func addSubscriber(_ id: ObjectIdentifier, send: @escaping (Data) -> Void) {
+        queue.async {
+            if let desc = self.cachedDescription { send(desc) }
+            self.pendingKeyframe = true
+            self.subscribers[id] = send
+            self.hasSubscribers.withLock { $0 = true }
+        }
+    }
+
+    func removeSubscriber(_ id: ObjectIdentifier) {
+        queue.async {
+            self.subscribers.removeValue(forKey: id)
+            self.hasSubscribers.withLock { $0 = !self.subscribers.isEmpty }
+        }
+    }
+
+    func stop() {
+        encoder.stop()
+        queue.sync {
+            subscribers.removeAll()
+            hasSubscribers.withLock { $0 = false }
+            cachedDescription = nil
+        }
+    }
+
+    private func handleEncoded(_ encoded: H264Encoder.Encoded) {
+        queue.async {
+            if let description = encoded.description {
+                let env = AVCCEnvelope.description(avcc: description)
+                self.cachedDescription = env
+                for send in self.subscribers.values { send(env) }
+            }
+            let env =
+                encoded.kind == .keyframe
+                ? AVCCEnvelope.keyframe(avcc: encoded.avcc)
+                : AVCCEnvelope.delta(avcc: encoded.avcc)
+            for send in self.subscribers.values { send(env) }
+        }
+    }
+}

--- a/Sources/PreviewsIOS/FrameSource.swift
+++ b/Sources/PreviewsIOS/FrameSource.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// A source of JPEG frames for the app interface stream. The app interface taps
+/// the shell-composite display surface; concrete sources map that onto a
+/// backend.
+public protocol FrameSource: Sendable {
+    func nextFrame() async -> Data?
+}
+
+/// Captures the simulator display (the shell composite) as JPEG via the
+/// direct-IOSurface path. A first cut: it re-captures per frame with no
+/// seed-skip and reuses the retrying `screenshotData`; event-driven capture and
+/// change detection are later optimizations.
+public struct SimulatorFrameSource: FrameSource {
+    private let manager: SimulatorManager
+    private let udid: String
+    private let jpegQuality: Double
+
+    public init(manager: SimulatorManager, udid: String, jpegQuality: Double = 0.7) {
+        self.manager = manager
+        self.udid = udid
+        self.jpegQuality = jpegQuality
+    }
+
+    public func nextFrame() async -> Data? {
+        try? await manager.screenshotData(udid: udid, jpegQuality: jpegQuality)
+    }
+}

--- a/Sources/PreviewsIOS/FrameSource.swift
+++ b/Sources/PreviewsIOS/FrameSource.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+@preconcurrency import SimulatorBridge
+
 /// A source of JPEG frames for the app interface stream. The app interface taps
 /// the shell-composite display surface; concrete sources map that onto a
 /// backend.
@@ -7,22 +9,23 @@ public protocol FrameSource: Sendable {
     func nextFrame() async -> Data?
 }
 
-/// Captures the simulator display (the shell composite) as JPEG via the
-/// direct-IOSurface path. A first cut: it re-captures per frame with no
-/// seed-skip and reuses the retrying `screenshotData`; event-driven capture and
-/// change detection are later optimizations.
-public struct SimulatorFrameSource: FrameSource {
-    private let manager: SimulatorManager
-    private let udid: String
-    private let jpegQuality: Double
+/// Captures the simulator display (the shell composite) as JPEG via an
+/// event-driven `SBFramebufferStreamer`. The streamer holds the display
+/// pipeline open and re-encodes only when the IOSurface seed changes, caching
+/// the latest frame; `nextFrame` just returns that cache, so a stalled display
+/// never blocks the pull loop the way the retrying `screenshotData` did.
+public final class EventDrivenFrameSource: FrameSource, @unchecked Sendable {
+    private let streamer: SBFramebufferStreamer
 
-    public init(manager: SimulatorManager, udid: String, jpegQuality: Double = 0.7) {
-        self.manager = manager
-        self.udid = udid
-        self.jpegQuality = jpegQuality
+    public init(streamer: SBFramebufferStreamer) {
+        self.streamer = streamer
     }
 
     public func nextFrame() async -> Data? {
-        try? await manager.screenshotData(udid: udid, jpegQuality: jpegQuality)
+        streamer.latestFrame()
+    }
+
+    public func stop() {
+        streamer.stop()
     }
 }

--- a/Sources/PreviewsIOS/FrameSource.swift
+++ b/Sources/PreviewsIOS/FrameSource.swift
@@ -1,5 +1,4 @@
 import Foundation
-
 @preconcurrency import SimulatorBridge
 
 /// A source of JPEG frames for the app interface stream. The app interface taps

--- a/Sources/PreviewsIOS/H264Encoder.swift
+++ b/Sources/PreviewsIOS/H264Encoder.swift
@@ -1,0 +1,266 @@
+import CoreMedia
+import CoreVideo
+import Foundation
+import VideoToolbox
+
+/// Real-time H.264 encoder backed by `VTCompressionSession`, producing AVCC
+/// (length-prefixed NAL) output for the `/stream.avcc` endpoint.
+///
+/// Submission is fire-and-forget: the caller hands in a `CVPixelBuffer` and the
+/// encoded chunk comes back via `onEncoded` on VideoToolbox's own queue. The
+/// incoming buffer wraps the simulator's live framebuffer IOSurface, which
+/// SimulatorKit recycles in place, so we deep-copy into a private pooled buffer
+/// before submitting to avoid a torn frame while VT encodes asynchronously.
+final class H264Encoder: @unchecked Sendable {
+    struct Encoded {
+        /// avcC parameter-set blob — emitted once on the first IDR per session.
+        let description: Data?
+        let kind: Kind
+        /// Length-prefixed AVCC NAL bytes (not Annex-B start codes).
+        let avcc: Data
+        enum Kind { case keyframe, delta }
+    }
+
+    var onEncoded: ((Encoded) -> Void)?
+
+    private let lock = NSLock()
+    private var session: VTCompressionSession?
+    private var pool: CVPixelBufferPool?
+    private var width: Int32 = 0
+    private var height: Int32 = 0
+    private let fps: Int32
+    private let bitrate: Int
+    private let stateQueue = DispatchQueue(label: "com.previewsmcp.h264.state")
+    private var emittedDescription = false
+    private var frameCount: Int64 = 0
+
+    init(fps: Int = 60, bitrate: Int = 6_000_000) {
+        self.fps = Int32(fps)
+        self.bitrate = bitrate
+    }
+
+    deinit {
+        if let session { VTCompressionSessionInvalidate(session) }
+    }
+
+    /// Submit a frame. Returns immediately; `onEncoded` fires on VT's queue.
+    func encode(_ source: CVPixelBuffer, forceKeyframe: Bool = false) {
+        lock.lock()
+        let w = Int32(CVPixelBufferGetWidth(source))
+        let h = Int32(CVPixelBufferGetHeight(source))
+        if session == nil || w != width || h != height {
+            width = w
+            height = h
+            rebuildSession()
+        }
+        guard let session, let copy = copyBuffer(source) else {
+            lock.unlock()
+            return
+        }
+
+        frameCount += 1
+        let pts = CMTime(value: frameCount, timescale: fps)
+        let frameProps: NSDictionary? =
+            forceKeyframe
+            ? [kVTEncodeFrameOptionKey_ForceKeyFrame: kCFBooleanTrue!] as NSDictionary
+            : nil
+        lock.unlock()
+
+        VTCompressionSessionEncodeFrame(
+            session,
+            imageBuffer: copy,
+            presentationTimeStamp: pts,
+            duration: .invalid,
+            frameProperties: frameProps,
+            infoFlagsOut: nil
+        ) { [weak self] status, _, sampleBuffer in
+            guard let self, status == noErr, let sb = sampleBuffer else { return }
+            if let encoded = self.extract(from: sb) { self.onEncoded?(encoded) }
+        }
+    }
+
+    func stop() {
+        lock.lock()
+        defer { lock.unlock() }
+        if let session {
+            VTCompressionSessionInvalidate(session)
+            self.session = nil
+        }
+        pool = nil
+    }
+
+    // MARK: - private
+
+    /// Deep-copy `source` (which wraps the recycled framebuffer IOSurface) into
+    /// a private pooled buffer that VT can hold past this call.
+    private func copyBuffer(_ source: CVPixelBuffer) -> CVPixelBuffer? {
+        guard let pool else { return nil }
+        var out: CVPixelBuffer?
+        guard CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &out) == kCVReturnSuccess,
+            let dst = out
+        else { return nil }
+
+        CVPixelBufferLockBaseAddress(source, .readOnly)
+        CVPixelBufferLockBaseAddress(dst, [])
+        defer {
+            CVPixelBufferUnlockBaseAddress(dst, [])
+            CVPixelBufferUnlockBaseAddress(source, .readOnly)
+        }
+        guard let src = CVPixelBufferGetBaseAddress(source),
+            let dstAddr = CVPixelBufferGetBaseAddress(dst)
+        else { return nil }
+        let srcStride = CVPixelBufferGetBytesPerRow(source)
+        let dstStride = CVPixelBufferGetBytesPerRow(dst)
+        let rows = CVPixelBufferGetHeight(source)
+        let copyBytes = min(srcStride, dstStride)
+        for row in 0..<rows {
+            memcpy(dstAddr + row * dstStride, src + row * srcStride, copyBytes)
+        }
+        return dst
+    }
+
+    private func rebuildSession() {
+        if let session {
+            VTCompressionSessionInvalidate(session)
+            self.session = nil
+        }
+
+        // Low-latency rate control puts VideoToolbox in its real-time pipeline
+        // and emits a bitstream the decoder treats as low-latency (small
+        // max_dec_frame_buffering); without it the decoder fills a large DPB
+        // before emitting, adding ~300ms of latency. Falls back to the default
+        // spec on the rare hardware that rejects it.
+        let lowLatencySpec: NSDictionary = [
+            kVTVideoEncoderSpecification_EnableLowLatencyRateControl: kCFBooleanTrue!
+        ]
+        var sess: VTCompressionSession?
+        func create(spec: CFDictionary?) -> OSStatus {
+            VTCompressionSessionCreate(
+                allocator: kCFAllocatorDefault,
+                width: width, height: height,
+                codecType: kCMVideoCodecType_H264,
+                encoderSpecification: spec,
+                imageBufferAttributes: nil,
+                compressedDataAllocator: kCFAllocatorDefault,
+                outputCallback: nil,
+                refcon: nil,
+                compressionSessionOut: &sess
+            )
+        }
+        var status = create(spec: lowLatencySpec)
+        if status != noErr || sess == nil {
+            sess = nil
+            status = create(spec: nil)
+        }
+        guard status == noErr, let sess else { return }
+
+        let props: [(CFString, Any)] = [
+            (kVTCompressionPropertyKey_RealTime, kCFBooleanTrue!),
+            (kVTCompressionPropertyKey_ProfileLevel, kVTProfileLevel_H264_High_AutoLevel),
+            (kVTCompressionPropertyKey_AllowFrameReordering, kCFBooleanFalse!),
+            (kVTCompressionPropertyKey_AverageBitRate, NSNumber(value: bitrate)),
+            (kVTCompressionPropertyKey_ExpectedFrameRate, NSNumber(value: fps)),
+            // 5s keyframe interval: IDRs are far larger than P-frames, so spacing
+            // them keeps scroll/animation smooth. Late joiners don't wait for the
+            // natural IDR — we force one on connect.
+            (kVTCompressionPropertyKey_MaxKeyFrameInterval, NSNumber(value: fps * 5)),
+        ]
+        for (key, value) in props {
+            VTSessionSetProperty(sess, key: key, value: value as CFTypeRef)
+        }
+        VTCompressionSessionPrepareToEncodeFrames(sess)
+        session = sess
+        stateQueue.sync { emittedDescription = false }
+
+        let attrs: [String: Any] = [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+            kCVPixelBufferWidthKey as String: Int(width),
+            kCVPixelBufferHeightKey as String: Int(height),
+            kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+        ]
+        var newPool: CVPixelBufferPool?
+        CVPixelBufferPoolCreate(kCFAllocatorDefault, nil, attrs as CFDictionary, &newPool)
+        pool = newPool
+    }
+
+    private func extract(from sample: CMSampleBuffer) -> Encoded? {
+        let isKeyframe = !notSync(sample)
+        guard let dataBuf = CMSampleBufferGetDataBuffer(sample) else { return nil }
+
+        var totalLength = 0
+        var dataPointer: UnsafeMutablePointer<Int8>?
+        guard
+            CMBlockBufferGetDataPointer(
+                dataBuf, atOffset: 0, lengthAtOffsetOut: nil,
+                totalLengthOut: &totalLength, dataPointerOut: &dataPointer
+            ) == noErr, let dataPointer
+        else { return nil }
+        let avcc = Data(bytes: dataPointer, count: totalLength)
+
+        var description: Data?
+        if isKeyframe, let format = CMSampleBufferGetFormatDescription(sample) {
+            let nextDescription = avcCBlob(from: format)
+            let shouldEmit = stateQueue.sync { () -> Bool in
+                if emittedDescription { return false }
+                emittedDescription = nextDescription != nil
+                return nextDescription != nil
+            }
+            if shouldEmit { description = nextDescription }
+        }
+        return Encoded(description: description, kind: isKeyframe ? .keyframe : .delta, avcc: avcc)
+    }
+
+    private func notSync(_ sample: CMSampleBuffer) -> Bool {
+        guard
+            let attachments = CMSampleBufferGetSampleAttachmentsArray(sample, createIfNecessary: false),
+            CFArrayGetCount(attachments) > 0,
+            let dict = CFArrayGetValueAtIndex(attachments, 0)
+        else { return false }
+        let cfDict = unsafeBitCast(dict, to: CFDictionary.self)
+        return CFDictionaryContainsKey(
+            cfDict, Unmanaged.passUnretained(kCMSampleAttachmentKey_NotSync).toOpaque())
+    }
+
+    /// avcC parameter-set blob (ISO/IEC 14496-15 §5.2.4.1) carrying SPS + PPS.
+    private func avcCBlob(from format: CMFormatDescription) -> Data? {
+        var spsCount = 0
+        var spsPtr: UnsafePointer<UInt8>?
+        var spsSize = 0
+        var nalSize: Int32 = 0
+        guard
+            CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
+                format, parameterSetIndex: 0,
+                parameterSetPointerOut: &spsPtr, parameterSetSizeOut: &spsSize,
+                parameterSetCountOut: &spsCount, nalUnitHeaderLengthOut: &nalSize
+            ) == noErr, let spsPtr, spsSize >= 4
+        else { return nil }
+
+        var ppsPtr: UnsafePointer<UInt8>?
+        var ppsSize = 0
+        guard
+            CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
+                format, parameterSetIndex: 1,
+                parameterSetPointerOut: &ppsPtr, parameterSetSizeOut: &ppsSize,
+                parameterSetCountOut: nil, nalUnitHeaderLengthOut: nil
+            ) == noErr, let ppsPtr
+        else { return nil }
+
+        let sps = UnsafeBufferPointer(start: spsPtr, count: spsSize)
+        let pps = UnsafeBufferPointer(start: ppsPtr, count: ppsSize)
+        var blob = Data()
+        blob.append(0x01)
+        blob.append(sps[1])
+        blob.append(sps[2])
+        blob.append(sps[3])
+        blob.append(0xFF)
+        blob.append(0xE1)
+        blob.append(UInt8((spsSize >> 8) & 0xFF))
+        blob.append(UInt8(spsSize & 0xFF))
+        blob.append(contentsOf: sps)
+        blob.append(0x01)
+        blob.append(UInt8((ppsSize >> 8) & 0xFF))
+        blob.append(UInt8(ppsSize & 0xFF))
+        blob.append(contentsOf: pps)
+        return blob
+    }
+}

--- a/Sources/PreviewsIOS/IOSPreviewSession.swift
+++ b/Sources/PreviewsIOS/IOSPreviewSession.swift
@@ -108,6 +108,7 @@ public actor IOSPreviewSession {
     /// the device, not the agent process).
     private var appServer: PreviewAppServer?
     private var appFrameSource: EventDrivenFrameSource?
+    private var appVideoStream: AVCCVideoStream?
     public private(set) var appServerPort: UInt16?
 
     /// Serializes the mutating render entry points (`reload`, `handleSourceChange`). The file
@@ -305,13 +306,17 @@ public actor IOSPreviewSession {
             let hidClient = try await simulatorManager.makeHIDClient(udid: deviceUDID)
             let streamer = try await simulatorManager.makeFramebufferStreamer(udid: deviceUDID)
             let frameSource = EventDrivenFrameSource(streamer: streamer)
+            let videoStream = AVCCVideoStream()
+            streamer.onFrameSurface = { surface in videoStream.feed(surface: surface) }
             let server = PreviewAppServer(
                 sink: IndigoHIDInputSink(client: hidClient),
-                frameSource: frameSource
+                frameSource: frameSource,
+                videoStream: videoStream
             )
             appServerPort = try await server.start()
             appServer = server
             appFrameSource = frameSource
+            appVideoStream = videoStream
             stage("app interface on 127.0.0.1:\(appServerPort ?? 0)")
         } catch {
             Log.info("iOS preview: app interface unavailable: \(error)")
@@ -356,6 +361,8 @@ public actor IOSPreviewSession {
         appServer = nil
         appFrameSource?.stop()
         appFrameSource = nil
+        appVideoStream?.stop()
+        appVideoStream = nil
         appServerPort = nil
 
         // Take the render lock so stop wins the respawn race (#257). An iOS

--- a/Sources/PreviewsIOS/IOSPreviewSession.swift
+++ b/Sources/PreviewsIOS/IOSPreviewSession.swift
@@ -1,6 +1,7 @@
 import Darwin
 import Foundation
 import PreviewsCore
+@preconcurrency import SimulatorBridge
 
 /// Orchestrates the full iOS preview pipeline:
 /// boot simulator → install agent app → compile object → launch → JIT-link + render.
@@ -101,6 +102,12 @@ public actor IOSPreviewSession {
     /// respawns so the long-lived shell reconnects to the same path the new
     /// agent rebinds (the shell is never relaunched).
     private var agentSockPath: String?
+
+    /// Per-session app interface (loopback stream + control). Hosted here so it
+    /// captures the display in-process and survives agent respawn (it targets
+    /// the device, not the agent process).
+    private var appServer: PreviewAppServer?
+    public private(set) var appServerPort: UInt16?
 
     /// Serializes the mutating render entry points (`reload`, `handleSourceChange`). The file
     /// watcher fires a Task per change, so without this two edits could interleave at an
@@ -293,6 +300,22 @@ public actor IOSPreviewSession {
             throw await enrichedJITFailure(error)
         }
 
+        // Start the app interface in-process so it captures the shell composite
+        // and drives input over the same device. Best-effort: a failure here
+        // must not fail the preview itself.
+        do {
+            let hidClient = try await simulatorManager.makeHIDClient(udid: deviceUDID)
+            let server = PreviewAppServer(
+                sink: IndigoHIDInputSink(client: hidClient),
+                frameSource: SimulatorFrameSource(manager: simulatorManager, udid: deviceUDID)
+            )
+            appServerPort = try await server.start()
+            appServer = server
+            stage("app interface on 127.0.0.1:\(appServerPort ?? 0)")
+        } catch {
+            Log.info("iOS preview: app interface unavailable: \(error)")
+        }
+
         stage("connected; start complete")
 
         await channel.setOnDisconnect { [weak self] in
@@ -327,6 +350,10 @@ public actor IOSPreviewSession {
     /// `IOSAgentChannel.close()` is safe to call when nothing was opened.
     public func stop() async {
         stopping = true
+
+        appServer?.stop()
+        appServer = nil
+        appServerPort = nil
 
         // Take the render lock so stop wins the respawn race (#257). An iOS
         // eviction can have a `_relaunch` in flight (via `handleUnexpectedAgentDeath`)

--- a/Sources/PreviewsIOS/IOSPreviewSession.swift
+++ b/Sources/PreviewsIOS/IOSPreviewSession.swift
@@ -300,9 +300,6 @@ public actor IOSPreviewSession {
             throw await enrichedJITFailure(error)
         }
 
-        // Start the app interface in-process so it captures the shell composite
-        // and drives input over the same device. Best-effort: a failure here
-        // must not fail the preview itself.
         do {
             let hidClient = try await simulatorManager.makeHIDClient(udid: deviceUDID)
             let server = PreviewAppServer(

--- a/Sources/PreviewsIOS/IOSPreviewSession.swift
+++ b/Sources/PreviewsIOS/IOSPreviewSession.swift
@@ -107,6 +107,7 @@ public actor IOSPreviewSession {
     /// captures the display in-process and survives agent respawn (it targets
     /// the device, not the agent process).
     private var appServer: PreviewAppServer?
+    private var appFrameSource: EventDrivenFrameSource?
     public private(set) var appServerPort: UInt16?
 
     /// Serializes the mutating render entry points (`reload`, `handleSourceChange`). The file
@@ -302,12 +303,15 @@ public actor IOSPreviewSession {
 
         do {
             let hidClient = try await simulatorManager.makeHIDClient(udid: deviceUDID)
+            let streamer = try await simulatorManager.makeFramebufferStreamer(udid: deviceUDID)
+            let frameSource = EventDrivenFrameSource(streamer: streamer)
             let server = PreviewAppServer(
                 sink: IndigoHIDInputSink(client: hidClient),
-                frameSource: SimulatorFrameSource(manager: simulatorManager, udid: deviceUDID)
+                frameSource: frameSource
             )
             appServerPort = try await server.start()
             appServer = server
+            appFrameSource = frameSource
             stage("app interface on 127.0.0.1:\(appServerPort ?? 0)")
         } catch {
             Log.info("iOS preview: app interface unavailable: \(error)")
@@ -350,6 +354,8 @@ public actor IOSPreviewSession {
 
         appServer?.stop()
         appServer = nil
+        appFrameSource?.stop()
+        appFrameSource = nil
         appServerPort = nil
 
         // Take the render lock so stop wins the respawn race (#257). An iOS

--- a/Sources/PreviewsIOS/InputSink.swift
+++ b/Sources/PreviewsIOS/InputSink.swift
@@ -1,0 +1,28 @@
+import Foundation
+@preconcurrency import SimulatorBridge
+
+/// A destination for normalized (0..1) pointer input on a preview surface. The
+/// app interface speaks normalized coordinates; concrete sinks map them onto a
+/// backend. This is independent of the in-app host-app touch path used by
+/// `preview_touch`.
+public protocol InputSink: Sendable {
+    func tap(x: Double, y: Double)
+    func drag(fromX: Double, fromY: Double, toX: Double, toY: Double, steps: Int)
+}
+
+/// Drives input at the simulator digitizer through a daemon-side HID client.
+public struct IndigoHIDInputSink: InputSink {
+    private let client: SBHIDClient
+
+    public init(client: SBHIDClient) {
+        self.client = client
+    }
+
+    public func tap(x: Double, y: Double) {
+        _ = client.tapAt(x: x, y: y)
+    }
+
+    public func drag(fromX: Double, fromY: Double, toX: Double, toY: Double, steps: Int) {
+        _ = client.dragFrom(x: fromX, fromY: fromY, toX: toX, toY: toY, steps: steps)
+    }
+}

--- a/Sources/PreviewsIOS/PreviewAppServer.swift
+++ b/Sources/PreviewsIOS/PreviewAppServer.swift
@@ -14,6 +14,7 @@ import Network
 public final class PreviewAppServer: @unchecked Sendable {
     private let sink: any InputSink
     private let frameSource: (any FrameSource)?
+    private let videoStream: AVCCVideoStream?
     private let streamIntervalMS: UInt64
     private let queue = DispatchQueue(label: "com.previewsmcp.app-server")
     private var listener: NWListener?
@@ -23,10 +24,12 @@ public final class PreviewAppServer: @unchecked Sendable {
     public init(
         sink: any InputSink,
         frameSource: (any FrameSource)? = nil,
+        videoStream: AVCCVideoStream? = nil,
         streamIntervalMS: UInt64 = 80
     ) {
         self.sink = sink
         self.frameSource = frameSource
+        self.videoStream = videoStream
         self.streamIntervalMS = streamIntervalMS
     }
 
@@ -127,6 +130,12 @@ public final class PreviewAppServer: @unchecked Sendable {
                 } else {
                     self.respond(connection, status: "503 Service Unavailable")
                 }
+            case ("GET", "/stream.avcc"):
+                if let video = self.videoStream {
+                    self.streamAVCC(connection, video: video)
+                } else {
+                    self.respond(connection, status: "503 Service Unavailable")
+                }
             case ("POST", "/control"):
                 let contentLength = Self.contentLength(header)
                 let body = buffer[headerRange.upperBound...]
@@ -207,6 +216,39 @@ public final class PreviewAppServer: @unchecked Sendable {
                     try await Task.sleep(for: .milliseconds(intervalMS))
                 }
             } catch {
+                connection.cancel()
+            }
+        }
+        queue.async { self.streamTasks[ObjectIdentifier(connection)] = task }
+    }
+
+    // MARK: - H.264 (avcC) stream
+
+    private func streamAVCC(_ connection: NWConnection, video: AVCCVideoStream) {
+        let task = Task { [weak self] in
+            guard let self else { return }
+            let id = ObjectIdentifier(connection)
+            let head =
+                "HTTP/1.1 200 OK\r\n"
+                + "Content-Type: application/octet-stream\r\n"
+                + "Cache-Control: no-cache, no-store\r\n"
+                + "Connection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\n"
+            do {
+                try await self.send(connection, Data(head.utf8))
+                if let seed = await self.frameSource?.nextFrame() {
+                    try await self.send(connection, AVCCEnvelope.seed(jpeg: seed))
+                }
+                video.addSubscriber(id) { data in
+                    connection.send(content: data, completion: .contentProcessed { _ in })
+                }
+                // Encoded chunks arrive via the subscriber sink; hold the
+                // connection open until it is cancelled on close (or teardown).
+                while true {
+                    try Task.checkCancellation()
+                    try await Task.sleep(for: .seconds(30))
+                }
+            } catch {
+                video.removeSubscriber(id)
                 connection.cancel()
             }
         }

--- a/Sources/PreviewsIOS/PreviewAppServer.swift
+++ b/Sources/PreviewsIOS/PreviewAppServer.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Network
+
+/// Per-session app interface bound to loopback. This is the surface the streamed
+/// MCP app (and a browser) connect to, separate from the agent MCP tools and the
+/// CLI. Today it exposes a control endpoint that accepts normalized pointer
+/// input and forwards it to an `InputSink`. The pixel stream is layered on the
+/// same server later.
+///
+/// Control protocol: `POST /control` with a JSON body, one of
+///   {"action":"tap","x":0.5,"y":0.5}
+///   {"action":"drag","fromX":0.5,"fromY":0.7,"toX":0.5,"toY":0.3,"steps":12}
+public final class PreviewAppServer: @unchecked Sendable {
+    private let sink: any InputSink
+    private let queue = DispatchQueue(label: "com.previewsmcp.app-server")
+    private var listener: NWListener?
+
+    public init(sink: any InputSink) {
+        self.sink = sink
+    }
+
+    /// Bind to 127.0.0.1 on an ephemeral port and start listening. Returns the
+    /// assigned port.
+    public func start() async throws -> UInt16 {
+        let params = NWParameters.tcp
+        params.requiredLocalEndpoint = .hostPort(host: "127.0.0.1", port: .any)
+        params.allowLocalEndpointReuse = true
+
+        let listener = try NWListener(using: params)
+        self.listener = listener
+        listener.newConnectionHandler = { [weak self] connection in
+            self?.handle(connection)
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            listener.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    listener.stateUpdateHandler = nil
+                    if let port = listener.port?.rawValue {
+                        continuation.resume(returning: port)
+                    } else {
+                        continuation.resume(throwing: PreviewAppServerError.noPort)
+                    }
+                case .failed(let error):
+                    listener.stateUpdateHandler = nil
+                    continuation.resume(throwing: error)
+                default:
+                    break
+                }
+            }
+            listener.start(queue: queue)
+        }
+    }
+
+    public func stop() {
+        listener?.cancel()
+        listener = nil
+    }
+
+    // MARK: - Connection handling
+
+    private func handle(_ connection: NWConnection) {
+        connection.start(queue: queue)
+        receive(connection, buffer: Data())
+    }
+
+    private func receive(_ connection: NWConnection, buffer: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) {
+            [weak self] data, _, isComplete, error in
+            guard let self else { return }
+            var buffer = buffer
+            if let data { buffer.append(data) }
+
+            if let body = Self.completedBody(buffer) {
+                self.dispatch(body)
+                self.respondAndClose(connection)
+                return
+            }
+            if isComplete || error != nil {
+                self.respondAndClose(connection)
+                return
+            }
+            self.receive(connection, buffer: buffer)
+        }
+    }
+
+    /// Return the request body once the full headers + Content-Length bytes have
+    /// arrived, otherwise nil.
+    private static func completedBody(_ buffer: Data) -> Data? {
+        let separator = Data("\r\n\r\n".utf8)
+        guard let range = buffer.range(of: separator) else { return nil }
+        let header = String(decoding: buffer[..<range.lowerBound], as: UTF8.self)
+        let body = buffer[range.upperBound...]
+
+        var contentLength = 0
+        for line in header.split(separator: "\r\n") where line.lowercased().hasPrefix("content-length:") {
+            contentLength = Int(line.drop(while: { $0 != ":" }).dropFirst().trimmingCharacters(in: .whitespaces)) ?? 0
+        }
+        guard body.count >= contentLength else { return nil }
+        return Data(body.prefix(contentLength))
+    }
+
+    private func dispatch(_ body: Data) {
+        guard let command = try? JSONDecoder().decode(ControlCommand.self, from: body) else { return }
+        switch command.action {
+        case "tap":
+            if let x = command.x, let y = command.y {
+                sink.tap(x: x, y: y)
+            }
+        case "drag":
+            if let fromX = command.fromX, let fromY = command.fromY,
+                let toX = command.toX, let toY = command.toY
+            {
+                sink.drag(fromX: fromX, fromY: fromY, toX: toX, toY: toY, steps: command.steps ?? 10)
+            }
+        default:
+            break
+        }
+    }
+
+    private func respondAndClose(_ connection: NWConnection) {
+        let response = Data("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".utf8)
+        connection.send(
+            content: response,
+            completion: .contentProcessed { _ in
+                connection.cancel()
+            })
+    }
+}
+
+private struct ControlCommand: Decodable {
+    let action: String
+    let x: Double?
+    let y: Double?
+    let fromX: Double?
+    let fromY: Double?
+    let toX: Double?
+    let toY: Double?
+    let steps: Int?
+}
+
+public enum PreviewAppServerError: Error {
+    case noPort
+}

--- a/Sources/PreviewsIOS/PreviewAppServer.swift
+++ b/Sources/PreviewsIOS/PreviewAppServer.swift
@@ -18,6 +18,7 @@ public final class PreviewAppServer: @unchecked Sendable {
     private let queue = DispatchQueue(label: "com.previewsmcp.app-server")
     private var listener: NWListener?
     private var connections: [NWConnection] = []
+    private var streamTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
 
     public init(
         sink: any InputSink,
@@ -55,6 +56,9 @@ public final class PreviewAppServer: @unchecked Sendable {
                 case .failed(let error):
                     listener.stateUpdateHandler = nil
                     continuation.resume(throwing: error)
+                case .cancelled:
+                    listener.stateUpdateHandler = nil
+                    continuation.resume(throwing: PreviewAppServerError.cancelled)
                 default:
                     break
                 }
@@ -65,6 +69,8 @@ public final class PreviewAppServer: @unchecked Sendable {
 
     public func stop() {
         queue.sync {
+            streamTasks.values.forEach { $0.cancel() }
+            streamTasks.removeAll()
             connections.forEach { $0.cancel() }
             connections.removeAll()
             listener?.cancel()
@@ -77,9 +83,15 @@ public final class PreviewAppServer: @unchecked Sendable {
     private func handle(_ connection: NWConnection) {
         connections.append(connection)
         connection.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
             switch state {
             case .cancelled, .failed:
-                self?.queue.async { self?.connections.removeAll { $0 === connection } }
+                self.queue.async {
+                    let key = ObjectIdentifier(connection)
+                    self.streamTasks[key]?.cancel()
+                    self.streamTasks[key] = nil
+                    self.connections.removeAll { $0 === connection }
+                }
             default:
                 break
             }
@@ -173,7 +185,7 @@ public final class PreviewAppServer: @unchecked Sendable {
 
     private func stream(_ connection: NWConnection, source: any FrameSource) {
         let intervalMS = streamIntervalMS
-        Task { [weak self] in
+        let task = Task { [weak self] in
             guard let self else { return }
             let head =
                 "HTTP/1.1 200 OK\r\n"
@@ -182,6 +194,7 @@ public final class PreviewAppServer: @unchecked Sendable {
             do {
                 try await self.send(connection, Data(head.utf8))
                 while true {
+                    try Task.checkCancellation()
                     guard let jpeg = await source.nextFrame() else {
                         try await Task.sleep(for: .milliseconds(100))
                         continue
@@ -197,6 +210,7 @@ public final class PreviewAppServer: @unchecked Sendable {
                 connection.cancel()
             }
         }
+        queue.async { self.streamTasks[ObjectIdentifier(connection)] = task }
     }
 
     private func send(_ connection: NWConnection, _ data: Data) async throws {
@@ -227,4 +241,5 @@ private struct ControlCommand: Decodable {
 
 public enum PreviewAppServerError: Error {
     case noPort
+    case cancelled
 }

--- a/Sources/PreviewsIOS/PreviewAppServer.swift
+++ b/Sources/PreviewsIOS/PreviewAppServer.swift
@@ -3,20 +3,30 @@ import Network
 
 /// Per-session app interface bound to loopback. This is the surface the streamed
 /// MCP app (and a browser) connect to, separate from the agent MCP tools and the
-/// CLI. Today it exposes a control endpoint that accepts normalized pointer
-/// input and forwards it to an `InputSink`. The pixel stream is layered on the
-/// same server later.
+/// CLI. It exposes:
+///   - `POST /control`  normalized pointer input forwarded to an `InputSink`.
+///   - `GET /stream.mjpeg`  an MJPEG stream of the shell composite (when a
+///     `FrameSource` is provided).
 ///
-/// Control protocol: `POST /control` with a JSON body, one of
+/// Control bodies are JSON, one of
 ///   {"action":"tap","x":0.5,"y":0.5}
 ///   {"action":"drag","fromX":0.5,"fromY":0.7,"toX":0.5,"toY":0.3,"steps":12}
 public final class PreviewAppServer: @unchecked Sendable {
     private let sink: any InputSink
+    private let frameSource: (any FrameSource)?
+    private let streamIntervalMS: UInt64
     private let queue = DispatchQueue(label: "com.previewsmcp.app-server")
     private var listener: NWListener?
+    private var connections: [NWConnection] = []
 
-    public init(sink: any InputSink) {
+    public init(
+        sink: any InputSink,
+        frameSource: (any FrameSource)? = nil,
+        streamIntervalMS: UInt64 = 80
+    ) {
         self.sink = sink
+        self.frameSource = frameSource
+        self.streamIntervalMS = streamIntervalMS
     }
 
     /// Bind to 127.0.0.1 on an ephemeral port and start listening. Returns the
@@ -54,13 +64,26 @@ public final class PreviewAppServer: @unchecked Sendable {
     }
 
     public func stop() {
-        listener?.cancel()
-        listener = nil
+        queue.sync {
+            connections.forEach { $0.cancel() }
+            connections.removeAll()
+            listener?.cancel()
+            listener = nil
+        }
     }
 
     // MARK: - Connection handling
 
     private func handle(_ connection: NWConnection) {
+        connections.append(connection)
+        connection.stateUpdateHandler = { [weak self] state in
+            switch state {
+            case .cancelled, .failed:
+                self?.queue.async { self?.connections.removeAll { $0 === connection } }
+            default:
+                break
+            }
+        }
         connection.start(queue: queue)
         receive(connection, buffer: Data())
     }
@@ -72,33 +95,53 @@ public final class PreviewAppServer: @unchecked Sendable {
             var buffer = buffer
             if let data { buffer.append(data) }
 
-            if let body = Self.completedBody(buffer) {
-                self.dispatch(body)
-                self.respondAndClose(connection)
+            let separator = Data("\r\n\r\n".utf8)
+            guard let headerRange = buffer.range(of: separator) else {
+                if isComplete || error != nil {
+                    connection.cancel()
+                    return
+                }
+                self.receive(connection, buffer: buffer)
                 return
             }
-            if isComplete || error != nil {
-                self.respondAndClose(connection)
-                return
+
+            let header = String(decoding: buffer[..<headerRange.lowerBound], as: UTF8.self)
+            let (method, path) = Self.requestLine(header)
+
+            switch (method, path) {
+            case ("GET", "/stream.mjpeg"):
+                if let source = self.frameSource {
+                    self.stream(connection, source: source)
+                } else {
+                    self.respond(connection, status: "503 Service Unavailable")
+                }
+            case ("POST", "/control"):
+                let contentLength = Self.contentLength(header)
+                let body = buffer[headerRange.upperBound...]
+                if body.count >= contentLength {
+                    self.dispatch(Data(body.prefix(contentLength)))
+                    self.respond(connection, status: "200 OK")
+                } else {
+                    self.receive(connection, buffer: buffer)
+                }
+            default:
+                self.respond(connection, status: "404 Not Found")
             }
-            self.receive(connection, buffer: buffer)
         }
     }
 
-    /// Return the request body once the full headers + Content-Length bytes have
-    /// arrived, otherwise nil.
-    private static func completedBody(_ buffer: Data) -> Data? {
-        let separator = Data("\r\n\r\n".utf8)
-        guard let range = buffer.range(of: separator) else { return nil }
-        let header = String(decoding: buffer[..<range.lowerBound], as: UTF8.self)
-        let body = buffer[range.upperBound...]
+    private static func requestLine(_ header: String) -> (method: String, path: String) {
+        guard let firstLine = header.split(separator: "\r\n").first else { return ("", "") }
+        let parts = firstLine.split(separator: " ")
+        guard parts.count >= 2 else { return ("", "") }
+        return (String(parts[0]), String(parts[1]))
+    }
 
-        var contentLength = 0
+    private static func contentLength(_ header: String) -> Int {
         for line in header.split(separator: "\r\n") where line.lowercased().hasPrefix("content-length:") {
-            contentLength = Int(line.drop(while: { $0 != ":" }).dropFirst().trimmingCharacters(in: .whitespaces)) ?? 0
+            return Int(line.drop(while: { $0 != ":" }).dropFirst().trimmingCharacters(in: .whitespaces)) ?? 0
         }
-        guard body.count >= contentLength else { return nil }
-        return Data(body.prefix(contentLength))
+        return 0
     }
 
     private func dispatch(_ body: Data) {
@@ -119,13 +162,55 @@ public final class PreviewAppServer: @unchecked Sendable {
         }
     }
 
-    private func respondAndClose(_ connection: NWConnection) {
-        let response = Data("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".utf8)
+    private func respond(_ connection: NWConnection, status: String) {
+        let response = Data("HTTP/1.1 \(status)\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".utf8)
         connection.send(
             content: response,
-            completion: .contentProcessed { _ in
+            completion: .contentProcessed { _ in connection.cancel() })
+    }
+
+    // MARK: - MJPEG stream
+
+    private func stream(_ connection: NWConnection, source: any FrameSource) {
+        let intervalMS = streamIntervalMS
+        Task { [weak self] in
+            guard let self else { return }
+            let head =
+                "HTTP/1.1 200 OK\r\n"
+                + "Content-Type: multipart/x-mixed-replace; boundary=frame\r\n"
+                + "Cache-Control: no-cache\r\nConnection: close\r\n\r\n"
+            do {
+                try await self.send(connection, Data(head.utf8))
+                while true {
+                    guard let jpeg = await source.nextFrame() else {
+                        try await Task.sleep(for: .milliseconds(100))
+                        continue
+                    }
+                    var part = Data(
+                        "--frame\r\nContent-Type: image/jpeg\r\nContent-Length: \(jpeg.count)\r\n\r\n".utf8)
+                    part.append(jpeg)
+                    part.append(contentsOf: [0x0d, 0x0a])
+                    try await self.send(connection, part)
+                    try await Task.sleep(for: .milliseconds(intervalMS))
+                }
+            } catch {
                 connection.cancel()
-            })
+            }
+        }
+    }
+
+    private func send(_ connection: NWConnection, _ data: Data) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            connection.send(
+                content: data,
+                completion: .contentProcessed { error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume()
+                    }
+                })
+        }
     }
 }
 

--- a/Sources/PreviewsIOS/PreviewAppServer.swift
+++ b/Sources/PreviewsIOS/PreviewAppServer.swift
@@ -124,6 +124,8 @@ public final class PreviewAppServer: @unchecked Sendable {
             let (method, path) = Self.requestLine(header)
 
             switch (method, path) {
+            case ("GET", "/"), ("GET", "/index.html"):
+                self.respondHTML(connection, Self.clientHTML)
             case ("GET", "/stream.mjpeg"):
                 if let source = self.frameSource {
                     self.stream(connection, source: source)
@@ -185,6 +187,22 @@ public final class PreviewAppServer: @unchecked Sendable {
 
     private func respond(_ connection: NWConnection, status: String) {
         let response = Data("HTTP/1.1 \(status)\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".utf8)
+        connection.send(
+            content: response,
+            completion: .contentProcessed { _ in connection.cancel() })
+    }
+
+    /// The self-contained viewer page served at `GET /`: it decodes
+    /// `/stream.avcc` via WebCodecs (MJPEG fallback) and forwards pointer input
+    /// to `/control`, all same-origin on this loopback port.
+    static let clientHTML = Data(PackageResources.client_html)
+
+    private func respondHTML(_ connection: NWConnection, _ html: Data) {
+        let header =
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n"
+            + "Content-Length: \(html.count)\r\nConnection: close\r\n\r\n"
+        var response = Data(header.utf8)
+        response.append(html)
         connection.send(
             content: response,
             completion: .contentProcessed { _ in connection.cancel() })

--- a/Sources/PreviewsIOS/Resources/client.html
+++ b/Sources/PreviewsIOS/Resources/client.html
@@ -27,6 +27,7 @@
 
   const norm = (el, e) => {
     const r = el.getBoundingClientRect();
+    if (r.width === 0 || r.height === 0) return null;
     return {
       x: Math.min(1, Math.max(0, (e.clientX - r.left) / r.width)),
       y: Math.min(1, Math.max(0, (e.clientY - r.top) / r.height)),
@@ -42,12 +43,15 @@
   let down = null;
   const bindInput = (el) => {
     el.addEventListener("pointerdown", (e) => {
-      down = norm(el, e);
+      const p = norm(el, e);
+      if (!p) return;
+      down = p;
       el.setPointerCapture(e.pointerId);
     });
     el.addEventListener("pointerup", (e) => {
       if (!down) return;
       const up = norm(el, e);
+      if (!up) { down = null; return; }
       const dx = Math.abs(up.x - down.x), dy = Math.abs(up.y - down.y);
       if (dx < 0.02 && dy < 0.02) post({ action: "tap", x: up.x, y: up.y });
       else post({ action: "drag", fromX: down.x, fromY: down.y, toX: up.x, toY: up.y, steps: 12 });
@@ -58,6 +62,7 @@
   bindInput(fallback);
 
   const useMjpeg = () => {
+    down = null;
     canvas.style.display = "none";
     fallback.style.display = "";
     fallback.src = "/stream.mjpeg";

--- a/Sources/PreviewsIOS/Resources/client.html
+++ b/Sources/PreviewsIOS/Resources/client.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<title>iOS Preview</title>
+<style>
+  html, body { margin: 0; height: 100%; background: #000;
+    display: flex; align-items: center; justify-content: center; }
+  #screen, #fallback { max-width: 100vw; max-height: 100vh;
+    touch-action: none; cursor: crosshair; image-rendering: auto; }
+  #fallback { display: none; }
+  #status { position: fixed; top: 8px; left: 8px;
+    font: 12px -apple-system, system-ui, sans-serif; color: #888; }
+</style>
+</head>
+<body>
+<canvas id="screen"></canvas>
+<img id="fallback" alt="">
+<div id="status">connecting…</div>
+<script>
+(() => {
+  const canvas = document.getElementById("screen");
+  const ctx = canvas.getContext("2d");
+  const fallback = document.getElementById("fallback");
+  const status = document.getElementById("status");
+
+  const norm = (el, e) => {
+    const r = el.getBoundingClientRect();
+    return {
+      x: Math.min(1, Math.max(0, (e.clientX - r.left) / r.width)),
+      y: Math.min(1, Math.max(0, (e.clientY - r.top) / r.height)),
+    };
+  };
+  const post = (body) =>
+    fetch("/control", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }).catch(() => {});
+
+  let down = null;
+  const bindInput = (el) => {
+    el.addEventListener("pointerdown", (e) => {
+      down = norm(el, e);
+      el.setPointerCapture(e.pointerId);
+    });
+    el.addEventListener("pointerup", (e) => {
+      if (!down) return;
+      const up = norm(el, e);
+      const dx = Math.abs(up.x - down.x), dy = Math.abs(up.y - down.y);
+      if (dx < 0.02 && dy < 0.02) post({ action: "tap", x: up.x, y: up.y });
+      else post({ action: "drag", fromX: down.x, fromY: down.y, toX: up.x, toY: up.y, steps: 12 });
+      down = null;
+    });
+  };
+  bindInput(canvas);
+  bindInput(fallback);
+
+  const useMjpeg = () => {
+    canvas.style.display = "none";
+    fallback.style.display = "";
+    fallback.src = "/stream.mjpeg";
+    status.textContent = "MJPEG";
+  };
+
+  if (!("VideoDecoder" in window)) { useMjpeg(); return; }
+
+  const codecString = (d) =>
+    "avc1." + [d[1], d[2], d[3]].map((b) => b.toString(16).padStart(2, "0")).join("");
+
+  let decoder = null, ts = 0, painted = false;
+
+  const paint = (frame) => {
+    if (canvas.width !== frame.displayWidth || canvas.height !== frame.displayHeight) {
+      canvas.width = frame.displayWidth;
+      canvas.height = frame.displayHeight;
+    }
+    ctx.drawImage(frame, 0, 0);
+    frame.close();
+    painted = true;
+    status.style.display = "none";
+  };
+
+  const seed = async (jpeg) => {
+    if (painted) return;
+    try {
+      const bmp = await createImageBitmap(new Blob([jpeg], { type: "image/jpeg" }));
+      if (!painted) { canvas.width = bmp.width; canvas.height = bmp.height; ctx.drawImage(bmp, 0, 0); }
+      bmp.close();
+    } catch (_) {}
+  };
+
+  const onChunk = (tag, payload) => {
+    if (tag === 0x04) { seed(payload); return; }
+    if (tag === 0x01) {
+      if (decoder) { try { decoder.close(); } catch (_) {} }
+      decoder = new VideoDecoder({ output: paint, error: () => useMjpeg() });
+      decoder.configure({
+        codec: codecString(payload),
+        description: payload,
+        optimizeFor: "latency",
+        hardwareAcceleration: "prefer-hardware",
+      });
+      return;
+    }
+    if ((tag === 0x02 || tag === 0x03) && decoder && decoder.state === "configured") {
+      decoder.decode(new EncodedVideoChunk({ type: tag === 0x02 ? "key" : "delta", timestamp: ts, data: payload }));
+      ts += 16666;
+    }
+  };
+
+  const run = async () => {
+    let res;
+    try { res = await fetch("/stream.avcc"); } catch (_) { useMjpeg(); return; }
+    if (!res.ok || !res.body) { useMjpeg(); return; }
+    const reader = res.body.getReader();
+    let buf = new Uint8Array(0);
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const merged = new Uint8Array(buf.length + value.length);
+      merged.set(buf);
+      merged.set(value, buf.length);
+      buf = merged;
+      let off = 0;
+      while (buf.length - off >= 4) {
+        const len = ((buf[off] << 24) | (buf[off + 1] << 16) | (buf[off + 2] << 8) | buf[off + 3]) >>> 0;
+        if (buf.length - off < 4 + len) break;
+        onChunk(buf[off + 4], buf.slice(off + 5, off + 4 + len));
+        off += 4 + len;
+      }
+      if (off > 0) buf = buf.slice(off);
+    }
+    useMjpeg();
+  };
+  run();
+})();
+</script>
+</body>
+</html>

--- a/Sources/PreviewsIOS/SimulatorManager.swift
+++ b/Sources/PreviewsIOS/SimulatorManager.swift
@@ -113,6 +113,24 @@ public actor SimulatorManager {
         return client
     }
 
+    /// Create a daemon-side event-driven framebuffer streamer bound to a device.
+    /// Registers screen callbacks to keep the display pipeline wired to us and
+    /// caches the latest frame as it changes — the hot-loop counterpart to the
+    /// one-shot `screenshotData`.
+    public func makeFramebufferStreamer(
+        udid: String, jpegQuality: Double = 0.7
+    ) throws -> SBFramebufferStreamer {
+        try ensureLoaded()
+        var error: NSError?
+        guard let sbDevice = SBFindDeviceByUDID(udid, &error) else {
+            throw SimulatorError.deviceNotFound(error?.localizedDescription ?? "device not found: \(udid)")
+        }
+        guard let streamer = SBCreateFramebufferStreamer(sbDevice, jpegQuality, &error) else {
+            throw SimulatorError.screenshotFailed(error?.localizedDescription ?? "unknown")
+        }
+        return streamer
+    }
+
     // MARK: - Device Operations
 
     /// Boot a simulator device and block until it's fully booted (SpringBoard

--- a/Sources/PreviewsIOS/SimulatorManager.swift
+++ b/Sources/PreviewsIOS/SimulatorManager.swift
@@ -99,6 +99,20 @@ public actor SimulatorManager {
         return device(from: sbDevice)
     }
 
+    /// Create a daemon-side HID input client bound to a device. Injects events
+    /// at the simulator digitizer, independent of the in-app host touch path.
+    public func makeHIDClient(udid: String) throws -> SBHIDClient {
+        try ensureLoaded()
+        var error: NSError?
+        guard let sbDevice = SBFindDeviceByUDID(udid, &error) else {
+            throw SimulatorError.deviceNotFound(error?.localizedDescription ?? "device not found: \(udid)")
+        }
+        guard let client = SBCreateHIDClient(sbDevice, &error) else {
+            throw SimulatorError.hidClientFailed(error?.localizedDescription ?? "unknown")
+        }
+        return client
+    }
+
     // MARK: - Device Operations
 
     /// Boot a simulator device and block until it's fully booted (SpringBoard
@@ -499,6 +513,7 @@ public enum SimulatorError: Error, LocalizedError, CustomStringConvertible {
     case installFailed(String)
     case launchFailed(String)
     case screenshotFailed(String)
+    case hidClientFailed(String)
 
     public var description: String {
         switch self {
@@ -510,6 +525,7 @@ public enum SimulatorError: Error, LocalizedError, CustomStringConvertible {
         case .installFailed(let msg): return "Install failed: \(msg)"
         case .launchFailed(let msg): return "Launch failed: \(msg)"
         case .screenshotFailed(let msg): return "Screenshot failed: \(msg)"
+        case .hidClientFailed(let msg): return "HID client creation failed: \(msg)"
         }
     }
 

--- a/Sources/SimulatorBridge/SimulatorBridge.m
+++ b/Sources/SimulatorBridge/SimulatorBridge.m
@@ -53,11 +53,18 @@
 - (NSString *)identifier;
 @end
 
+@protocol _SimDeviceLegacyHIDClient
+- (instancetype)initWithDevice:(id)device error:(NSError **)error;
+@end
+
 #pragma mark - Framework State
 
 static BOOL _frameworkLoaded = NO;
 static Class _SimServiceContextClass = Nil;
 static dispatch_once_t _loadOnce;
+
+static Class _SimDeviceLegacyHIDClientClass = Nil;
+static dispatch_once_t _hidLoadOnce;
 
 static NSString *_developerDir(void) {
   static NSString *cached = nil;
@@ -126,6 +133,37 @@ static id _defaultDeviceSet(NSError **error) {
   if (!context)
     return nil;
   return [(id<_SimServiceContext>)context defaultDeviceSetWithError:error];
+}
+
+// SimDeviceLegacyHIDClient lives in SimulatorKit, which ships inside Xcode and
+// moved from PrivateFrameworks (Xcode 26 and older) to SharedFrameworks (Xcode
+// 27+). Loaded lazily and separately from CoreSimulator so non-HID callers
+// never pay for it or fail if SimulatorKit moved.
+static Class _loadSimulatorKitHIDClass(NSError **error) {
+  dispatch_once(&_hidLoadOnce, ^{
+    NSString *dev = _developerDir();
+    if (!dev)
+      return;
+    NSArray<NSString *> *candidates = @[
+      [dev stringByAppendingPathComponent:
+               @"Library/PrivateFrameworks/SimulatorKit.framework"],
+      [dev stringByAppendingPathComponent:
+               @"../SharedFrameworks/SimulatorKit.framework"],
+    ];
+    for (NSString *path in candidates) {
+      NSBundle *bundle = [NSBundle bundleWithPath:path];
+      if (bundle && [bundle loadAndReturnError:NULL])
+        break;
+    }
+    _SimDeviceLegacyHIDClientClass =
+        objc_lookUpClass("_TtC12SimulatorKit24SimDeviceLegacyHIDClient");
+  });
+
+  if (!_SimDeviceLegacyHIDClientClass && error) {
+    *error = _makeError(30, @"SimDeviceLegacyHIDClient unavailable (could not "
+                            @"load SimulatorKit from this Xcode)");
+  }
+  return _SimDeviceLegacyHIDClientClass;
 }
 
 #pragma mark - SBDevice
@@ -275,13 +313,13 @@ static id _defaultDeviceSet(NSError **error) {
     if (env)
       options[@"environment"] = env;
 
-    int pid = [(id<_SimDevice>)_simDevice spawnWithPath:path
-                                                options:options
-                                       terminationQueue:
-                                           dispatch_get_global_queue(
-                                               QOS_CLASS_USER_INITIATED, 0)
-                                     terminationHandler:handler
-                                                  error:error];
+    int pid = [(id<_SimDevice>)_simDevice
+             spawnWithPath:path
+                   options:options
+          terminationQueue:dispatch_get_global_queue(QOS_CLASS_USER_INITIATED,
+                                                     0)
+        terminationHandler:handler
+                     error:error];
     return (NSInteger)pid;
   } @catch (NSException *exception) {
     if (error) {
@@ -467,10 +505,59 @@ SBDevice *SBFindBootedDevice(NSError **error) {
   return nil;
 }
 
-// Touch injection is handled in-app by the iOS host app using the Hammer
+// In-app touch injection is handled by the iOS agent app using the Hammer
 // approach: IOHIDEvent + BKSHIDEventSetDigitizerInfo +
 // UIApplication._enqueueHIDEvent: See IOSAgentAppSource.swift for the
-// implementation. No SimulatorBridge involvement needed for touch.
+// implementation. That path is independent of the daemon-side HID client below,
+// which injects at the simulator digitizer for streamed/agent sessions.
+
+#pragma mark - HID Input Client
+
+@interface SBHIDClient ()
+@property(nonatomic, strong) id hidClient;
+- (instancetype)initWithHIDClient:(id)client;
+@end
+
+@implementation SBHIDClient
+
+- (instancetype)initWithHIDClient:(id)client {
+  self = [super init];
+  if (self) {
+    _hidClient = client;
+  }
+  return self;
+}
+
+@end
+
+SBHIDClient *SBCreateHIDClient(SBDevice *device, NSError **error) {
+  if (!_frameworkLoaded && !SBLoadFramework(error))
+    return nil;
+
+  Class hidClass = _loadSimulatorKitHIDClass(error);
+  if (!hidClass)
+    return nil;
+
+  id simDevice = device.simDevice;
+  if (!simDevice) {
+    if (error)
+      *error = _makeError(31, @"SBDevice has no underlying SimDevice");
+    return nil;
+  }
+
+  NSError *initError = nil;
+  id<_SimDeviceLegacyHIDClient> raw = [hidClass alloc];
+  id client = [raw initWithDevice:simDevice error:&initError];
+  if (!client) {
+    if (error)
+      *error =
+          initError
+              ?: _makeError(32, @"Failed to create SimDeviceLegacyHIDClient");
+    return nil;
+  }
+
+  return [[SBHIDClient alloc] initWithHIDClient:client];
+}
 
 #pragma mark - Framebuffer Capture
 

--- a/Sources/SimulatorBridge/SimulatorBridge.m
+++ b/Sources/SimulatorBridge/SimulatorBridge.m
@@ -651,6 +651,15 @@ SBHIDClient *SBCreateHIDClient(SBDevice *device, NSError **error) {
 - (IOSurfaceRef)ioSurface;
 @end
 
+static CIContext *_sharedCIContext(void) {
+  static CIContext *ctx = nil;
+  static dispatch_once_t once;
+  dispatch_once(&once, ^{
+    ctx = [CIContext contextWithOptions:@{kCIContextUseSoftwareRenderer : @NO}];
+  });
+  return ctx;
+}
+
 static NSData *_encodeImage(CGImageRef cgImage, double jpegQuality) {
   BOOL usePNG = (jpegQuality >= 1.0);
   CFStringRef utType = usePNG ? (__bridge CFStringRef)UTTypePNG.identifier
@@ -749,14 +758,8 @@ NSData *SBCaptureFramebuffer(SBDevice *device, double jpegQuality,
   CGImageRef cgImage = NULL;
 
   if (ciImage) {
-    static CIContext *ctx = nil;
-    static dispatch_once_t ciOnce;
-    dispatch_once(&ciOnce, ^{
-      ctx = [CIContext contextWithOptions:@{
-        kCIContextUseSoftwareRenderer : @NO
-      }];
-    });
-    cgImage = [ctx createCGImage:ciImage fromRect:ciImage.extent];
+    cgImage = [_sharedCIContext() createCGImage:ciImage
+                                       fromRect:ciImage.extent];
   }
 
   IOSurfaceUnlock(surface, kIOSurfaceLockReadOnly, NULL);
@@ -783,4 +786,370 @@ NSData *SBCaptureFramebuffer(SBDevice *device, double jpegQuality,
   }
 
   return result;
+}
+
+#pragma mark - Framebuffer Streamer
+
+@protocol _SBStreamIOClient
+- (void)updateIOPorts;
+- (NSArray *)ioPorts;
+@end
+
+@protocol _SBStreamPort
+- (NSString *)portIdentifier;
+- (id)descriptor;
+- (id)ioPortDescriptor;
+@end
+
+@protocol _SBStreamDescriptor
+- (IOSurfaceRef)framebufferSurface;
+- (void)registerScreenCallbacksWithUUID:(NSUUID *)uuid
+                          callbackQueue:(dispatch_queue_t)queue
+                          frameCallback:(void (^)(void))frameCallback
+                surfacesChangedCallback:(void (^)(void))surfacesChangedCallback
+              propertiesChangedCallback:
+                  (void (^)(void))propertiesChangedCallback;
+- (void)unregisterScreenCallbacksWithUUID:(NSUUID *)uuid;
+@end
+
+// Marks our capture queue so `stop` can detect a re-entrant call (dealloc fired
+// from a capture-queue block) and avoid a dispatch_sync self-deadlock.
+static const void *const kFBStreamerQueueKey = &kFBStreamerQueueKey;
+
+@implementation SBFramebufferStreamer {
+  id _ioClient;
+  double _jpegQuality;
+  dispatch_queue_t _captureQueue;
+  NSMutableArray *_descriptors;
+  NSMutableDictionary<NSNumber *, NSUUID *> *_callbackUUIDs;
+  NSMutableDictionary<NSNumber *, NSNumber *> *_lastSeeds;
+  NSData *_latestFrame;
+  BOOL _hasFrame;
+  dispatch_source_t _healTimer;
+  BOOL _stopRequested;
+  BOOL _stopped;
+}
+
+- (instancetype)initWithIOClient:(id)ioClient jpegQuality:(double)jpegQuality {
+  if ((self = [super init])) {
+    _ioClient = ioClient;
+    _jpegQuality = jpegQuality;
+    _captureQueue = dispatch_queue_create("com.previewsmcp.fb-streamer",
+                                          DISPATCH_QUEUE_SERIAL);
+    dispatch_queue_set_specific(_captureQueue, kFBStreamerQueueKey,
+                                (__bridge void *)_captureQueue, NULL);
+    _descriptors = [NSMutableArray array];
+    _callbackUUIDs = [NSMutableDictionary dictionary];
+    _lastSeeds = [NSMutableDictionary dictionary];
+    dispatch_async(_captureQueue, ^{
+      [self wireUpFramebuffer];
+    });
+    [self startHealTimer];
+  }
+  return self;
+}
+
+- (void)dealloc {
+  [self stop];
+}
+
+// Find every framebuffer display descriptor that supports the screen-callback
+// SPI. The simulator exposes more than one `com.apple.framebuffer.display`
+// port (main screen plus secondary planes/overlays); we listen on all and let
+// `captureFrame` pick whichever currently has the largest live surface.
+- (NSArray *)findFramebufferDescriptors {
+  id io = _ioClient;
+  if ([io respondsToSelector:@selector(updateIOPorts)]) {
+    @try {
+      [(id<_SBStreamIOClient>)io updateIOPorts];
+    } @catch (NSException *e) {
+    }
+  }
+
+  NSArray *ports = nil;
+  @try {
+    ports = [io valueForKey:@"deviceIOPorts"];
+  } @catch (NSException *e) {
+  }
+  if (![ports isKindOfClass:[NSArray class]] &&
+      [io respondsToSelector:@selector(ioPorts)]) {
+    @try {
+      ports = [(id<_SBStreamIOClient>)io ioPorts];
+    } @catch (NSException *e) {
+    }
+  }
+  if (![ports isKindOfClass:[NSArray class]])
+    return @[];
+
+  NSMutableArray *result = [NSMutableArray array];
+  for (id port in ports) {
+    if ([port respondsToSelector:@selector(portIdentifier)]) {
+      NSString *pid = nil;
+      @try {
+        pid = [(id<_SBStreamPort>)port portIdentifier];
+      } @catch (NSException *e) {
+      }
+      if (pid && ![[NSString stringWithFormat:@"%@", pid]
+                     isEqualToString:@"com.apple.framebuffer.display"])
+        continue;
+    }
+
+    id desc = nil;
+    @try {
+      if ([port respondsToSelector:@selector(descriptor)])
+        desc = [(id<_SBStreamPort>)port descriptor];
+      else if ([port respondsToSelector:@selector(ioPortDescriptor)])
+        desc = [(id<_SBStreamPort>)port ioPortDescriptor];
+    } @catch (NSException *e) {
+    }
+    if (!desc)
+      continue;
+
+    if ([desc respondsToSelector:@selector(framebufferSurface)] &&
+        [desc
+            respondsToSelector:
+                @selector(
+                    registerScreenCallbacksWithUUID:callbackQueue:frameCallback:
+                    surfacesChangedCallback:propertiesChangedCallback:)]) {
+      [result addObject:desc];
+    }
+  }
+  return result;
+}
+
+// Register callbacks on the current descriptors. Registering is what causes
+// SimulatorKit to wire the display pipeline to us and populate
+// `framebufferSurface`. Runs on the capture queue; safe to re-call to recover
+// from a stale descriptor set.
+- (void)wireUpFramebuffer {
+  if (_stopped)
+    return;
+
+  for (id old in _descriptors) {
+    NSUUID *uuid = _callbackUUIDs[@((uintptr_t)old)];
+    if (uuid &&
+        [old
+            respondsToSelector:@selector(unregisterScreenCallbacksWithUUID:)]) {
+      @try {
+        [(id<_SBStreamDescriptor>)old unregisterScreenCallbacksWithUUID:uuid];
+      } @catch (NSException *e) {
+      }
+    }
+  }
+  [_callbackUUIDs removeAllObjects];
+  [_lastSeeds removeAllObjects];
+
+  NSArray *candidates = [self findFramebufferDescriptors];
+  [_descriptors setArray:candidates];
+
+  for (id desc in candidates) {
+    NSUUID *uuid = [NSUUID UUID];
+    _callbackUUIDs[@((uintptr_t)desc)] = uuid;
+    __weak SBFramebufferStreamer *weakSelf = self;
+    void (^onChange)(void) = ^{
+      SBFramebufferStreamer *strongSelf = weakSelf;
+      if (!strongSelf)
+        return;
+      dispatch_async(strongSelf->_captureQueue, ^{
+        [strongSelf captureFrame];
+      });
+    };
+    @try {
+      [(id<_SBStreamDescriptor>)desc
+          registerScreenCallbacksWithUUID:uuid
+                            callbackQueue:_captureQueue
+                            frameCallback:onChange
+                  surfacesChangedCallback:onChange
+                propertiesChangedCallback:^{
+                }];
+    } @catch (NSException *e) {
+    }
+  }
+
+  [self captureFrame];
+}
+
+// Pick the descriptor whose live surface has the largest area, returning that
+// surface in `outSurface` so the caller need not re-fetch it. Secondary
+// planes/overlays are typically smaller than the main screen.
+- (id<_SBStreamDescriptor>)pickBestDescriptor:(IOSurfaceRef *)outSurface {
+  id<_SBStreamDescriptor> best = nil;
+  IOSurfaceRef bestSurface = NULL;
+  size_t bestArea = 0;
+  for (id<_SBStreamDescriptor> desc in _descriptors) {
+    IOSurfaceRef surface = NULL;
+    @try {
+      surface = [desc framebufferSurface];
+    } @catch (NSException *e) {
+      continue;
+    }
+    if (!surface)
+      continue;
+    size_t area = IOSurfaceGetWidth(surface) * IOSurfaceGetHeight(surface);
+    if (area > bestArea) {
+      best = desc;
+      bestSurface = surface;
+      bestArea = area;
+    }
+  }
+  if (outSurface)
+    *outSurface = bestSurface;
+  return best;
+}
+
+// Runs on the capture queue. Re-encodes only when the surface seed changed
+// since the last encode (seed-skip), so duplicate or vsync-rate callbacks on
+// static content cost nothing.
+- (void)captureFrame {
+  if (_stopped)
+    return;
+
+  IOSurfaceRef surface = NULL;
+  id<_SBStreamDescriptor> desc = [self pickBestDescriptor:&surface];
+  if (!desc || !surface)
+    return;
+
+  NSNumber *key = @((uintptr_t)desc);
+  uint32_t seed = IOSurfaceGetSeed(surface);
+  NSNumber *last = _lastSeeds[key];
+  if (_hasFrame && last && last.unsignedIntValue == seed)
+    return;
+  _lastSeeds[key] = @(seed);
+
+  size_t w = IOSurfaceGetWidth(surface);
+  size_t h = IOSurfaceGetHeight(surface);
+  if (w == 0 || h == 0)
+    return;
+
+  IOSurfaceLock(surface, kIOSurfaceLockReadOnly, NULL);
+  CIImage *ciImage = [CIImage imageWithIOSurface:surface];
+  CGImageRef cgImage = NULL;
+  if (ciImage)
+    cgImage = [_sharedCIContext() createCGImage:ciImage
+                                       fromRect:ciImage.extent];
+  IOSurfaceUnlock(surface, kIOSurfaceLockReadOnly, NULL);
+  if (!cgImage)
+    return;
+
+  NSData *jpeg = _encodeImage(cgImage, _jpegQuality);
+  CGImageRelease(cgImage);
+  if (!jpeg)
+    return;
+
+  @synchronized(self) {
+    _latestFrame = jpeg;
+  }
+
+  // Frames are flowing: the heal timer's only job (re-wire while we have none)
+  // is done, so stop its 1 Hz wakeups for the life of the streamer.
+  if (!_hasFrame) {
+    _hasFrame = YES;
+    if (_healTimer)
+      dispatch_source_cancel(_healTimer);
+  }
+}
+
+// Re-wire periodically until frames start flowing. A freshly created streamer
+// often races display attach; an app may also not have a display yet. The tick
+// is a no-op once any frame has been captured.
+- (void)startHealTimer {
+  _healTimer =
+      dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _captureQueue);
+  dispatch_source_set_timer(_healTimer,
+                            dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC),
+                            NSEC_PER_SEC, 100 * NSEC_PER_MSEC);
+  __weak SBFramebufferStreamer *weakSelf = self;
+  dispatch_source_set_event_handler(_healTimer, ^{
+    SBFramebufferStreamer *self = weakSelf;
+    if (!self || self->_stopped)
+      return;
+    if (!self->_hasFrame)
+      [self wireUpFramebuffer];
+  });
+  dispatch_resume(_healTimer);
+}
+
+- (NSData *)latestFrame {
+  @synchronized(self) {
+    return _latestFrame;
+  }
+}
+
+- (void)stop {
+  @synchronized(self) {
+    if (_stopRequested)
+      return;
+    _stopRequested = YES;
+  }
+
+  dispatch_source_t timer = _healTimer;
+  _healTimer = nil;
+  if (timer)
+    dispatch_source_cancel(timer);
+
+  void (^teardown)(void) = ^{
+    if (_stopped)
+      return;
+    _stopped = YES;
+    for (id desc in _descriptors) {
+      NSUUID *uuid = _callbackUUIDs[@((uintptr_t)desc)];
+      if (uuid &&
+          [desc respondsToSelector:@selector(
+                                       unregisterScreenCallbacksWithUUID:)]) {
+        @try {
+          [(id<_SBStreamDescriptor>)desc
+              unregisterScreenCallbacksWithUUID:uuid];
+        } @catch (NSException *e) {
+        }
+      }
+    }
+    [_descriptors removeAllObjects];
+    [_callbackUUIDs removeAllObjects];
+    [_lastSeeds removeAllObjects];
+  };
+
+  // If stop is re-entered on the capture queue (dealloc fired from one of its
+  // blocks), run teardown inline; dispatch_sync onto the current queue would
+  // deadlock.
+  if (dispatch_get_specific(kFBStreamerQueueKey))
+    teardown();
+  else
+    dispatch_sync(_captureQueue, teardown);
+}
+
+@end
+
+SBFramebufferStreamer *SBCreateFramebufferStreamer(SBDevice *device,
+                                                   double jpegQuality,
+                                                   NSError **error) {
+  if (!_frameworkLoaded && !SBLoadFramework(error))
+    return nil;
+
+  id simDevice = device.simDevice;
+  if (![simDevice respondsToSelector:@selector(io)]) {
+    if (error)
+      *error = _makeError(40, @"SimDevice does not respond to -io (Xcode "
+                              @"version may be unsupported)");
+    return nil;
+  }
+
+  id ioClient = nil;
+  @try {
+    ioClient = [simDevice valueForKey:@"io"];
+  } @catch (NSException *e) {
+    if (error)
+      *error = _makeError(
+          41, [NSString stringWithFormat:@"Failed to access SimDevice.io: %@",
+                                         e.reason]);
+    return nil;
+  }
+  if (!ioClient) {
+    if (error)
+      *error =
+          _makeError(42, @"SimDevice.io is nil (device may not be booted)");
+    return nil;
+  }
+
+  return [[SBFramebufferStreamer alloc] initWithIOClient:ioClient
+                                             jpegQuality:jpegQuality];
 }

--- a/Sources/SimulatorBridge/SimulatorBridge.m
+++ b/Sources/SimulatorBridge/SimulatorBridge.m
@@ -3,7 +3,9 @@
 #import <IOSurface/IOSurface.h>
 #import <ImageIO/ImageIO.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+#import <dlfcn.h>
 #import <objc/runtime.h>
+#import <unistd.h>
 
 #pragma mark - Private API Protocols
 
@@ -55,6 +57,10 @@
 
 @protocol _SimDeviceLegacyHIDClient
 - (instancetype)initWithDevice:(id)device error:(NSError **)error;
+- (void)sendWithMessage:(void *)message
+           freeWhenDone:(BOOL)freeWhenDone
+        completionQueue:(dispatch_queue_t)queue
+             completion:(void (^)(void))completion;
 @end
 
 #pragma mark - Framework State
@@ -513,8 +519,27 @@ SBDevice *SBFindBootedDevice(NSError **error) {
 
 #pragma mark - HID Input Client
 
+// IndigoHIDMessageForMouseNSEvent(const CGPoint *, const CGPoint *,
+//   IndigoHIDTarget, NSEventType, NSSize, IndigoHIDEdge) -> IndigoMessage *.
+// Apple's Simulator.app always passes NSSize(1,1), so the Indigo ratio reduces
+// to the point itself, i.e. our normalized 0..1 coordinate. Resolved once from
+// the simulator frameworks loaded for the HID client.
+typedef void *(*SBIndigoMouseFunc)(const CGPoint *, const CGPoint *, uint32_t,
+                                   int32_t, CGFloat, CGFloat, uint32_t);
+static SBIndigoMouseFunc _mouseFunc = NULL;
+static dispatch_once_t _mouseFuncOnce;
+
+static SBIndigoMouseFunc _loadMouseFunc(void) {
+  dispatch_once(&_mouseFuncOnce, ^{
+    _mouseFunc = (SBIndigoMouseFunc)dlsym(RTLD_DEFAULT,
+                                          "IndigoHIDMessageForMouseNSEvent");
+  });
+  return _mouseFunc;
+}
+
 @interface SBHIDClient ()
 @property(nonatomic, strong) id hidClient;
+@property(nonatomic, strong) dispatch_queue_t inputQueue;
 - (instancetype)initWithHIDClient:(id)client;
 @end
 
@@ -524,8 +549,61 @@ SBDevice *SBFindBootedDevice(NSError **error) {
   self = [super init];
   if (self) {
     _hidClient = client;
+    _inputQueue = dispatch_queue_create("com.previewsmcp.hid-input",
+                                        DISPATCH_QUEUE_SERIAL);
   }
   return self;
+}
+
+// 0x32 = digitizer target. eventType 1 = down (begin and move), 2 = up. Must
+// run on `inputQueue` so concurrent gestures never interleave on the shared
+// client.
+- (void)_sendEventType:(int32_t)eventType x:(double)x y:(double)y {
+  SBIndigoMouseFunc mouse = _loadMouseFunc();
+  if (!mouse)
+    return;
+  CGPoint pt = CGPointMake(x, y);
+  void *msg = mouse(&pt, NULL, 0x32, eventType, 1.0, 1.0, 0);
+  if (!msg)
+    return;
+  [(id<_SimDeviceLegacyHIDClient>)self.hidClient sendWithMessage:msg
+                                                    freeWhenDone:YES
+                                                 completionQueue:NULL
+                                                      completion:nil];
+}
+
+- (BOOL)tapAtX:(double)x y:(double)y {
+  if (!_loadMouseFunc())
+    return NO;
+  dispatch_async(self.inputQueue, ^{
+    [self _sendEventType:1 x:x y:y];
+    usleep(60000);
+    [self _sendEventType:2 x:x y:y];
+  });
+  return YES;
+}
+
+- (BOOL)dragFromX:(double)fromX
+            fromY:(double)fromY
+              toX:(double)toX
+              toY:(double)toY
+            steps:(NSInteger)steps {
+  if (!_loadMouseFunc())
+    return NO;
+  NSInteger n = steps < 1 ? 10 : steps;
+  dispatch_async(self.inputQueue, ^{
+    [self _sendEventType:1 x:fromX y:fromY];
+    usleep(8000);
+    for (NSInteger i = 1; i <= n; i++) {
+      double t = (double)i / (double)n;
+      [self _sendEventType:1
+                         x:fromX + (toX - fromX) * t
+                         y:fromY + (toY - fromY) * t];
+      usleep(16000);
+    }
+    [self _sendEventType:2 x:toX y:toY];
+  });
+  return YES;
 }
 
 @end

--- a/Sources/SimulatorBridge/SimulatorBridge.m
+++ b/Sources/SimulatorBridge/SimulatorBridge.m
@@ -1021,6 +1021,10 @@ static const void *const kFBStreamerQueueKey = &kFBStreamerQueueKey;
   if (w == 0 || h == 0)
     return;
 
+  void (^frameSink)(IOSurfaceRef) = self.onFrameSurface;
+  if (frameSink)
+    frameSink(surface);
+
   IOSurfaceLock(surface, kIOSurfaceLockReadOnly, NULL);
   CIImage *ciImage = [CIImage imageWithIOSurface:surface];
   CGImageRef cgImage = NULL;

--- a/Sources/SimulatorBridge/include/SimulatorBridge.h
+++ b/Sources/SimulatorBridge/include/SimulatorBridge.h
@@ -82,6 +82,34 @@ typedef NS_ENUM(NSInteger, SBDeviceState) {
             steps:(NSInteger)steps;
 @end
 
+/// Daemon-side event-driven framebuffer streamer. Registers screen callbacks on
+/// the device's framebuffer display descriptor(s) — which is what wires the
+/// display pipeline to this client and populates a live `framebufferSurface` —
+/// then encodes a fresh frame only when the surface's IOSurface seed changes,
+/// caching the most recent one. Unlike `SBCaptureFramebuffer` (a one-shot pull
+/// that walks the IO ports on every call), this holds the pipeline open and is
+/// meant to back a hot stream. Must be created and used from the same process
+/// that owns the device's display (the daemon that launched the apps).
+@interface SBFramebufferStreamer : NSObject
+
+/// The most recently encoded frame, or nil before the first frame arrives.
+- (nullable NSData *)latestFrame;
+
+/// Stop streaming and unregister callbacks. Idempotent; also called on dealloc.
+- (void)stop;
+
+@end
+
+/// Create an event-driven framebuffer streamer bound to a booted device. Loads
+/// CoreSimulator on first use. The display pipeline wires up lazily, so
+/// `latestFrame` may return nil for a short while (and indefinitely if no app
+/// has launched a display). Returns nil only if the device IO client is
+/// unavailable.
+/// @param device A booted SBDevice.
+/// @param jpegQuality JPEG quality 0.0–1.0 (values >= 1.0 produce PNG).
+SBFramebufferStreamer *_Nullable SBCreateFramebufferStreamer(
+    SBDevice *device, double jpegQuality, NSError *_Nullable *_Nullable error);
+
 /// Load CoreSimulator.framework at runtime. Safe to call multiple times.
 BOOL SBLoadFramework(NSError *_Nullable *_Nullable error);
 

--- a/Sources/SimulatorBridge/include/SimulatorBridge.h
+++ b/Sources/SimulatorBridge/include/SimulatorBridge.h
@@ -65,8 +65,21 @@ typedef NS_ENUM(NSInteger, SBDeviceState) {
 
 /// Daemon-side HID input client. Injects events at the simulator digitizer via
 /// SimulatorKit's SimDeviceLegacyHIDClient, independent of the in-app host
-/// touch path (see the touch note in SimulatorBridge.m).
+/// touch path (see the touch note in SimulatorBridge.m). Coordinates are
+/// normalized 0..1 across the device screen. Gestures run asynchronously on a
+/// private serial queue; the BOOL reports only whether the HID symbol resolved.
 @interface SBHIDClient : NSObject
+
+/// Tap at a normalized point.
+- (BOOL)tapAtX:(double)x y:(double)y;
+
+/// Drag from one normalized point to another over `steps` interpolated moves
+/// (a value < 1 uses a default of 10).
+- (BOOL)dragFromX:(double)fromX
+            fromY:(double)fromY
+              toX:(double)toX
+              toY:(double)toY
+            steps:(NSInteger)steps;
 @end
 
 /// Load CoreSimulator.framework at runtime. Safe to call multiple times.

--- a/Sources/SimulatorBridge/include/SimulatorBridge.h
+++ b/Sources/SimulatorBridge/include/SimulatorBridge.h
@@ -63,6 +63,12 @@ typedef NS_ENUM(NSInteger, SBDeviceState) {
 
 @end
 
+/// Daemon-side HID input client. Injects events at the simulator digitizer via
+/// SimulatorKit's SimDeviceLegacyHIDClient, independent of the in-app host
+/// touch path (see the touch note in SimulatorBridge.m).
+@interface SBHIDClient : NSObject
+@end
+
 /// Load CoreSimulator.framework at runtime. Safe to call multiple times.
 BOOL SBLoadFramework(NSError *_Nullable *_Nullable error);
 
@@ -89,5 +95,10 @@ SBDevice *_Nullable SBFindBootedDevice(NSError *_Nullable *_Nullable error);
 /// @return Image data, or nil on failure.
 NSData *_Nullable SBCaptureFramebuffer(SBDevice *device, double jpegQuality,
                                        NSError *_Nullable *_Nullable error);
+
+/// Create a HID input client bound to a device. Loads SimulatorKit (separate
+/// from CoreSimulator) on first use. Returns nil on failure.
+SBHIDClient *_Nullable SBCreateHIDClient(SBDevice *device,
+                                         NSError *_Nullable *_Nullable error);
 
 NS_ASSUME_NONNULL_END

--- a/Sources/SimulatorBridge/include/SimulatorBridge.h
+++ b/Sources/SimulatorBridge/include/SimulatorBridge.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <IOSurface/IOSurface.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -91,6 +92,13 @@ typedef NS_ENUM(NSInteger, SBDeviceState) {
 /// meant to back a hot stream. Must be created and used from the same process
 /// that owns the device's display (the daemon that launched the apps).
 @interface SBFramebufferStreamer : NSObject
+
+/// Optional sink invoked on the capture queue with each newly captured
+/// (seed-changed) display surface, alongside the cached JPEG. Used to feed an
+/// H.264 encoder. The surface is valid only for the duration of the call, so a
+/// consumer that encodes asynchronously must copy or retain it synchronously.
+@property(nonatomic, copy, nullable) void (^onFrameSurface)
+    (IOSurfaceRef surface);
 
 /// The most recently encoded frame, or nil before the first frame arrives.
 - (nullable NSData *)latestFrame;

--- a/Tests/MCPIntegrationTests/IOSAppServerTests.swift
+++ b/Tests/MCPIntegrationTests/IOSAppServerTests.swift
@@ -62,7 +62,7 @@ struct IOSAppServerTests {
             sessionID: sessionID, baseline: beforeDrag, timeout: .seconds(10))
 
         // Stream: the in-process capture serves a real JPEG over /stream.mjpeg.
-        let sample = try await streamSample(port: port)
+        let sample = try await readStreamSample(port: port, limit: 20_000)
         #expect(
             sample.range(of: Data([0xFF, 0xD8, 0xFF])) != nil,
             "stream should carry a real JPEG frame")
@@ -70,24 +70,25 @@ struct IOSAppServerTests {
         _ = try await server.callToolResult(
             name: "preview_stop", arguments: ["sessionID": .string(sessionID)])
     }
+}
 
-    /// Read a bounded sample of the MJPEG stream. URLSession unwraps
-    /// multipart/x-mixed-replace and delivers the JPEG part bodies.
-    private func streamSample(port: Int) async throws -> Data {
-        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/stream.mjpeg")!)
-        request.timeoutInterval = 15
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
-        let contentType = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Type") ?? ""
-        #expect(contentType.contains("multipart/x-mixed-replace"), "stream should be MJPEG multipart")
+/// Read a bounded sample of an MJPEG stream, asserting the multipart content
+/// type. URLSession unwraps multipart/x-mixed-replace and delivers the JPEG
+/// part bodies without the boundary.
+private func readStreamSample(port: Int, limit: Int) async throws -> Data {
+    var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/stream.mjpeg")!)
+    request.timeoutInterval = 15
+    let (bytes, response) = try await URLSession.shared.bytes(for: request)
+    let contentType = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Type") ?? ""
+    #expect(contentType.contains("multipart/x-mixed-replace"), "stream should be MJPEG multipart")
 
-        var buffer = Data()
-        let deadline = ContinuousClock.now + .seconds(10)
-        for try await byte in bytes {
-            buffer.append(byte)
-            if buffer.count >= 20_000 || ContinuousClock.now >= deadline { break }
-        }
-        return buffer
+    var buffer = Data()
+    let deadline = ContinuousClock.now + .seconds(10)
+    for try await byte in bytes {
+        buffer.append(byte)
+        if buffer.count >= limit || ContinuousClock.now >= deadline { break }
     }
+    return buffer
 }
 
 /// Verifies the PreviewAppServer MJPEG plumbing with a stub frame source. No
@@ -117,19 +118,7 @@ struct PreviewAppServerStreamTests {
         let port = try await appServer.start()
         defer { appServer.stop() }
 
-        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/stream.mjpeg")!)
-        request.timeoutInterval = 10
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
-        let contentType = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Type") ?? ""
-        #expect(contentType.contains("multipart/x-mixed-replace"), "stream should be MJPEG multipart")
-
-        // URLSession unwraps multipart/x-mixed-replace, delivering the part
-        // bodies without the boundary, so assert on the JPEG payload itself.
-        var buffer = Data()
-        for try await byte in bytes {
-            buffer.append(byte)
-            if buffer.count >= 256 { break }
-        }
-        #expect(buffer.range(of: jpeg) != nil, "stream should carry the source JPEG bytes")
+        let sample = try await readStreamSample(port: Int(port), limit: 256)
+        #expect(sample.range(of: jpeg) != nil, "stream should carry the source JPEG bytes")
     }
 }

--- a/Tests/MCPIntegrationTests/IOSAppServerTests.swift
+++ b/Tests/MCPIntegrationTests/IOSAppServerTests.swift
@@ -92,7 +92,7 @@ private func readStreamSample(port: Int, limit: Int) async throws -> Data {
 }
 
 /// Verifies the PreviewAppServer MJPEG plumbing with a stub frame source. No
-/// simulator: in production the real SimulatorFrameSource runs in the daemon,
+/// simulator: in production the real EventDrivenFrameSource runs in the daemon,
 /// in-process with the session that owns the display.
 @Suite("PreviewAppServer stream")
 struct PreviewAppServerStreamTests {

--- a/Tests/MCPIntegrationTests/IOSAppServerTests.swift
+++ b/Tests/MCPIntegrationTests/IOSAppServerTests.swift
@@ -67,6 +67,20 @@ struct IOSAppServerTests {
             sample.range(of: Data([0xFF, 0xD8, 0xFF])) != nil,
             "stream should carry a real JPEG frame")
 
+        // H.264: /stream.avcc serves the avcC description (0x01) and an IDR
+        // keyframe (0x02). The encoder produces frames on screen change and
+        // arms a keyframe on connect, so we drive a scroll once connected.
+        let tags = try await readAVCCTags(port: port, need: [0x01, 0x02], timeout: .seconds(20)) {
+            var drag = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/control")!)
+            drag.httpMethod = "POST"
+            drag.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            drag.httpBody = Data(
+                #"{"action":"drag","fromX":0.5,"fromY":0.3,"toX":0.5,"toY":0.7,"steps":12}"#.utf8)
+            _ = try? await URLSession.shared.data(for: drag)
+        }
+        #expect(tags.contains(0x01), "avcc stream should carry an avcC description")
+        #expect(tags.contains(0x02), "avcc stream should carry an H.264 keyframe")
+
         _ = try await server.callToolResult(
             name: "preview_stop", arguments: ["sessionID": .string(sessionID)])
     }
@@ -89,6 +103,43 @@ private func readStreamSample(port: Int, limit: Int) async throws -> Data {
         if buffer.count >= limit || ContinuousClock.now >= deadline { break }
     }
     return buffer
+}
+
+/// Read the length-prefixed `/stream.avcc` envelope stream and collect the chunk
+/// tags seen. `onConnected` runs once the first byte arrives (the subscriber is
+/// registered by then) to drive a screen change so an IDR is produced. Returns
+/// when every tag in `need` has been seen or `timeout` elapses.
+private func readAVCCTags(
+    port: Int, need: Set<UInt8>, timeout: Duration, onConnected: @escaping () async -> Void
+) async throws -> Set<UInt8> {
+    var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/stream.avcc")!)
+    request.timeoutInterval = 25
+    let (bytes, response) = try await URLSession.shared.bytes(for: request)
+    let contentType = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Type") ?? ""
+    #expect(contentType.contains("application/octet-stream"), "avcc stream should be octet-stream")
+
+    var buffer = [UInt8]()
+    var offset = 0
+    var seen = Set<UInt8>()
+    var triggered = false
+    let deadline = ContinuousClock.now + timeout
+    for try await byte in bytes {
+        if !triggered {
+            triggered = true
+            await onConnected()
+        }
+        buffer.append(byte)
+        while buffer.count - offset >= 4 {
+            let length =
+                Int(buffer[offset]) << 24 | Int(buffer[offset + 1]) << 16
+                | Int(buffer[offset + 2]) << 8 | Int(buffer[offset + 3])
+            guard buffer.count - offset >= 4 + length else { break }
+            seen.insert(buffer[offset + 4])
+            offset += 4 + length
+        }
+        if need.isSubset(of: seen) || ContinuousClock.now >= deadline { break }
+    }
+    return seen
 }
 
 /// Verifies the PreviewAppServer MJPEG plumbing with a stub frame source. No

--- a/Tests/MCPIntegrationTests/IOSAppServerTests.swift
+++ b/Tests/MCPIntegrationTests/IOSAppServerTests.swift
@@ -41,19 +41,11 @@ struct IOSAppServerTests {
         try await Task.sleep(for: .seconds(3))
 
         // Stand up the app interface over loopback, backed by the IndigoHID sink.
-        let hid = try await SimulatorManager().makeHIDClient(udid: deviceUDID)
-        let appServer = PreviewAppServer(sink: IndigoHIDInputSink(client: hid))
+        let appServer = PreviewAppServer(
+            sink: IndigoHIDInputSink(client: try await SimulatorManager().makeHIDClient(udid: deviceUDID))
+        )
         let port = try await appServer.start()
         defer { appServer.stop() }
-
-        func control(_ body: String) async throws {
-            var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/control")!)
-            request.httpMethod = "POST"
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.httpBody = Data(body.utf8)
-            let (_, response) = try await URLSession.shared.data(for: request)
-            #expect((response as? HTTPURLResponse)?.statusCode == 200, "control POST should return 200")
-        }
 
         // Drag over the control channel to scroll the list. A vertical drag over
         // the list changes the framebuffer on any device, proving the POST drove
@@ -61,11 +53,61 @@ struct IOSAppServerTests {
         // device-position-sensitive and is covered at the sink in
         // IOSHIDInputTests; tap and drag share this same /control pipe.)
         let beforeDrag = try await server.snapshotBytes(sessionID: sessionID)
-        try await control(#"{"action":"drag","fromX":0.5,"fromY":0.7,"toX":0.5,"toY":0.3,"steps":12}"#)
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/control")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Data(#"{"action":"drag","fromX":0.5,"fromY":0.7,"toX":0.5,"toY":0.3,"steps":12}"#.utf8)
+        let (_, response) = try await URLSession.shared.data(for: request)
+        #expect((response as? HTTPURLResponse)?.statusCode == 200, "control POST should return 200")
+
         _ = try await server.awaitSnapshotChange(
             sessionID: sessionID, baseline: beforeDrag, timeout: .seconds(10))
 
         _ = try await server.callTool(
             name: "preview_stop", arguments: ["sessionID": .string(sessionID)])
+    }
+}
+
+/// Verifies the PreviewAppServer MJPEG plumbing with a stub frame source. No
+/// simulator: cross-process display capture is owned by the daemon in
+/// production, and the real IOSurface capture is covered by preview_snapshot.
+@Suite("PreviewAppServer stream")
+struct PreviewAppServerStreamTests {
+
+    private struct StubFrameSource: FrameSource {
+        let jpeg: Data
+        func nextFrame() async -> Data? { jpeg }
+    }
+
+    private struct NoopInputSink: InputSink {
+        func tap(x: Double, y: Double) {}
+        func drag(fromX: Double, fromY: Double, toX: Double, toY: Double, steps: Int) {}
+    }
+
+    @Test("GET /stream.mjpeg serves multipart JPEG frames")
+    func streamServesFrames() async throws {
+        let jpeg = Data([0xFF, 0xD8, 0xFF, 0x01, 0x02, 0x03, 0xFF, 0xD9])
+        let appServer = PreviewAppServer(
+            sink: NoopInputSink(),
+            frameSource: StubFrameSource(jpeg: jpeg),
+            streamIntervalMS: 10
+        )
+        let port = try await appServer.start()
+        defer { appServer.stop() }
+
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/stream.mjpeg")!)
+        request.timeoutInterval = 10
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        let contentType = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Type") ?? ""
+        #expect(contentType.contains("multipart/x-mixed-replace"), "stream should be MJPEG multipart")
+
+        // URLSession unwraps multipart/x-mixed-replace, delivering the part
+        // bodies without the boundary, so assert on the JPEG payload itself.
+        var buffer = Data()
+        for try await byte in bytes {
+            buffer.append(byte)
+            if buffer.count >= 256 { break }
+        }
+        #expect(buffer.range(of: jpeg) != nil, "stream should carry the source JPEG bytes")
     }
 }

--- a/Tests/MCPIntegrationTests/IOSAppServerTests.swift
+++ b/Tests/MCPIntegrationTests/IOSAppServerTests.swift
@@ -172,4 +172,21 @@ struct PreviewAppServerStreamTests {
         let sample = try await readStreamSample(port: Int(port), limit: 256)
         #expect(sample.range(of: jpeg) != nil, "stream should carry the source JPEG bytes")
     }
+
+    @Test("GET / serves the self-contained viewer page")
+    func servesClientPage() async throws {
+        let appServer = PreviewAppServer(sink: NoopInputSink())
+        let port = try await appServer.start()
+        defer { appServer.stop() }
+
+        let (data, response) = try await URLSession.shared.data(
+            from: URL(string: "http://127.0.0.1:\(port)/")!)
+        let http = response as? HTTPURLResponse
+        #expect(http?.statusCode == 200)
+        #expect(http?.value(forHTTPHeaderField: "Content-Type")?.contains("text/html") == true)
+        let html = String(decoding: data, as: UTF8.self)
+        #expect(html.contains("/stream.avcc"), "page should wire the avcc stream")
+        #expect(html.contains("VideoDecoder"), "page should use WebCodecs")
+        #expect(html.contains("/stream.mjpeg"), "page should keep the MJPEG fallback")
+    }
 }

--- a/Tests/MCPIntegrationTests/IOSAppServerTests.swift
+++ b/Tests/MCPIntegrationTests/IOSAppServerTests.swift
@@ -1,23 +1,27 @@
 import Foundation
 import MCP
 import PreviewsIOS
-@preconcurrency import SimulatorBridge
 import Testing
 
-/// Verifies the per-session app interface (PreviewAppServer): normalized pointer
-/// input POSTed to its loopback `/control` endpoint drives the hosted agent
-/// scene through the IndigoHID sink. Separate from the agent MCP/CLI path.
-@Suite("iOS app server control", .serialized)
+/// Verifies the per-session app interface that the daemon hosts in-process:
+/// `preview_start` returns its loopback port, `POST /control` drives the hosted
+/// scene through IndigoHID, and `GET /stream.mjpeg` streams the shell composite.
+/// Separate from the agent MCP/CLI path.
+@Suite("iOS app server", .serialized)
 struct IOSAppServerTests {
 
+    private struct StartInfo: Decodable {
+        let appServerPort: Int?
+    }
+
     @Test(
-        "POST /control drives the preview via IndigoHID",
+        "daemon-hosted app server drives and streams the preview",
         .timeLimit(.minutes(20)),
         .disabled(
             if: ProcessInfo.processInfo.environment["CI"] != nil,
             "boots a simulator + compiles a preview; local-only like fullIOSWorkflow"
         ))
-    func controlDrivesPreview() async throws {
+    func appServerEndToEnd() async throws {
         guard let deviceUDID = try await IOSSimulatorPicker.pickUDID(index: 3) else {
             print("No iOS simulator at picker index 3 — skipping")
             return
@@ -26,7 +30,7 @@ struct IOSAppServerTests {
         let server = try await MCPTestServer.start()
         defer { server.stop() }
 
-        let (startContent, startError) = try await server.callTool(
+        let startResult = try await server.callToolResult(
             name: "preview_start",
             arguments: [
                 "filePath": .string(MCPTestServer.toDoViewPath),
@@ -36,22 +40,17 @@ struct IOSAppServerTests {
                 "projectPath": .string(MCPTestServer.spmExampleRoot.path),
             ]
         )
-        #expect(startError != true, "iOS preview_start should succeed")
-        let sessionID = try MCPTestServer.extractSessionID(from: startContent)
+        #expect(startResult.isError != true, "iOS preview_start should succeed")
+        let sessionID = try MCPTestServer.extractSessionID(from: startResult.content)
+        let info = try MCPTestServer.decodeStructured(StartInfo.self, from: startResult)
+        guard let port = info.appServerPort else {
+            Issue.record("preview_start did not return an app server port")
+            return
+        }
         try await Task.sleep(for: .seconds(3))
 
-        // Stand up the app interface over loopback, backed by the IndigoHID sink.
-        let appServer = PreviewAppServer(
-            sink: IndigoHIDInputSink(client: try await SimulatorManager().makeHIDClient(udid: deviceUDID))
-        )
-        let port = try await appServer.start()
-        defer { appServer.stop() }
-
-        // Drag over the control channel to scroll the list. A vertical drag over
-        // the list changes the framebuffer on any device, proving the POST drove
-        // the hosted scene through the IndigoHID sink. (Tap-on-a-control is
-        // device-position-sensitive and is covered at the sink in
-        // IOSHIDInputTests; tap and drag share this same /control pipe.)
+        // Control: a drag over /control scrolls the list, proving the
+        // daemon-hosted server forwards input to IndigoHID.
         let beforeDrag = try await server.snapshotBytes(sessionID: sessionID)
         var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/control")!)
         request.httpMethod = "POST"
@@ -59,18 +58,41 @@ struct IOSAppServerTests {
         request.httpBody = Data(#"{"action":"drag","fromX":0.5,"fromY":0.7,"toX":0.5,"toY":0.3,"steps":12}"#.utf8)
         let (_, response) = try await URLSession.shared.data(for: request)
         #expect((response as? HTTPURLResponse)?.statusCode == 200, "control POST should return 200")
-
         _ = try await server.awaitSnapshotChange(
             sessionID: sessionID, baseline: beforeDrag, timeout: .seconds(10))
 
-        _ = try await server.callTool(
+        // Stream: the in-process capture serves a real JPEG over /stream.mjpeg.
+        let sample = try await streamSample(port: port)
+        #expect(
+            sample.range(of: Data([0xFF, 0xD8, 0xFF])) != nil,
+            "stream should carry a real JPEG frame")
+
+        _ = try await server.callToolResult(
             name: "preview_stop", arguments: ["sessionID": .string(sessionID)])
+    }
+
+    /// Read a bounded sample of the MJPEG stream. URLSession unwraps
+    /// multipart/x-mixed-replace and delivers the JPEG part bodies.
+    private func streamSample(port: Int) async throws -> Data {
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/stream.mjpeg")!)
+        request.timeoutInterval = 15
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        let contentType = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Type") ?? ""
+        #expect(contentType.contains("multipart/x-mixed-replace"), "stream should be MJPEG multipart")
+
+        var buffer = Data()
+        let deadline = ContinuousClock.now + .seconds(10)
+        for try await byte in bytes {
+            buffer.append(byte)
+            if buffer.count >= 20_000 || ContinuousClock.now >= deadline { break }
+        }
+        return buffer
     }
 }
 
 /// Verifies the PreviewAppServer MJPEG plumbing with a stub frame source. No
-/// simulator: cross-process display capture is owned by the daemon in
-/// production, and the real IOSurface capture is covered by preview_snapshot.
+/// simulator: in production the real SimulatorFrameSource runs in the daemon,
+/// in-process with the session that owns the display.
 @Suite("PreviewAppServer stream")
 struct PreviewAppServerStreamTests {
 

--- a/Tests/MCPIntegrationTests/IOSAppServerTests.swift
+++ b/Tests/MCPIntegrationTests/IOSAppServerTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import MCP
+import PreviewsIOS
+@preconcurrency import SimulatorBridge
+import Testing
+
+/// Verifies the per-session app interface (PreviewAppServer): normalized pointer
+/// input POSTed to its loopback `/control` endpoint drives the hosted agent
+/// scene through the IndigoHID sink. Separate from the agent MCP/CLI path.
+@Suite("iOS app server control", .serialized)
+struct IOSAppServerTests {
+
+    @Test(
+        "POST /control drives the preview via IndigoHID",
+        .timeLimit(.minutes(20)),
+        .disabled(
+            if: ProcessInfo.processInfo.environment["CI"] != nil,
+            "boots a simulator + compiles a preview; local-only like fullIOSWorkflow"
+        ))
+    func controlDrivesPreview() async throws {
+        guard let deviceUDID = try await IOSSimulatorPicker.pickUDID(index: 3) else {
+            print("No iOS simulator at picker index 3 — skipping")
+            return
+        }
+
+        let server = try await MCPTestServer.start()
+        defer { server.stop() }
+
+        let (startContent, startError) = try await server.callTool(
+            name: "preview_start",
+            arguments: [
+                "filePath": .string(MCPTestServer.toDoViewPath),
+                "platform": .string("ios"),
+                "deviceUDID": .string(deviceUDID),
+                "headless": .bool(true),
+                "projectPath": .string(MCPTestServer.spmExampleRoot.path),
+            ]
+        )
+        #expect(startError != true, "iOS preview_start should succeed")
+        let sessionID = try MCPTestServer.extractSessionID(from: startContent)
+        try await Task.sleep(for: .seconds(3))
+
+        // Stand up the app interface over loopback, backed by the IndigoHID sink.
+        let hid = try await SimulatorManager().makeHIDClient(udid: deviceUDID)
+        let appServer = PreviewAppServer(sink: IndigoHIDInputSink(client: hid))
+        let port = try await appServer.start()
+        defer { appServer.stop() }
+
+        func control(_ body: String) async throws {
+            var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/control")!)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = Data(body.utf8)
+            let (_, response) = try await URLSession.shared.data(for: request)
+            #expect((response as? HTTPURLResponse)?.statusCode == 200, "control POST should return 200")
+        }
+
+        // Drag over the control channel to scroll the list. A vertical drag over
+        // the list changes the framebuffer on any device, proving the POST drove
+        // the hosted scene through the IndigoHID sink. (Tap-on-a-control is
+        // device-position-sensitive and is covered at the sink in
+        // IOSHIDInputTests; tap and drag share this same /control pipe.)
+        let beforeDrag = try await server.snapshotBytes(sessionID: sessionID)
+        try await control(#"{"action":"drag","fromX":0.5,"fromY":0.7,"toX":0.5,"toY":0.3,"steps":12}"#)
+        _ = try await server.awaitSnapshotChange(
+            sessionID: sessionID, baseline: beforeDrag, timeout: .seconds(10))
+
+        _ = try await server.callTool(
+            name: "preview_stop", arguments: ["sessionID": .string(sessionID)])
+    }
+}

--- a/Tests/MCPIntegrationTests/IOSHIDInputTests.swift
+++ b/Tests/MCPIntegrationTests/IOSHIDInputTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import MCP
+import PreviewsIOS
+@preconcurrency import SimulatorBridge
+import Testing
+
+/// Verifies the daemon-side IndigoHID input path (SBHIDClient) drives the hosted
+/// agent scene through the shell: a digitizer tap flips the SwiftUI toggle, and
+/// a digitizer drag scrolls the list. Independent of the in-app host-app touch
+/// path that `preview_touch` uses.
+@Suite("iOS IndigoHID input", .serialized)
+struct IOSHIDInputTests {
+
+    @Test(
+        "IndigoHID tap flips the toggle and drag scrolls the list",
+        .timeLimit(.minutes(20)),
+        .disabled(
+            if: ProcessInfo.processInfo.environment["CI"] != nil,
+            "boots a simulator + compiles a preview; local-only like fullIOSWorkflow"
+        ))
+    func tapAndDrag() async throws {
+        guard let deviceUDID = try await IOSSimulatorPicker.pickUDID(index: 2) else {
+            print("No iOS simulator at picker index 2 — skipping")
+            return
+        }
+
+        let server = try await MCPTestServer.start()
+        defer { server.stop() }
+
+        let (startContent, startError) = try await server.callTool(
+            name: "preview_start",
+            arguments: [
+                "filePath": .string(MCPTestServer.toDoViewPath),
+                "platform": .string("ios"),
+                "deviceUDID": .string(deviceUDID),
+                "headless": .bool(true),
+                "projectPath": .string(MCPTestServer.spmExampleRoot.path),
+            ]
+        )
+        #expect(startError != true, "iOS preview_start should succeed")
+        let sessionID = try MCPTestServer.extractSessionID(from: startContent)
+        try await Task.sleep(for: .seconds(3))
+
+        let hid = try await SimulatorManager().makeHIDClient(udid: deviceUDID)
+
+        // Tap the "Show Completed" toggle (normalized). Flipping it hides the
+        // completed rows, a visible change, which proves the digitizer tap
+        // reached the hosted agent scene through the shell and fired the real
+        // SwiftUI action.
+        let beforeTap = try await server.snapshotBytes(sessionID: sessionID)
+        #expect(hid.tapAt(x: 0.86, y: 0.39), "HID symbol should resolve")
+        _ = try await server.awaitSnapshotChange(
+            sessionID: sessionID, baseline: beforeTap, timeout: .seconds(10))
+
+        // Toggle back on so the list is long enough to scroll, then drag and
+        // confirm the framebuffer changes again.
+        #expect(hid.tapAt(x: 0.86, y: 0.39), "HID symbol should resolve")
+        try await Task.sleep(for: .seconds(1))
+
+        let beforeDrag = try await server.snapshotBytes(sessionID: sessionID)
+        #expect(
+            hid.dragFrom(x: 0.5, fromY: 0.7, toX: 0.5, toY: 0.3, steps: 12),
+            "HID symbol should resolve")
+        _ = try await server.awaitSnapshotChange(
+            sessionID: sessionID, baseline: beforeDrag, timeout: .seconds(10))
+
+        _ = try await server.callTool(
+            name: "preview_stop", arguments: ["sessionID": .string(sessionID)])
+    }
+}

--- a/Tests/MCPIntegrationTests/IOSSimulatorPicker.swift
+++ b/Tests/MCPIntegrationTests/IOSSimulatorPicker.swift
@@ -31,6 +31,7 @@ enum IOSSimulatorPicker {
     /// - index 1: `IOSPreviewSessionTests.endToEnd`
     /// - index 1: `IOSMCPTests.fullIOSWorkflow`
     /// - index 2: `IOSHIDInputTests.tapAndDrag`
+    /// - index 3: `IOSAppServerTests.controlDrivesPreview`
     static func pickUDID(index: Int) async throws -> String? {
         // Must drain stdout concurrently: `simctl list devices --json` on a
         // CI runner with 100+ simulators produces >64KB of JSON, filling

--- a/Tests/MCPIntegrationTests/IOSSimulatorPicker.swift
+++ b/Tests/MCPIntegrationTests/IOSSimulatorPicker.swift
@@ -31,7 +31,7 @@ enum IOSSimulatorPicker {
     /// - index 1: `IOSPreviewSessionTests.endToEnd`
     /// - index 1: `IOSMCPTests.fullIOSWorkflow`
     /// - index 2: `IOSHIDInputTests.tapAndDrag`
-    /// - index 3: `IOSAppServerTests.controlDrivesPreview`
+    /// - index 3: `IOSAppServerTests.appServerEndToEnd`
     static func pickUDID(index: Int) async throws -> String? {
         // Must drain stdout concurrently: `simctl list devices --json` on a
         // CI runner with 100+ simulators produces >64KB of JSON, filling

--- a/Tests/MCPIntegrationTests/IOSSimulatorPicker.swift
+++ b/Tests/MCPIntegrationTests/IOSSimulatorPicker.swift
@@ -29,7 +29,8 @@ enum IOSSimulatorPicker {
     ///
     /// - index 0: `SimulatorManagerTests.bootAndShutdown`
     /// - index 1: `IOSPreviewSessionTests.endToEnd`
-    /// - index 2: `IOSMCPTests.fullIOSWorkflow`
+    /// - index 1: `IOSMCPTests.fullIOSWorkflow`
+    /// - index 2: `IOSHIDInputTests.tapAndDrag`
     static func pickUDID(index: Int) async throws -> String? {
         // Must drain stdout concurrently: `simctl list devices --json` on a
         // CI runner with 100+ simulators produces >64KB of JSON, filling

--- a/Tests/PreviewsIOSTests/H264EncoderTests.swift
+++ b/Tests/PreviewsIOSTests/H264EncoderTests.swift
@@ -1,0 +1,86 @@
+import CoreVideo
+import Foundation
+import Testing
+
+@testable import PreviewsIOS
+
+@Suite("AVCC envelope")
+struct AVCCEnvelopeTests {
+
+    @Test("wrap emits 4-byte BE length (tag+payload), tag, then payload")
+    func framing() {
+        let payload = Data([0xDE, 0xAD, 0xBE, 0xEF])
+        let env = AVCCEnvelope.keyframe(avcc: payload)
+
+        #expect(env.count == 4 + 1 + payload.count)
+        let length =
+            UInt32(env[0]) << 24 | UInt32(env[1]) << 16 | UInt32(env[2]) << 8 | UInt32(env[3])
+        #expect(length == UInt32(payload.count + 1))
+        #expect(env[4] == AVCCEnvelope.keyframeTag)
+        #expect(Array(env[5...]) == Array(payload))
+    }
+
+    @Test("each tag round-trips its own value")
+    func tags() {
+        let p = Data([0x01])
+        #expect(AVCCEnvelope.description(avcc: p)[4] == 0x01)
+        #expect(AVCCEnvelope.keyframe(avcc: p)[4] == 0x02)
+        #expect(AVCCEnvelope.delta(avcc: p)[4] == 0x03)
+        #expect(AVCCEnvelope.seed(jpeg: p)[4] == 0x04)
+    }
+}
+
+@Suite("H264Encoder")
+struct H264EncoderTests {
+
+    private func makePixelBuffer(width: Int, height: Int, fill: UInt8) -> CVPixelBuffer {
+        var pb: CVPixelBuffer?
+        let attrs = [kCVPixelBufferIOSurfacePropertiesKey as String: [:]] as CFDictionary
+        let status = CVPixelBufferCreate(
+            kCFAllocatorDefault, width, height, kCVPixelFormatType_32BGRA, attrs, &pb)
+        precondition(status == kCVReturnSuccess, "CVPixelBufferCreate failed")
+        let buffer = pb!
+        CVPixelBufferLockBaseAddress(buffer, [])
+        if let base = CVPixelBufferGetBaseAddress(buffer) {
+            memset(base, Int32(fill), CVPixelBufferGetBytesPerRow(buffer) * height)
+        }
+        CVPixelBufferUnlockBaseAddress(buffer, [])
+        return buffer
+    }
+
+    @Test("encodes a synthetic frame into a keyframe carrying an avcC description")
+    func encodesKeyframeWithDescription() async {
+        let encoder = H264Encoder(fps: 30, bitrate: 2_000_000)
+
+        let result: H264Encoder.Encoded? = await withCheckedContinuation { cont in
+            let lock = NSLock()
+            var resumed = false
+            func finish(_ encoded: H264Encoder.Encoded?) {
+                lock.lock()
+                let first = !resumed
+                resumed = true
+                lock.unlock()
+                if first { cont.resume(returning: encoded) }
+            }
+
+            encoder.onEncoded = { encoded in
+                if encoded.kind == .keyframe, encoded.description != nil { finish(encoded) }
+            }
+
+            DispatchQueue.global().async {
+                let frame = self.makePixelBuffer(width: 320, height: 240, fill: 0x80)
+                for i in 0..<10 {
+                    encoder.encode(frame, forceKeyframe: i == 0)
+                    usleep(20_000)
+                }
+            }
+            DispatchQueue.global().asyncAfter(deadline: .now() + 5) { finish(nil) }
+        }
+
+        #expect(result != nil, "encoder should emit a keyframe within 5s")
+        #expect(result?.avcc.isEmpty == false)
+        // avcC blob is ISO/IEC 14496-15: first byte is the configuration version 1.
+        #expect(result?.description?.first == 0x01)
+        encoder.stop()
+    }
+}

--- a/Tests/PreviewsIOSTests/IOSSimulatorPicker.swift
+++ b/Tests/PreviewsIOSTests/IOSSimulatorPicker.swift
@@ -30,6 +30,7 @@ enum IOSSimulatorPicker {
     /// - index 2: `IOSMCPTests.fullIOSWorkflow` (in MCP target; uses UDID
     ///   via preview_start's `deviceUDID` arg)
     /// - index 3: `IOSPreviewSessionTests.endToEndUIViewBodyKindProbe`
+    /// - index 4: `SimulatorManagerTests.makeHIDClient`
     ///
     /// Sort order matches the MCP-target sibling's
     /// `IOSSimulatorPicker.pickUDID(index:)` for consistency: iOS runtime

--- a/Tests/PreviewsIOSTests/SimulatorManagerTests.swift
+++ b/Tests/PreviewsIOSTests/SimulatorManagerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+@preconcurrency import SimulatorBridge
 import Testing
 
 @testable import PreviewsIOS
@@ -111,6 +112,40 @@ struct SimulatorManagerTests {
                 || afterShutdown.state == SimulatorManager.DeviceState.shuttingDown
         )
         print("State after shutdown: \(afterShutdown.stateString)")
+
+        if let testError { throw testError }
+    }
+
+    @Test("Create a daemon-side HID client against a booted device")
+    func makeHIDClient() async throws {
+        guard let target = try await IOSSimulatorPicker.pick(index: 4) else {
+            print("No iOS simulator at picker index 4 — skipping")
+            return
+        }
+        let manager = SimulatorManager()
+
+        // Boot only if needed, and shut down only what we booted, so the test
+        // leaves the device in the state it found it.
+        let initial = try await manager.findDevice(udid: target.udid)
+        let weBootedIt = initial.state != SimulatorManager.DeviceState.booted
+        if weBootedIt {
+            print("Booting \(target.name) (\(target.udid)) for HID client test...")
+            try await manager.bootDevice(udid: target.udid)
+        }
+
+        var testError: (any Error)?
+        do {
+            let c1 = try await manager.makeHIDClient(udid: target.udid)
+            let c2 = try await manager.makeHIDClient(udid: target.udid)
+            #expect(c1 !== c2)
+        } catch {
+            testError = error
+        }
+
+        if weBootedIt {
+            print("Shutting down...")
+            try await manager.shutdownDevice(udid: target.udid)
+        }
 
         if let testError { throw testError }
     }

--- a/Tests/PreviewsIOSTests/SimulatorManagerTests.swift
+++ b/Tests/PreviewsIOSTests/SimulatorManagerTests.swift
@@ -149,4 +149,41 @@ struct SimulatorManagerTests {
 
         if let testError { throw testError }
     }
+
+    @Test("Create a daemon-side framebuffer streamer against a booted device")
+    func makeFramebufferStreamer() async throws {
+        guard let target = try await IOSSimulatorPicker.pick(index: 1) else {
+            print("No iOS simulator at picker index 1 — skipping")
+            return
+        }
+        let manager = SimulatorManager()
+
+        let initial = try await manager.findDevice(udid: target.udid)
+        let weBootedIt = initial.state != SimulatorManager.DeviceState.booted
+        if weBootedIt {
+            print("Booting \(target.name) (\(target.udid)) for streamer test...")
+            try await manager.bootDevice(udid: target.udid)
+        }
+
+        var testError: (any Error)?
+        do {
+            // Creation only asserts the bridge symbol resolves and the device
+            // IO client is reachable; with no app launched the display may not
+            // wire up, so `latestFrame` returning nil here is expected and must
+            // not crash. End-to-end frame capture is covered by
+            // IOSAppServerTests.appServerEndToEnd (which launches a preview).
+            let streamer = try await manager.makeFramebufferStreamer(udid: target.udid)
+            _ = streamer.latestFrame()
+            streamer.stop()
+        } catch {
+            testError = error
+        }
+
+        if weBootedIt {
+            print("Shutting down...")
+            try await manager.shutdownDevice(udid: target.udid)
+        }
+
+        if let testError { throw testError }
+    }
 }


### PR DESCRIPTION
## Summary

Agent-native interactive preview for iOS. A per-session loopback server streams the running simulator preview and accepts pointer input, hosted in the daemon and kept separate from the agent MCP tools and the CLI.

https://github.com/user-attachments/assets/ce1f05a6-bb5b-4c41-be4c-e108f4468da8

## What's in it

- **IndigoHID input** — a daemon-side HID client (SimulatorKit) drives tap and drag at the simulator digitizer, normalized 0..1.
- **Per-session app server** — `PreviewAppServer` on `127.0.0.1` exposes `POST /control` (tap/drag), `GET /stream.mjpeg`, `GET /stream.avcc`, and `GET /` (the viewer). Hosted in `IOSPreviewSession`, in-process with the display owner so it survives agent respawn.
- **Event-driven capture** — `SBFramebufferStreamer` registers simulator screen callbacks and re-encodes only when the IOSurface seed changes, replacing the per-frame `screenshotData` polling.
- **H.264 (avcC) stream** — `H264Encoder` (VideoToolbox) plus `AVCCVideoStream` fan out length-prefixed NAL chunks over `GET /stream.avcc`, gated on having a subscriber so an MJPEG-only session pays no H.264 cost.
- **Web viewer** — a self-contained page at `GET /` decodes the avcC stream with WebCodecs (MJPEG fallback) and forwards pointer input. This mirrors the serve-sim model, so a browser or in-app webview opens the localhost URL directly.

## Testing

Full local suite green (no CI). New coverage: hermetic `H264EncoderTests`, `AVCC envelope`, and `PreviewAppServer stream` (including `GET /`), plus real-sim `IOSAppServerTests.appServerEndToEnd` which drives `/control` and asserts a JPEG over `/stream.mjpeg` and an avcC description plus IDR keyframe over `/stream.avcc`, and `SimulatorManager` HID/streamer creation. One unrelated pre-existing macOS reloader failure is tracked in #276.

## Follow-ups

- #275 — more input verbs (keyboard, scroll, buttons, rotation)
- #274 — daemon `PREVIEWSMCP_SOCKET_DIR` symlink readiness bug
- MCP app client — reuse this web viewer; only the data transport changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
