### PR TITLE
iOS: surface interactive viewer URL + Codex skill to auto-open it

### DIFF
--- a/.agents/skills/previewsmcp-ios/SKILL.md
+++ b/.agents/skills/previewsmcp-ios/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: previewsmcp-ios
+description: View and interact with a running SwiftUI preview in the iOS Simulator through the PreviewsMCP server. Use whenever the user wants to see, open, tap, drag, or hot-reload an iOS SwiftUI preview, or asks to open the interactive preview/viewer for an iOS file.
+---
+
+# iOS interactive preview (PreviewsMCP)
+
+PreviewsMCP renders a SwiftUI preview in a real iOS Simulator and hosts a
+per-session viewer over a loopback web server. The viewer streams the live
+preview and forwards taps and drags back to the Simulator. Your job is to start
+the preview and open that viewer so the user sees it without leaving the host.
+
+## Steps
+
+1. **Pick a simulator.** Call `simulator_list` and choose a booted iOS device,
+   or one the user names. Keep its `udid`.
+
+2. **Start the preview.** Call `preview_start` with the SwiftUI source file:
+   `{ filePath: "<abs path>", platform: "ios", deviceUDID: "<udid>" }`. The
+   result text ends with a line of the form:
+
+   `Interactive viewer: http://127.0.0.1:<port>/ — open it in the in-app browser.`
+
+   The port is also in `structuredContent.appServerPort`. Capture the URL.
+
+3. **Open the viewer.** Open the captured `http://127.0.0.1:<port>/` URL in the
+   host's in-app browser so the user sees the live, interactive preview. Probe
+   the tools available in this session and use whichever opens a URL:
+   - Codex: open it in the in-app browser (`@Browser`).
+   - A host preview/browser tool that takes `{ url }`: hand off the URL.
+   Do not assume a specific tool exists. If none does, present the URL
+   prominently and tell the user to open it in their browser.
+
+4. **Interact.** Drive the preview with `preview_touch` (tap and swipe) and read
+   the screen with `preview_snapshot`. Edits to the source file hot-reload
+   automatically; the viewer updates live. Use `preview_switch` to change the
+   active preview and `preview_stop` to end the session.
+
+## Notes
+
+- The viewer is a real browser page on loopback, not a sandboxed panel. Opening
+  it in an in-app browser or an external browser both work; a sandboxed MCP-app
+  iframe cannot reach loopback and will not.
+- One viewer per session. Re-running `preview_start` for the same file reuses
+  the session and its port.

--- a/previewsmcp/PreviewsCLI/Handlers/PreviewStartHandler.swift
+++ b/previewsmcp/PreviewsCLI/Handlers/PreviewStartHandler.swift
@@ -363,10 +363,13 @@ private func handleIOSPreviewStart(
         setupWarning: nil,
         appServerPort: (await session.appServerPort).map(Int.init)
     )
+    let viewerHint = structured.appServerPort.map {
+        "\nInteractive viewer: http://127.0.0.1:\($0)/ — open it in the in-app browser."
+    } ?? ""
     return try CallTool.Result(
         content: [
             .text(
-                "iOS simulator preview started on device \(deviceUDID). Session ID: \(sessionID). PID: \(pid).\(traitInfo) File is being watched for changes.\n\(previewList)\(switchHint)"
+                "iOS simulator preview started on device \(deviceUDID). Session ID: \(sessionID). PID: \(pid).\(traitInfo) File is being watched for changes.\n\(previewList)\(switchHint)\(viewerHint)"
             ),
         ],
         structuredContent: structured

--- a/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
@@ -54,6 +54,11 @@ struct IOSAppServerTests {
             Issue.record("preview_start did not return an app server port")
             return
         }
+        let resultText = MCPTestServer.extractText(from: startResult.content)
+        #expect(
+            resultText.contains("http://127.0.0.1:\(port)/"),
+            "preview_start result should surface the interactive viewer URL"
+        )
         try await Task.sleep(for: .seconds(3))
 
         // Control: a drag over /control scrolls the list, proving the


### PR DESCRIPTION
## What

Make the shipped iOS interactive preview viewer auto-openable by an agent, mirroring OpenAI Codex's `build-ios-apps` pattern (open the loopback URL in the in-app browser).

Two parts:
1. **Viewer URL in `preview_start`** — when the per-session app server is up, the iOS `preview_start` result text now ends with `Interactive viewer: http://127.0.0.1:<port>/ — open it in the in-app browser.` The port is already in `structuredContent.appServerPort`; this surfaces a ready-to-open URL.
2. **Codex skill** — `.agents/skills/previewsmcp-ios/SKILL.md` tells the agent to call `preview_start`, then open the returned viewer URL in the host's in-app browser. This is the behavior layer that makes the open automatic.

## Why this approach

A `ui://` MCP-app panel (Claude Desktop) was spiked and rejected: the sandboxed iframe cannot fetch loopback. A real/in-app browser is not sandboxed, so opening the URL there is the working path (what Codex does).

## Verification

- Bazel build green.
- `/simplify` + `/code-review` (high) clean.
- iOS app-server e2e (`IOSAppServerTests.appServerEndToEnd`) **passes on iOS 26.2** (36s), exercising the live viewer-URL assertion.
- Non-sim unit suites: 5/5 targets pass.
- The one red on this machine (`appServerEndToEnd` `preview_snapshot` 30s timeout) reproduces on **clean `main` without this change**, so it is pre-existing (#269-area streamer-pipeline flake), not a regression here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)