### PR TITLE
Fix #292: poll preview_elements for render-readiness instead of a fixed sleep

### DIFF
--- a/previewsmcp/Tests/MCPIntegrationTests/IOSMCPTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSMCPTests.swift
@@ -96,8 +96,6 @@ struct IOSMCPTests {
         #expect(startError != true, "iOS preview_start should succeed")
         let sessionID = try MCPTestServer.extractSessionID(from: startContent)
 
-        try await Task.sleep(for: .seconds(3))
-
         // --- Snapshot ---
         let (snapshotContent, snapshotError) = try await server.callTool(
             name: "preview_snapshot",
@@ -107,17 +105,11 @@ struct IOSMCPTests {
         try MCPTestServer.assertValidImage(snapshotContent)
 
         // --- Elements with accessibility assertions ---
-        let (elementsContent, elementsError) = try await server.callTool(
-            name: "preview_elements",
-            arguments: [
-                "sessionID": .string(sessionID),
-                "filter": .string("all"),
-            ]
+        let elementsText = try await server.awaitElementsText(
+            sessionID: sessionID,
+            contains: "My Items",
+            timeout: .seconds(30)
         )
-        #expect(elementsError != true, "preview_elements should succeed")
-        let elementsText = MCPTestServer.extractText(from: elementsContent)
-        #expect(!elementsText.isEmpty, "Should return accessibility data")
-        #expect(elementsText.contains("My Items"), "Should contain navigation title")
         #expect(elementsText.contains("Show Completed"), "Should contain toggle")
         #expect(elementsText.contains("Design UI"), "Should contain first item")
         #expect(elementsText.contains("Write code"), "Should contain second item")

--- a/previewsmcp/Tests/MCPIntegrationTests/MCPTestServer.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/MCPTestServer.swift
@@ -496,6 +496,36 @@ final class MCPTestServer: @unchecked Sendable {
         throw MCPTestError.timedOut(operation: "awaitStderrContains(\(needle.debugDescription))", duration: timeout)
     }
 
+    /// Poll `preview_elements` until the accessibility text contains `needle`,
+    /// up to `timeout`, then return that text. The lightweight PreviewBanner
+    /// registers in the a11y tree before the wrapped content, so a fixed sleep
+    /// races the agent's render (#292).
+    func awaitElementsText(
+        sessionID: String,
+        contains needle: String,
+        timeout: Duration
+    ) async throws -> String {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            let (content, isError) = try await callTool(
+                name: "preview_elements",
+                arguments: ["sessionID": .string(sessionID), "filter": .string("all")]
+            )
+            let text = Self.extractText(from: content)
+            if isError == true {
+                throw MCPTestError.toolError(tool: "preview_elements", content: text)
+            }
+            if text.contains(needle) { return text }
+            try await Task.sleep(for: .milliseconds(500))
+        }
+        Issue.record(
+            "preview_elements did not contain \(needle.debugDescription) within \(timeout). Server stderr:\n\(stderrLog())"
+        )
+        throw MCPTestError.timedOut(
+            operation: "awaitElementsText(contains: \(needle.debugDescription))", duration: timeout
+        )
+    }
+
     // MARK: - Snapshot helpers
 
     /// Capture a snapshot and return its raw image bytes. Decodes via the existing
@@ -615,6 +645,7 @@ enum MCPTestError: Error, LocalizedError {
     case cannotCreateStderrLog(String)
     case timedOut(operation: String, duration: Duration)
     case snapshotFailed
+    case toolError(tool: String, content: String)
 
     var errorDescription: String? {
         switch self {
@@ -625,6 +656,7 @@ enum MCPTestError: Error, LocalizedError {
         case let .cannotCreateStderrLog(path): "Could not open stderr log for writing at \(path)"
         case let .timedOut(operation, duration): "\(operation) timed out after \(duration)"
         case .snapshotFailed: "preview_snapshot returned isError=true"
+        case let .toolError(tool, content): "\(tool) returned isError=true. Content: \(content)"
         }
     }
 }


### PR DESCRIPTION
## Summary

`IOSMCPTests.fullIOSWorkflow` flaked: it queried `preview_elements` after a fixed `Task.sleep(3)`, which raced the agent's accessibility render. The lightweight `PreviewBanner` registers in the a11y tree before the wrapped `ToDoView` content, so under load the tree was banner-only and the `My Items`/item assertions failed (#292).

## Changes

- Add `MCPTestServer.awaitElementsText(sessionID:contains:timeout:)`, a poll helper that mirrors the existing `awaitStderrContains`/`awaitSnapshotChange` pattern (ContinuousClock deadline, `Issue.record` + throw on timeout). It retries `preview_elements` until the content appears.
- It fails fast via a new `MCPTestError.toolError` when the tool genuinely errors, instead of polling a real failure into an opaque 30s timeout.
- Replace the fixed sleep + single elements call in `fullIOSWorkflow` with the helper; drop the now-redundant `elementsError`/`!isEmpty`/duplicate `My Items` asserts.
- The snapshot step needs no settling sleep: #269 made `preview_start` gate on the first frame.

## Verification

- `IOSMCPTests` green across 4 clean isolated runs (~22-26s each).
- Full local suite `bazel test //previewsmcp/...` (serialized test jobs): **9/9 targets pass**; the affected `MCPIntegrationTests` target passed fresh in 75s.
- Gates: `/simplify` + `/code-review` (high) run; confirmed findings fixed.

Closes #292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)