### PR TITLE
Test restructure step 5c: Switch/Elements/Configure proof conversions

### DIFF
--- a/previewsmcp/PreviewsCLI/ConfigureCommand.swift
+++ b/previewsmcp/PreviewsCLI/ConfigureCommand.swift
@@ -66,40 +66,47 @@ struct ConfigureCommand: AsyncParsableCommand {
         try validateTraitValues()
 
         try await DaemonClient.withDaemonClient(name: "previewsmcp-configure") { client in
-            let resolution = try await SessionResolver.resolve(
-                session: target.session,
-                file: target.file,
-                client: client
-            )
-
-            guard case let .found(sessionID) = resolution else {
-                throw ValidationError(
-                    "No session found to configure. Start one with "
-                        + "`previewsmcp run <file> --detach` or pass an explicit "
-                        + "--session <uuid>."
-                )
-            }
-
-            var args: [String: Value] = ["sessionID": .string(sessionID)]
-            if let colorScheme { args["colorScheme"] = .string(colorScheme) }
-            if let dynamicTypeSize { args["dynamicTypeSize"] = .string(dynamicTypeSize) }
-            if let locale { args["locale"] = .string(locale) }
-            if let layoutDirection { args["layoutDirection"] = .string(layoutDirection) }
-            if let legibilityWeight { args["legibilityWeight"] = .string(legibilityWeight) }
-
-            let response = try await client.callToolStructured(
-                name: "preview_configure", arguments: args
-            )
-            if response.isError == true {
-                let text = response.content.joinedText()
-                throw DaemonToolError.daemonError(text)
-            }
-
-            // Surface the daemon's response (typically a summary of what
-            // changed) to the user.
-            let text = response.content.joinedText()
-            if !text.isEmpty { fputs("\(text)\n", stderr) }
+            try await execute(on: client)
         }
+    }
+
+    /// The daemon-relay body of `run()`, factored out so tests can call it
+    /// directly against a fake `DaemonToolCalling` without a real daemon
+    /// connection. Callers must have already validated the trait flags.
+    func execute(on client: any DaemonToolCalling) async throws {
+        let resolution = try await SessionResolver.resolve(
+            session: target.session,
+            file: target.file,
+            client: client
+        )
+
+        guard case let .found(sessionID) = resolution else {
+            throw ValidationError(
+                "No session found to configure. Start one with "
+                    + "`previewsmcp run <file> --detach` or pass an explicit "
+                    + "--session <uuid>."
+            )
+        }
+
+        var args: [String: Value] = ["sessionID": .string(sessionID)]
+        if let colorScheme { args["colorScheme"] = .string(colorScheme) }
+        if let dynamicTypeSize { args["dynamicTypeSize"] = .string(dynamicTypeSize) }
+        if let locale { args["locale"] = .string(locale) }
+        if let layoutDirection { args["layoutDirection"] = .string(layoutDirection) }
+        if let legibilityWeight { args["legibilityWeight"] = .string(legibilityWeight) }
+
+        let response = try await client.callToolStructured(
+            name: "preview_configure", arguments: args
+        )
+        if response.isError == true {
+            let text = response.content.joinedText()
+            throw DaemonToolError.daemonError(text)
+        }
+
+        // Surface the daemon's response (typically a summary of what
+        // changed) to the user.
+        let text = response.content.joinedText()
+        if !text.isEmpty { fputs("\(text)\n", stderr) }
     }
 
     // MARK: - Helpers

