### PR TITLE
Test restructure step 5a: DaemonToolCalling seam

### DIFF
--- a/previewsmcp/PreviewsCLI/ConfigureCommand.swift
+++ b/previewsmcp/PreviewsCLI/ConfigureCommand.swift
@@ -87,7 +87,7 @@ struct ConfigureCommand: AsyncParsableCommand {
             if let layoutDirection { args["layoutDirection"] = .string(layoutDirection) }
             if let legibilityWeight { args["legibilityWeight"] = .string(legibilityWeight) }
 
-            let response = try await client.callTool(
+            let response = try await client.callToolStructured(
                 name: "preview_configure", arguments: args
             )
             if response.isError == true {

--- a/previewsmcp/PreviewsCLI/DaemonClient.swift
+++ b/previewsmcp/PreviewsCLI/DaemonClient.swift
@@ -159,7 +159,7 @@ enum DaemonClient {
         name: String,
         stallThreshold: Duration = .seconds(30),
         configure: ((Client) async -> Void)? = nil,
-        body: (Client) async throws -> T
+        body: (any DaemonToolCalling) async throws -> T
     ) async throws -> T {
         let timer = StallTimer()
 

--- a/previewsmcp/PreviewsCLI/MCPContentHelpers.swift
+++ b/previewsmcp/PreviewsCLI/MCPContentHelpers.swift
@@ -13,11 +13,6 @@ extension [Tool.Content] {
     }
 }
 
-/// Result shape the `client.callTool(...)` tuple overload returns. The MCP
-/// SDK drops `structuredContent` from that overload; CLI commands that need
-/// the structured payload go through `callToolStructured` on `DaemonClient`.
-typealias CallToolTuple = (content: [Tool.Content], isError: Bool?)
-
 enum DecodeStructuredError: Error, CustomStringConvertible {
     case missingStructuredContent
     case decodeFailed(underlying: Error)
@@ -32,7 +27,21 @@ enum DecodeStructuredError: Error, CustomStringConvertible {
     }
 }
 
-extension Client {
+/// The tool-calling surface CLI commands actually depend on: send a named
+/// tool call to the daemon and get back its full result, including
+/// `structuredContent`. Everything else `DaemonClient.withDaemonClient` does
+/// (connect, spawn, version-mismatch restart, stall detection, log
+/// forwarding) is connection lifecycle, not something command bodies touch —
+/// so it stays on the concrete `Client`/`DaemonClient` and isn't part of this
+/// protocol. A future test double can conform without any real socket.
+protocol DaemonToolCalling: Sendable {
+    func callToolStructured(
+        name: String,
+        arguments: [String: Value]?
+    ) async throws -> CallTool.Result
+}
+
+extension Client: DaemonToolCalling {
     /// Call an MCP tool and return the full `CallTool.Result` including
     /// `structuredContent`. The SDK's primary `callTool(name:arguments:)`
     /// overload drops that field; CLI commands that need the structured

--- a/previewsmcp/PreviewsCLI/RunCommand.swift
+++ b/previewsmcp/PreviewsCLI/RunCommand.swift
@@ -163,7 +163,7 @@ struct RunCommand: AsyncParsableCommand {
             await blockUntilSignal()
 
             do {
-                _ = try await client.callTool(
+                _ = try await client.callToolStructured(
                     name: "preview_stop",
                     arguments: ["sessionID": .string(sessionID)]
                 )

--- a/previewsmcp/PreviewsCLI/SessionResolver.swift
+++ b/previewsmcp/PreviewsCLI/SessionResolver.swift
@@ -16,7 +16,7 @@ enum SessionResolver {
     static func resolve(
         session: String?,
         file: String?,
-        client: Client
+        client: any DaemonToolCalling
     ) async throws -> Resolution {
         // Explicit --session wins over everything else. We don't verify
         // existence here — the subsequent MCP call will fail with a useful
@@ -70,8 +70,8 @@ enum SessionResolver {
     }
 
     /// Query the daemon for the list of active sessions.
-    private static func listSessions(client: Client) async throws -> [SessionInfo] {
-        let response = try await client.callTool(name: "session_list", arguments: [:])
+    private static func listSessions(client: any DaemonToolCalling) async throws -> [SessionInfo] {
+        let response = try await client.callToolStructured(name: "session_list", arguments: [:])
         if response.isError == true {
             throw SessionResolverError.daemonError(
                 response.content.joinedText()

--- a/previewsmcp/PreviewsCLI/SnapshotCommand.swift
+++ b/previewsmcp/PreviewsCLI/SnapshotCommand.swift
@@ -162,7 +162,7 @@ struct SnapshotCommand: AsyncParsableCommand {
 
     /// Snapshot a session that's already running. Trait flags are ignored;
     /// we use whatever traits the session was configured with.
-    private func snapshotExisting(sessionID: String, client: Client) async throws {
+    private func snapshotExisting(sessionID: String, client: any DaemonToolCalling) async throws {
         if hasTraitFlags {
             fputs(
                 "note: trait flags (--color-scheme / --dynamic-type-size / "
@@ -176,7 +176,7 @@ struct SnapshotCommand: AsyncParsableCommand {
         var args: [String: Value] = ["sessionID": .string(sessionID)]
         args["quality"] = .double(resolvedQuality())
 
-        let response = try await client.callTool(name: "preview_snapshot", arguments: args)
+        let response = try await client.callToolStructured(name: "preview_snapshot", arguments: args)
         try handleSnapshotResponse(response, sessionID: sessionID)
     }
 
@@ -199,7 +199,7 @@ struct SnapshotCommand: AsyncParsableCommand {
 
     /// Create an ephemeral session for the target file, capture, tear down.
     /// Trait flags are applied at start.
-    private func snapshotEphemeral(file: String, client: Client) async throws {
+    private func snapshotEphemeral(file: String, client: any DaemonToolCalling) async throws {
         // `file` is canonicalized at the argument boundary. The absolute
         // path is sent to the daemon, which runs in its own process and
         // does not share our CWD; the daemon re-normalizes on receipt for
@@ -262,7 +262,7 @@ struct SnapshotCommand: AsyncParsableCommand {
         // complete in time, leaving an orphan session in the daemon that
         // future snapshots of the same file would ambiguously match.
         do {
-            let snapResponse = try await client.callTool(
+            let snapResponse = try await client.callToolStructured(
                 name: "preview_snapshot", arguments: snapshotArgs
             )
             await stopEphemeralSession(sessionID: sessionID, client: client)
@@ -279,9 +279,9 @@ struct SnapshotCommand: AsyncParsableCommand {
     /// The session would still be cleaned up when the daemon exits, but a
     /// long-lived daemon with many leaked sessions could confuse future
     /// snapshot reuse.
-    private func stopEphemeralSession(sessionID: String, client: Client) async {
+    private func stopEphemeralSession(sessionID: String, client: any DaemonToolCalling) async {
         do {
-            _ = try await client.callTool(
+            _ = try await client.callToolStructured(
                 name: "preview_stop",
                 arguments: ["sessionID": .string(sessionID)]
             )
@@ -333,7 +333,7 @@ struct SnapshotCommand: AsyncParsableCommand {
     /// Prints either a bare path or a JSON document (when `--json` is set) to
     /// stdout on success.
     private func handleSnapshotResponse(
-        _ response: (content: [Tool.Content], isError: Bool?),
+        _ response: CallTool.Result,
         sessionID: String
     ) throws {
         if response.isError == true {

--- a/previewsmcp/PreviewsCLI/StopCommand.swift
+++ b/previewsmcp/PreviewsCLI/StopCommand.swift
@@ -46,7 +46,7 @@ struct StopCommand: AsyncParsableCommand {
         }
     }
 
-    private func stopOne(client: Client) async throws {
+    private func stopOne(client: any DaemonToolCalling) async throws {
         let resolution = try await SessionResolver.resolve(
             session: target.session,
             file: target.file,
@@ -64,8 +64,8 @@ struct StopCommand: AsyncParsableCommand {
         try await sendStop(sessionID: sessionID, client: client)
     }
 
-    private func stopAll(client: Client) async throws {
-        let response = try await client.callTool(name: "session_list", arguments: [:])
+    private func stopAll(client: any DaemonToolCalling) async throws {
+        let response = try await client.callToolStructured(name: "session_list", arguments: [:])
         if response.isError == true {
             throw DaemonToolError.daemonError(response.content.joinedText())
         }
@@ -95,8 +95,8 @@ struct StopCommand: AsyncParsableCommand {
         if let firstFailure { throw firstFailure }
     }
 
-    private func sendStop(sessionID: String, client: Client) async throws {
-        let response = try await client.callTool(
+    private func sendStop(sessionID: String, client: any DaemonToolCalling) async throws {
+        let response = try await client.callToolStructured(
             name: "preview_stop",
             arguments: ["sessionID": .string(sessionID)]
         )

--- a/previewsmcp/PreviewsCLI/SwitchCommand.swift
+++ b/previewsmcp/PreviewsCLI/SwitchCommand.swift
@@ -55,7 +55,7 @@ struct SwitchCommand: AsyncParsableCommand {
                 )
             }
 
-            let response = try await client.callTool(
+            let response = try await client.callToolStructured(
                 name: "preview_switch",
                 arguments: [
                     "sessionID": .string(sessionID),

--- a/previewsmcp/PreviewsCLI/TouchCommand.swift
+++ b/previewsmcp/PreviewsCLI/TouchCommand.swift
@@ -91,7 +91,7 @@ struct TouchCommand: AsyncParsableCommand {
                 if let duration { arguments["duration"] = .double(duration) }
             }
 
-            let response = try await client.callTool(
+            let response = try await client.callToolStructured(
                 name: "preview_touch",
                 arguments: arguments
             )

--- a/previewsmcp/PreviewsCLI/VariantsCommand.swift
+++ b/previewsmcp/PreviewsCLI/VariantsCommand.swift
@@ -206,7 +206,7 @@ struct VariantsCommand: AsyncParsableCommand {
         file: String,
         labels: [String],
         outputDir: URL,
-        client: Client
+        client: any DaemonToolCalling
     ) async throws -> Int32 {
         // `file` is canonicalized at the argument boundary. The absolute
         // path is sent to the daemon, which runs in its own process and
@@ -275,7 +275,7 @@ struct VariantsCommand: AsyncParsableCommand {
         sessionID: String,
         labels: [String],
         outputDir: URL,
-        client: Client
+        client: any DaemonToolCalling
     ) async throws -> Int32 {
         let requestedQuality = resolvedQuality()
 
@@ -428,9 +428,9 @@ struct VariantsCommand: AsyncParsableCommand {
         return Self.exitCode(successCount: successCount, failCount: failCount)
     }
 
-    private func stopEphemeralSession(sessionID: String, client: Client) async {
+    private func stopEphemeralSession(sessionID: String, client: any DaemonToolCalling) async {
         do {
-            _ = try await client.callTool(
+            _ = try await client.callToolStructured(
                 name: "preview_stop",
                 arguments: ["sessionID": .string(sessionID)]
             )


### PR DESCRIPTION
## Summary
- Introduces `DaemonToolCalling`, a narrow one-method protocol (`callToolStructured(name:arguments:) async throws -> CallTool.Result`) capturing the exact tool-calling surface CLI commands depend on today.
- The real MCP `Client` conforms via its pre-existing `callToolStructured` extension (body unchanged).
- `DaemonClient.withDaemonClient`'s connection lifecycle (spawn/auto-start, version-mismatch restart, stall-timer detection, log forwarding, disconnect) stays entirely on the concrete `Client` type — only the `body` closure parameter narrows to `any DaemonToolCalling`. Investigated the real behavior first (per review from mergequeue-lead) to avoid faking connection-lifecycle machinery that command bodies never touch.
- Every CLI command (Configure/Run/Snapshot/Stop/Switch/Touch/Variants) plus `SessionResolver` retypes `client: Client` → `client: any DaemonToolCalling` and renames `client.callTool(...)` → `client.callToolStructured(...)`. Verified against the SDK source that both `callTool` overloads funnel through the identical `send()` + `await context.value` path — the rename is behaviorally a no-op (the plain overload just discards `structuredContent` afterward).
- Removed a dead `CallToolTuple` typealias + stale doc comment whose last real consumer (`SnapshotCommand.handleSnapshotResponse`'s tuple param) this diff retypes to `CallTool.Result`.

Seam-only PR, no test conversions — follow-on PRs will add `FakeDaemonClient` and convert CLI command tests to use this seam, per the earlier chunking request.

## Gates run
- `bazel build //...` — clean
- `bazel run //tools/lint:check` — clean (0/242 files need formatting, no new lint findings)
- `/simplify` — 4 parallel review agents (reuse/simplification/efficiency/altitude), 1 finding (dead `CallToolTuple` typealias) applied
- `/code-review` (workflow, high effort) — 1 low-severity finding (doc comment referenced a not-yet-existing `FakeDaemonClient` type name), fixed by generalizing the wording
- Full local suite (`bazel test //previewsmcp/Tests/...`, 9 targets): 8/9 passed on first run; `MCPIntegrationTests` failed due to stray `previewsmcp serve` daemons + 6 booted simulators left over from an unrelated earlier session wedging the CoreSimulator pool (known class of infra flake). Killed the stray daemons/sims and reran `MCPIntegrationTests` in isolation — passed clean (67.9s). Confirmed pre-existing, unrelated to this diff.

## Test plan
- [x] Full local bazel suite green (post stray-daemon cleanup)
- [x] `/simplify` + `/code-review` gates applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPF6gjyr2BBuz31yRSnMvG