### PR TITLE
Test restructure step 5b: TouchCommand proof conversion via FakeDaemonClient

### DIFF
--- a/previewsmcp/PreviewsCLI/TouchCommand.swift
+++ b/previewsmcp/PreviewsCLI/TouchCommand.swift
@@ -65,42 +65,49 @@ struct TouchCommand: AsyncParsableCommand {
         }
 
         try await DaemonClient.withDaemonClient(name: "previewsmcp-touch") { client in
-            let resolution = try await SessionResolver.resolve(
-                session: target.session,
-                file: target.file,
-                client: client
-            )
-
-            guard case let .found(sessionID) = resolution else {
-                throw ValidationError(
-                    "No session found. Start an iOS session with "
-                        + "`previewsmcp run <file> --platform ios --detach` or "
-                        + "pass an explicit --session <uuid>."
-                )
-            }
-
-            var arguments: [String: Value] = [
-                "sessionID": .string(sessionID),
-                "x": .double(x),
-                "y": .double(y),
-            ]
-            if isSwipe, let toX, let toY {
-                arguments["action"] = .string("swipe")
-                arguments["toX"] = .double(toX)
-                arguments["toY"] = .double(toY)
-                if let duration { arguments["duration"] = .double(duration) }
-            }
-
-            let response = try await client.callToolStructured(
-                name: "preview_touch",
-                arguments: arguments
-            )
-            if response.isError == true {
-                throw DaemonToolError.daemonError(response.content.joinedText())
-            }
-
-            let text = response.content.joinedText()
-            if !text.isEmpty { fputs("\(text)\n", stderr) }
+            try await execute(on: client)
         }
+    }
+
+    /// The daemon-relay body of `run()`, factored out so tests can call it
+    /// directly against a fake `DaemonToolCalling` without a real daemon
+    /// connection. Callers must have already validated swipe/duration flags.
+    func execute(on client: any DaemonToolCalling) async throws {
+        let resolution = try await SessionResolver.resolve(
+            session: target.session,
+            file: target.file,
+            client: client
+        )
+
+        guard case let .found(sessionID) = resolution else {
+            throw ValidationError(
+                "No session found. Start an iOS session with "
+                    + "`previewsmcp run <file> --platform ios --detach` or "
+                    + "pass an explicit --session <uuid>."
+            )
+        }
+
+        var arguments: [String: Value] = [
+            "sessionID": .string(sessionID),
+            "x": .double(x),
+            "y": .double(y),
+        ]
+        if let toX, let toY {
+            arguments["action"] = .string("swipe")
+            arguments["toX"] = .double(toX)
+            arguments["toY"] = .double(toY)
+            if let duration { arguments["duration"] = .double(duration) }
+        }
+
+        let response = try await client.callToolStructured(
+            name: "preview_touch",
+            arguments: arguments
+        )
+        if response.isError == true {
+            throw DaemonToolError.daemonError(response.content.joinedText())
+        }
+
+        let text = response.content.joinedText()
+        if !text.isEmpty { fputs("\(text)\n", stderr) }
     }
 }

--- a/previewsmcp/Tests/CLIIntegrationTests/TouchCommandTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/TouchCommandTests.swift
@@ -15,23 +15,10 @@ struct TouchCommandTests {
     // PreviewsCLITests/CLIValidationTests.swift, which invokes TouchCommand
     // in-process instead of spawning a subprocess + daemon.
 
-    // MARK: - No-session error path
-
-    @Test("touch errors when no session is running")
-    func touchNoSession() async throws {
-        try await DaemonTestLock.run {
-            try await Self.cleanSlate()
-
-            let result = try await CLIRunner.run(
-                "touch", arguments: ["100", "200"]
-            )
-            #expect(result.exitCode != 0)
-            #expect(
-                result.stderr.contains("No session found"),
-                "stderr: \(result.stderr)"
-            )
-        }
-    }
+    // "touch errors when no session is running" moved to
+    // PreviewsCLITests/TouchCommandLogicTests.swift, which invokes
+    // TouchCommand.execute(on:) against a FakeDaemonClient instead of
+    // spawning a subprocess + daemon.
 
     /// The daemon's `preview_touch` tool is iOS-only. Against a running
     /// macOS session it should surface the iOS-only error.