--- a/previewsmcp/PreviewsCLI/ElementsCommand.swift
+++ b/previewsmcp/PreviewsCLI/ElementsCommand.swift
@@ -49,45 +49,52 @@ struct ElementsCommand: AsyncParsableCommand {
 
     mutating func run() async throws {
         try await DaemonClient.withDaemonClient(name: "previewsmcp-elements") { client in
-            let resolution = try await SessionResolver.resolve(
-                session: target.session,
-                file: target.file,
-                client: client
-            )
+            try await execute(on: client)
+        }
+    }
 
-            guard case let .found(sessionID) = resolution else {
-                throw ValidationError(
-                    "No session found. Start an iOS session with "
-                        + "`previewsmcp run <file> --platform ios --detach` or "
-                        + "pass an explicit --session <uuid>."
+    /// The daemon-relay body of `run()`, factored out so tests can call it
+    /// directly against a fake `DaemonToolCalling` without a real daemon
+    /// connection.
+    func execute(on client: any DaemonToolCalling) async throws {
+        let resolution = try await SessionResolver.resolve(
+            session: target.session,
+            file: target.file,
+            client: client
+        )
+
+        guard case let .found(sessionID) = resolution else {
+            throw ValidationError(
+                "No session found. Start an iOS session with "
+                    + "`previewsmcp run <file> --platform ios --detach` or "
+                    + "pass an explicit --session <uuid>."
+            )
+        }
+
+        let response = try await client.callToolStructured(
+            name: "preview_elements",
+            arguments: [
+                "sessionID": .string(sessionID),
+                "filter": .string(filter.rawValue),
+            ]
+        )
+        if response.isError == true {
+            throw DaemonToolError.daemonError(response.content.joinedText())
+        }
+
+        if json {
+            guard let structured = response.structuredContent else {
+                throw DaemonToolError.daemonError(
+                    "preview_elements response missing structuredContent"
                 )
             }
-
-            let response = try await client.callToolStructured(
-                name: "preview_elements",
-                arguments: [
-                    "sessionID": .string(sessionID),
-                    "filter": .string(filter.rawValue),
-                ]
-            )
-            if response.isError == true {
-                throw DaemonToolError.daemonError(response.content.joinedText())
-            }
-
-            if json {
-                guard let structured = response.structuredContent else {
-                    throw DaemonToolError.daemonError(
-                        "preview_elements response missing structuredContent"
-                    )
-                }
-                try emitJSON(structured)
-                return
-            }
-
-            // Default: write the bare accessibility tree JSON to stdout
-            // so existing scripts piping into `jq` keep working.
-            let text = response.content.joinedText()
-            if !text.isEmpty { print(text) }
+            try emitJSON(structured)
+            return
         }
+
+        // Default: write the bare accessibility tree JSON to stdout
+        // so existing scripts piping into `jq` keep working.
+        let text = response.content.joinedText()
+        if !text.isEmpty { print(text) }
     }
 }

--- a/previewsmcp/PreviewsCLI/SwitchCommand.swift
+++ b/previewsmcp/PreviewsCLI/SwitchCommand.swift
@@ -41,33 +41,40 @@ struct SwitchCommand: AsyncParsableCommand {
         }
 
         try await DaemonClient.withDaemonClient(name: "previewsmcp-switch") { client in
-            let resolution = try await SessionResolver.resolve(
-                session: target.session,
-                file: target.file,
-                client: client
-            )
-
-            guard case let .found(sessionID) = resolution else {
-                throw ValidationError(
-                    "No session found to switch. Start one with "
-                        + "`previewsmcp run <file> --detach` or pass an "
-                        + "explicit --session <uuid>."
-                )
-            }
-
-            let response = try await client.callToolStructured(
-                name: "preview_switch",
-                arguments: [
-                    "sessionID": .string(sessionID),
-                    "previewIndex": .int(previewIndex),
-                ]
-            )
-            if response.isError == true {
-                throw DaemonToolError.daemonError(response.content.joinedText())
-            }
-
-            let text = response.content.joinedText()
-            if !text.isEmpty { fputs("\(text)\n", stderr) }
+            try await execute(on: client)
         }
+    }
+
+    /// The daemon-relay body of `run()`, factored out so tests can call it
+    /// directly against a fake `DaemonToolCalling` without a real daemon
+    /// connection. Callers must have already validated `previewIndex`.
+    func execute(on client: any DaemonToolCalling) async throws {
+        let resolution = try await SessionResolver.resolve(
+            session: target.session,
+            file: target.file,
+            client: client
+        )
+
+        guard case let .found(sessionID) = resolution else {
+            throw ValidationError(
+                "No session found to switch. Start one with "
+                    + "`previewsmcp run <file> --detach` or pass an "
+                    + "explicit --session <uuid>."
+            )
+        }
+
+        let response = try await client.callToolStructured(
+            name: "preview_switch",
+            arguments: [
+                "sessionID": .string(sessionID),
+                "previewIndex": .int(previewIndex),
+            ]
+        )
+        if response.isError == true {
+            throw DaemonToolError.daemonError(response.content.joinedText())
+        }
+
+        let text = response.content.joinedText()
+        if !text.isEmpty { fputs("\(text)\n", stderr) }
     }
 }

