### PR TITLE
Fix #281 (xcodeproj+SwiftPM previews) and #282 (pre-iOS-26 gate), with repro fixtures

### DIFF
--- a/docs/repro-pre-ios26-shell-crash.md
+++ b/docs/repro-pre-ios26-shell-crash.md
@@ -1,0 +1,74 @@
+# Repro: iOS shell crash on pre-iOS-26 simulators (#282)
+
+The scene-hosting initializer the shell uses aborts on simulators older than
+iOS 26 with:
+
+```
+NSInvalidArgumentException: -[_UISceneHostingControllerAdvancedConfiguration initWithClientIdentity:]: unrecognized selector
+```
+
+The crash site is `ios-host/shell/ShellMain.m` in `hostWithToken:`, which calls
+`initWithClientIdentity:` through `performSelector` with no `respondsToSelector:`
+guard. That private initializer exists on iOS 26 but not on earlier runtimes.
+
+Verified on iOS 18.6: the class `_UISceneHostingControllerAdvancedConfiguration`
+exists, but `instancesRespondToSelector:@selector(initWithClientIdentity:)` is
+`NO`. On iOS 26.2 the selector is present. The issue was first reported on 18.3;
+Apple no longer serves that point release for download, and any sub-26 runtime
+shows the same selector gap.
+
+## Why there is no `examples/` fixture
+
+This is a runtime-compatibility bug in the shell, not a project-shape bug. The
+trigger is the runtime, not the project, so it lives as a test plus this recipe.
+
+## A nuance: the full session does not always reach the crash
+
+On iOS 18.6 the production `IOSPreviewSession` does **not** crash. The shell
+returns early in `clientIdentityForToken:` (FrontBoard hands back no client
+identity on that runtime) before reaching the `initWithClientIdentity:` line, and
+the agent renders to its own window regardless. So an end-to-end render check
+passes even though the scene-hosting path is broken. The reporter's 18.3 runtime
+returned a client identity, so its shell reached the crash line and aborted.
+
+Because of this, the test below fires the **exact unguarded call** ShellMain
+makes, rather than relying on the full session reaching it.
+
+## Prerequisites
+
+A sub-26 iOS simulator runtime installed. iOS 18.3 is no longer downloadable;
+use a served point release such as 18.6:
+
+```bash
+xcodebuild -downloadPlatform iOS -buildVersion 18.6
+xcrun simctl list runtimes | grep -i ios
+```
+
+## Reproduce via the test
+
+`Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift` has
+`sceneHostingInitIsUnrecognizedSelectorOnPreIOS26`. It self-skips unless a sub-26
+iPhone runtime is available, then spawns a probe inside that simulator that fires
+ShellMain's `initWithClientIdentity:` call and asserts the `unrecognized selector`
+abort.
+
+```bash
+swift test --filter sceneHostingInitIsUnrecognizedSelectorOnPreIOS26
+```
+
+- No pre-26 runtime installed → the test is skipped.
+- Pre-26 runtime installed → the probe aborts with the unrecognized-selector
+  signature and the test passes (reproduction confirmed).
+
+## Reproduce manually
+
+```objc
+// Compile for the iphonesimulator and `xcrun simctl spawn <pre-26 udid> ./probe`.
+dlopen("/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore", RTLD_NOW);
+Class AdvCfg = NSClassFromString(@"_UISceneHostingControllerAdvancedConfiguration");
+@try {
+    [[AdvCfg alloc] performSelector:@selector(initWithClientIdentity:) withObject:[NSObject new]];
+} @catch (NSException *e) {
+    NSLog(@"%@", e.reason);  // -[... initWithClientIdentity:]: unrecognized selector ... on pre-26
+}
+```

--- a/examples/xcodeproj/Packages/DeviceFlag/Package.swift
+++ b/examples/xcodeproj/Packages/DeviceFlag/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "DeviceFlag",
+    platforms: [.macOS(.v14), .iOS(.v17)],
+    products: [
+        .library(name: "DeviceFlag", targets: ["DeviceFlag"]),
+    ],
+    targets: [
+        .target(name: "DeviceFlag"),
+    ]
+)

--- a/examples/xcodeproj/Packages/DeviceFlag/Sources/DeviceFlag/DeviceFlag.swift
+++ b/examples/xcodeproj/Packages/DeviceFlag/Sources/DeviceFlag/DeviceFlag.swift
@@ -1,0 +1,12 @@
+import DeviceCheck
+import Foundation
+
+/// Touches the DeviceCheck system framework so this package's object closure
+/// references a framework the preview agent never links itself (issue #281, layer 4).
+public enum DeviceFlag {
+    public static let isDeviceCheckSupported: Bool = DCDevice.current.isSupported
+
+    public static func badgeText() -> String {
+        isDeviceCheckSupported ? "Verified device" : "Unverified device"
+    }
+}

--- a/examples/xcodeproj/README.md
+++ b/examples/xcodeproj/README.md
@@ -7,12 +7,28 @@ A minimal SwiftUI framework built with Xcode (via XcodeGen), with a cross-file t
 ```
 Sources/ToDo/
 ├── Item.swift                — defines Item model (used by views)
-├── ToDoView.swift            — view + #Preview that references Item
+├── ToDoView.swift            — view + #Preview that references Item; renders DeviceFlag.badgeText()
 └── ToDoProviderPreview.swift — PreviewProvider-based preview for integration testing
+Packages/DeviceFlag/          — local SwiftPM package the target integrates (touches the DeviceCheck system framework)
 project.yml                   — XcodeGen spec (generates ToDo.xcodeproj)
 ```
 
 The `#Preview` blocks in `ToDoView.swift` use `Item.samples` which is defined in `Item.swift`. This requires PreviewsMCP to detect the Xcode project, build it, and compile the preview against the target's build artifacts. The file has two previews: the default (with sample data) and "Empty State" (no items).
