### PR TITLE
lint: format 6 files to pass //tools/lint:check

### DIFF
--- a/previewsmcp/PreviewsCore/XcodeBuildSystem.swift
+++ b/previewsmcp/PreviewsCore/XcodeBuildSystem.swift
@@ -621,11 +621,14 @@ extension XcodeBuildSystem {
             for object in objects {
                 group.addTask {
                     await Self.archivePackageObject(
-                        object: object, builtProductsDir: builtProductsDir, cacheDir: cacheDir)
+                        object: object, builtProductsDir: builtProductsDir, cacheDir: cacheDir
+                    )
                 }
             }
             var results: [(base: String, frameworks: Set<String>)] = []
-            for await result in group { results.append(result) }
+            for await result in group {
+                results.append(result)
+            }
             return results.sorted { $0.base < $1.base }
         }
 
@@ -654,21 +657,23 @@ extension XcodeBuildSystem {
         let thin = (cacheDir as NSString).appendingPathComponent("\(base).o")
         _ = try? await runAsync(
             "/usr/bin/lipo", arguments: ["-thin", hostArch, objectPath, "-output", thin],
-            discardStderr: true)
+            discardStderr: true
+        )
         let linkObject = fm.fileExists(atPath: thin) ? thin : objectPath
         let archive = (cacheDir as NSString).appendingPathComponent("lib\(base).a")
         try? fm.removeItem(atPath: archive)
         _ = try? await runAsync(
-            "/usr/bin/ar", arguments: ["rcs", archive, linkObject], discardStderr: true)
+            "/usr/bin/ar", arguments: ["rcs", archive, linkObject], discardStderr: true
+        )
         return (base, await frameworks)
     }
 
     /// The arch the JIT agent runs as, used to thin universal package objects.
     static var hostArch: String {
         #if arch(arm64)
-        return "arm64"
+            return "arm64"
         #else
-        return "x86_64"
+            return "x86_64"
         #endif
     }
 
@@ -682,11 +687,13 @@ extension XcodeBuildSystem {
         let lines = output.stdout.split(separator: "\n")
         var names = Set<String>()
         for (index, line) in lines.enumerated()
-        where line.contains("string #1 -framework") && index + 1 < lines.count {
+            where line.contains("string #1 -framework") && index + 1 < lines.count
+        {
             if let range = lines[index + 1].range(of: "string #2 ") {
                 names.insert(
                     String(lines[index + 1][range.upperBound...])
-                        .trimmingCharacters(in: .whitespaces))
+                        .trimmingCharacters(in: .whitespaces)
+                )
             }
         }
         return names

--- a/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
+++ b/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
@@ -151,7 +151,8 @@ public actor IOSPreviewSession {
         let device = try await simulatorManager.findDevice(udid: deviceUDID)
         if !device.isPreviewSupported {
             throw IOSPreviewSessionError.unsupportedRuntime(
-                device.runtimeName ?? device.iosMajorVersion.map { "iOS \($0)" } ?? "this simulator")
+                device.runtimeName ?? device.iosMajorVersion.map { "iOS \($0)" } ?? "this simulator"
+            )
         }
 
         /// Mirror stage transitions to the diagnostic log so operators
@@ -790,7 +791,7 @@ public enum IOSPreviewSessionError: Error, LocalizedError, CustomStringConvertib
         case let .jitExecutorFailed(stage, code):
             let suffix = code.map { " (code \($0))" } ?? ""
             return "In-app JIT executor failed during \(stage)\(suffix)"
-        case .unsupportedRuntime(let detail):
+        case let .unsupportedRuntime(detail):
             return "iOS simulator unsupported for live preview: \(detail). Use an iOS 26+ simulator."
         }
     }

--- a/previewsmcp/PreviewsIOS/SimulatorManager.swift
+++ b/previewsmcp/PreviewsIOS/SimulatorManager.swift
@@ -28,12 +28,12 @@ public actor SimulatorManager {
         /// non-iOS or unparseable runtime.
         public var iosMajorVersion: Int? {
             if let id = runtimeIdentifier, let range = id.range(of: "SimRuntime.iOS-"),
-                let value = Int(id[range.upperBound...].prefix { $0 != "-" })
+               let value = Int(id[range.upperBound...].prefix { $0 != "-" })
             {
                 return value
             }
             if let name = runtimeName, let range = name.range(of: "iOS "),
-                let value = Int(name[range.upperBound...].prefix { $0.isNumber })
+               let value = Int(name[range.upperBound...].prefix { $0.isNumber })
             {
                 return value
             }

--- a/previewsmcp/Tests/PreviewsIOSTests/IOSRuntimeGateTests.swift
+++ b/previewsmcp/Tests/PreviewsIOSTests/IOSRuntimeGateTests.swift
@@ -1,6 +1,5 @@
-import Testing
-
 @testable import PreviewsIOS
+import Testing
 
 /// The pre-iOS-26 gate (#282) keys off `SimulatorManager.Device.iosMajorVersion`
 /// and `isPreviewSupported`, parsed from the runtime identifier or name.
@@ -15,7 +14,8 @@ struct IOSRuntimeGateTests {
             runtimeName: name,
             runtimeIdentifier: identifier,
             deviceTypeName: "iPhone 16",
-            isAvailable: true)
+            isAvailable: true
+        )
     }
 
     @Test("parses major from the runtime identifier")

