### PR TITLE
build: drop the stray third_party symlink squashed in via #246

### DIFF
--- a/third_party
+++ b/third_party
@@ -1,1 +1,0 @@
-../../third_party


### PR DESCRIPTION
The #246 squash accidentally tracked a worktree-local `third_party -> ../../third_party` symlink (staged by a `git add -A` during merge resolution). It's unused (Bazel builds LLVM from source; slim Package.swift doesn't reference the prebuilt artifacts) and dangles in a fresh clone. Removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)