+
+## SwiftPM-package integration (issue #281)
+
+`project.yml` declares a `packages:` entry for the local `Packages/DeviceFlag` package, and the `ToDo` target depends on it. `DeviceFlag` imports the `DeviceCheck` system framework. This is the regression fixture for [#281](https://github.com/obj-p/PreviewsMCP/issues/281): a native `.xcodeproj` that integrates Xcode-managed SwiftPM packages.
+
+Such packages do **not** arrive as frameworks or `-l` static archives. After a build, `BUILT_PRODUCTS_DIR` holds a bare `DeviceFlag.swiftmodule` plus a loose `DeviceFlag.o` (no `.a`). This exercises all four layers from the issue:
+
+| Layer | What the fixture triggers |
+|---|---|
+| 1. Compile | the `.swiftmodule` needs `-I`, not just `-F BUILT_PRODUCTS_DIR` |
+| 2. Link | the dep is a loose `.o` with no `.a` archive to collect |
+| 3. JIT-link | on an iOS-simulator build the `.o` is universal (arm64 + x86_64) and must be thinned (the macOS build is already thin arm64) |
+| 4. JIT-materialize | linking the `.o` resolves DeviceCheck symbols, a system framework the agent never links — the open layer |
+
+To reproduce end to end, run `preview_start` on `Sources/ToDo/ToDoView.swift` with `projectPath` set to `examples/xcodeproj/`. Before the #281 fix the preview fails to compile (`no such module 'DeviceFlag'`) or link.
 
 The UI includes tappable item rows (toggle completion), a toggle switch, and a horizontally paged summary card section — suitable for testing tap, toggle, and swipe interactions.
 

--- a/examples/xcodeproj/Sources/ToDo/ToDoView.swift
+++ b/examples/xcodeproj/Sources/ToDo/ToDoView.swift
@@ -1,3 +1,4 @@
+import DeviceFlag
 import SwiftUI
 
 /// A view that references `Item` from Item.swift.
@@ -58,6 +59,10 @@ struct ToDoView: View {
                             }
                         })
                 }
+
+                Text(DeviceFlag.badgeText())
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
             .navigationTitle("My Items")
         }

--- a/examples/xcodeproj/project.yml
+++ b/examples/xcodeproj/project.yml
@@ -8,10 +8,15 @@ settings:
   base:
     SWIFT_VERSION: "6.0"
     SWIFT_STRICT_CONCURRENCY: complete
+packages:
+  DeviceFlag:
+    path: Packages/DeviceFlag
 targets:
   ToDo:
     type: framework
     supportedDestinations: [macOS, iOS]
+    dependencies:
+      - package: DeviceFlag
     sources:
       - path: Sources/ToDo
     settings:

--- a/previewsmcp/PreviewsCore/BuildContext.swift
+++ b/previewsmcp/PreviewsCore/BuildContext.swift
@@ -14,6 +14,13 @@ public struct BuildContext: Sendable {
     /// The target name within the project that contains the source file.
     public let targetName: String
 
+    /// System framework binaries the JIT agent must `dlopen` so a linked dependency
+    /// object's symbols resolve, e.g. DeviceCheck autolinked by an Xcode-managed
+    /// SwiftPM package. These resolve from the dyld shared cache by canonical path,
+    /// so they are pre-resolved here rather than routed through `-framework` flags
+    /// (which would also reach swiftc).
+    public let frameworkPaths: [URL]
+
     // MARK: - Tier 2 (optional): compile all target sources + literal hot-reload
 
     /// All source files in the target EXCEPT the preview file.
@@ -31,12 +38,14 @@ public struct BuildContext: Sendable {
         compilerFlags: [String],
         projectRoot: URL,
         targetName: String,
+        frameworkPaths: [URL] = [],
         sourceFiles: [URL]? = nil
     ) {
         self.moduleName = moduleName
         self.compilerFlags = compilerFlags
         self.projectRoot = projectRoot
         self.targetName = targetName
+        self.frameworkPaths = frameworkPaths
         self.sourceFiles = sourceFiles
     }
 }

--- a/previewsmcp/PreviewsCore/PreviewSession.swift
+++ b/previewsmcp/PreviewsCore/PreviewSession.swift
@@ -202,6 +202,7 @@ public actor PreviewSession {
             archivePaths.append(URL(fileURLWithPath: runtimeArchive))
         }
         var dylibPaths = Self.dependencyDylibs(in: linkFlags)
+        dylibPaths += buildContext?.frameworkPaths ?? []
         if let path = setupDylibPath, hasSetup {
             dylibPaths.insert(path, at: 0)
         }

--- a/previewsmcp/PreviewsCore/XcodeBuildSystem.swift
+++ b/previewsmcp/PreviewsCore/XcodeBuildSystem.swift
@@ -139,13 +139,16 @@ public actor XcodeBuildSystem: BuildSystem {
         }
 
         // 6. Build compiler flags
-        let compilerFlags = buildCompilerFlags(settings: settings)
+        var compilerFlags = buildCompilerFlags(settings: settings)
+        let package = await Self.swiftPMPackageProducts(builtProductsDir: builtProductsDir)
+        compilerFlags += package.flags
 
         return BuildContext(
             moduleName: moduleName,
             compilerFlags: compilerFlags,
             projectRoot: projectRoot,
             targetName: targetName,
+            frameworkPaths: package.frameworkPaths,
             sourceFiles: sourceFiles
         )
     }
@@ -432,6 +435,111 @@ public actor XcodeBuildSystem: BuildSystem {
         }
 
         return flags
