### PR TITLE
bazel: pin Xcode to 26.2 via --xcode_version

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
 build --apple_platform_type=macos
+build --xcode_version=26.2
 build --macos_minimum_os=14.0
 build --ios_minimum_os=14.0
 build --verbose_failures


### PR DESCRIPTION
## What

Pin the Bazel toolchain to Xcode 26.2 with a single `.bazelrc` line:

```
build --xcode_version=26.2
```

## Why

The Xcode SDK version is part of the Bazel **action cache key**. Without a pin, a machine on a different Xcode (e.g. 26.3) hashes every action differently, so it misses the self-hosted remote cache and rebuilds from scratch, and can fail outright (`SDK "macosx26.X" cannot be located`). Pinning keeps cache keys aligned across the host and the merge-queue VMs.

## Why `--xcode_version` and not a checked-in `xcode_config`

`--xcode_version=26.2` selects from Bazel's **auto-detected** host config (`@local_config_xcode`). That is the idiomatic form and it **validates**: if the host has no 26.2 installed, the build fails loudly rather than silently mislabeling a mismatched toolchain under a 26.2 cache key. A hand-written `xcode_config` with explicit `versions`/`default` would re-derive what Bazel already detects and could mask a mismatch. Pinning the marketing version (not the exact build `17C52`) is deliberate: a machine on another 26.2 build just gets cache misses, never silent poisoning, and the gate machines all run 17C52 so they still share.

Split out from the merge-queue work (#261) because it benefits all Bazel users immediately.

## Verification

On the host (Xcode 26.2 / `17C52`):

```
$ bazel build --nobuild //previewsmcp/...
INFO: Analyzed 22 targets ... Build completed successfully

$ bazel build --nobuild --xcode_version=99.9 //previewsmcp/...
ERROR: --xcode_version=99.9 specified, but '99.9' is not an available Xcode version
```

The pin resolves on a 26.2 host and the validation fires on a wrong version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)