--- a/previewsmcp/Tests/PreviewsCLITests/CLIValidationTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/CLIValidationTests.swift
@@ -184,7 +184,7 @@ struct CLIValidationTests {
 /// Records an `Issue` (rather than letting the caller's own `throws` bubble
 /// up) so a wrong-error-type failure reports the mismatch instead of
 /// crashing out of the test with an unrelated stack trace.
-private func expectValidationError(
+func expectValidationError(
     predicate: (String) -> Bool = { _ in true },
     run: () async throws -> Void
 ) async {
@@ -198,7 +198,7 @@ private func expectValidationError(
     }
 }
 
-private func expectValidationError(
+func expectValidationError(
     contains substring: String,
     run: () async throws -> Void
 ) async {

--- a/previewsmcp/Tests/PreviewsCLITests/FakeDaemonClient.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/FakeDaemonClient.swift
@@ -1,0 +1,47 @@
+import Foundation
+import MCP
+@testable import PreviewsCLI
+
+/// Test double for `DaemonToolCalling`. Scripted with one canned
+/// `CallTool.Result` per tool name — no socket, no spawned daemon. Records
+/// every call so tests can assert on what a command actually sent.
+///
+/// One response per tool name only: a command that calls the same tool name
+/// more than once per `execute` (e.g. `StopCommand.stopAll`'s per-session
+/// `preview_stop` loop) can't yet script distinct results per call. Extend
+/// `responses` to a per-name queue if a future conversion needs that.
+final class FakeDaemonClient: DaemonToolCalling, @unchecked Sendable {
+    private let responses: [String: CallTool.Result]
+    private(set) var calls: [(name: String, arguments: [String: Value]?)] = []
+
+    init(responses: [String: CallTool.Result] = [:]) {
+        self.responses = responses
+    }
+
+    func callToolStructured(
+        name: String,
+        arguments: [String: Value]?
+    ) async throws -> CallTool.Result {
+        calls.append((name, arguments))
+        guard let result = responses[name] else {
+            throw FakeDaemonClientError.noCannedResponse(name)
+        }
+        return result
+    }
+}
+
+enum FakeDaemonClientError: Error, CustomStringConvertible {
+    case noCannedResponse(String)
+
+    var description: String {
+        switch self {
+        case let .noCannedResponse(name):
+            "FakeDaemonClient has no canned response for tool \"\(name)\""
+        }
+    }
+}
+
+extension CallTool.Result {
+    /// An empty `session_list` response — no active sessions.
+    static let noSessions = CallTool.Result(content: [.text("")])
+}

--- a/previewsmcp/Tests/PreviewsCLITests/TouchCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/TouchCommandLogicTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import MCP
+@testable import PreviewsCLI
+import Testing
+
+/// `touch`'s daemon-relay logic (`TouchCommand.execute(on:)`), tested
+/// against a `FakeDaemonClient` — no daemon spawn, no simulator. Real
+/// subprocess coverage (macOS-session error path, which depends on the
+/// daemon's own policy) stays in `CLIIntegrationTests/TouchCommandTests.swift`.
+@Suite("touch daemon-relay logic")
+struct TouchCommandLogicTests {
+    @Test("touch errors when no session is running")
+    func touchNoSession() async throws {
+        let command = try TouchCommand.parse(["100", "200"])
+        let client = FakeDaemonClient(responses: ["session_list": .noSessions])
+
+        await expectValidationError(contains: "No session found") {
+            try await command.execute(on: client)
+        }
+
+        #expect(client.calls.map(\.name) == ["session_list"])
+    }
+}


### PR DESCRIPTION
## Summary
- First command converted using the `DaemonToolCalling` seam from step 5a (#309).
- `TouchCommand.run()`'s `withDaemonClient` closure body is extracted into `execute(on: any DaemonToolCalling) async throws`, so tests can exercise the daemon-relay logic directly without a real daemon connection or subprocess.
- New `FakeDaemonClient`: a test double scripted with one canned `CallTool.Result` per tool name, records every call made. Doc comment documents a known limitation up front — it can't script distinct results for repeated calls to the *same* tool name (relevant to a future `StopCommand` conversion, whose `--all` sweep calls `preview_stop` once per session — not needed for this command).
- Converts "touch errors when no session is running" from a subprocess + auto-spawned-daemon test (wrapped in `DaemonTestLock.run`) to a millisecond in-process call against the fake. The real macOS-session-rejection test (`touchRejectsMacOSSession`, which depends on the daemon's own policy enforcement) is untouched — that's genuine daemon-side behavior, not CLI-side logic, so it correctly stays a real integration test.
- `expectValidationError` test helpers widened from `private` to internal so the new test file can reuse them.

This establishes the pattern for the remaining commands (Switch/Stop/Configure/Snapshot/Variants/Simulators/Elements), which will be converted in follow-on PRs grouped by command or by `FakeDaemonClient` surface needed, per the earlier chunking request.

## Gates run
- `bazel build //...` — clean
- `bazel run //tools/lint:check` — clean
- `/simplify` — 4 parallel review agents (reuse/simplification/efficiency/altitude): reuse and efficiency clean; simplification found `responses` should be `let` not `var` (fixed) and flagged the call-recording as speculative until used (fixed by asserting on it in the new test); altitude confirmed the extraction pattern generalizes correctly and flagged the repeat-same-tool-name limitation, now documented in `FakeDaemonClient`'s doc comment
- `/code-review` (workflow, high effort) — 0 findings after independent re-verification of the isSwipe-removal precondition, the `.noSessions` → `SessionResolver.resolve` → `.notFound` trace, and coverage equivalence with the deleted subprocess test
- Full local suite (`bazel test //previewsmcp/Tests/...`, 9 targets): all green. Checked for the stray-daemon/booted-sim infra issue found in step 5a before running (none present this time).

## Test plan
- [x] `TouchCommandLogicTests.touchNoSession` passes against `FakeDaemonClient` in ~0.01s (was a full subprocess+daemon-spawn test)
- [x] Full local bazel suite green
- [x] `/simplify` + `/code-review` gates applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPF6gjyr2BBuz31yRSnMvG