+    }
+
+    /// Xcode-managed SwiftPM packages land in `BUILT_PRODUCTS_DIR` as a bare
+    /// `<Module>.swiftmodule` plus a loose, universal `<Module>.o` (no `.a`, and no
+    /// `-l`/`-framework` surface in the build settings). Turn each into the inputs the
+    /// JIT pipeline consumes:
+    ///   - `-I <dir>` so the overlay recompile resolves `import <Module>`.
+    ///   - thin each `.o` to the host arch and wrap it in a single-member
+    ///     `lib<Module>.a`, emitted as `-L`/`-l`. One archive per object means the
+    ///     linker pulls only the modules the preview actually imports.
+    ///   - the canonical path of each system framework the object autolinks (e.g.
+    ///     DeviceCheck, read from `LC_LINKER_OPTION`), returned separately so the agent
+    ///     `dlopen`s it from the dyld shared cache without the name reaching swiftc.
+    /// Inert when `BUILT_PRODUCTS_DIR` holds no loose objects (the rules_xcodeproj and
+    /// framework-only cases), so it only affects the native SwiftPM-package path.
+    static func swiftPMPackageProducts(
+        builtProductsDir: String
+    ) async -> (flags: [String], frameworkPaths: [URL]) {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(atPath: builtProductsDir) else {
+            return ([], [])
+        }
+        let objects = entries.filter { $0.hasSuffix(".o") }.sorted()
+        guard !objects.isEmpty else { return ([], []) }
+
+        let cacheDir = (builtProductsDir as NSString)
+            .appendingPathComponent("previewsmcp-package-archives")
+        try? fm.createDirectory(atPath: cacheDir, withIntermediateDirectories: true)
+
+        // Each object's archive + autolink work is independent, so process them
+        // concurrently; a large package closure is the case #281 targets.
+        let archived = await withTaskGroup(of: (base: String, frameworks: Set<String>).self) {
+            group in
+            for object in objects {
+                group.addTask {
+                    await Self.archivePackageObject(
+                        object: object, builtProductsDir: builtProductsDir, cacheDir: cacheDir)
+                }
+            }
+            var results: [(base: String, frameworks: Set<String>)] = []
+            for await result in group { results.append(result) }
+            return results.sorted { $0.base < $1.base }
+        }
+
+        var flags = ["-I", builtProductsDir]
+        var frameworks = Set<String>()
+        for entry in archived {
+            flags += ["-L", cacheDir, "-l\(entry.base)"]
+            frameworks.formUnion(entry.frameworks)
+        }
+        let frameworkPaths = frameworks.sorted().map {
+            URL(fileURLWithPath: "/System/Library/Frameworks/\($0).framework/\($0)")
+        }
+        return (flags, frameworkPaths)
+    }
+
+    /// Thin one package object to the host arch, wrap it in a single-member
+    /// `lib<base>.a` under `cacheDir`, and return its autolinked frameworks.
+    private static func archivePackageObject(
+        object: String, builtProductsDir: String, cacheDir: String
+    ) async -> (base: String, frameworks: Set<String>) {
+        let fm = FileManager.default
+        let objectPath = (builtProductsDir as NSString).appendingPathComponent(object)
+        let base = String(object.dropLast(2))
+        async let frameworks = autolinkFrameworks(objectPath: objectPath)
+
+        let thin = (cacheDir as NSString).appendingPathComponent("\(base).o")
+        _ = try? await runAsync(
+            "/usr/bin/lipo", arguments: ["-thin", hostArch, objectPath, "-output", thin],
+            discardStderr: true)
+        let linkObject = fm.fileExists(atPath: thin) ? thin : objectPath
+        let archive = (cacheDir as NSString).appendingPathComponent("lib\(base).a")
+        try? fm.removeItem(atPath: archive)
+        _ = try? await runAsync(
+            "/usr/bin/ar", arguments: ["rcs", archive, linkObject], discardStderr: true)
+        return (base, await frameworks)
+    }
+
+    /// The arch the JIT agent runs as, used to thin universal package objects.
+    static var hostArch: String {
+        #if arch(arm64)
+        return "arm64"
+        #else
+        return "x86_64"
+        #endif
+    }
+
+    /// Read the `-framework <name>` autolink directives Swift bakes into an object's
+    /// `LC_LINKER_OPTION` load commands. These name the system frameworks the object
+    /// depends on (e.g. DeviceCheck) that have no presence in the build settings.
+    static func autolinkFrameworks(objectPath: String) async -> Set<String> {
+        guard let output = try? await runAsync("/usr/bin/otool", arguments: ["-l", objectPath]) else {
+            return []
+        }
+        let lines = output.stdout.split(separator: "\n")
+        var names = Set<String>()
+        for (index, line) in lines.enumerated()
+        where line.contains("string #1 -framework") && index + 1 < lines.count {
+            if let range = lines[index + 1].range(of: "string #2 ") {
+                names.insert(
+                    String(lines[index + 1][range.upperBound...])
+                        .trimmingCharacters(in: .whitespaces))
+            }
+        }
+        return names
     }
 
     /// Split a build-setting flag string into non-empty whitespace-separated tokens.

--- a/previewsmcp/PreviewsCore/XcodeBuildSystem.swift
+++ b/previewsmcp/PreviewsCore/XcodeBuildSystem.swift
@@ -437,111 +437,6 @@ public actor XcodeBuildSystem: BuildSystem {
         return flags
     }
 
-    /// Xcode-managed SwiftPM packages land in `BUILT_PRODUCTS_DIR` as a bare
-    /// `<Module>.swiftmodule` plus a loose, universal `<Module>.o` (no `.a`, and no
-    /// `-l`/`-framework` surface in the build settings). Turn each into the inputs the
-    /// JIT pipeline consumes:
-    ///   - `-I <dir>` so the overlay recompile resolves `import <Module>`.
-    ///   - thin each `.o` to the host arch and wrap it in a single-member
-    ///     `lib<Module>.a`, emitted as `-L`/`-l`. One archive per object means the
-    ///     linker pulls only the modules the preview actually imports.
-    ///   - the canonical path of each system framework the object autolinks (e.g.
-    ///     DeviceCheck, read from `LC_LINKER_OPTION`), returned separately so the agent
-    ///     `dlopen`s it from the dyld shared cache without the name reaching swiftc.
-    /// Inert when `BUILT_PRODUCTS_DIR` holds no loose objects (the rules_xcodeproj and
-    /// framework-only cases), so it only affects the native SwiftPM-package path.
-    static func swiftPMPackageProducts(
-        builtProductsDir: String
-    ) async -> (flags: [String], frameworkPaths: [URL]) {
-        let fm = FileManager.default
-        guard let entries = try? fm.contentsOfDirectory(atPath: builtProductsDir) else {
-            return ([], [])
-        }
-        let objects = entries.filter { $0.hasSuffix(".o") }.sorted()
-        guard !objects.isEmpty else { return ([], []) }
-
-        let cacheDir = (builtProductsDir as NSString)
-            .appendingPathComponent("previewsmcp-package-archives")
-        try? fm.createDirectory(atPath: cacheDir, withIntermediateDirectories: true)
-
-        // Each object's archive + autolink work is independent, so process them
-        // concurrently; a large package closure is the case #281 targets.
-        let archived = await withTaskGroup(of: (base: String, frameworks: Set<String>).self) {
-            group in
-            for object in objects {
-                group.addTask {
-                    await Self.archivePackageObject(
-                        object: object, builtProductsDir: builtProductsDir, cacheDir: cacheDir)
-                }
-            }
-            var results: [(base: String, frameworks: Set<String>)] = []
-            for await result in group { results.append(result) }
-            return results.sorted { $0.base < $1.base }
-        }
-
-        var flags = ["-I", builtProductsDir]
-        var frameworks = Set<String>()
-        for entry in archived {
-            flags += ["-L", cacheDir, "-l\(entry.base)"]
-            frameworks.formUnion(entry.frameworks)
-        }
-        let frameworkPaths = frameworks.sorted().map {
-            URL(fileURLWithPath: "/System/Library/Frameworks/\($0).framework/\($0)")
-        }
-        return (flags, frameworkPaths)
-    }
-
-    /// Thin one package object to the host arch, wrap it in a single-member
-    /// `lib<base>.a` under `cacheDir`, and return its autolinked frameworks.
-    private static func archivePackageObject(
-        object: String, builtProductsDir: String, cacheDir: String
-    ) async -> (base: String, frameworks: Set<String>) {
-        let fm = FileManager.default
-        let objectPath = (builtProductsDir as NSString).appendingPathComponent(object)
-        let base = String(object.dropLast(2))
-        async let frameworks = autolinkFrameworks(objectPath: objectPath)
-
-        let thin = (cacheDir as NSString).appendingPathComponent("\(base).o")
-        _ = try? await runAsync(
-            "/usr/bin/lipo", arguments: ["-thin", hostArch, objectPath, "-output", thin],
-            discardStderr: true)
-        let linkObject = fm.fileExists(atPath: thin) ? thin : objectPath
-        let archive = (cacheDir as NSString).appendingPathComponent("lib\(base).a")
-        try? fm.removeItem(atPath: archive)
-        _ = try? await runAsync(
-            "/usr/bin/ar", arguments: ["rcs", archive, linkObject], discardStderr: true)
-        return (base, await frameworks)
-    }
-
-    /// The arch the JIT agent runs as, used to thin universal package objects.
-    static var hostArch: String {
-        #if arch(arm64)
-        return "arm64"
-        #else
-        return "x86_64"
-        #endif
-    }
-
-    /// Read the `-framework <name>` autolink directives Swift bakes into an object's
-    /// `LC_LINKER_OPTION` load commands. These name the system frameworks the object
-    /// depends on (e.g. DeviceCheck) that have no presence in the build settings.
-    static func autolinkFrameworks(objectPath: String) async -> Set<String> {
-        guard let output = try? await runAsync("/usr/bin/otool", arguments: ["-l", objectPath]) else {
-            return []
-        }
-        let lines = output.stdout.split(separator: "\n")
-        var names = Set<String>()
-        for (index, line) in lines.enumerated()
-        where line.contains("string #1 -framework") && index + 1 < lines.count {
-            if let range = lines[index + 1].range(of: "string #2 ") {
-                names.insert(
-                    String(lines[index + 1][range.upperBound...])
-                        .trimmingCharacters(in: .whitespaces))
-            }
-        }
-        return names
-    }
-
     /// Split a build-setting flag string into non-empty whitespace-separated tokens.
     static func tokenizeFlags(_ value: String) -> [String] {
         value
@@ -686,6 +581,115 @@ public actor XcodeBuildSystem: BuildSystem {
             )
         }
         return output.stdout
