### PR TITLE
Test restructure step 3: unit-test list's pure CLI-glue logic

### DIFF
--- a/previewsmcp/PreviewsCLI/ListCommand.swift
+++ b/previewsmcp/PreviewsCLI/ListCommand.swift
@@ -32,7 +32,7 @@ struct ListCommand: ParsableCommand {
     func run() throws {
         var isDirectory: ObjCBool = false
         FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
-        let files = isDirectory.boolValue ? swiftFiles(in: path) : [path]
+        let files = isDirectory.boolValue ? Self.swiftFiles(in: path) : [path]
 
         var total = 0
         var failures = 0
@@ -54,13 +54,13 @@ struct ListCommand: ParsableCommand {
                 guard !previews.isEmpty else { continue }
                 print(file)
                 for preview in previews {
-                    print("  " + humanLine(preview))
+                    print("  " + Self.humanLine(preview))
                 }
             } else if previews.isEmpty {
                 print("No #Preview blocks found in \(URL(fileURLWithPath: file).lastPathComponent)")
             } else {
                 for preview in previews {
-                    print(humanLine(preview))
+                    print(Self.humanLine(preview))
                 }
             }
             total += previews.count
@@ -75,7 +75,7 @@ struct ListCommand: ParsableCommand {
     }
 }
 
-private struct PreviewLine: Encodable {
+struct PreviewLine: Encodable {
     let file: String
     let index: Int
     let name: String?
@@ -91,8 +91,8 @@ private struct PreviewLine: Encodable {
     }
 }
 
-private extension ListCommand {
-    func swiftFiles(in path: String) -> [String] {
+extension ListCommand {
+    static func swiftFiles(in path: String) -> [String] {
         let url = URL(fileURLWithPath: path)
         guard
             let enumerator = FileManager.default.enumerator(
@@ -109,11 +109,13 @@ private extension ListCommand {
                 .sorted()
     }
 
-    func humanLine(_ preview: PreviewInfo) -> String {
+    static func humanLine(_ preview: PreviewInfo) -> String {
         let name = preview.name ?? "Preview"
         return "[\(preview.index)] \(name) (line \(preview.line)): \(preview.snippet)"
     }
+}
 
+private extension ListCommand {
     func emitJSONLine(_ record: PreviewLine) throws {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]

--- a/previewsmcp/Tests/CLIIntegrationTests/ListCommandTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/ListCommandTests.swift
@@ -42,6 +42,14 @@ struct ListCommandTests {
         #expect(result.stdout.contains("No #Preview blocks found"))
     }
 
+    // Local (pre-daemon) path-validation message content moved to
+    // PreviewsCLITests/ListCommandLogicTests.swift, which invokes
+    // ListCommand in-process instead of spawning a subprocess.
+    // This one stays too, as a black-box smoke test: it's the only
+    // remaining coverage of the real binary's validate()-throws-to-exit-code
+    // dispatch (PreviewsMCPApp.swift) for `list`, matching how
+    // VariantsCommandTests kept its own nonexistent-file case.
+
     @Test("Returns non-zero exit code for nonexistent file")
     func listNonexistentFile() async throws {
         let result = try await CLIRunner.run("list", arguments: ["/nonexistent/file.swift"])

--- a/previewsmcp/Tests/PreviewsCLITests/ListCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/ListCommandLogicTests.swift
@@ -1,0 +1,90 @@
+import ArgumentParser
+import Foundation
+@testable import PreviewsCLI
+import PreviewsCore
+import Testing
+
+/// `list`'s actual #Preview/PreviewProvider parsing is exercised exhaustively
+/// against inline source in PreviewsCoreTests/PreviewParserTests.swift — this
+/// suite covers `list`'s own logic on top of that: the pre-daemon path
+/// validation, directory scanning, and output formatting. `list` never talks
+/// to the daemon (it's a `local` CLI subcommand per AGENTS.md), so none of
+/// this needs a fake/seam, just direct in-process calls.
+@Suite("list command logic")
+struct ListCommandLogicTests {
+    @Test("rejects a nonexistent path")
+    func rejectsNonexistentPath() throws {
+        // `ParsableCommand.parse(_:)` wraps a `validate()` throw in
+        // ArgumentParser's internal (non-public) CommandError/ParserError, so
+        // parse with a valid path first and call `validate()` directly to
+        // assert on the public `ValidationError` instead.
+        var command = try ListCommand.parse([NSTemporaryDirectory()])
+        command.path = "/nonexistent/file.swift"
+        do {
+            try command.validate()
+            Issue.record("expected validate() to throw for a nonexistent path")
+        } catch let error as ValidationError {
+            #expect(error.message.contains("path does not exist: /nonexistent/file.swift"))
+        }
+    }
+
+    @Test("swiftFiles finds .swift files recursively, sorted, skipping hidden files")
+    func swiftFilesScansRecursively() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-list-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("Sub"), withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        try "".write(to: dir.appendingPathComponent("B.swift"), atomically: true, encoding: .utf8)
+        try "".write(to: dir.appendingPathComponent("A.swift"), atomically: true, encoding: .utf8)
+        try "".write(
+            to: dir.appendingPathComponent("Sub/C.swift"), atomically: true, encoding: .utf8
+        )
+        try "".write(to: dir.appendingPathComponent("notes.txt"), atomically: true, encoding: .utf8)
+        try "".write(to: dir.appendingPathComponent(".hidden.swift"), atomically: true, encoding: .utf8)
+
+        let files = ListCommand.swiftFiles(in: dir.path)
+
+        #expect(files.map { URL(fileURLWithPath: $0).lastPathComponent } == [
+            "A.swift", "B.swift", "C.swift",
+        ])
+    }
+
+    @Test("humanLine formats a named preview")
+    func humanLineFormatsNamedPreview() throws {
+        let preview = try #require(
+            PreviewParser.parse(source: #"#Preview("Loading") { Text("hi") }"#).first
+        )
+
+        #expect(ListCommand.humanLine(preview) == "[0] Loading (line 1): Text(\"hi\")")
+    }
+
+    @Test("humanLine falls back to 'Preview' when unnamed")
+    func humanLineFallsBackWhenUnnamed() throws {
+        let preview = try #require(
+            PreviewParser.parse(source: #"#Preview { Text("hi") }"#).first
+        )
+
+        #expect(ListCommand.humanLine(preview) == "[0] Preview (line 1): Text(\"hi\")")
+    }
+
+    @Test("PreviewLine encodes the fields list --json documents")
+    func previewLineEncodesExpectedFields() throws {
+        let preview = try #require(
+            PreviewParser.parse(source: #"#Preview("Loading") { Text("hi") }"#).first
+        )
+        let line = PreviewLine(from: preview, file: "/tmp/View.swift")
+
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: JSONEncoder().encode(line)) as? [String: Any]
+        )
+
+        #expect(object["file"] as? String == "/tmp/View.swift")
+        #expect(object["index"] as? Int == 0)
+        #expect(object["name"] as? String == "Loading")
+        #expect(object["line"] as? Int == 1)
+        #expect(object["snippet"] as? String == #"Text("hi")"#)
+    }
+}


### PR DESCRIPTION
## Summary
- `list` never talks to the daemon, and its actual `#Preview`/`PreviewProvider` parsing is already exhaustively unit-tested in `PreviewsCoreTests/PreviewParserTests.swift`. This step adds fast in-process coverage for the previously-untested pure logic `ListCommand` builds on top of that parsing: directory scanning (recursive, sorted, hidden-file/extension filtering), human-readable line formatting, `PreviewLine`'s JSON field shape, and path validation.
- Widened `swiftFiles(in:)` and `humanLine(_:)` from private to internal `static` functions (neither reads `self`) and `PreviewLine` from private to internal, so the new `PreviewsCLITests/ListCommandLogicTests.swift` can call them directly via `@testable import PreviewsCLI`. `emitJSONLine`/`warn` stay private.
- The remaining 6 subprocess-based `ListCommandTests` stay as-is — they exercise `run()`'s actual output orchestration (directory-vs-file mode, NDJSON streaming, "no previews" message) against real fixture files, which the new unit tests deliberately don't attempt to replicate.

`/code-review` (workflow, high effort) caught the same class of issue as step 2: removing `listNonexistentFile` left `list` with zero end-to-end coverage of the real binary's `validate()`-throws-to-exit-code dispatch. Restored it as a black-box smoke test, matching the pattern `VariantsCommandTests` already established. Also strengthened the in-process validation test to assert on the actual error message, not just the exception type.

`/simplify` (4 parallel review agents) caught: two tests were spinning up a full `ListCommand` instance via `parse()` just to call methods that never touch `self` (fixed by making them `static`), a test asserted on ArgumentParser's internal wrapped error type instead of the public `ValidationError` (fixed to call `validate()` directly), unnecessary `JSONEncoder` formatting options with no effect on the test's assertions, and slightly over-widened access control on two unrelated helpers (split back out to a `private` extension).

Step 3 of the iOS/MCP test restructure (previous steps: #305, #306).

## Test plan
- [x] `bazel build //...` — clean
- [x] `bazel run //tools/lint:check` — clean
- [x] `bazel test //previewsmcp/Tests/PreviewsCLITests //previewsmcp/Tests/CLIIntegrationTests` — uncached PASSED
- [x] `bazel test //previewsmcp/Tests/...` (full local suite) — all 9 targets passed
- [x] `/simplify` — 4 findings, all fixed
- [x] `/code-review` (workflow, high effort) — 2 findings, both fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)