### PR TITLE
Test restructure step 1: SessionRouting DI seam for MCP handler tests

### DIFF
--- a/previewsmcp/PreviewsCLI/Handlers/HandlerContext.swift
+++ b/previewsmcp/PreviewsCLI/Handlers/HandlerContext.swift
@@ -14,7 +14,7 @@ struct HandlerContext {
     let host: PreviewHost
     let iosState: IOSSessionManager
     let configCache: ConfigCache
-    let router: SessionRouter
+    let router: any SessionRouting
     let registry: SessionRegistry
     let macCompiler: Compiler
     let server: Server

--- a/previewsmcp/PreviewsCore/PreviewSessionHandle.swift
+++ b/previewsmcp/PreviewsCore/PreviewSessionHandle.swift
@@ -56,3 +56,10 @@ public protocol PreviewSessionHandle: Sendable {
     /// registry. After this returns, the handle should not be reused.
     func stop() async
 }
+
+/// Resolves a session ID to a platform-agnostic handle. Kept as a
+/// protocol so MCP tool handler tests can supply deterministic in-memory
+/// sessions without booting AppKit/CoreSimulator or compiling previews.
+public protocol SessionRouting: Sendable {
+    func handle(for sessionID: String) async -> (any PreviewSessionHandle)?
+}

--- a/previewsmcp/PreviewsEngine/SessionRouter.swift
+++ b/previewsmcp/PreviewsEngine/SessionRouter.swift
@@ -20,7 +20,7 @@ import PreviewsMacOS
 /// knowledge and lets the iOS adapter own the manager-de-register hook
 /// in `stop()`, symmetric with the way macOS's `host.closePreview` does
 /// teardown and bookkeeping in one call.
-public actor SessionRouter {
+public actor SessionRouter: SessionRouting {
     private let host: PreviewHost
     private let iosManager: IOSSessionManager
 

--- a/previewsmcp/Tests/PreviewsCLITests/BUILD.bazel
+++ b/previewsmcp/Tests/PreviewsCLITests/BUILD.bazel
@@ -17,6 +17,9 @@ swift_test(
     visibility = ["//visibility:public"],
     deps = [
         "//previewsmcp/PreviewsCLI",
+        "//previewsmcp/PreviewsCore",
+        "//previewsmcp/PreviewsEngine",
+        "//previewsmcp/PreviewsMacOS",
         "@swiftpkg_swift_sdk//:MCP",
     ],
 )

--- a/previewsmcp/Tests/PreviewsCLITests/MCPHandlerContractTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/MCPHandlerContractTests.swift
@@ -1,0 +1,456 @@
+import Foundation
+import MCP
+@testable import PreviewsCLI
+import PreviewsCore
+import PreviewsEngine
+import PreviewsMacOS
+import Testing
+
+@Suite("MCP handler contracts")
+struct MCPHandlerContractTests {
+    @Test("preview_list returns structured preview metadata without launching a server")
+    func previewListStructuredContent() async throws {
+        let ctx = try await HandlerContractSupport.context()
+        let source = try HandlerContractSupport.previewFile()
+
+        let result = try await PreviewListHandler.handle(
+            params(.previewList, ["filePath": .string(source.path)]),
+            ctx: ctx
+        )
+
+        let payload = try decodeStructured(DaemonProtocol.PreviewListResult.self, from: result)
+        #expect(payload.file == source.path)
+        #expect(payload.previews.count == 2)
+        #expect(payload.previews.map(\.index) == [0, 1])
+        #expect(payload.previews.allSatisfy { !$0.active })
+    }
+
+    @Test("preview_list reports missing files as tool errors")
+    func previewListMissingFile() async throws {
+        let ctx = try await HandlerContractSupport.context()
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-missing-\(UUID().uuidString).swift")
+
+        let result = try await PreviewListHandler.handle(
+            params(.previewList, ["filePath": .string(missing.path)]),
+            ctx: ctx
+        )
+
+        #expect(result.isError == true)
+        #expect(text(in: result).contains("File not found"))
+        #expect(result.structuredContent == nil)
+    }
+
+    @Test("session_list returns an empty structured payload without daemon state")
+    func sessionListEmptyStructuredContent() async throws {
+        let ctx = try await HandlerContractSupport.context()
+
+        let result = try await SessionListHandler.handle(params(.sessionList), ctx: ctx)
+
+        let payload = try decodeStructured(DaemonProtocol.SessionListResult.self, from: result)
+        #expect(payload.sessions.isEmpty)
+        #expect(text(in: result).isEmpty)
+    }
+
+    @Test("preview_snapshot uses the routed handle and returns the requested image type")
+    func previewSnapshotUsesRoutedHandle() async throws {
+        let source = try HandlerContractSupport.previewFile()
+        let handle = FakePreviewSessionHandle(id: "snapshot-session", sourceFile: source)
+        let ctx = try await HandlerContractSupport.context(handles: [handle])
+
+        let result = try await PreviewSnapshotHandler.handle(
+            params(
+                .previewSnapshot,
+                ["sessionID": .string(handle.id), "quality": .double(1.0)]
+            ),
+            ctx: ctx
+        )
+
+        let image = try #require(imageContents(in: result).first)
+        #expect(image.mimeType == "image/png")
+        #expect(image.data == handle.snapshotData)
+        #expect(await handle.snapshotQualities == [1.0])
+    }
+
+    @Test("preview_snapshot reports a missing session without capturing")
+    func previewSnapshotMissingSession() async throws {
+        let ctx = try await HandlerContractSupport.context()
+
+        let result = try await PreviewSnapshotHandler.handle(
+            params(.previewSnapshot, ["sessionID": .string("missing")]),
+            ctx: ctx
+        )
+
+        #expect(result.isError == true)
+        #expect(text(in: result).contains("No session found"))
+    }
+
+    @Test("preview_configure validates traits and calls reconfigure")
+    func previewConfigureCallsHandle() async throws {
+        let source = try HandlerContractSupport.previewFile()
+        let handle = FakePreviewSessionHandle(
+            id: "configure-session",
+            sourceFile: source,
+            traits: PreviewTraits(colorScheme: "dark", locale: "en")
+        )
+        let ctx = try await HandlerContractSupport.context(handles: [handle])
+
+        let result = try await PreviewConfigureHandler.handle(
+            params(
+                .previewConfigure,
+                [
+                    "sessionID": .string(handle.id),
+                    "colorScheme": .string("light"),
+                    "locale": .string(""),
+                ]
+            ),
+            ctx: ctx
+        )
+
+        #expect(result.isError != true)
+        #expect(await handle.reconfigureCalls.count == 1)
+        #expect(await handle.currentTraits.colorScheme == "light")
+        #expect(await handle.currentTraits.locale == nil)
+        #expect(text(in: result).contains("colorScheme=light"))
+    }
+
+    @Test("preview_switch returns structured active preview metadata")
+    func previewSwitchStructuredContent() async throws {
+        let source = try HandlerContractSupport.previewFile()
+        let handle = FakePreviewSessionHandle(id: "switch-session", sourceFile: source)
+        let ctx = try await HandlerContractSupport.context(handles: [handle])
+
+        let result = try await PreviewSwitchHandler.handle(
+            params(
+                .previewSwitch,
+                ["sessionID": .string(handle.id), "previewIndex": .int(1)]
+            ),
+            ctx: ctx
+        )
+
+        let payload = try decodeStructured(DaemonProtocol.SwitchResult.self, from: result)
+        #expect(payload.sessionID == handle.id)
+        #expect(payload.activeIndex == 1)
+        #expect(payload.previews.first(where: { $0.index == 1 })?.active == true)
+        #expect(await handle.switchCalls == [1])
+    }
+
+    @Test("preview_variants returns structured outcomes and restores traits")
+    func previewVariantsStructuredContent() async throws {
+        let source = try HandlerContractSupport.previewFile()
+        let originalTraits = PreviewTraits(colorScheme: "dark")
+        let handle = FakePreviewSessionHandle(
+            id: "variants-session",
+            sourceFile: source,
+            traits: originalTraits
+        )
+        let ctx = try await HandlerContractSupport.context(handles: [handle])
+
+        let result = try await PreviewVariantsHandler.handle(
+            params(
+                .previewVariants,
+                [
+                    "sessionID": .string(handle.id),
+                    "variants": .array([.string("light"), .string("boldText")]),
+                ]
+            ),
+            ctx: ctx
+        )
+
+        let payload = try decodeStructured(DaemonProtocol.VariantsResult.self, from: result)
+        #expect(payload.successCount == 2)
+        #expect(payload.failCount == 0)
+        #expect(payload.variants.map(\.label) == ["light", "boldText"])
+        #expect(payload.variants.compactMap(\.imageIndex).count == 2)
+        #expect(result.content.count(where: { if case .image = $0 { true } else { false } }) == 2)
+        #expect(await handle.currentTraits == originalTraits)
+    }
+
+    @Test("preview_variants supports custom JSON labels and distinct image blocks")
+    func previewVariantsCustomJSONAndDistinctImages() async throws {
+        let source = try HandlerContractSupport.previewFile()
+        let firstImage = Data([0x01, 0x02, 0x03])
+        let secondImage = Data([0x04, 0x05, 0x06])
+        let handle = FakePreviewSessionHandle(
+            id: "variants-custom-session",
+            sourceFile: source,
+            snapshotPayloads: [firstImage, secondImage]
+        )
+        let ctx = try await HandlerContractSupport.context(handles: [handle])
+        let customJSON = #"{"colorScheme":"dark","dynamicTypeSize":"large","label":"dark-large"}"#
+
+        let result = try await PreviewVariantsHandler.handle(
+            params(
+                .previewVariants,
+                [
+                    "sessionID": .string(handle.id),
+                    "variants": .array([.string("light"), .string(customJSON)]),
+                ]
+            ),
+            ctx: ctx
+        )
+
+        #expect(result.isError != true)
+        let payload = try decodeStructured(DaemonProtocol.VariantsResult.self, from: result)
+        #expect(payload.variants.map(\.label) == ["light", "dark-large"])
+        let images = imageContents(in: result)
+        #expect(images.map(\.data) == [firstImage, secondImage])
+        #expect(images[0].data != images[1].data)
+        #expect(text(in: result).contains("[1] dark-large:"))
+    }
+
+    @Test("preview_variants restores the pre-call traits")
+    func previewVariantsRestoresOriginalTraits() async throws {
+        let source = try HandlerContractSupport.previewFile()
+        let originalTraits = PreviewTraits(colorScheme: "dark", dynamicTypeSize: "large")
+        let handle = FakePreviewSessionHandle(
+            id: "variants-restore-session",
+            sourceFile: source,
+            traits: originalTraits
+        )
+        let ctx = try await HandlerContractSupport.context(handles: [handle])
+
+        let result = try await PreviewVariantsHandler.handle(
+            params(
+                .previewVariants,
+                [
+                    "sessionID": .string(handle.id),
+                    "variants": .array([.string("light")]),
+                ]
+            ),
+            ctx: ctx
+        )
+
+        #expect(result.isError != true)
+        #expect(await handle.currentTraits == originalTraits)
+        let setTraitCalls = await handle.setTraitsCalls
+        #expect(setTraitCalls.count == 2)
+        #expect(setTraitCalls.first?.colorScheme == "light")
+        #expect(setTraitCalls.last == originalTraits)
+    }
+
+    @Test("preview_variants validates empty and invalid variants before rendering")
+    func previewVariantsValidationErrors() async throws {
+        let source = try HandlerContractSupport.previewFile()
+        let handle = FakePreviewSessionHandle(id: "variants-error-session", sourceFile: source)
+        let ctx = try await HandlerContractSupport.context(handles: [handle])
+
+        let empty = try await PreviewVariantsHandler.handle(
+            params(
+                .previewVariants,
+                ["sessionID": .string(handle.id), "variants": .array([])]
+            ),
+            ctx: ctx
+        )
+        #expect(empty.isError == true)
+        #expect(text(in: empty).contains("must not be empty"))
+
+        let invalid = try await PreviewVariantsHandler.handle(
+            params(
+                .previewVariants,
+                ["sessionID": .string(handle.id), "variants": .array([.string("neon")])]
+            ),
+            ctx: ctx
+        )
+        #expect(invalid.isError == true)
+        #expect(text(in: invalid).contains("neon"))
+        #expect(await handle.snapshotQualities.isEmpty)
+    }
+
+    @Test("preview_stop calls the routed handle")
+    func previewStopCallsHandle() async throws {
+        let source = try HandlerContractSupport.previewFile()
+        let handle = FakePreviewSessionHandle(id: "stop-session", sourceFile: source)
+        let ctx = try await HandlerContractSupport.context(handles: [handle])
+
+        let result = try await PreviewStopHandler.handle(
+            params(.previewStop, ["sessionID": .string(handle.id)]),
+            ctx: ctx
+        )
+
+        #expect(result.isError != true)
+        #expect(await handle.stopCallCount == 1)
+        #expect(text(in: result).contains("Preview session \(handle.id) closed"))
+    }
+}
+
+private enum HandlerContractSupport {
+    @MainActor
+    private final class StubReloader: StructuralReloader, @unchecked Sendable {
+        func render(_: JITRenderBuild) async throws {}
+    }
+
+    /// None of these tests exercise `preview_start` (the only handler that
+    /// reads `HandlerContext.macCompiler`), but the struct requires a real
+    /// `Compiler`, whose init resolves the toolchain via `xcrun`. Sharing one
+    /// instance across the suite avoids paying that resolution cost per test.
+    private static let sharedCompiler = Task { try await Compiler() }
+
+    static func context(handles: [FakePreviewSessionHandle] = []) async throws -> HandlerContext {
+        let host = await MainActor.run {
+            PreviewHost(makeStructuralReloader: { StubReloader() })
+        }
+        let iosManager = IOSSessionManager()
+        let configCache = ConfigCache()
+        let router = FakeSessionRouter(handles: handles)
+        let registry = SessionRegistry(
+            registryDir: FileManager.default.temporaryDirectory
+                .appendingPathComponent("previewsmcp-handler-contract-\(UUID().uuidString)")
+        )
+        let compiler = try await sharedCompiler.value
+        let server = Server(
+            name: "previewsmcp-test",
+            version: "test",
+            capabilities: .init(logging: .init(), tools: .init(listChanged: false))
+        )
+        return HandlerContext(
+            host: host,
+            iosState: iosManager,
+            configCache: configCache,
+            router: router,
+            registry: registry,
+            macCompiler: compiler,
+            server: server
+        )
+    }
+
+    static func previewFile() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-handler-contract-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("ContractPreview.swift")
+        try """
+        import SwiftUI
+
+        struct ContractPreview: View {
+            var body: some View { Text("Contract") }
+        }
+
+        #Preview("First") {
+            ContractPreview()
+        }
+
+        #Preview("Second") {
+            Text("Second")
+        }
+        """.write(to: file, atomically: true, encoding: .utf8)
+        return file
+    }
+}
+
+private final class FakeSessionRouter: SessionRouting, @unchecked Sendable {
+    private let handles: [String: any PreviewSessionHandle]
+
+    init(handles: [FakePreviewSessionHandle]) {
+        self.handles = Dictionary(uniqueKeysWithValues: handles.map { ($0.id, $0) })
+    }
+
+    func handle(for sessionID: String) async -> (any PreviewSessionHandle)? {
+        handles[sessionID]
+    }
+}
+
+private actor FakePreviewSessionHandle: PreviewSessionHandle {
+    nonisolated let id: String
+    nonisolated let sourceFile: URL
+    nonisolated let platform: PreviewPlatform
+    let snapshotData: Data
+    private let snapshotPayloads: [Data]
+    private(set) var traits: PreviewTraits
+    private(set) var setTraitsCalls: [PreviewTraits] = []
+    private(set) var reconfigureCalls: [(PreviewTraits, Set<PreviewTraits.Field>)] = []
+    private(set) var switchCalls: [Int] = []
+    private(set) var snapshotQualities: [Double] = []
+    private(set) var stopCallCount = 0
+    private var registered = true
+
+    init(
+        id: String,
+        sourceFile: URL,
+        platform: PreviewPlatform = .macOS,
+        traits: PreviewTraits = PreviewTraits(),
+        snapshotData: Data = Data([0x89, 0x50, 0x4E, 0x47]),
+        snapshotPayloads: [Data]? = nil
+    ) {
+        self.id = id
+        self.sourceFile = sourceFile
+        self.platform = platform
+        self.traits = traits
+        self.snapshotData = snapshotData
+        self.snapshotPayloads = snapshotPayloads ?? [snapshotData]
+    }
+
+    var currentTraits: PreviewTraits {
+        traits
+    }
+
+    var isRegistered: Bool {
+        registered
+    }
+
+    func setTraits(_ traits: PreviewTraits) async throws {
+        setTraitsCalls.append(traits)
+        self.traits = traits
+    }
+
+    func reconfigure(
+        traits: PreviewTraits,
+        clearing: Set<PreviewTraits.Field>
+    ) async throws {
+        reconfigureCalls.append((traits, clearing))
+        self.traits = self.traits.merged(with: traits).clearing(clearing)
+    }
+
+    func switchPreview(to index: Int) async throws {
+        switchCalls.append(index)
+    }
+
+    func snapshot(quality: Double) async throws -> Data {
+        snapshotQualities.append(quality)
+        let index = min(snapshotQualities.count - 1, snapshotPayloads.count - 1)
+        return snapshotPayloads[index]
+    }
+
+    func awaitLayoutSettle() async {}
+
+    func stop() async {
+        stopCallCount += 1
+        registered = false
+    }
+}
+
+private func params(
+    _ name: ToolName,
+    _ arguments: [String: Value] = [:]
+) -> CallTool.Parameters {
+    CallTool.Parameters(name: name.rawValue, arguments: arguments)
+}
+
+private func decodeStructured<T: Decodable>(
+    _: T.Type,
+    from result: CallTool.Result
+) throws -> T {
+    let structured = try #require(result.structuredContent)
+    let data = try JSONEncoder().encode(structured)
+    return try JSONDecoder().decode(T.self, from: data)
+}
+
+private func text(in result: CallTool.Result) -> String {
+    result.content.compactMap {
+        if case let .text(text) = $0 { return text }
+        return nil
+    }.joined(separator: "\n")
+}
+
+private func imageContents(
+    in result: CallTool.Result
+) -> [(data: Data, mimeType: String)] {
+    result.content.compactMap { item in
+        if case let .image(base64, mimeType, _) = item,
+           let data = Data(base64Encoded: base64)
+        {
+            return (data, mimeType)
+        }
+        return nil
+    }
+}

--- a/previewsmcp/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
+++ b/previewsmcp/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
@@ -222,6 +222,99 @@ struct PreviewHostJITReloadTests {
         #expect(reloader.calls.count == 1, "unchanged source must not trigger a reload")
     }
 
+    @Test func primaryLiteralOnlyFireRerendersWithoutStructuralReload() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("p297l-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let sourceFile = dir.appendingPathComponent("HelloView.swift")
+        let original = """
+        import SwiftUI
+
+        struct HelloView: View {
+            var body: some View { Text("hello") }
+        }
+
+        #Preview {
+            HelloView()
+        }
+        """
+        try original.write(to: sourceFile, atomically: true, encoding: .utf8)
+        let primary = FileWatcher.canonicalPath(sourceFile.path) ?? sourceFile.path
+
+        let compiler = try await Compiler()
+        let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
+
+        let reloader = RecordingReloader()
+        let host = PreviewHost(makeStructuralReloader: { reloader })
+        try await host.jitStart(
+            sessionID: "s1", session: session,
+            title: "t", size: NSSize(width: 8, height: 8), headless: true
+        )
+        #expect(reloader.calls.count == 1)
+        let originalSnapshot = host.agentSnapshotPath(for: "s1")
+
+        let edited = original.replacingOccurrences(of: "hello", with: "world")
+        try edited.write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        await host.handleWatchedChange(
+            sessionID: "s1", canonicalPrimary: primary, firedPaths: [primary]
+        )
+
+        #expect(reloader.calls.count == 2, "literal-only edit should re-render the existing object")
+        #expect(
+            reloader.calls.first?.objectPath == reloader.calls.last?.objectPath,
+            "literal-only edit must not compile a new object"
+        )
+        #expect(host.agentSnapshotPath(for: "s1") == originalSnapshot)
+        guard case .unchanged = await session.classifySourceChange(newSource: edited) else {
+            Issue.record("successful literal reload should commit the edited source baseline")
+            return
+        }
+    }
+
+    @Test func primaryStructuralFireRunsStructuralReload() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("p297s-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let sourceFile = dir.appendingPathComponent("ColorView.swift")
+        let original = """
+        import SwiftUI
+
+        #Preview {
+            Color.red.frame(width: 8, height: 8)
+        }
+        """
+        try original.write(to: sourceFile, atomically: true, encoding: .utf8)
+        let primary = FileWatcher.canonicalPath(sourceFile.path) ?? sourceFile.path
+
+        let compiler = try await Compiler()
+        let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
+
+        let reloader = RecordingReloader()
+        let host = PreviewHost(makeStructuralReloader: { reloader })
+        try await host.jitStart(
+            sessionID: "s1", session: session,
+            title: "t", size: NSSize(width: 8, height: 8), headless: true
+        )
+        #expect(reloader.calls.count == 1)
+
+        let edited = original.replacingOccurrences(
+            of: ".frame(width: 8, height: 8)",
+            with: ".frame(width: 8, height: 8).padding(1)"
+        )
+        try edited.write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        await host.handleWatchedChange(
+            sessionID: "s1", canonicalPrimary: primary, firedPaths: [primary]
+        )
+
+        #expect(reloader.calls.count == 2, "structural primary edit must structurally reload")
+    }
+
     @Test func secondaryFileFireForcesStructuralReload() async throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("p297x-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary
- Extracts `SessionRouting` (into `previewsmcp/PreviewsCore/PreviewSessionHandle.swift`) from the concrete `SessionRouter` actor so the 7 MCP tool handlers can be tested against `FakeSessionRouter`/`FakePreviewSessionHandle` — no daemon, no simulator, no AppKit window, no real preview compile.
- New `previewsmcp/Tests/PreviewsCLITests/MCPHandlerContractTests.swift` covers `preview_list`, `session_list`, `preview_snapshot`, `preview_configure`, `preview_switch`, `preview_variants`, `preview_stop`.
- Two new tests in the existing `PreviewHostJITReloadTests.swift` cover literal-only vs. structural hot-reload dispatch directly against `PreviewHost`.
- **Purely additive** — no existing test deleted or trimmed. `MacOSMCPTests.swift` is untouched.

Step 1 of the iOS/MCP test restructure (see issue tracking the pivot away from grinding the merge-queue bar's flaky heavyweight integration suite, toward extracting handler/session logic into fast DI-backed unit tests with only a thin real-sim/daemon e2e layer remaining).

A first attempt at also deleting `MacOSMCPTests.swift`'s now-overlapping daemon-based tests in this same PR was reverted after `/code-review` (workflow, high effort) surfaced a real coverage gap: `session_list`/`preview_start`/`simulator_list` structuredContent decoding and `preview_variants` real-rendering had exactly one test each and it was the one being deleted, and the new hot-reload unit tests call `PreviewHost.handleWatchedChange` directly rather than exercising the real FileWatcher/FSEvents wiring. That deletion moves to a later restructure step, landing alongside its real replacement instead of before it.

Also surfaced (tracked for a later step, not actioned here): `SessionListHandler` reads `ctx.host`/`ctx.registry` directly rather than `ctx.router`, so the `SessionRouting` fake seam doesn't reach `session_list`'s populated path — a future step will need a registry/host seam too.

## Test plan
- [x] `bazel build //...` — clean
- [x] `bazel run //tools/lint:check` — clean
- [x] `bazel test //previewsmcp/Tests/PreviewsCLITests //previewsmcp/Tests/PreviewsMacOSTests` — uncached PASSED
- [x] `bazel test //previewsmcp/Tests/...` (full local suite) — 8/9 targets passed; `MCPIntegrationTests` failed on the first full-suite run due to a transient concurrent-build race over the shared `examples/spm` tree between iOS suites (a known pre-existing flake class, not caused by this change) — re-ran `//previewsmcp/Tests/MCPIntegrationTests` in isolation and it passed clean.
- [x] `/simplify` (4 parallel review agents) — fixed: moved `SessionRouting` to `PreviewsCore` (matches `StructuralReloader` precedent), merged duplicate image-extraction test helpers, dropped dead `settleCallCount` state, memoized the real `Compiler()` build across the test suite instead of rebuilding it per test.
- [x] `/code-review` (workflow, high effort) — findings led to reverting the `MacOSMCPTests.swift` deletion (see above); no findings remain against the additive diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)