### PR TITLE
Fix #286: register reloader tests via jitStart to drop the FSEvents flake

### DIFF
--- a/previewsmcp/Tests/PreviewsEngineTests/MacOSPreviewHandleAgentSnapshotTests.swift
+++ b/previewsmcp/Tests/PreviewsEngineTests/MacOSPreviewHandleAgentSnapshotTests.swift
@@ -80,9 +80,10 @@ struct MacOSPreviewHandleAgentSnapshotTests {
         let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
         let reloader = RecordingReloader()
         let host = PreviewHost(makeStructuralReloader: { reloader })
-        host.watchFile(sessionID: "s1", session: session, filePath: sourceFile.path, compiler: compiler)
-
-        _ = try await host.jitStructuralReload(sessionID: "s1", session: session)
+        try await host.jitStart(
+            sessionID: "s1", session: session,
+            title: "s1", size: NSSize(width: 8, height: 8), headless: true
+        )
         #expect(reloader.builds.count == 1)
         let handle = MacOSPreviewHandle(id: "s1", session: session, host: host)
 

--- a/previewsmcp/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
+++ b/previewsmcp/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
@@ -71,11 +71,14 @@ struct PreviewHostJITReloadTests {
             made.append(reloader)
             return reloader
         })
-        host.watchFile(sessionID: "a", session: session, filePath: sourceFile.path, compiler: compiler)
-        host.watchFile(sessionID: "b", session: session, filePath: sourceFile.path, compiler: compiler)
-
-        _ = try await host.jitStructuralReload(sessionID: "a", session: session)
-        _ = try await host.jitStructuralReload(sessionID: "b", session: session)
+        try await host.jitStart(
+            sessionID: "a", session: session,
+            title: "a", size: NSSize(width: 8, height: 8), headless: true
+        )
+        try await host.jitStart(
+            sessionID: "b", session: session,
+            title: "b", size: NSSize(width: 8, height: 8), headless: true
+        )
         #expect(made.count == 2)
         #expect(made.first !== made.last)
         #expect(made.first?.calls.count == 1)


### PR DESCRIPTION
## Summary

Two macOS JIT reload tests failed with reload/build counts one higher than expected (#286). The reds are a test-setup artifact, not Xcode-26.2 drift. Each test wrote its source file with `atomically: true` and then immediately called `watchFile`, which installs an FSEvents watcher. `kFSEventStreamEventIdSinceNow` replays the just-finished write as a spurious change, so the watcher fires once right after install and adds one extra structural reload. Captured stderr confirmed it (`watch-fire` events, then "Structural change, recompiling").

Neither test exercises the watcher; they used `watchFile` only to register the session. This change registers + baselines via `jitStart` (the production entry point), which does not install a watcher, so the spurious fire cannot occur. The counts are deterministic and match the original expectations, because `jitStart` performs the first structural reload the tests already expected.

## Changes

- `PreviewHostJITReloadTests.swift` (`sessionsGetSeparateReloadersAndCloseReleasesThem`): replace `watchFile` + `jitStructuralReload` for sessions "a"/"b" with `jitStart`.
- `MacOSPreviewHandleAgentSnapshotTests.swift` (`agentBackedSwitchAndConfigureRouteThroughReloader`): same, for "s1".

## Verification

- Both targets fresh, 3x: deterministic green.
- Full `PreviewsMacOSTests` + `PreviewsEngineTests` (no filter): green, no sibling regressions.
- Gates: `/simplify` (clean) + `/code-review` high.

## Scope

This fixes the failing tests only. The real product bug it surfaced — an unchanged-content FSEvents event still triggers a structural reload and loses live `@State`, on both macOS and iOS — is tracked in #297. `watchFile` registration stays covered by `structuralReloadRecordsAgentImage` and `literalReloadRewritesValuesAndRecordsImage`; those remain on `watchFile` (the latter compiles its own build and cannot convert cleanly), and #297's fix makes a spurious fire harmless for them.

Closes #286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)