### PR TITLE
Test restructure step 4: SimulatorLister seam for simulator_list

### DIFF
--- a/previewsmcp/PreviewsCLI/Handlers/HandlerContext.swift
+++ b/previewsmcp/PreviewsCLI/Handlers/HandlerContext.swift
@@ -1,6 +1,7 @@
 import MCP
 import PreviewsCore
 import PreviewsEngine
+import PreviewsIOS
 import PreviewsMacOS
 
 /// Engine-layer dependencies bundled for a single MCP tool invocation.
@@ -15,6 +16,7 @@ struct HandlerContext {
     let iosState: IOSSessionManager
     let configCache: ConfigCache
     let router: any SessionRouting
+    let simulatorLister: any SimulatorLister
     let registry: SessionRegistry
     let macCompiler: Compiler
     let server: Server

--- a/previewsmcp/PreviewsCLI/Handlers/SimulatorListHandler.swift
+++ b/previewsmcp/PreviewsCLI/Handlers/SimulatorListHandler.swift
@@ -16,8 +16,7 @@ enum SimulatorListHandler: ToolHandler {
         _: CallTool.Parameters,
         ctx: HandlerContext
     ) async throws -> CallTool.Result {
-        let manager = await ctx.iosState.simulatorManager
-        let devices = try await manager.listDevices()
+        let devices = try await ctx.simulatorLister.listDevices()
         let available = devices.filter { $0.isAvailable }
 
         let structured = DaemonProtocol.SimulatorListResult(

--- a/previewsmcp/PreviewsCLI/MCPServer.swift
+++ b/previewsmcp/PreviewsCLI/MCPServer.swift
@@ -74,6 +74,7 @@ func configureMCPServer(
         iosState: iosManager,
         configCache: cache,
         router: router,
+        simulatorLister: await iosManager.simulatorManager,
         registry: registry,
         macCompiler: compiler,
         server: server

--- a/previewsmcp/PreviewsIOS/SimulatorManager.swift
+++ b/previewsmcp/PreviewsIOS/SimulatorManager.swift
@@ -3,8 +3,15 @@ import os
 import PreviewsCore
 @preconcurrency import SimulatorBridge
 
+/// Resolves the available iOS simulator devices. Kept as a protocol so
+/// `simulator_list`'s formatting/DTO-mapping logic can be tested against a
+/// deterministic in-memory device list without loading CoreSimulator.
+public protocol SimulatorLister: Sendable {
+    func listDevices() async throws -> [SimulatorManager.Device]
+}
+
 /// Manages iOS simulator devices via CoreSimulator.framework (loaded at runtime).
-public actor SimulatorManager {
+public actor SimulatorManager: SimulatorLister {
     /// Sendable snapshot of a simulator device.
     public struct Device: Sendable, CustomStringConvertible {
         public let name: String
@@ -15,6 +22,26 @@ public actor SimulatorManager {
         public let runtimeIdentifier: String?
         public let deviceTypeName: String?
         public let isAvailable: Bool
+
+        public init(
+            name: String,
+            udid: String,
+            state: DeviceState,
+            stateString: String,
+            runtimeName: String?,
+            runtimeIdentifier: String?,
+            deviceTypeName: String?,
+            isAvailable: Bool
+        ) {
+            self.name = name
+            self.udid = udid
+            self.state = state
+            self.stateString = stateString
+            self.runtimeName = runtimeName
+            self.runtimeIdentifier = runtimeIdentifier
+            self.deviceTypeName = deviceTypeName
+            self.isAvailable = isAvailable
+        }
 
         public var description: String {
             "\(name) (\(udid)) \(stateString) — \(runtimeName ?? "no runtime")"

--- a/previewsmcp/Tests/PreviewsCLITests/MCPHandlerContractTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/MCPHandlerContractTests.swift
@@ -3,6 +3,7 @@ import MCP
 @testable import PreviewsCLI
 import PreviewsCore
 import PreviewsEngine
+import PreviewsIOS
 import PreviewsMacOS
 import Testing
 
@@ -272,6 +273,63 @@ struct MCPHandlerContractTests {
         #expect(await handle.stopCallCount == 1)
         #expect(text(in: result).contains("Preview session \(handle.id) closed"))
     }
+
+    @Test("simulator_list reports the no-devices sentinel when none are available")
+    func simulatorListEmpty() async throws {
+        let ctx = try await HandlerContractSupport.context()
+
+        let result = try await SimulatorListHandler.handle(params(.simulatorList), ctx: ctx)
+
+        #expect(result.isError != true)
+        #expect(text(in: result) == "No available simulator devices found.")
+        let payload = try decodeStructured(DaemonProtocol.SimulatorListResult.self, from: result)
+        #expect(payload.simulators.isEmpty)
+    }
+
+    @Test("simulator_list filters unavailable devices and formats booted state")
+    func simulatorListFiltersAndFormats() async throws {
+        let booted = HandlerContractSupport.device(
+            name: "iPhone 16 Pro", udid: "AAAA", state: .booted, stateString: "Booted",
+            runtimeName: "iOS 18.5"
+        )
+        let shutdown = HandlerContractSupport.device(
+            name: "iPhone 15", udid: "BBBB", state: .shutdown, stateString: "Shutdown",
+            runtimeName: "iOS 17.5"
+        )
+        // Only `.booted` earns the `[BOOTED]` marker — a device mid-transition
+        // (booting/shutting down) reads identically to a shut-down one in the
+        // human-readable line, which is today's intended behavior: the marker
+        // means "usable right now," not "not fully shut down." structuredContent
+        // still carries the precise stateString regardless.
+        let booting = HandlerContractSupport.device(
+            name: "iPhone 14", udid: "DDDD", state: .booting, stateString: "Booting",
+            runtimeName: "iOS 16.4"
+        )
+        let unavailable = HandlerContractSupport.device(
+            name: "iPhone 12", udid: "CCCC", runtimeName: nil, isAvailable: false
+        )
+        let ctx = try await HandlerContractSupport.context(
+            simulators: [booted, shutdown, booting, unavailable]
+        )
+
+        let result = try await SimulatorListHandler.handle(params(.simulatorList), ctx: ctx)
+
+        #expect(result.isError != true)
+        let lines = text(in: result).split(separator: "\n").map(String.init)
+        #expect(lines == [
+            "iPhone 16 Pro — AAAA [BOOTED] (iOS 18.5)",
+            "iPhone 15 — BBBB (iOS 17.5)",
+            "iPhone 14 — DDDD (iOS 16.4)",
+        ])
+
+        let payload = try decodeStructured(DaemonProtocol.SimulatorListResult.self, from: result)
+        #expect(
+            payload.simulators.map(\.udid) == ["AAAA", "BBBB", "DDDD"],
+            "unavailable device excluded"
+        )
+        #expect(payload.simulators[2].state == "Booting", "structuredContent keeps the precise state")
+        #expect(payload.simulators[0].state == "Booted")
+    }
 }
 
 private enum HandlerContractSupport {
@@ -286,7 +344,10 @@ private enum HandlerContractSupport {
     /// instance across the suite avoids paying that resolution cost per test.
     private static let sharedCompiler = Task { try await Compiler() }
 
-    static func context(handles: [FakePreviewSessionHandle] = []) async throws -> HandlerContext {
+    static func context(
+        handles: [FakePreviewSessionHandle] = [],
+        simulators: [SimulatorManager.Device] = []
+    ) async throws -> HandlerContext {
         let host = await MainActor.run {
             PreviewHost(makeStructuralReloader: { StubReloader() })
         }
@@ -308,9 +369,30 @@ private enum HandlerContractSupport {
             iosState: iosManager,
             configCache: configCache,
             router: router,
+            simulatorLister: FakeSimulatorLister(devices: simulators),
             registry: registry,
             macCompiler: compiler,
             server: server
+        )
+    }
+
+    static func device(
+        name: String,
+        udid: String,
+        state: SimulatorManager.DeviceState = .shutdown,
+        stateString: String = "Shutdown",
+        runtimeName: String?,
+        isAvailable: Bool = true
+    ) -> SimulatorManager.Device {
+        SimulatorManager.Device(
+            name: name,
+            udid: udid,
+            state: state,
+            stateString: stateString,
+            runtimeName: runtimeName,
+            runtimeIdentifier: nil,
+            deviceTypeName: nil,
+            isAvailable: isAvailable
         )
     }
 
@@ -335,6 +417,14 @@ private enum HandlerContractSupport {
         }
         """.write(to: file, atomically: true, encoding: .utf8)
         return file
+    }
+}
+
+private struct FakeSimulatorLister: SimulatorLister {
+    let devices: [SimulatorManager.Device]
+
+    func listDevices() async throws -> [SimulatorManager.Device] {
+        devices
     }
 }
 


### PR DESCRIPTION
## Summary
- Introduces a narrow `SimulatorLister` protocol (`previewsmcp/PreviewsIOS/SimulatorManager.swift`, single method `listDevices()`) so `simulator_list`'s formatting/DTO-mapping logic can be tested against a deterministic in-memory device list without loading CoreSimulator. The real `SimulatorManager` actor conforms to it directly, mirroring the `SessionRouting`/`SessionRouter` pattern from step 1.
- `HandlerContext` gets a new `simulatorLister` field, wired to the real `SimulatorManager` at the one production construction site (`MCPServer.swift`); `SimulatorListHandler` now goes through `ctx.simulatorLister` instead of reaching through `ctx.iosState.simulatorManager` directly.
- Added an explicit `public init` to `SimulatorManager.Device` (previously only constructible via the compiler-synthesized *internal* memberwise init) — the existing `device(from:)` factory now calls this same init, so there's still exactly one construction path in production code.

**Scope correction from the original survey:** `SimulatorsCommandTests.swift` turned out to need a `DaemonClienting` seam (a later step), not this one — `SimulatorsCommand.run()` has zero local logic, it only forwards to the daemon. Left both of its tests untouched, along with `IOSMCPTests.simulatorListReturnsDevices` (a genuine real-CoreSimulator integration check worth keeping). Verified the new wiring doesn't break that real test by running it in isolation before and after this change.

`/code-review` (workflow, high effort) caught a real coverage gap: the existing `[BOOTED]`-marker logic (unchanged by this diff) only special-cases `.booted`, so transitional states (`.booting`/`.shuttingDown`) render identically to `.shutdown` in the human-readable text — a pre-existing production behavior the new tests hadn't exercised. Extended the fake-based test to cover a `.booting` device and confirm `structuredContent` still carries the precise state even when the text line doesn't distinguish it.

`/simplify` (4 parallel review agents) found the pattern fidelity, protocol placement, and `Device` init all correctly pitched; one cosmetic fix applied.

Step 4 of the iOS/MCP test restructure (previous steps: #305, #306, #307).

## Test plan
- [x] `bazel build //...` — clean
- [x] `bazel run //tools/lint:check` — clean
- [x] `bazel test //previewsmcp/Tests/PreviewsCLITests //previewsmcp/Tests/PreviewsIOSTests` — uncached PASSED
- [x] `bazel test //previewsmcp/Tests/MCPIntegrationTests --test_filter=".*simulatorList.*"` — real end-to-end `simulator_list` test passes through the new wiring
- [x] `bazel test //previewsmcp/Tests/...` (full local suite) — 8/9 targets passed; `MCPIntegrationTests` failed on the full-suite run from the same pre-existing concurrent-build-race flake seen in step 1 (unrelated to this diff — none of the 3 failures touch `simulator_list` or anything this PR changes) — re-ran that target alone and it passed clean.
- [x] `/simplify` — 1 cosmetic finding, fixed
- [x] `/code-review` (workflow, high effort) — 1 finding, fixed (extended test coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)