### PR TITLE
Test restructure step 5e: SnapshotCommand pure logic + cleanup-on-throw

### DIFF
--- a/previewsmcp/PreviewsCLI/SnapshotCommand.swift
+++ b/previewsmcp/PreviewsCLI/SnapshotCommand.swift
@@ -187,7 +187,7 @@ struct SnapshotCommand: AsyncParsableCommand {
     ///   `.jpg`/`.jpeg` → 0.85 default (JPEG). The daemon uses `quality >= 1.0`
     ///   as its PNG trigger.
     /// - Unknown extensions fall through to 0.85 (JPEG).
-    private func resolvedQuality() -> Double {
+    func resolvedQuality() -> Double {
         if let quality { return quality }
         let ext = (output as NSString).pathExtension.lowercased()
         switch ext {
@@ -199,7 +199,7 @@ struct SnapshotCommand: AsyncParsableCommand {
 
     /// Create an ephemeral session for the target file, capture, tear down.
     /// Trait flags are applied at start.
-    private func snapshotEphemeral(file: String, client: any DaemonToolCalling) async throws {
+    func snapshotEphemeral(file: String, client: any DaemonToolCalling) async throws {
         // `file` is canonicalized at the argument boundary. The absolute
         // path is sent to the daemon, which runs in its own process and
         // does not share our CWD; the daemon re-normalizes on receipt for

--- a/previewsmcp/Tests/PreviewsCLITests/SnapshotCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SnapshotCommandLogicTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import MCP
+@testable import PreviewsCLI
+import PreviewsCore
+import Testing
+
+/// `snapshot`'s CLI-side logic, tested without a real daemon or renderer.
+///
+/// Every test in `CLIIntegrationTests/SnapshotCommandTests.swift` exercises
+/// real rendering or real build-system behavior (PNG/JPEG validity,
+/// generated-source handling, live-session reuse) — none of that is
+/// convertible here. What *is* covered: the two previously-untested pure
+/// helpers (`resolvedQuality`, `resolvePlatform`), and `snapshotEphemeral`'s
+/// cleanup-on-throw path, which no integration test reaches (the only
+/// error case there, an out-of-range `--preview` index, is rejected by
+/// `preview_start` itself, never by the mid-flow `preview_snapshot` call).
+@Suite("snapshot CLI-glue logic")
+struct SnapshotCommandLogicTests {
+    // MARK: - resolvedQuality
+
+    @Test("resolvedQuality: explicit --quality wins over the output extension")
+    func explicitQualityWins() throws {
+        let command = try SnapshotCommand.parse(["a.swift", "-o", "out.png", "--quality", "0.5"])
+        #expect(command.resolvedQuality() == 0.5)
+    }
+
+    @Test("resolvedQuality: .png output defaults to 1.0")
+    func pngDefaultsToMaxQuality() throws {
+        let command = try SnapshotCommand.parse(["a.swift", "-o", "out.png"])
+        #expect(command.resolvedQuality() == 1.0)
+    }
+
+    @Test("resolvedQuality: .jpg/.jpeg output defaults to 0.85")
+    func jpegDefaultsTo085() throws {
+        let jpg = try SnapshotCommand.parse(["a.swift", "-o", "out.jpg"])
+        let jpeg = try SnapshotCommand.parse(["a.swift", "-o", "out.jpeg"])
+        #expect(jpg.resolvedQuality() == 0.85)
+        #expect(jpeg.resolvedQuality() == 0.85)
+    }
+
+    @Test("resolvedQuality: an unrecognized extension falls back to 0.85")
+    func unknownExtensionDefaultsTo085() throws {
+        let command = try SnapshotCommand.parse(["a.swift", "-o", "out.bmp"])
+        #expect(command.resolvedQuality() == 0.85)
+    }
+
+    // MARK: - resolvePlatform
+
+    /// A source path with no real SPM package around it, so
+    /// `SPMBuildSystem.inferredPlatform` reliably returns `nil` — isolates
+    /// the explicit/config precedence from real file-system inference.
+    /// The inference-returns-`.iOS` branch itself has no coverage, direct
+    /// or indirect: the only real SPM fixture (`examples/spm`) declares
+    /// both macOS and iOS platforms, and `inferredPlatform` only returns
+    /// `.iOS` for iOS-*only* packages, so no existing test drives it.
+    private static let noInferenceFile = URL(
+        fileURLWithPath: "/nonexistent/previewsmcp-logic-test/File.swift"
+    )
+
+    /// `ProjectConfig`'s memberwise init is internal despite its properties
+    /// being public, so tests build one via its `Codable` conformance
+    /// instead of reaching for `@testable import PreviewsCore`.
+    private static func projectConfig(platform: String) throws -> ProjectConfig {
+        try JSONDecoder().decode(
+            ProjectConfig.self,
+            from: Data(#"{"platform": "\#(platform)"}"#.utf8)
+        )
+    }
+
+    @Test("resolvePlatform: explicit flag wins over everything")
+    func explicitPlatformWins() throws {
+        let resolved = SnapshotCommand.resolvePlatform(
+            explicit: .ios,
+            config: try Self.projectConfig(platform: "macos"),
+            project: nil,
+            fileURL: Self.noInferenceFile
+        )
+        #expect(resolved == .ios)
+    }
+
+    @Test("resolvePlatform: config platform wins when no explicit flag is set")
+    func configPlatformWins() throws {
+        let resolved = SnapshotCommand.resolvePlatform(
+            explicit: nil,
+            config: try Self.projectConfig(platform: "ios"),
+            project: nil,
+            fileURL: Self.noInferenceFile
+        )
+        #expect(resolved == .ios)
+    }
+
+    @Test("resolvePlatform: falls back to macos with no explicit flag, config, or inference")
+    func defaultsToMacOS() {
+        let resolved = SnapshotCommand.resolvePlatform(
+            explicit: nil,
+            config: nil,
+            project: nil,
+            fileURL: Self.noInferenceFile
+        )
+        #expect(resolved == .macos)
+    }
+
+    // MARK: - snapshotEphemeral cleanup-on-throw
+
+    @Test("snapshotEphemeral stops the session it started even when the snapshot call fails")
+    func ephemeralSessionStoppedAfterSnapshotFailure() async throws {
+        let command = try SnapshotCommand.parse([
+            "/nonexistent/previewsmcp-logic-test/File.swift", "--platform", "macos",
+        ])
+        let startResult = try CallTool.Result(
+            structuredContent: DaemonProtocol.PreviewStartResult(
+                sessionID: "test-session", platform: "macos",
+                sourceFilePath: "/nonexistent/previewsmcp-logic-test/File.swift",
+                deviceUDID: nil, pid: nil, traits: nil, previews: [],
+                activeIndex: 0, setupWarning: nil, appServerPort: nil
+            )
+        )
+        // preview_snapshot is deliberately unscripted — FakeDaemonClient
+        // throws for it, simulating a mid-flow daemon failure after the
+        // session already started. preview_stop IS scripted so the
+        // assertion below proves cleanup actually succeeds, not just that
+        // it was attempted.
+        let client = FakeDaemonClient(responses: [
+            "preview_start": startResult,
+            "preview_stop": CallTool.Result(content: []),
+        ])
+
+        await #expect(throws: FakeDaemonClientError.self) {
+            try await command.snapshotEphemeral(
+                file: "/nonexistent/previewsmcp-logic-test/File.swift", client: client
+            )
+        }
+
+        #expect(client.calls.map(\.name) == ["preview_start", "preview_snapshot", "preview_stop"])
+        #expect(client.calls.last?.arguments?["sessionID"] == .string("test-session"))
+    }
+}


### PR DESCRIPTION
## Summary
- SnapshotCommand has no existing daemon-relay test convertible the way Touch/Switch/Elements/Configure were — every test in `CLIIntegrationTests/SnapshotCommandTests.swift` needs real rendering or real build-system behavior (PNG/JPEG validity, SPM/Xcode/Bazel generated-source guards, live-session reuse). Investigating turned up two previously-untested methods worth covering directly instead:
  - `resolvedQuality()` and `resolvePlatform(...)`: pure CLI-glue logic, zero seam needed — same treatment `ListCommand`'s pure logic got in an earlier step.
  - `snapshotEphemeral`'s cleanup-on-throw path: genuine daemon-relay logic (`preview_start` succeeds, `preview_snapshot` fails mid-flow, the ephemeral session still gets torn down) that no integration test reaches. The only real error case in the integration suite is an out-of-range `--preview` index, which is rejected by `preview_start` itself, never by a mid-flow snapshot failure.
- **Scope correction:** an earlier draft of this PR only widened `resolvedQuality`/`resolvePlatform` and skipped `snapshotEphemeral` entirely. An altitude-focused `/simplify` review caught that this substituted easier work for the step's actual planned deliverable — `snapshotEphemeral` already had the `any DaemonToolCalling` seam from an earlier step, it just needed widening and a test. Corrected by widening `snapshotEphemeral` too and adding the cleanup-on-throw test.
- Also fixes a misleading doc comment that claimed the SPM-infers-iOS branch was "covered indirectly by real integration tests" — it isn't; the only real SPM fixture (`examples/spm`) declares both macOS and iOS platforms, so `inferredPlatform` never actually returns `.iOS` in any existing test, direct or indirect. The comment now says so honestly instead.
- Replaced `@testable import PreviewsCore` with a plain `import PreviewsCore` + `JSONDecoder().decode(ProjectConfig.self, from:)` helper, since `ProjectConfig`'s memberwise init is internal despite public properties — the plain-import approach needs less access.

## Gates run
- `bazel build //...` — clean
- `bazel run //tools/lint:check` — clean
- `/simplify` — 3 parallel review agents (reuse, simplification, altitude): reuse clean (with an informational note that `VariantsCommand` has its own separate, still-untested `resolvedQuality()` — a candidate for the same treatment later, out of scope here); simplification caught the misleading doc comment and the overly-broad `@testable import PreviewsCore`, both fixed; altitude caught the scope shortfall described above
- `/code-review` (workflow, high effort) — 0 findings, including independent verification that the `snapshotEphemeral` test's `FakeDaemonClient` script faithfully exercises the real call sequence and cleanup-on-throw shape, and that the `CallTool.Result` construction round-trips through the same decode path production code uses
- Full local suite (`bazel test //previewsmcp/Tests/...`, 9 targets): 2 consecutive `MCPIntegrationTests` timeouts, root-caused to genuine resource contention — **5 stale `bazel` JVM servers (~1GB RSS each) left running from already-deleted worktrees** during this long session, plus a zombied `PreviewsMCPShell.app` process from the first hung run. This is a new class of infra issue distinct from the previously-documented stray-daemon/booted-sim wedge. Cleaned up (killed stale worktree bazel servers + the zombie shell process), confirmed ~19.5GB free memory, reran — passed clean in 64.7s.

## Test plan
- [x] All 8 new tests pass in milliseconds against `FakeDaemonClient`
- [x] Full local bazel suite green (post genuine resource-contention cleanup)
- [x] `/simplify` + `/code-review` gates applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPF6gjyr2BBuz31yRSnMvG