### PR TITLE
Fix #297: unchanged-content save is a no-op that preserves live @State

### DIFF
--- a/previewsmcp/PreviewsCLI/Handlers/PreviewStartHandler.swift
+++ b/previewsmcp/PreviewsCLI/Handlers/PreviewStartHandler.swift
@@ -327,11 +327,14 @@ private func handleIOSPreviewStart(
     let sessionID = session.id
     let allPaths = [fileURL.path] + (buildContext?.sourceFiles?.map(\.path) ?? [])
     let iosState = ctx.iosState
-    let watcher = try? FileWatcher(paths: allPaths) { _ in
+    let canonicalPrimary = FileWatcher.canonicalPath(fileURL.path) ?? fileURL.path
+    let watcher = try? FileWatcher(paths: allPaths) { firedPaths in
         Task {
             Log.info("MCP: iOS file change detected, reloading session \(sessionID)...")
             do {
-                try await session.handleSourceChange()
+                try await session.handleSourceChange(
+                    firedPaths: firedPaths, canonicalPrimary: canonicalPrimary
+                )
                 Log.info("MCP: iOS source change — recompiled and re-linked over JIT")
             } catch {
                 Log.error("MCP: iOS reload failed for session \(sessionID): \(error)")

--- a/previewsmcp/PreviewsCore/FileWatcher.swift
+++ b/previewsmcp/PreviewsCore/FileWatcher.swift
@@ -17,14 +17,14 @@ public final class FileWatcher: @unchecked Sendable {
 
     public convenience init(
         path: String,
-        callback: @escaping @Sendable (String) -> Void
+        callback: @escaping @Sendable (Set<String>) -> Void
     ) throws {
         try self.init(paths: [path], callback: callback)
     }
 
     public init(
         paths: [String],
-        callback: @escaping @Sendable (String) -> Void
+        callback: @escaping @Sendable (Set<String>) -> Void
     ) throws {
         guard !paths.isEmpty else {
             throw FileWatcherError.cannotOpen(path: "<empty>")
@@ -76,13 +76,15 @@ public final class FileWatcher: @unchecked Sendable {
             let box = Unmanaged<CallbackBox>.fromOpaque(info).takeUnretainedValue()
             let cfPaths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue()
             let nsPaths = cfPaths as NSArray
-            // First match wins: a single change-event burst yields one
-            // callback regardless of how many watched paths it touched,
-            // matching the "one reload per change burst" intent.
+            // One callback per change-event burst, carrying every watched path the burst
+            // touched. A coalesced multi-file save (atomic rename of several files within
+            // the latency window) delivers them together so the caller can tell a
+            // cross-file edit apart from a primary-only one.
+            var fired = Set<String>()
             for case let path as String in nsPaths where box.canonicalPaths.contains(path) {
-                box.callback(path)
-                return
+                fired.insert(path)
             }
+            if !fired.isEmpty { box.callback(fired) }
         }
 
         guard
@@ -127,6 +129,13 @@ public final class FileWatcher: @unchecked Sendable {
         stop()
     }
 
+    /// Resolve a path to the canonical form the FSEvents callback reports. A caller
+    /// canonicalizes its watched paths once at setup, then compares the fired paths
+    /// (already canonical) against them by string equality with no per-fire syscall.
+    public static func canonicalPath(_ path: String) -> String? {
+        canonicalize(path)
+    }
+
     private static func canonicalize(_ path: String) -> String? {
         guard let resolved = realpath(path, nil) else { return nil }
         defer { free(resolved) }
@@ -142,9 +151,9 @@ public final class FileWatcher: @unchecked Sendable {
 /// deinit without racing in-flight callbacks against partial destruction.
 private final class CallbackBox: @unchecked Sendable {
     let canonicalPaths: Set<String>
-    let callback: @Sendable (String) -> Void
+    let callback: @Sendable (Set<String>) -> Void
 
-    init(canonicalPaths: Set<String>, callback: @escaping @Sendable (String) -> Void) {
+    init(canonicalPaths: Set<String>, callback: @escaping @Sendable (Set<String>) -> Void) {
         self.canonicalPaths = canonicalPaths
         self.callback = callback
     }

--- a/previewsmcp/PreviewsCore/PreviewSession.swift
+++ b/previewsmcp/PreviewsCore/PreviewSession.swift
@@ -429,21 +429,68 @@ public actor PreviewSession {
         }
     }
 
+    /// How a watcher-fired source change should be applied to a live preview session.
+    public enum SourceChangeKind: Sendable {
+        /// Content is byte-identical (or only reformats to identical literal values). The
+        /// preview should be left untouched so live `@State` is preserved.
+        case unchanged
+        /// Only literal values changed. Re-render in place without recompiling.
+        case literal([(id: String, newValue: LiteralValue)])
+        /// The structure changed. Requires a full recompile / agent respawn.
+        case structural
+    }
+
+    /// Decide how a watcher burst should be applied. A burst that touched any SECONDARY
+    /// watched file (a cross-file dependency) forces a structural reload, so a real cross-file
+    /// edit is never dropped even when the primary file is in the same burst. Only a
+    /// primary-only burst takes the unchanged or literal fast path. `firedPaths` and
+    /// `canonicalPrimary` are canonical, resolved when the watch was installed.
+    public func classifyWatchedChange(
+        firedPaths: Set<String>, canonicalPrimary: String, newPrimarySource: String
+    ) -> SourceChangeKind {
+        if firedPaths.contains(where: { $0 != canonicalPrimary }) { return .structural }
+        return classifySourceChange(newSource: newPrimarySource)
+    }
+
+    /// Three-way classification of the PRIMARY file's content, so an UNCHANGED file (a no-op
+    /// editor save, an mtime touch, or an atomic-rename replay) is a no-op that preserves live
+    /// `@State` instead of a structural reload that recompiles and respawns the agent. This does
+    /// NOT advance the baseline, so a caller whose reload fails can retry on the next identical
+    /// fire. Structural and literal reloads commit the baseline only on success. Content-equality
+    /// is checked first so the unchanged case is caught even in Tier 1 (bridge-only, no thunks).
+    public func classifySourceChange(newSource: String) -> SourceChangeKind {
+        if lastOriginalSource == newSource { return .unchanged }
+        guard let kind = literalDiff(newSource: newSource) else { return .structural }
+        switch kind {
+        case let .literalOnly(changes):
+            return changes.isEmpty ? .unchanged : .literal(changes)
+        case .structural:
+            return .structural
+        }
+    }
+
+    /// Record `source` as the live baseline after a reload applied it, so a later identical fire
+    /// classifies as unchanged. Structural reloads set this via `compileObjectForJIT`. The literal
+    /// fast path has no recompile, so its caller commits here once the re-render succeeds.
+    public func commitSourceBaseline(_ source: String) {
+        lastOriginalSource = source
+    }
+
+    /// Literal-vs-structural diff against the current baseline, without mutating it. Returns nil
+    /// for Tier 1 (bridge-only, no thunks) and before the first compile sets a baseline.
+    private func literalDiff(newSource: String) -> ChangeKind? {
+        if let ctx = buildContext, !ctx.supportsTier2 { return nil }
+        guard let oldSource = lastOriginalSource else { return nil }
+        return LiteralDiffer.diff(old: oldSource, new: newSource)
+    }
+
     /// Attempt a fast literal-only update. Returns changed literal IDs and new values,
     /// or nil if a structural recompile is needed.
     /// Returns nil for Tier 1 project mode (bridge-only, no thunks).
     public func tryLiteralUpdate(newSource: String) -> [(id: String, newValue: LiteralValue)]? {
-        // Tier 1 bridge-only has no DesignTimeStore thunks
-        if let ctx = buildContext, !ctx.supportsTier2 { return nil }
-        guard let oldSource = lastOriginalSource else { return nil }
-
-        switch LiteralDiffer.diff(old: oldSource, new: newSource) {
-        case let .literalOnly(changes):
-            lastOriginalSource = newSource
-            return changes
-        case .structural:
-            return nil
-        }
+        guard case let .literalOnly(changes) = literalDiff(newSource: newSource) else { return nil }
+        lastOriginalSource = newSource
+        return changes
     }
 
     /// Switch to a different preview index and recompile. Traits are preserved. @State is lost.

--- a/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
+++ b/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
@@ -539,11 +539,16 @@ public actor IOSPreviewSession {
         try await jitReloader.render(build)
     }
 
-    /// Handle a source file change. Fast path: a literal-only edit rewrites the design-time
-    /// values JSON and re-runs the same linked object over EPC (no recompile, no relink),
-    /// mirroring the macOS path. Otherwise fall back to a structural reload that reuses the
-    /// persistent session so its stable-module cache and literal baseline carry forward.
-    public func handleSourceChange() async throws {
+    /// Handle a watcher burst, mirroring macOS. An UNCHANGED primary file (no-op save, mtime
+    /// touch, atomic-rename replay) is a no-op so the agent keeps its live `@State`. A literal-only
+    /// edit rewrites the design-time values JSON and re-runs the same linked object over EPC (no
+    /// recompile, no relink). A structural edit, or any burst that touched a SECONDARY watched
+    /// file (a cross-file dependency), reuses the persistent session so its stable-module cache and
+    /// literal baseline carry forward. `firedPaths` and `canonicalPrimary` are canonical, resolved
+    /// when the watch was installed. An empty `firedPaths` treats the change as a primary edit.
+    public func handleSourceChange(
+        firedPaths: Set<String> = [], canonicalPrimary: String? = nil
+    ) async throws {
         await acquireRenderLock()
         defer { releaseRenderLock() }
 
@@ -552,11 +557,22 @@ public actor IOSPreviewSession {
         }
 
         let newSource = try String(contentsOf: sourceFile, encoding: .utf8)
-        if let changes = await session.tryLiteralUpdate(newSource: newSource), !changes.isEmpty,
-           let build = try await session.applyLiteralValuesForJIT(changes)
-        {
-            try await jitReloader.render(build)
+        switch await session.classifyWatchedChange(
+            firedPaths: firedPaths,
+            canonicalPrimary: canonicalPrimary ?? sourceFile.path,
+            newPrimarySource: newSource
+        ) {
+        case .unchanged:
             return
+        case let .literal(changes):
+            if let build = try await session.applyLiteralValuesForJIT(changes) {
+                try await jitReloader.render(build)
+                await session.commitSourceBaseline(newSource)
+                return
+            }
+        // No prior JIT build to patch: fall through to a structural reload.
+        case .structural:
+            break
         }
 
         let build = try await session.compileObjectForJIT()

--- a/previewsmcp/PreviewsMacOS/HostApp.swift
+++ b/previewsmcp/PreviewsMacOS/HostApp.swift
@@ -90,64 +90,70 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     ) {
         sessions[sessionID] = session
         notifySessionsChanged()
-        let fileURL = URL(fileURLWithPath: filePath)
         let allPaths = [filePath] + additionalPaths
+        let canonicalPrimary = FileWatcher.canonicalPath(filePath) ?? filePath
         fileWatchers[sessionID]?.stop()
-        fileWatchers[sessionID] = try? FileWatcher(paths: allPaths) { [weak self] _ in
+        fileWatchers[sessionID] = try? FileWatcher(paths: allPaths) { [weak self] firedPaths in
             Task {
-                guard let self else { return }
-                Log.info("jit_latency: watch-fire")
-
-                let newSource: String
-                do {
-                    newSource = try String(contentsOf: fileURL, encoding: .utf8)
-                } catch {
-                    fputs("Failed to read file: \(error)\n", stderr)
-                    return
-                }
-
-                // Fast path: try literal-only update. The agent re-renders in place
-                // (rewrite the design-time values JSON, re-run the same object — no
-                // recompile).
-                if let currentSession = await MainActor.run(body: { self.sessions[sessionID] }),
-                   let changes = await currentSession.tryLiteralUpdate(newSource: newSource),
-                   !changes.isEmpty
-                {
-                    fputs("Literal-only change: \(changes.count) value(s)\n", stderr)
-                    do {
-                        try await self.jitLiteralReload(
-                            sessionID: sessionID, session: currentSession, changes: changes
-                        )
-                        fputs("Literal re-rendered in agent (no recompile)\n", stderr)
-                    } catch {
-                        fputs("JIT literal reload failed: \(error)\n", stderr)
-                    }
-                    return
-                }
-
-                // Slow path: structural change, full recompile.
-                // Reuse the existing session so traits set via preview_configure are
-                // preserved without a race — the reload re-reads the source file and
-                // uses the session's stored traits, which live inside the actor.
-                fputs("Structural change, recompiling...\n", stderr)
-                do {
-                    guard
-                        let existingSession = await MainActor.run(body: {
-                            self.sessions[sessionID]
-                        })
-                    else {
-                        fputs("Session \(sessionID) no longer exists\n", stderr)
-                        return
-                    }
-
-                    _ = try await self.jitStructuralReload(
-                        sessionID: sessionID, session: existingSession
-                    )
-                    fputs("Reloaded (JIT agent)!\n", stderr); fflush(stderr)
-                } catch {
-                    fputs("Recompilation failed: \(error)\n", stderr)
-                }
+                await self?.handleWatchedChange(
+                    sessionID: sessionID, canonicalPrimary: canonicalPrimary, firedPaths: firedPaths
+                )
             }
+        }
+    }
+
+    /// Apply a watcher burst to a session. An UNCHANGED primary file (no-op save, mtime touch,
+    /// atomic-rename replay) does nothing so live `@State` is preserved. A literal-only edit
+    /// re-renders in place. A structural edit, or any burst that touched a SECONDARY watched
+    /// file (a cross-file dependency), recompiles. The slow path reuses the existing session so
+    /// traits set via `preview_configure` survive.
+    func handleWatchedChange(
+        sessionID: String, canonicalPrimary: String, firedPaths: Set<String>
+    ) async {
+        guard let session = sessions[sessionID] else {
+            fputs("Session \(sessionID) no longer exists\n", stderr)
+            return
+        }
+        Log.info("jit_latency: watch-fire")
+
+        let newSource = try? String(contentsOf: session.sourceFile, encoding: .utf8)
+        let kind: PreviewSession.SourceChangeKind = if let newSource {
+            await session.classifyWatchedChange(
+                firedPaths: firedPaths, canonicalPrimary: canonicalPrimary, newPrimarySource: newSource
+            )
+        } else {
+            .structural
+        }
+
+        switch kind {
+        case .unchanged:
+            fputs("Unchanged source, preserving state (no reload)\n", stderr)
+            return
+        case let .literal(changes):
+            fputs("Literal-only change: \(changes.count) value(s)\n", stderr)
+            do {
+                if try await jitLiteralReload(
+                    sessionID: sessionID, session: session, changes: changes
+                ) != nil {
+                    if let newSource { await session.commitSourceBaseline(newSource) }
+                    fputs("Literal re-rendered in agent (no recompile)\n", stderr)
+                    return
+                }
+            } catch {
+                fputs("JIT literal reload failed: \(error)\n", stderr)
+                return
+            }
+        // No prior JIT build to patch: fall through to a structural reload.
+        case .structural:
+            break
+        }
+
+        fputs("Structural change, recompiling...\n", stderr)
+        do {
+            _ = try await jitStructuralReload(sessionID: sessionID, session: session)
+            fputs("Reloaded (JIT agent)!\n", stderr); fflush(stderr)
+        } catch {
+            fputs("Recompilation failed: \(error)\n", stderr)
         }
     }
 

--- a/previewsmcp/Tests/PreviewsCoreTests/BuildSystemTests.swift
+++ b/previewsmcp/Tests/PreviewsCoreTests/BuildSystemTests.swift
@@ -489,9 +489,9 @@ struct BuildSystemTests {
         try "initial 1".write(to: file1, atomically: true, encoding: .utf8)
         try "initial 2".write(to: file2, atomically: true, encoding: .utf8)
 
-        let changedPath = Mutex<String?>(nil)
-        let watcher = try FileWatcher(paths: [file1.path, file2.path]) { path in
-            changedPath.withLock { $0 = path }
+        let changedPaths = Mutex<Set<String>>([])
+        let watcher = try FileWatcher(paths: [file1.path, file2.path]) { paths in
+            changedPaths.withLock { $0.formUnion(paths) }
         }
         defer { watcher.stop() }
 
@@ -499,8 +499,8 @@ struct BuildSystemTests {
         try "modified 2".write(to: file2, atomically: true, encoding: .utf8)
         try await Task.sleep(for: .milliseconds(200))
 
-        let captured = changedPath.withLock { $0 }
-        #expect(captured?.hasSuffix("second.swift") == true)
+        let captured = changedPaths.withLock { $0 }
+        #expect(captured.contains { $0.hasSuffix("second.swift") })
     }
 
     // MARK: - BuildContext

--- a/previewsmcp/Tests/PreviewsCoreTests/PreviewSessionBuildContextTests.swift
+++ b/previewsmcp/Tests/PreviewsCoreTests/PreviewSessionBuildContextTests.swift
@@ -197,6 +197,140 @@ struct PreviewSessionBuildContextTests {
         )
     }
 
+    @Test("classifySourceChange is three-way: unchanged / literal / structural")
+    func classifySourceChangeThreeWay() async throws {
+        let ctx = try await Self.buildSPMExample()
+
+        let compiler = try await Compiler()
+        let session = PreviewSession(
+            sourceFile: Self.toDoViewFile,
+            previewIndex: 0,
+            compiler: compiler,
+            buildContext: ctx
+        )
+
+        _ = try await session.compileObjectForJIT()
+        let original = try String(contentsOf: Self.toDoViewFile, encoding: .utf8)
+
+        // Byte-identical content (a no-op save) must NOT reload — preserves live @State (#297).
+        guard case .unchanged = await session.classifySourceChange(newSource: original) else {
+            Issue.record("identical source should classify as .unchanged")
+            return
+        }
+
+        // A literal-only edit re-renders in place.
+        let literalEdited = original.replacingOccurrences(of: "\"My Items\"", with: "\"My Tasks\"")
+        guard case let .literal(changes) =
+            await session.classifySourceChange(newSource: literalEdited)
+        else {
+            Issue.record("literal-only edit should classify as .literal")
+            return
+        }
+        #expect(changes.contains(where: { $0.newValue == .string("My Tasks") }))
+
+        // A structural edit (adding a type) recompiles.
+        let structuralEdited = literalEdited
+            + "\nstruct Extra_p297: View { var body: some View { Color.red } }\n"
+        guard case .structural =
+            await session.classifySourceChange(newSource: structuralEdited)
+        else {
+            Issue.record("adding a type should classify as .structural")
+            return
+        }
+    }
+
+    @Test("classifySourceChange goes structural for a Tier 1 edit with no baseline")
+    func classifySourceChangeTier1Structural() async throws {
+        let fullCtx = try await Self.buildSPMExample()
+        let ctx = Self.tier1Context(from: fullCtx)
+
+        let compiler = try await Compiler()
+        let session = PreviewSession(
+            sourceFile: Self.toDoViewFile,
+            previewIndex: 0,
+            compiler: compiler,
+            buildContext: ctx
+        )
+
+        let original = try String(contentsOf: Self.toDoViewFile, encoding: .utf8)
+        let modified = original.replacingOccurrences(of: "\"My Items\"", with: "\"My Tasks\"")
+
+        guard case .structural = await session.classifySourceChange(newSource: modified) else {
+            Issue.record("Tier 1 with no literal thunks should classify a real edit as .structural")
+            return
+        }
+    }
+
+    @Test("classifySourceChange does not advance the baseline until committed")
+    func classifySourceChangeNonMutatingUntilCommit() async throws {
+        let ctx = try await Self.buildSPMExample()
+
+        let compiler = try await Compiler()
+        let session = PreviewSession(
+            sourceFile: Self.toDoViewFile,
+            previewIndex: 0,
+            compiler: compiler,
+            buildContext: ctx
+        )
+
+        _ = try await session.compileObjectForJIT()
+        let original = try String(contentsOf: Self.toDoViewFile, encoding: .utf8)
+        let edited = original.replacingOccurrences(of: "\"My Items\"", with: "\"My Tasks\"")
+
+        // A failed reload would not commit. Classifying the same edit twice must keep returning
+        // .literal so it can be retried, not collapse to .unchanged and strand the old value (#297).
+        guard case .literal = await session.classifySourceChange(newSource: edited) else {
+            Issue.record("first classify should be .literal")
+            return
+        }
+        guard case .literal = await session.classifySourceChange(newSource: edited) else {
+            Issue.record("repeat classify must still be .literal before commit")
+            return
+        }
+
+        // After a successful reload commits the baseline, the same content reads as unchanged.
+        await session.commitSourceBaseline(edited)
+        guard case .unchanged = await session.classifySourceChange(newSource: edited) else {
+            Issue.record("after commit the same content should be .unchanged")
+            return
+        }
+    }
+
+    @Test("classifyWatchedChange forces structural when a secondary file fired")
+    func classifyWatchedChangeSecondaryStructural() async throws {
+        let ctx = try await Self.buildSPMExample()
+
+        let compiler = try await Compiler()
+        let session = PreviewSession(
+            sourceFile: Self.toDoViewFile,
+            previewIndex: 0,
+            compiler: compiler,
+            buildContext: ctx
+        )
+
+        _ = try await session.compileObjectForJIT()
+        let original = try String(contentsOf: Self.toDoViewFile, encoding: .utf8)
+        let primary = Self.toDoViewFile.path
+
+        // A primary-only burst with unchanged content stays a no-op.
+        guard case .unchanged = await session.classifyWatchedChange(
+            firedPaths: [primary], canonicalPrimary: primary, newPrimarySource: original
+        ) else {
+            Issue.record("primary-only unchanged burst should be .unchanged")
+            return
+        }
+
+        // A secondary path in the burst forces structural even though the primary is unchanged.
+        guard case .structural = await session.classifyWatchedChange(
+            firedPaths: [primary, "/some/other/Helper.swift"],
+            canonicalPrimary: primary,
+            newPrimarySource: original
+        ) else {
+            Issue.record("a secondary fire must be .structural")
+            return
+        }
+    }
+
     // MARK: - Dynamic library product exclusion
 
     /// Regression guard for the swift-issue-reporting / `Testing.framework`

--- a/previewsmcp/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
+++ b/previewsmcp/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
@@ -187,6 +187,117 @@ struct PreviewHostJITReloadTests {
         #expect(host.agentWindowSpec(for: "visible") == nil)
     }
 
+    @Test func unchangedSourceFireDoesNotReload() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("p297u-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let sourceFile = dir.appendingPathComponent("ColorView.swift")
+        try """
+        import SwiftUI
+
+        #Preview {
+            Color.red.frame(width: 8, height: 8)
+        }
+        """.write(to: sourceFile, atomically: true, encoding: .utf8)
+        let primary = FileWatcher.canonicalPath(sourceFile.path) ?? sourceFile.path
+
+        let compiler = try await Compiler()
+        let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
+
+        let reloader = RecordingReloader()
+        let host = PreviewHost(makeStructuralReloader: { reloader })
+        try await host.jitStart(
+            sessionID: "s1", session: session,
+            title: "t", size: NSSize(width: 8, height: 8), headless: true
+        )
+        #expect(reloader.calls.count == 1)
+
+        // The watcher fires for the primary file but its content did not change
+        // (a no-op save, mtime touch, or atomic-rename replay). No reload, so @State survives.
+        await host.handleWatchedChange(
+            sessionID: "s1", canonicalPrimary: primary, firedPaths: [primary]
+        )
+        #expect(reloader.calls.count == 1, "unchanged source must not trigger a reload")
+    }
+
+    @Test func secondaryFileFireForcesStructuralReload() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("p297x-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let sourceFile = dir.appendingPathComponent("ColorView.swift")
+        try """
+        import SwiftUI
+
+        #Preview {
+            Color.red.frame(width: 8, height: 8)
+        }
+        """.write(to: sourceFile, atomically: true, encoding: .utf8)
+        let secondaryFile = dir.appendingPathComponent("Helper.swift")
+        try "import SwiftUI\n".write(to: secondaryFile, atomically: true, encoding: .utf8)
+        let primary = FileWatcher.canonicalPath(sourceFile.path) ?? sourceFile.path
+        let secondary = FileWatcher.canonicalPath(secondaryFile.path) ?? secondaryFile.path
+
+        let compiler = try await Compiler()
+        let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
+
+        let reloader = RecordingReloader()
+        let host = PreviewHost(makeStructuralReloader: { reloader })
+        try await host.jitStart(
+            sessionID: "s1", session: session,
+            title: "t", size: NSSize(width: 8, height: 8), headless: true
+        )
+        #expect(reloader.calls.count == 1)
+
+        // A cross-file dependency changed while the primary stayed byte-identical. Only a
+        // structural recompile picks the edit up, so the unchanged shortcut must not skip it.
+        await host.handleWatchedChange(
+            sessionID: "s1", canonicalPrimary: primary, firedPaths: [secondary]
+        )
+        #expect(reloader.calls.count == 2, "a secondary-file change must force a structural reload")
+    }
+
+    @Test func coalescedBurstWithUnchangedPrimaryStillStructural() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("p297b-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let sourceFile = dir.appendingPathComponent("ColorView.swift")
+        try """
+        import SwiftUI
+
+        #Preview {
+            Color.red.frame(width: 8, height: 8)
+        }
+        """.write(to: sourceFile, atomically: true, encoding: .utf8)
+        let secondaryFile = dir.appendingPathComponent("Helper.swift")
+        try "import SwiftUI\n".write(to: secondaryFile, atomically: true, encoding: .utf8)
+        let primary = FileWatcher.canonicalPath(sourceFile.path) ?? sourceFile.path
+        let secondary = FileWatcher.canonicalPath(secondaryFile.path) ?? secondaryFile.path
+
+        let compiler = try await Compiler()
+        let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
+
+        let reloader = RecordingReloader()
+        let host = PreviewHost(makeStructuralReloader: { reloader })
+        try await host.jitStart(
+            sessionID: "s1", session: session,
+            title: "t", size: NSSize(width: 8, height: 8), headless: true
+        )
+        #expect(reloader.calls.count == 1)
+
+        // One coalesced burst reports both the unchanged primary and a changed secondary.
+        // The secondary in the set must force structural so the cross-file edit is not dropped.
+        await host.handleWatchedChange(
+            sessionID: "s1", canonicalPrimary: primary, firedPaths: [primary, secondary]
+        )
+        #expect(reloader.calls.count == 2, "a co-changed secondary in the burst must force structural")
+    }
+
     @Test func closedSessionNeverGetsANewAgent() async throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("p34ci3f-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
Closes #297.

## Problem

The macOS and iOS preview watchers did a **structural** reload (recompile + agent respawn) on every FSEvents fire, including ones where the source content did not change: a no-op editor save (many editors rewrite the file on cmd-S), an mtime touch, or an atomic-rename replay. The render stayed correct, but the user's live `@State` (toggles, scroll, entered text) was silently reset for a non-edit.

## Fix

The watcher decision is now **three-way** (unchanged / literal / structural), classified in the shared `PreviewSession` layer.

- **`classifySourceChange`** checks content-equality first, so the unchanged case is caught even in Tier 1 (bridge-only, no literal thunks). It is **non-mutating**: a failed literal reload can retry on the next identical fire instead of being stranded showing the old value. Reloads commit the baseline only on success via **`commitSourceBaseline`**.
- **`classifyWatchedChange`** centralizes the primary-vs-secondary gate plus the classify so macOS and iOS share one decision. Any burst that touched a **secondary** watched file (a cross-file dependency) forces structural, so a real cross-file edit is never dropped even when the primary is also in the same burst.
- **`FileWatcher`** now delivers every matched path in a coalesced burst (not just the first) and exposes `canonicalPath` so callers resolve the primary once at watch setup rather than per fire.

A no-op touch of a *secondary* file still forces structural. That matches #297's stated design (a secondary fire forces structural). Making it free would require baselining every watched file and is left as a follow-up.

## Verification

All fresh (`--cache_test_results=no`), full local suite (9/9 targets) green, `//tools/lint:check` clean.

New tests:
- unchanged primary fire does no reload (`@State` preserved)
- a secondary-only fire and a coalesced primary+secondary burst both force structural
- classify stays `.literal` until committed (failed-reload recovery)
- three-way classify on Tier 1 and Tier 2

## Review

Gated with `/simplify` and a multi-agent `/code-review` at high effort. All 8 confirmed findings were fixed and re-verified (non-mutating baseline, all-paths watcher, setup-time canonicalization, unified literal-nil fallthrough, shared decision, comment style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