--- a/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
@@ -682,15 +682,19 @@ struct IOSPreviewE2ETests {
     func sceneHostingInitIsUnrecognizedSelectorOnPreIOS26() throws {
         let udid = try IOSPreviewE2ESupport.bootLegacySimulator()
         let probe = try IOSPreviewE2ESupport.compileObjCExecutableForIOSSim(
-            source: Self.sceneHostingProbeSource, name: "scene_host_sel_probe")
+            source: Self.sceneHostingProbeSource, name: "scene_host_sel_probe"
+        )
         let output = try IOSPreviewE2ESupport.spawnAndCapture(udid: udid, program: probe.path)
         #expect(
             output.contains(
-                "-[_UISceneHostingControllerAdvancedConfiguration initWithClientIdentity:]"),
-            "probe output did not name the scene-hosting init:\n\(output)")
+                "-[_UISceneHostingControllerAdvancedConfiguration initWithClientIdentity:]"
+            ),
+            "probe output did not name the scene-hosting init:\n\(output)"
+        )
         #expect(
             output.contains("unrecognized selector"),
-            "scene-hosting init did not abort with an unrecognized-selector on a pre-26 runtime:\n\(output)")
+            "scene-hosting init did not abort with an unrecognized-selector on a pre-26 runtime:\n\(output)"
+        )
     }
 
     static var jitOrcRuntimePresent: Bool {
@@ -707,23 +711,23 @@ struct IOSPreviewE2ETests {
     /// `unrecognized selector` (#282). The argument is a throwaway object — pre-26
     /// the selector is missing, so the call throws before the argument is used.
     static let sceneHostingProbeSource = """
-        #import <Foundation/Foundation.h>
-        #import <objc/runtime.h>
-        #include <dlfcn.h>
-        #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-        int main(void) {
-            dlopen("/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore", RTLD_NOW);
-            Class AdvCfg = NSClassFromString(@"_UISceneHostingControllerAdvancedConfiguration");
-            @try {
-                id adv = [[AdvCfg alloc] performSelector:@selector(initWithClientIdentity:)
-                                              withObject:[NSObject new]];
-                printf("RESULT: no crash, adv=%s\\n", adv ? "non-nil" : "nil");
-            } @catch (NSException *e) {
-                printf("RESULT: %s\\n", e.reason.UTF8String);
-            }
-            return 0;
+    #import <Foundation/Foundation.h>
+    #import <objc/runtime.h>
+    #include <dlfcn.h>
+    #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    int main(void) {
+        dlopen("/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore", RTLD_NOW);
+        Class AdvCfg = NSClassFromString(@"_UISceneHostingControllerAdvancedConfiguration");
+        @try {
+            id adv = [[AdvCfg alloc] performSelector:@selector(initWithClientIdentity:)
+                                          withObject:[NSObject new]];
+            printf("RESULT: no crash, adv=%s\\n", adv ? "non-nil" : "nil");
+        } @catch (NSException *e) {
+            printf("RESULT: %s\\n", e.reason.UTF8String);
         }
-        """
+        return 0;
+    }
+    """
 
     static let helloViewSource = """
     import SwiftUI
@@ -997,7 +1001,8 @@ enum IOSPreviewE2ESupport {
             [
                 "clang", "-target", target, "-isysroot", sdk, "-fobjc-arc",
                 "-framework", "Foundation", src.path, "-o", exe.path,
-            ])
+            ]
+        )
         guard result.status == 0 else {
             throw SpikeError.message("compiling ObjC executable \(name) for iossim failed:\n\(result.output)")
         }
@@ -1038,7 +1043,8 @@ enum IOSPreviewE2ESupport {
     private static func iPhoneUDID(state: String, whereMajor predicate: (Int) -> Bool) -> String? {
         guard
             let result = try? run(
-                "/usr/bin/xcrun", ["simctl", "list", "devices", state, "--json"]),
+                "/usr/bin/xcrun", ["simctl", "list", "devices", state, "--json"]
+            ),
             let data = result.output.data(using: .utf8),
             let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
             let devices = root["devices"] as? [String: Any]

--- a/previewsmcp/ios-host/shell/ShellMain.m
+++ b/previewsmcp/ios-host/shell/ShellMain.m
@@ -135,7 +135,8 @@ static NSString *argval(NSString *key, NSString *def) {
   // it aborts with an unrecognized-selector exception (#282), so bail cleanly;
   // the daemon gates pre-26 simulators out before launch.
   if (![AdvCfg instancesRespondToSelector:@selector(initWithClientIdentity:)]) {
-    NSLog(@"[SHELL] scene hosting unsupported on this OS (no initWithClientIdentity:)");
+    NSLog(@"[SHELL] scene hosting unsupported on this OS (no "
+          @"initWithClientIdentity:)");
     return;
   }
   id adv = [[AdvCfg alloc] performSelector:@selector(initWithClientIdentity:)


### PR DESCRIPTION
Six files from #284/#266 fail the hermetic `//tools/lint:check` SwiftFormat + clang-format gates on `main`. This applies `bazel run //tools/lint:format` so the gate is green.

Formatting only — line wraps, `case let` hoisting, indent alignment, string-literal wrap. No semantic changes.

Why now: the merge-queue bar (chunk D, #261) rebases each candidate onto `origin/main` and runs `//tools/lint:check`. While these files fail on main, that lint lane is red for every candidate regardless of its own quality. Landing this on main makes the lane meaningful.

Verified: `bazel run //tools/lint:check` exits 0 after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)