### PR TITLE
Fix #269: reliable iOS preview capture under load via the streamer pipeline

### DIFF
--- a/previewsmcp/PreviewsIOS/FrameSource.swift
+++ b/previewsmcp/PreviewsIOS/FrameSource.swift
@@ -15,6 +15,7 @@ public protocol FrameSource: Sendable {
 /// never blocks the pull loop the way the retrying `screenshotData` did.
 public final class EventDrivenFrameSource: FrameSource, @unchecked Sendable {
     private let streamer: SBFramebufferStreamer
+    private let captureQueue = DispatchQueue(label: "com.previewsmcp.frame-capture", qos: .userInitiated)
 
     public init(streamer: SBFramebufferStreamer) {
         self.streamer = streamer
@@ -22,6 +23,44 @@ public final class EventDrivenFrameSource: FrameSource, @unchecked Sendable {
 
     public func nextFrame() async -> Data? {
         streamer.latestFrame()
+    }
+
+    /// Capture the live display surface on demand at `jpegQuality` (PNG when
+    /// `jpegQuality >= 1.0`), reusing the streamer's wired pipeline. Unlike
+    /// `nextFrame`, this re-encodes current content at the requested quality
+    /// rather than returning the cached stream JPEG. Nil if no surface is wired.
+    ///
+    /// `captureFrame(atQuality:)` blocks on the streamer's capture queue, so run
+    /// it off the caller's executor: a caller on an actor must not have its
+    /// executor thread parked while the private framebuffer framework works.
+    public func captureFresh(jpegQuality: Double) async -> Data? {
+        await withCheckedContinuation { continuation in
+            captureQueue.async {
+                continuation.resume(returning: self.streamer.captureFrame(atQuality: jpegQuality))
+            }
+        }
+    }
+
+    /// Block until the streamer has captured at least one frame, proving the
+    /// SimulatorKit display pipeline is wired. Creating the streamer registers
+    /// the screen callbacks that wire the pipeline, and its heal timer re-wires
+    /// once per second until the first frame lands — so a freshly started
+    /// streamer that races display attach under load recovers here instead of
+    /// the caller's first one-shot capture failing with "No IOSurface."
+    /// Returns true once a frame is available, false if none arrives in `timeout`.
+    public func waitForFirstFrame(timeout: Duration) async -> Bool {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if streamer.latestFrame() != nil {
+                return true
+            }
+            do {
+                try await Task.sleep(for: .milliseconds(200))
+            } catch {
+                return false
+            }
+        }
+        return false
     }
 
     public func stop() {

--- a/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
+++ b/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
@@ -151,7 +151,8 @@ public actor IOSPreviewSession {
         let device = try await simulatorManager.findDevice(udid: deviceUDID)
         if !device.isPreviewSupported {
             throw IOSPreviewSessionError.unsupportedRuntime(
-                device.runtimeName ?? device.iosMajorVersion.map { "iOS \($0)" } ?? "this simulator")
+                device.runtimeName ?? device.iosMajorVersion.map { "iOS \($0)" } ?? "this simulator"
+            )
         }
 
         /// Mirror stage transitions to the diagnostic log so operators
@@ -322,6 +323,10 @@ public actor IOSPreviewSession {
             let frameSource = EventDrivenFrameSource(streamer: streamer)
             let videoStream = AVCCVideoStream()
             streamer.onFrameSurface = { surface in videoStream.feed(surface: surface) }
+            stage("waiting for first framebuffer frame")
+            let ready = await frameSource.waitForFirstFrame(timeout: .seconds(20))
+            try Task.checkCancellation()
+            stage(ready ? "display pipeline wired" : "display pipeline not wired (degraded)")
             let server = PreviewAppServer(
                 sink: IndigoHIDInputSink(client: hidClient),
                 frameSource: frameSource,
@@ -332,6 +337,8 @@ public actor IOSPreviewSession {
             appFrameSource = frameSource
             appVideoStream = videoStream
             stage("app interface on 127.0.0.1:\(appServerPort ?? 0)")
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             Log.info("iOS preview: app interface unavailable: \(error)")
         }
@@ -713,8 +720,26 @@ public actor IOSPreviewSession {
     }
 
     /// Capture a screenshot of the simulator.
+    ///
+    /// Capture through the live framebuffer streamer: it holds the SimulatorKit
+    /// display pipeline wired open, so it succeeds at the requested quality even
+    /// when the one-shot `SBCaptureFramebuffer` path cannot find an IOSurface
+    /// (its cold port enumeration races display attach under load). Falls back
+    /// to the one-shot capture when no streamer surface is wired yet.
     public func screenshot(jpegQuality: Double = 0.85) async throws -> Data {
-        try await simulatorManager.screenshotData(udid: deviceUDID, jpegQuality: jpegQuality)
+        if let source = appFrameSource {
+            // Ride over brief surface gaps (e.g. the agent respawn the OS forces
+            // periodically) before conceding to the load-racing one-shot path.
+            for attempt in 0 ..< 3 {
+                if let frame = await source.captureFresh(jpegQuality: jpegQuality) {
+                    return frame
+                }
+                if attempt < 2 {
+                    try? await Task.sleep(for: .milliseconds(100))
+                }
+            }
+        }
+        return try await simulatorManager.screenshotData(udid: deviceUDID, jpegQuality: jpegQuality)
     }
 
     // MARK: - Accessibility tree filtering
@@ -790,7 +815,7 @@ public enum IOSPreviewSessionError: Error, LocalizedError, CustomStringConvertib
         case let .jitExecutorFailed(stage, code):
             let suffix = code.map { " (code \($0))" } ?? ""
             return "In-app JIT executor failed during \(stage)\(suffix)"
-        case .unsupportedRuntime(let detail):
+        case let .unsupportedRuntime(detail):
             return "iOS simulator unsupported for live preview: \(detail). Use an iOS 26+ simulator."
         }
     }

--- a/previewsmcp/SimulatorBridge/SimulatorBridge.m
+++ b/previewsmcp/SimulatorBridge/SimulatorBridge.m
@@ -686,6 +686,26 @@ static NSData *_encodeImage(CGImageRef cgImage, double jpegQuality) {
   return ok ? [data copy] : nil;
 }
 
+// Lock a display IOSurface, render it to a CGImage via the shared CIContext,
+// and encode at `jpegQuality` (PNG when >= 1.0). Returns nil if the surface
+// cannot be rendered. Shared by the streamer's cached-frame and on-demand
+// capture paths.
+static NSData *_encodeSurface(IOSurfaceRef surface, double jpegQuality) {
+  IOSurfaceLock(surface, kIOSurfaceLockReadOnly, NULL);
+  CIImage *ciImage = [CIImage imageWithIOSurface:surface];
+  CGImageRef cgImage = NULL;
+  if (ciImage)
+    cgImage = [_sharedCIContext() createCGImage:ciImage
+                                       fromRect:ciImage.extent];
+  IOSurfaceUnlock(surface, kIOSurfaceLockReadOnly, NULL);
+  if (!cgImage)
+    return nil;
+
+  NSData *data = _encodeImage(cgImage, jpegQuality);
+  CGImageRelease(cgImage);
+  return data;
+}
+
 NSData *SBCaptureFramebuffer(SBDevice *device, double jpegQuality,
                              NSError **error) {
   if (!_frameworkLoaded && !SBLoadFramework(error))
@@ -1024,18 +1044,7 @@ static const void *const kFBStreamerQueueKey = &kFBStreamerQueueKey;
   if (frameSink)
     frameSink(surface);
 
-  IOSurfaceLock(surface, kIOSurfaceLockReadOnly, NULL);
-  CIImage *ciImage = [CIImage imageWithIOSurface:surface];
-  CGImageRef cgImage = NULL;
-  if (ciImage)
-    cgImage = [_sharedCIContext() createCGImage:ciImage
-                                       fromRect:ciImage.extent];
-  IOSurfaceUnlock(surface, kIOSurfaceLockReadOnly, NULL);
-  if (!cgImage)
-    return;
-
-  NSData *jpeg = _encodeImage(cgImage, _jpegQuality);
-  CGImageRelease(cgImage);
+  NSData *jpeg = _encodeSurface(surface, _jpegQuality);
   if (!jpeg)
     return;
 
@@ -1076,6 +1085,31 @@ static const void *const kFBStreamerQueueKey = &kFBStreamerQueueKey;
   @synchronized(self) {
     return _latestFrame;
   }
+}
+
+- (NSData *)captureFrameAtQuality:(double)jpegQuality {
+  NSData * (^capture)(void) = ^NSData * {
+    if (_stopped)
+      return nil;
+    IOSurfaceRef surface = NULL;
+    id<_SBStreamDescriptor> desc = [self pickBestDescriptor:&surface];
+    if (!desc || !surface)
+      return nil;
+    if (IOSurfaceGetWidth(surface) == 0 || IOSurfaceGetHeight(surface) == 0)
+      return nil;
+    return _encodeSurface(surface, jpegQuality);
+  };
+
+  // pickBestDescriptor reads `_descriptors`, which is mutated only on the
+  // capture queue, so the encode must run there too. Guard against a
+  // re-entrant call from a capture-queue block (matching `stop`).
+  if (dispatch_get_specific(kFBStreamerQueueKey))
+    return capture();
+  __block NSData *result = nil;
+  dispatch_sync(_captureQueue, ^{
+    result = capture();
+  });
+  return result;
 }
 
 - (void)stop {

--- a/previewsmcp/SimulatorBridge/include/SimulatorBridge.h
+++ b/previewsmcp/SimulatorBridge/include/SimulatorBridge.h
@@ -103,6 +103,14 @@ typedef NS_ENUM(NSInteger, SBDeviceState) {
 /// The most recently encoded frame, or nil before the first frame arrives.
 - (nullable NSData *)latestFrame;
 
+/// Encode the live display surface on demand at `jpegQuality` (PNG when
+/// `jpegQuality >= 1.0`), bypassing the cached stream frame. Reuses the wired
+/// display pipeline this streamer holds open, so it succeeds under the same
+/// load where the one-shot `SBCaptureFramebuffer` cannot find an IOSurface,
+/// while still honoring the caller's quality and capturing current content.
+/// Returns nil if the pipeline has no surface yet.
+- (nullable NSData *)captureFrameAtQuality:(double)jpegQuality;
+
 /// Stop streaming and unregister callbacks. Idempotent; also called on dealloc.
 - (void)stop;
 

--- a/previewsmcp/Tests/MCPIntegrationTests/DaemonTestLock.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/DaemonTestLock.swift
@@ -12,7 +12,23 @@ enum DaemonTestLock {
         return (dir as NSString).appendingPathComponent("previewsmcp-daemon-test.lock")
     }
 
-    static func run<T: Sendable>(body: @Sendable () async throws -> T) async throws -> T {
+    /// A held exclusive lock. Call `release()` to let the next waiter proceed;
+    /// pair it with `defer` at the acquisition site.
+    final class Guard: Sendable {
+        private let fd: Int32
+        fileprivate init(fd: Int32) {
+            self.fd = fd
+        }
+
+        func release() {
+            _ = flock(fd, LOCK_UN)
+            close(fd)
+        }
+    }
+
+    /// Block until the cross-suite lock is held, then return a `Guard` the
+    /// caller releases (via `defer`) when its critical section ends.
+    static func acquire() async throws -> Guard {
         let path = lockPath
         let fd = try await withCheckedThrowingContinuation {
             (cont: CheckedContinuation<Int32, Error>) in
@@ -48,16 +64,12 @@ enum DaemonTestLock {
                 cont.resume(returning: fd)
             }
         }
+        return Guard(fd: fd)
+    }
 
-        let result: Swift.Result<T, Error>
-        do {
-            result = .success(try await body())
-        } catch {
-            result = .failure(error)
-        }
-
-        _ = flock(fd, LOCK_UN)
-        close(fd)
-        return try result.get()
+    static func run<T: Sendable>(body: @Sendable () async throws -> T) async throws -> T {
+        let lock = try await acquire()
+        defer { lock.release() }
+        return try await body()
     }
 }

--- a/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
@@ -22,6 +22,13 @@ struct IOSAppServerTests {
         )
     )
     func appServerEndToEnd() async throws {
+        // Serialize the heavy iOS e2e suites against each other: locally (these
+        // are .disabled on CI) three sims booting and driving their displays at
+        // once starve the single host GPU/window-server, so whichever loses the
+        // race flakes. One sim at a time keeps each render/capture healthy.
+        let lock = try await DaemonTestLock.acquire()
+        defer { lock.release() }
+
         guard let deviceUDID = try await IOSSimulatorPicker.pickUDID(index: 3) else {
             print("No iOS simulator at picker index 3 — skipping")
             return
@@ -83,6 +90,14 @@ struct IOSAppServerTests {
         }
         #expect(tags.contains(0x01), "avcc stream should carry an avcC description")
         #expect(tags.contains(0x02), "avcc stream should carry an H.264 keyframe")
+
+        // A lossless PNG snapshot (quality 1.0) must come back as a real PNG
+        // from the wired streamer pipeline, not the load-racing one-shot path.
+        let pngResult = try await server.callToolResult(
+            name: "preview_snapshot",
+            arguments: ["sessionID": .string(sessionID), "quality": .double(1.0)]
+        )
+        try MCPTestServer.assertValidImage(pngResult.content, expectedMimeType: "image/png")
 
         _ = try await server.callToolResult(
             name: "preview_stop", arguments: ["sessionID": .string(sessionID)]

--- a/previewsmcp/Tests/MCPIntegrationTests/IOSHIDInputTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSHIDInputTests.swift
@@ -19,6 +19,11 @@ struct IOSHIDInputTests {
         )
     )
     func tapAndDrag() async throws {
+        // Serialized against the other heavy iOS e2e suites — see the note in
+        // IOSAppServerTests.appServerEndToEnd.
+        let lock = try await DaemonTestLock.acquire()
+        defer { lock.release() }
+
         guard let deviceUDID = try await IOSSimulatorPicker.pickUDID(index: 2) else {
             print("No iOS simulator at picker index 2 — skipping")
             return

--- a/previewsmcp/Tests/MCPIntegrationTests/IOSMCPTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSMCPTests.swift
@@ -56,6 +56,11 @@ struct IOSMCPTests {
         )
     )
     func fullIOSWorkflow() async throws {
+        // Serialized against the other heavy iOS e2e suites — see the note in
+        // IOSAppServerTests.appServerEndToEnd.
+        let lock = try await DaemonTestLock.acquire()
+        defer { lock.release() }
+
         // Use picker index 1, the same device IOSPreviewSessionTests.endToEnd
         // uses in the PreviewsIOSTests target. That test runs in an earlier
         // CI step (different `swift test --filter` invocation) so there's no


### PR DESCRIPTION
## Summary

Fixes #269. The iOS one-shot `SBCaptureFramebuffer` enumerates the simulator's IO ports cold, so under host load it loses the race to attach the SimulatorKit display port and fails with "No IOSurface found on any display port." The `SBFramebufferStreamer` is the path that actually wires the display pipeline (`updateIOPorts` + screen-callback registration, with a 1Hz heal timer), so snapshots now capture through it.

## Changes

- **SimulatorBridge**: add `SBFramebufferStreamer.captureFrameAtQuality:` — on-demand capture of the live surface encoded at the caller's quality (lossless PNG at `>= 1.0`). Extract the shared surface→CGImage→encode step into `_encodeSurface`, used by both the stream and on-demand paths.
- **IOSPreviewSession**: `screenshot()` captures through the wired streamer (fresh content, requested quality, PNG-capable), retrying briefly before conceding to the one-shot fallback. `start()` gates on the streamer's first frame so the pipeline is proven wired before any capture, and propagates cancellation so an abandoned start does not bind the app server.
- **FrameSource**: `captureFresh` runs the blocking capture off the caller's executor (an actor is never parked on the capture queue); `waitForFirstFrame` polls with cancellation handling.
- **Tests**: serialize the three heavy iOS e2e suites (local-only, `.disabled` on CI) via a shared lock so they no longer contend for the single host GPU; add a PNG-fidelity snapshot assertion. `DaemonTestLock` gains `acquire()`/`release()`.

## Verification

- The reproduced load-race (`--test_filter='IOSAppServerTests|MacOSMCPTests'`) was 2/2 red before, now green.
- Full `MCPIntegrationTests` suite: 3/3 green (serialized iOS suites, ~70s, well under the 300s timeout).
- `/simplify` and high-effort `/code-review` both run twice; findings addressed. Changed files are lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)