### PR TITLE
Test restructure step 5d: SimulatorsCommand execute(on:) extraction

### DIFF
--- a/previewsmcp/PreviewsCLI/SimulatorsCommand.swift
+++ b/previewsmcp/PreviewsCLI/SimulatorsCommand.swift
@@ -35,28 +35,35 @@ struct SimulatorsCommand: AsyncParsableCommand {
 
     mutating func run() async throws {
         try await DaemonClient.withDaemonClient(name: "previewsmcp-simulators") { client in
-            let response = try await client.callToolStructured(
-                name: "simulator_list", arguments: [:]
-            )
-            if response.isError == true {
-                throw DaemonToolError.daemonError(response.content.joinedText())
-            }
-
-            if json {
-                guard let structured = response.structuredContent else {
-                    throw DaemonToolError.daemonError(
-                        "simulator_list response missing structuredContent"
-                    )
-                }
-                try emitJSON(structured)
-                return
-            }
-
-            // Unlike elements (where empty stdout is plausible),
-            // `simulator_list` always returns either device lines or the
-            // sentinel "No available simulator devices found." — so
-            // always surface the daemon's reply verbatim.
-            print(response.content.joinedText())
+            try await execute(on: client)
         }
+    }
+
+    /// The daemon-relay body of `run()`, factored out so tests can call it
+    /// directly against a fake `DaemonToolCalling` without a real daemon
+    /// connection.
+    func execute(on client: any DaemonToolCalling) async throws {
+        let response = try await client.callToolStructured(
+            name: "simulator_list", arguments: [:]
+        )
+        if response.isError == true {
+            throw DaemonToolError.daemonError(response.content.joinedText())
+        }
+
+        if json {
+            guard let structured = response.structuredContent else {
+                throw DaemonToolError.daemonError(
+                    "simulator_list response missing structuredContent"
+                )
+            }
+            try emitJSON(structured)
+            return
+        }
+
+        // Unlike elements (where empty stdout is plausible),
+        // `simulator_list` always returns either device lines or the
+        // sentinel "No available simulator devices found." — so
+        // always surface the daemon's reply verbatim.
+        print(response.content.joinedText())
     }
 }


### PR DESCRIPTION
## Summary
- Mechanical `execute(on: any DaemonToolCalling)` extraction for `SimulatorsCommand`, matching the pattern already merged for Touch/Switch/Elements/Configure (#310, #311). Sets up the seam for a future fake-based test.
- **Extraction-only — no test change.** An earlier draft of this PR also added two new tests for previously-untested defensive branches (a daemon `isError=true` response, and `--json` against a response missing `structuredContent`). An altitude-focused `/simplify` review caught that this would create an inconsistent coverage bar: Touch/Switch/Elements/Configure have the identical untested `isError` branch (Elements also has the identical missing-`structuredContent` branch under `--json`), and none of them were given equivalent coverage when converted in steps 5b/5c — those conversions deliberately scoped to "convert one existing test, don't expand net coverage." Adding it only for Simulators would leave an unexplained asymmetry across otherwise-identical commands. Removed the new tests; the isError/structuredContent coverage gap is deferred to a future dedicated chunk that closes it uniformly across all five single-call commands.
- `SimulatorsCommand`'s existing 2 integration tests (`CLIIntegrationTests/SimulatorsCommandTests.swift`, untouched) genuinely depend on real CoreSimulator device data and correctly stay as real daemon-integration coverage — there's no "no session" equivalent test to convert here since this command has no session targeting at all.

## Gates run
- `bazel build //...` — clean
- `bazel run //tools/lint:check` — clean
- `/simplify` — 3 parallel review agents (reuse, simplification, altitude): reuse and simplification clean; altitude caught the scope-consistency issue described above, which led to trimming this PR back to extraction-only
- `/code-review` (workflow, high effort) — 0 findings, including verification that this is genuinely a safe merge with zero test coverage change
- Full local suite (`bazel test //previewsmcp/Tests/...`, 9 targets): all green, no flakes this run

## Test plan
- [x] Full local bazel suite green
- [x] `/simplify` + `/code-review` gates applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPF6gjyr2BBuz31yRSnMvG