--- a/previewsmcp/Tests/CLIIntegrationTests/ConfigureCommandTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/ConfigureCommandTests.swift
@@ -15,21 +15,10 @@ struct ConfigureCommandTests {
     // moved to PreviewsCLITests/CLIValidationTests.swift, which invokes
     // ConfigureCommand in-process instead of spawning a subprocess + daemon.
 
-    // MARK: - No-session error path
-
-    @Test("configure errors when no session is running")
-    func configureNoSession() async throws {
-        try await DaemonTestLock.run {
-            try await Self.cleanSlate()
-
-            let result = try await CLIRunner.run(
-                "configure",
-                arguments: ["--color-scheme", "dark"]
-            )
-            #expect(result.exitCode != 0)
-            #expect(result.stderr.contains("No session found to configure"))
-        }
-    }
+    // "configure errors when no session is running" moved to
+    // PreviewsCLITests/ConfigureCommandLogicTests.swift, which invokes
+    // ConfigureCommand.execute(on:) against a FakeDaemonClient instead of
+    // spawning a subprocess + daemon.
 
     // MARK: - Happy path
 

--- a/previewsmcp/Tests/CLIIntegrationTests/ElementsCommandTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/ElementsCommandTests.swift
@@ -11,19 +11,10 @@ struct ElementsCommandTests {
         _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
     }
 
-    @Test("elements errors when no session is running")
-    func elementsNoSession() async throws {
-        try await DaemonTestLock.run {
-            try await Self.cleanSlate()
-
-            let result = try await CLIRunner.run("elements")
-            #expect(result.exitCode != 0)
-            #expect(
-                result.stderr.contains("No session found"),
-                "stderr: \(result.stderr)"
-            )
-        }
-    }
+    // "elements errors when no session is running" moved to
+    // PreviewsCLITests/ElementsCommandLogicTests.swift, which invokes
+    // ElementsCommand.execute(on:) against a FakeDaemonClient instead of
+    // spawning a subprocess + daemon.
 
     /// The daemon's `preview_elements` tool is iOS-only. Exercising it
     /// against a running macOS session should surface the daemon's error