+    }
+}
+
+// MARK: - Xcode-managed SwiftPM package products
+
+extension XcodeBuildSystem {
+    /// Xcode-managed SwiftPM packages land in `BUILT_PRODUCTS_DIR` as a bare
+    /// `<Module>.swiftmodule` plus a loose, universal `<Module>.o` (no `.a`, and no
+    /// `-l`/`-framework` surface in the build settings). Turn each into the inputs the
+    /// JIT pipeline consumes:
+    ///   - `-I <dir>` so the overlay recompile resolves `import <Module>`.
+    ///   - thin each `.o` to the host arch and wrap it in a single-member
+    ///     `lib<Module>.a`, emitted as `-L`/`-l`. One archive per object means the
+    ///     linker pulls only the modules the preview actually imports.
+    ///   - the canonical path of each system framework the object autolinks (e.g.
+    ///     DeviceCheck, read from `LC_LINKER_OPTION`), returned separately so the agent
+    ///     `dlopen`s it from the dyld shared cache without the name reaching swiftc.
+    /// Inert when `BUILT_PRODUCTS_DIR` holds no loose objects (the rules_xcodeproj and
+    /// framework-only cases), so it only affects the native SwiftPM-package path.
+    static func swiftPMPackageProducts(
+        builtProductsDir: String
+    ) async -> (flags: [String], frameworkPaths: [URL]) {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(atPath: builtProductsDir) else {
+            return ([], [])
+        }
+        let objects = entries.filter { $0.hasSuffix(".o") }.sorted()
+        guard !objects.isEmpty else { return ([], []) }
+
+        let cacheDir = (builtProductsDir as NSString)
+            .appendingPathComponent("previewsmcp-package-archives")
+        try? fm.createDirectory(atPath: cacheDir, withIntermediateDirectories: true)
+
+        // Each object's archive + autolink work is independent, so process them
+        // concurrently; a large package closure is the case #281 targets.
+        let archived = await withTaskGroup(of: (base: String, frameworks: Set<String>).self) {
+            group in
+            for object in objects {
+                group.addTask {
+                    await Self.archivePackageObject(
+                        object: object, builtProductsDir: builtProductsDir, cacheDir: cacheDir)
+                }
+            }
+            var results: [(base: String, frameworks: Set<String>)] = []
+            for await result in group { results.append(result) }
+            return results.sorted { $0.base < $1.base }
+        }
+
+        var flags = ["-I", builtProductsDir]
+        var frameworks = Set<String>()
+        for entry in archived {
+            flags += ["-L", cacheDir, "-l\(entry.base)"]
+            frameworks.formUnion(entry.frameworks)
+        }
+        let frameworkPaths = frameworks.sorted().map {
+            URL(fileURLWithPath: "/System/Library/Frameworks/\($0).framework/\($0)")
+        }
+        return (flags, frameworkPaths)
+    }
+
+    /// Thin one package object to the host arch, wrap it in a single-member
+    /// `lib<base>.a` under `cacheDir`, and return its autolinked frameworks.
+    private static func archivePackageObject(
+        object: String, builtProductsDir: String, cacheDir: String
+    ) async -> (base: String, frameworks: Set<String>) {
+        let fm = FileManager.default
+        let objectPath = (builtProductsDir as NSString).appendingPathComponent(object)
+        let base = String(object.dropLast(2))
+        async let frameworks = autolinkFrameworks(objectPath: objectPath)
+
+        let thin = (cacheDir as NSString).appendingPathComponent("\(base).o")
+        _ = try? await runAsync(
+            "/usr/bin/lipo", arguments: ["-thin", hostArch, objectPath, "-output", thin],
+            discardStderr: true)
+        let linkObject = fm.fileExists(atPath: thin) ? thin : objectPath
+        let archive = (cacheDir as NSString).appendingPathComponent("lib\(base).a")
+        try? fm.removeItem(atPath: archive)
+        _ = try? await runAsync(
+            "/usr/bin/ar", arguments: ["rcs", archive, linkObject], discardStderr: true)
+        return (base, await frameworks)
+    }
+
+    /// The arch the JIT agent runs as, used to thin universal package objects.
+    static var hostArch: String {
+        #if arch(arm64)
+        return "arm64"
+        #else
+        return "x86_64"
+        #endif
+    }
+
+    /// Read the `-framework <name>` autolink directives Swift bakes into an object's
+    /// `LC_LINKER_OPTION` load commands. These name the system frameworks the object
+    /// depends on (e.g. DeviceCheck) that have no presence in the build settings.
+    static func autolinkFrameworks(objectPath: String) async -> Set<String> {
+        guard let output = try? await runAsync("/usr/bin/otool", arguments: ["-l", objectPath]) else {
+            return []
+        }
+        let lines = output.stdout.split(separator: "\n")
+        var names = Set<String>()
+        for (index, line) in lines.enumerated()
+        where line.contains("string #1 -framework") && index + 1 < lines.count {
+            if let range = lines[index + 1].range(of: "string #2 ") {
+                names.insert(
+                    String(lines[index + 1][range.upperBound...])
+                        .trimmingCharacters(in: .whitespaces))
+            }
+        }
+        return names
     }
 }
 

--- a/previewsmcp/PreviewsEngine/BuildHelpers.swift
+++ b/previewsmcp/PreviewsEngine/BuildHelpers.swift
@@ -88,16 +88,17 @@ public func resolveDeviceUDID(
     if let provided {
         return provided
     }
-    do {
-        let booted = try await simulatorManager.findBootedDevice()
+    // Prefer a supported (iOS 26+) simulator. A booted pre-26 device or older
+    // installed runtimes must not be auto-picked, or the session would fail the
+    // pre-26 gate (#282) even when a usable simulator is available.
+    if let booted = try? await simulatorManager.findBootedDevice(), booted.isPreviewSupported {
         return booted.udid
-    } catch {
-        let devices = try await simulatorManager.listDevices()
-        guard let first = devices.first(where: { $0.isAvailable }) else {
-            throw NoSimulatorError()
-        }
-        return first.udid
     }
+    let devices = try await simulatorManager.listDevices()
+    guard let device = devices.first(where: { $0.isAvailable && $0.isPreviewSupported }) else {
+        throw NoSimulatorError()
+    }
+    return device.udid
 }
 
 public struct NoSimulatorError: LocalizedError {

--- a/previewsmcp/PreviewsIOS/IOSAgentBuilder.swift
+++ b/previewsmcp/PreviewsIOS/IOSAgentBuilder.swift
@@ -15,10 +15,15 @@ public actor IOSAgentBuilder {
     private var cachedShellAppPath: URL?
 
     public init(workDir: URL? = nil) async throws {
+        // Default to a per-instance directory so concurrent builders never share
+        // the agent/shell source on disk. Production keeps one builder per daemon
+        // (IOSSessionManager), so this still builds once and caches in the actor;
+        // tests create many builders, and a shared path raced ("input file ...
+        // PreviewsMCPAgent.swift was modified during the build").
         let dir =
             workDir
                 ?? FileManager.default.temporaryDirectory
-                .appendingPathComponent("previewsmcp-agent", isDirectory: true)
+                .appendingPathComponent("previewsmcp-agent-\(UUID().uuidString)", isDirectory: true)
 
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         self.workDir = dir

--- a/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
+++ b/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
@@ -144,6 +144,16 @@ public actor IOSPreviewSession {
             throw IOSPreviewSessionError.jitRuntimeMissing
         }
 
+        // Fail fast on pre-iOS-26 runtimes: the shell hosts the agent's scene via
+        // a private initializer that only exists on iOS 26, so on older runtimes
+        // hosting is impossible and every captured frame is the springboard, not
+        // the preview (#282). Refuse with a clear diagnostic instead.
+        let device = try await simulatorManager.findDevice(udid: deviceUDID)
+        if !device.isPreviewSupported {
+            throw IOSPreviewSessionError.unsupportedRuntime(
+                device.runtimeName ?? device.iosMajorVersion.map { "iOS \($0)" } ?? "this simulator")
+        }
+
         /// Mirror stage transitions to the diagnostic log so operators
         /// running `previewsmcp logs` (or scraping CI capture files) can
         /// see where a stall occurred. MCP LogMessageNotifications go
@@ -762,6 +772,9 @@ public enum IOSPreviewSessionError: Error, LocalizedError, CustomStringConvertib
     /// to start). Replaces the generic accept timeout / downstream link error
     /// with the host-side cause. See issue #217.
     case jitExecutorFailed(stage: String, code: Int?)
+    /// The target simulator runs iOS older than 26, whose private scene-hosting
+    /// API the shell needs is absent (#282). Live previews require iOS 26+.
+    case unsupportedRuntime(String)
 
     public var description: String {
         switch self {
@@ -777,6 +790,8 @@ public enum IOSPreviewSessionError: Error, LocalizedError, CustomStringConvertib
         case let .jitExecutorFailed(stage, code):
             let suffix = code.map { " (code \($0))" } ?? ""
             return "In-app JIT executor failed during \(stage)\(suffix)"
+        case .unsupportedRuntime(let detail):
+            return "iOS simulator unsupported for live preview: \(detail). Use an iOS 26+ simulator."
         }
     }
 

--- a/previewsmcp/PreviewsIOS/SimulatorManager.swift
+++ b/previewsmcp/PreviewsIOS/SimulatorManager.swift
@@ -19,6 +19,33 @@ public actor SimulatorManager {
         public var description: String {
             "\(name) (\(udid)) \(stateString) — \(runtimeName ?? "no runtime")"
         }
+
+        /// Live previews need the iOS 26+ scene-hosting API (#282).
+        public static let minimumSupportedIOSMajorVersion = 26
+
+        /// The major iOS version of this device's runtime, parsed from the runtime
+        /// identifier (`...SimRuntime.iOS-26-2`) or name (`iOS 26.2`). Nil for a
+        /// non-iOS or unparseable runtime.
+        public var iosMajorVersion: Int? {
+            if let id = runtimeIdentifier, let range = id.range(of: "SimRuntime.iOS-"),
+                let value = Int(id[range.upperBound...].prefix { $0 != "-" })
+            {
+                return value
+            }
+            if let name = runtimeName, let range = name.range(of: "iOS "),
+                let value = Int(name[range.upperBound...].prefix { $0.isNumber })
+            {
+                return value
+            }
+            return nil
+        }
+
+        /// Whether this device can host a live preview. A known pre-26 runtime
+        /// cannot (#282); an unparseable runtime is allowed through to the gate.
+        public var isPreviewSupported: Bool {
+            (iosMajorVersion ?? Self.minimumSupportedIOSMajorVersion)
+                >= Self.minimumSupportedIOSMajorVersion
+        }
     }
 
     public enum DeviceState: Int, Sendable {

--- a/previewsmcp/Tests/MCPIntegrationTests/IOSSimulatorPicker.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSSimulatorPicker.swift
@@ -71,6 +71,9 @@ enum IOSSimulatorPicker {
         // tests across targets get the same device for the same index.
         var iPhoneUDIDs: [String] = []
         for runtime in devicesByRuntime.keys.sorted() where runtime.contains("iOS") {
+            // Live previews need iOS 26+ (#282); skip older installed runtimes
+            // so the gate does not reject the picked device.
+            guard let major = iosMajor(fromRuntimeKey: runtime), major >= 26 else { continue }
             guard let list = devicesByRuntime[runtime] else { continue }
             let udids =
                 list
@@ -81,5 +84,12 @@ enum IOSSimulatorPicker {
         }
         guard index < iPhoneUDIDs.count else { return nil }
         return iPhoneUDIDs[index]
+    }
+
+    /// Parse the iOS major version from a runtime key like
+    /// `com.apple.CoreSimulator.SimRuntime.iOS-26-2`.
+    private static func iosMajor(fromRuntimeKey key: String) -> Int? {
+        guard let range = key.range(of: "SimRuntime.iOS-") else { return nil }
+        return Int(key[range.upperBound...].prefix { $0 != "-" })
     }
 }

--- a/previewsmcp/Tests/PreviewsIOSTests/IOSRuntimeGateTests.swift
+++ b/previewsmcp/Tests/PreviewsIOSTests/IOSRuntimeGateTests.swift
@@ -1,0 +1,46 @@
+import Testing
+
+@testable import PreviewsIOS
+
+/// The pre-iOS-26 gate (#282) keys off `SimulatorManager.Device.iosMajorVersion`
+/// and `isPreviewSupported`, parsed from the runtime identifier or name.
+@Suite("iOS runtime gate")
+struct IOSRuntimeGateTests {
+    private func device(identifier: String?, name: String?) -> SimulatorManager.Device {
+        SimulatorManager.Device(
+            name: "iPhone 16",
+            udid: "00000000-0000-0000-0000-000000000000",
+            state: .shutdown,
+            stateString: "Shutdown",
+            runtimeName: name,
+            runtimeIdentifier: identifier,
+            deviceTypeName: "iPhone 16",
+            isAvailable: true)
+    }
+
+    @Test("parses major from the runtime identifier")
+    func parsesFromIdentifier() {
+        let d = device(identifier: "com.apple.CoreSimulator.SimRuntime.iOS-18-6", name: nil)
+        #expect(d.iosMajorVersion == 18)
+    }
+
+    @Test("parses major from the runtime name when the identifier is absent")
+    func parsesFromName() {
+        let d = device(identifier: nil, name: "iOS 26.2")
+        #expect(d.iosMajorVersion == 26)
+    }
+
+    @Test("nil when neither yields an iOS version")
+    func nilWhenUnknown() {
+        let d = device(identifier: "com.apple.CoreSimulator.SimRuntime.watchOS-11-0", name: "watchOS 11.0")
+        #expect(d.iosMajorVersion == nil)
+    }
+
+    @Test("26 is supported, 25 is not, unknown is allowed through")
+    func previewSupport() {
+        #expect(device(identifier: "com.apple.CoreSimulator.SimRuntime.iOS-26-0", name: nil).isPreviewSupported)
+        #expect(!device(identifier: "com.apple.CoreSimulator.SimRuntime.iOS-25-9", name: nil).isPreviewSupported)
+        #expect(!device(identifier: "com.apple.CoreSimulator.SimRuntime.iOS-18-6", name: nil).isPreviewSupported)
+        #expect(device(identifier: nil, name: nil).isPreviewSupported)
+    }
+}

--- a/previewsmcp/Tests/PreviewsIOSTests/IOSSimulatorPicker.swift
+++ b/previewsmcp/Tests/PreviewsIOSTests/IOSSimulatorPicker.swift
@@ -49,6 +49,7 @@ enum IOSSimulatorPicker {
                     let runtime = d.runtimeName ?? ""
                     let name = d.name
                     return d.isAvailable && runtime.contains("iOS") && name.contains("iPhone")
+                        && d.isPreviewSupported
                 }
                 .sorted { a, b in
                     let aRuntime = a.runtimeName ?? ""

--- a/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
@@ -665,9 +665,65 @@ struct IOSPreviewE2ETests {
         await session.stop()
     }
 
+    /// Repro for #282: the scene-hosting init the shell uses
+    /// (`-[_UISceneHostingControllerAdvancedConfiguration initWithClientIdentity:]`,
+    /// ShellMain.m) only exists on iOS 26. This spawns a probe inside a sub-26
+    /// simulator that fires the SAME unguarded `performSelector:` and asserts it
+    /// aborts with the issue's `unrecognized selector` signature. Self-skips where
+    /// no pre-26 runtime is installed.
+    ///
+    /// Why a probe and not the production session: on this machine's pre-26 runtime
+    /// (18.6) the real shell returns early in `clientIdentityForToken:` (FrontBoard
+    /// hands back no client identity) before reaching the crash line, and the agent
+    /// renders to its own window regardless — so an end-to-end render check cannot
+    /// see the bug. The probe reproduces the crash deterministically on any sub-26
+    /// runtime by calling the exact selector ShellMain calls.
+    @Test(.enabled(if: preIOS26RuntimePresent), .timeLimit(.minutes(5)))
+    func sceneHostingInitIsUnrecognizedSelectorOnPreIOS26() throws {
+        let udid = try IOSPreviewE2ESupport.bootLegacySimulator()
+        let probe = try IOSPreviewE2ESupport.compileObjCExecutableForIOSSim(
+            source: Self.sceneHostingProbeSource, name: "scene_host_sel_probe")
+        let output = try IOSPreviewE2ESupport.spawnAndCapture(udid: udid, program: probe.path)
+        #expect(
+            output.contains(
+                "-[_UISceneHostingControllerAdvancedConfiguration initWithClientIdentity:]"),
+            "probe output did not name the scene-hosting init:\n\(output)")
+        #expect(
+            output.contains("unrecognized selector"),
+            "scene-hosting init did not abort with an unrecognized-selector on a pre-26 runtime:\n\(output)")
+    }
+
     static var jitOrcRuntimePresent: Bool {
         IOSAgentBuilder.jitOrcRuntimePath != nil
     }
+
+    static var preIOS26RuntimePresent: Bool {
+        IOSPreviewE2ESupport.availableUDIDBelowIOS26() != nil
+    }
+
+    /// Mirrors ShellMain.m's `hostWithToken:` crash site: resolve the private
+    /// scene-hosting config class and fire `initWithClientIdentity:` via
+    /// `performSelector`. On iOS 26 the selector exists; on pre-26 it aborts with
+    /// `unrecognized selector` (#282). The argument is a throwaway object — pre-26
+    /// the selector is missing, so the call throws before the argument is used.
+    static let sceneHostingProbeSource = """
+        #import <Foundation/Foundation.h>
+        #import <objc/runtime.h>
+        #include <dlfcn.h>
+        #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        int main(void) {
+            dlopen("/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore", RTLD_NOW);
+            Class AdvCfg = NSClassFromString(@"_UISceneHostingControllerAdvancedConfiguration");
+            @try {
+                id adv = [[AdvCfg alloc] performSelector:@selector(initWithClientIdentity:)
+                                              withObject:[NSObject new]];
+                printf("RESULT: no crash, adv=%s\\n", adv ? "non-nil" : "nil");
+            } @catch (NSException *e) {
+                printf("RESULT: %s\\n", e.reason.UTF8String);
+            }
+            return 0;
+        }
+        """
 
     static let helloViewSource = """
     import SwiftUI
@@ -923,6 +979,37 @@ enum IOSPreviewE2ESupport {
         return exe
     }
 
+    /// Compile + link a trivial Objective-C executable for the iphonesimulator
+    /// (links Foundation, ARC on). Returns the host path to the binary.
+    static func compileObjCExecutableForIOSSim(source: String, name: String) throws -> URL {
+        let outDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PreviewsJITLinkIOSSimObjCExe", isDirectory: true)
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+        let src = outDir.appendingPathComponent("\(name).m")
+        try source.write(to: src, atomically: true, encoding: .utf8)
+        let exe = outDir.appendingPathComponent(name)
+
+        let sdk = try run("/usr/bin/xcrun", ["--sdk", "iphonesimulator", "--show-sdk-path"])
+            .output.trimmingCharacters(in: .whitespacesAndNewlines)
+        let target = "arm64-apple-ios16.0-simulator"
+        let result = try run(
+            "/usr/bin/xcrun",
+            [
+                "clang", "-target", target, "-isysroot", sdk, "-fobjc-arc",
+                "-framework", "Foundation", src.path, "-o", exe.path,
+            ])
+        guard result.status == 0 else {
+            throw SpikeError.message("compiling ObjC executable \(name) for iossim failed:\n\(result.output)")
+        }
+        return exe
+    }
+
+    /// Run a program inside a booted simulator via `simctl spawn` and return its
+    /// combined stdout/stderr.
+    static func spawnAndCapture(udid: String, program: String) throws -> String {
+        try run("/usr/bin/xcrun", ["simctl", "spawn", udid, program]).output
+    }
+
     static func bootSimulator() throws -> String {
         if let udid = firstUDID(
             in: try run(
@@ -940,6 +1027,50 @@ enum IOSPreviewE2ESupport {
             )
         else {
             throw SpikeError.message("no available iPhone simulator to boot")
+        }
+        _ = try run("/usr/bin/xcrun", ["simctl", "boot", udid])
+        _ = try run("/usr/bin/xcrun", ["simctl", "bootstatus", udid, "-b"])
+        return udid
+    }
+
+    /// First available iPhone on a runtime older than iOS 26, or nil. Used to gate
+    /// and drive the #282 pre-iOS-26 scene-hosting repro. Runtime keys look like
+    /// `com.apple.CoreSimulator.SimRuntime.iOS-18-3`; the major version is parsed
+    /// from the `iOS-<major>-<minor>` segment.
+    static func availableUDIDBelowIOS26() -> String? {
+        guard
+            let result = try? run(
+                "/usr/bin/xcrun", ["simctl", "list", "devices", "available", "--json"]),
+            let data = result.output.data(using: .utf8),
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let devices = root["devices"] as? [String: Any]
+        else {
+            return nil
+        }
+        for (runtime, list) in devices {
+            guard let major = iOSMajorVersion(fromRuntimeKey: runtime), major < 26 else { continue }
+            guard let entries = list as? [[String: Any]] else { continue }
+            for entry in entries {
+                let name = entry["name"] as? String ?? ""
+                let available = entry["isAvailable"] as? Bool ?? false
+                if available, name.contains("iPhone"), let udid = entry["udid"] as? String {
+                    return udid
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func iOSMajorVersion(fromRuntimeKey key: String) -> Int? {
+        guard let range = key.range(of: "SimRuntime.iOS-") else { return nil }
+        let suffix = key[range.upperBound...]
+        let major = suffix.prefix { $0 != "-" }
+        return Int(major)
+    }
+
+    static func bootLegacySimulator() throws -> String {
+        guard let udid = availableUDIDBelowIOS26() else {
+            throw SpikeError.message("no available pre-iOS-26 iPhone simulator to boot")
         }
         _ = try run("/usr/bin/xcrun", ["simctl", "boot", udid])
         _ = try run("/usr/bin/xcrun", ["simctl", "bootstatus", udid, "-b"])

--- a/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
@@ -1011,22 +1011,14 @@ enum IOSPreviewE2ESupport {
     }
 
     static func bootSimulator() throws -> String {
-        if let udid = firstUDID(
-            in: try run(
-                "/usr/bin/xcrun", ["simctl", "list", "devices", "booted"]
-            ).output
-        ) {
-            return udid
+        // Reuse a booted iOS 26+ device if present; otherwise boot a supported
+        // one. Live previews require iOS 26+ (#282), so a booted pre-26 device
+        // (e.g. one left from the repro test) must not be picked here.
+        if let booted = iPhoneUDID(state: "booted", whereMajor: { $0 >= 26 }) {
+            return booted
         }
-        guard
-            let udid = firstUDID(
-                in: try run(
-                    "/usr/bin/xcrun", ["simctl", "list", "devices", "available"]
-                ).output,
-                onLinesMatching: "iPhone"
-            )
-        else {
-            throw SpikeError.message("no available iPhone simulator to boot")
+        guard let udid = iPhoneUDID(state: "available", whereMajor: { $0 >= 26 }) else {
+            throw SpikeError.message("no available iOS 26+ iPhone simulator to boot")
         }
         _ = try run("/usr/bin/xcrun", ["simctl", "boot", udid])
         _ = try run("/usr/bin/xcrun", ["simctl", "bootstatus", udid, "-b"])
@@ -1034,13 +1026,19 @@ enum IOSPreviewE2ESupport {
     }
 
     /// First available iPhone on a runtime older than iOS 26, or nil. Used to gate
-    /// and drive the #282 pre-iOS-26 scene-hosting repro. Runtime keys look like
-    /// `com.apple.CoreSimulator.SimRuntime.iOS-18-3`; the major version is parsed
-    /// from the `iOS-<major>-<minor>` segment.
+    /// and drive the #282 pre-iOS-26 scene-hosting repro.
     static func availableUDIDBelowIOS26() -> String? {
+        iPhoneUDID(state: "available", whereMajor: { $0 < 26 })
+    }
+
+    /// First iPhone in the given simctl device `state` ("available" / "booted")
+    /// whose iOS major version satisfies `predicate`. Runtime keys look like
+    /// `com.apple.CoreSimulator.SimRuntime.iOS-18-3`; the major is the
+    /// `iOS-<major>-<minor>` segment.
+    private static func iPhoneUDID(state: String, whereMajor predicate: (Int) -> Bool) -> String? {
         guard
             let result = try? run(
-                "/usr/bin/xcrun", ["simctl", "list", "devices", "available", "--json"]),
+                "/usr/bin/xcrun", ["simctl", "list", "devices", state, "--json"]),
             let data = result.output.data(using: .utf8),
             let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
             let devices = root["devices"] as? [String: Any]
@@ -1048,14 +1046,12 @@ enum IOSPreviewE2ESupport {
             return nil
         }
         for (runtime, list) in devices {
-            guard let major = iOSMajorVersion(fromRuntimeKey: runtime), major < 26 else { continue }
+            guard let major = iOSMajorVersion(fromRuntimeKey: runtime), predicate(major) else {
+                continue
+            }
             guard let entries = list as? [[String: Any]] else { continue }
-            for entry in entries {
-                let name = entry["name"] as? String ?? ""
-                let available = entry["isAvailable"] as? Bool ?? false
-                if available, name.contains("iPhone"), let udid = entry["udid"] as? String {
-                    return udid
-                }
+            for entry in entries where (entry["name"] as? String ?? "").contains("iPhone") {
+                if let udid = entry["udid"] as? String { return udid }
             }
         }
         return nil
@@ -1149,21 +1145,6 @@ enum IOSPreviewE2ESupport {
         let conn = accept(listenFD, nil, nil)
         guard conn >= 0 else { throw SpikeError.message("accept failed") }
         return conn
-    }
-
-    private static func firstUDID(in text: String, onLinesMatching needle: String? = nil)
-        -> String?
-    {
-        for line in text.split(separator: "\n") {
-            if let needle, !line.contains(needle) { continue }
-            guard let open = line.firstIndex(of: "("), line[open...].count >= 38 else { continue }
-            let start = line.index(after: open)
-            let candidate = line[start...].prefix(36)
-            if candidate.count == 36, candidate.allSatisfy({ $0.isHexDigit || $0 == "-" }) {
-                return String(candidate)
-            }
-        }
-        return nil
     }
 
     private static func run(_ executable: String, _ arguments: [String]) throws

--- a/previewsmcp/ios-host/shell/ShellMain.m
+++ b/previewsmcp/ios-host/shell/ShellMain.m
@@ -131,6 +131,13 @@ static NSString *argval(NSString *key, NSString *def) {
       NSClassFromString(@"_UISceneHostingControllerAdvancedConfiguration");
   Class HostC = NSClassFromString(@"_UISceneHostingController");
   Class SpecC = NSClassFromString(@"UIApplicationSceneSpecification");
+  // `initWithClientIdentity:` only exists on iOS 26+. On older runtimes calling
+  // it aborts with an unrecognized-selector exception (#282), so bail cleanly;
+  // the daemon gates pre-26 simulators out before launch.
+  if (![AdvCfg instancesRespondToSelector:@selector(initWithClientIdentity:)]) {
+    NSLog(@"[SHELL] scene hosting unsupported on this OS (no initWithClientIdentity:)");
+    return;
+  }
   id adv = [[AdvCfg alloc] performSelector:@selector(initWithClientIdentity:)
                                 withObject:clientId];
   id spec = [[SpecC alloc] init];


### PR DESCRIPTION
Reproduces and fixes #281 and #282. Two commits: the repro fixtures, then the fixes (the fixtures double as the regression checks).

## #281 — render previews in a native `.xcodeproj` that integrates SwiftPM packages
Xcode-managed SwiftPM packages arrive as a bare `<Module>.swiftmodule` + a loose universal `<Module>.o` in `BUILT_PRODUCTS_DIR`, with no `.a` and no `-l`/`-framework` surface. `XcodeBuildSystem` now:
- emits `-I BUILT_PRODUCTS_DIR` so the overlay compile resolves `import <Module>` (layer 1),
- thins each package `.o` to the host arch and wraps it in a single-member `lib<Module>.a` via `-L`/`-l`, so only imported modules link (layers 2 + 3),
- reads each object's `LC_LINKER_OPTION` autolink frameworks (e.g. DeviceCheck) and pre-resolves them to canonical paths on a new `BuildContext.frameworkPaths` channel the agent `dlopen`s — keeping the names out of swiftc and out of the generic `dependencyDylibs` path (layer 4).

Verified end-to-end: the `DeviceFlag` fixture renders "Verified device" on macOS and "Unverified device" on iOS 26.

**Fixture:** `examples/xcodeproj` now integrates a local `DeviceFlag` SwiftPM package that imports the DeviceCheck system framework.

## #282 — iOS shell crash on pre-iOS-26 simulators
The shell hosts the agent's scene via a private initializer that only exists on iOS 26, so pre-26 the call aborts with an unrecognized-selector exception, and the degrade path is unusable (every captured frame is springboard). Fix:
- `IOSPreviewSession.start()` fails fast with a clear "iOS simulator unsupported" diagnostic on a pre-26 device,
- `ShellMain` guards the initializer with `respondsToSelector` so it can never abort,
- because the gate makes runtime selection matter, `resolveDeviceUDID` and the test simulator pickers now prefer a supported (26+) runtime, centralized on `SimulatorManager.Device.iosMajorVersion` / `isPreviewSupported`.

**Repro:** `Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.sceneHostingInitIsUnrecognizedSelectorOnPreIOS26` spawns a probe in a sub-26 simulator that fires the exact unguarded call and asserts the crash signature; recipe in `docs/repro-pre-ios26-shell-crash.md`. Verified on a real iOS 18.6 runtime (18.3 is no longer downloadable).

## Verification
- `previewsmcp run`/`snapshot` on the #281 fixture renders on macOS and iOS 26.
- iOS 18.6 now fails fast; iOS 26 still renders.
- Gates: `/code-review` (caught and fixed two regressions in the first cut), `/simplify`, `swift-format --strict`.
- Full local suite (`swift test --no-parallel`, 534 tests): the only reds are pre-existing (verified by reproducing them on clean HEAD) — #285 `NSBitmapImageRep` Xcode-26.2 drift, the #269 iOS MCP stale-frame flake, and two reloader build/call-count tests that fail on main too. This change adds no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)