--- a/previewsmcp/Tests/CLIIntegrationTests/SwitchCommandTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/SwitchCommandTests.swift
@@ -12,15 +12,10 @@ struct SwitchCommandTests {
     // PreviewsCLITests/CLIValidationTests.swift, which invokes SwitchCommand
     // in-process instead of spawning a subprocess + daemon.
 
-    @Test("switch errors when no session is running")
-    func switchNoSession() async throws {
-        try await DaemonTestLock.run {
-            try await Self.cleanSlate()
-            let result = try await CLIRunner.run("switch", arguments: ["0"])
-            #expect(result.exitCode != 0)
-            #expect(result.stderr.contains("No session found to switch"))
-        }
-    }
+    // "switch errors when no session is running" moved to
+    // PreviewsCLITests/SwitchCommandLogicTests.swift, which invokes
+    // SwitchCommand.execute(on:) against a FakeDaemonClient instead of
+    // spawning a subprocess + daemon.
 
     /// Full round-trip: start a session showing preview 0, switch to preview
     /// 1, snapshot both, and confirm the rendered output differs. Preview 0

--- a/previewsmcp/Tests/PreviewsCLITests/ConfigureCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/ConfigureCommandLogicTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import MCP
+@testable import PreviewsCLI
+import Testing
+
+/// `configure`'s daemon-relay logic (`ConfigureCommand.execute(on:)`),
+/// tested against a `FakeDaemonClient` — no daemon spawn, no simulator.
+/// Real subprocess coverage (rendered-output diff, trait clearing,
+/// explicit --session targeting, which depend on the daemon's own
+/// behavior) stays in `CLIIntegrationTests/ConfigureCommandTests.swift`.
+@Suite("configure daemon-relay logic")
+struct ConfigureCommandLogicTests {
+    @Test("configure errors when no session is running")
+    func configureNoSession() async throws {
+        let command = try ConfigureCommand.parse(["--color-scheme", "dark"])
+        let client = FakeDaemonClient(responses: ["session_list": .noSessions])
+
+        await expectValidationError(contains: "No session found to configure") {
+            try await command.execute(on: client)
+        }
+
+        #expect(client.calls.map(\.name) == ["session_list"])
+    }
+}

--- a/previewsmcp/Tests/PreviewsCLITests/ElementsCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/ElementsCommandLogicTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import MCP
+@testable import PreviewsCLI
+import Testing
+
+/// `elements`'s daemon-relay logic (`ElementsCommand.execute(on:)`), tested
+/// against a `FakeDaemonClient` — no daemon spawn, no simulator. Real
+/// subprocess coverage (macOS-session error path, which depends on the
+/// daemon's own policy) stays in `CLIIntegrationTests/ElementsCommandTests.swift`.
+@Suite("elements daemon-relay logic")
+struct ElementsCommandLogicTests {
+    @Test("elements errors when no session is running")
+    func elementsNoSession() async throws {
+        let command = try ElementsCommand.parse([])
+        let client = FakeDaemonClient(responses: ["session_list": .noSessions])
+
+        await expectValidationError(contains: "No session found") {
+            try await command.execute(on: client)
+        }
+
+        #expect(client.calls.map(\.name) == ["session_list"])
+    }
+}

--- a/previewsmcp/Tests/PreviewsCLITests/SwitchCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SwitchCommandLogicTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import MCP
+@testable import PreviewsCLI
+import Testing
+
+/// `switch`'s daemon-relay logic (`SwitchCommand.execute(on:)`), tested
+/// against a `FakeDaemonClient` — no daemon spawn, no simulator. Real
+/// subprocess coverage (active-preview round trip, out-of-range index,
+/// which depend on the daemon's own behavior) stays in
+/// `CLIIntegrationTests/SwitchCommandTests.swift`.
+@Suite("switch daemon-relay logic")
+struct SwitchCommandLogicTests {
+    @Test("switch errors when no session is running")
+    func switchNoSession() async throws {
+        let command = try SwitchCommand.parse(["0"])
+        let client = FakeDaemonClient(responses: ["session_list": .noSessions])
+
+        await expectValidationError(contains: "No session found to switch") {
+            try await command.execute(on: client)
+        }
+
+        #expect(client.calls.map(\.name) == ["session_list"])
+    }
+}


### PR DESCRIPTION
## Summary
- Applies the `DaemonToolCalling` conversion pattern from step 5b (#310, TouchCommand) to three more commands: `SwitchCommand`, `ElementsCommand`, `ConfigureCommand`. Chunked together because they share the exact same shape (`SessionResolver.resolve` → one `callToolStructured` call) and need the identical `FakeDaemonClient` surface (`session_list` → `.noSessions`) — no new fake capability required.
- Each command's `run()` had its `withDaemonClient` closure body extracted verbatim into `execute(on: any DaemonToolCalling) async throws`. Validation logic (`SwitchCommand`'s `previewIndex >= 0`, `ConfigureCommand`'s `anyTraitSpecified`/`validateTraitValues()`) stays in `run()`, unchanged.
- Each gets one new logic-test file converting its "no session" test to run in-process against `FakeDaemonClient` instead of spawning a subprocess + daemon.
- Real subprocess coverage that depends on genuine daemon-side behavior is untouched: `SwitchCommandTests.switchChangesActivePreview`/`switchOutOfRange`, `ElementsCommandTests.elementsRejectsMacOSSession`, `ConfigureCommandTests.configureChangesRenderedOutput`/`configureClearsTrait`/`configureExplicitSession`.
- Fixed `SwitchCommand.execute(on:)`'s doc comment, which was missing the "callers must have already validated" precondition trailer that Touch's and Configure's already carry (caught by the altitude `/simplify` pass).

`SimulatorsCommand` (different shape — no session targeting at all), `SnapshotCommand`/`VariantsCommand` (multi-call sequences), and `StopCommand` (needs `FakeDaemonClient`'s per-name-queue extension for its `--all` sweep) are left for separate future chunks.

## Gates run
- `bazel build //...` — clean
- `bazel run //tools/lint:check` — clean
- `/simplify` — 3 parallel review agents (reuse, simplification+efficiency, altitude): reuse and simplification+efficiency clean (efficiency confirmed each `execute(on:)` extraction is byte-identical logic to its old closure body); altitude confirmed the "same shape as Touch" scoping call was correct and caught the one real finding — `SwitchCommand`'s missing doc-comment trailer, fixed
- `/code-review` (workflow, high effort) — 0 findings, including independent re-derivation of `SessionResolver.resolve`'s behavior against `.noSessions` and confirmation no coverage was silently lost
- Full local suite (`bazel test //previewsmcp/Tests/...`, 9 targets): 8/9 passed on first run; `MCPIntegrationTests` timed out at 300s — 3rd occurrence of the known stray-daemon/CoreSimulator-pool infra flake (a leftover `previewsmcp serve` process from an earlier run). Killed the stray daemon + booted sims, reran in isolation — passed clean in 66.2s.

## Test plan
- [x] All 3 new logic tests pass in ~0.01s each against `FakeDaemonClient`
- [x] Full local bazel suite green (post stray-daemon cleanup)
- [x] `/simplify` + `/code-review` gates applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPF6gjyr2BBuz31yRSnMvG