### PR TITLE
Test restructure step 5f: uniform isError/structuredContent coverage

### DIFF
--- a/previewsmcp/Tests/PreviewsCLITests/ConfigureCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/ConfigureCommandLogicTests.swift
@@ -21,4 +21,17 @@ struct ConfigureCommandLogicTests {
 
         #expect(client.calls.map(\.name) == ["session_list"])
     }
+
+    @Test("configure surfaces a daemon-reported tool error")
+    func configureDaemonError() async throws {
+        let command = try ConfigureCommand.parse(["--color-scheme", "dark"])
+        let client = FakeDaemonClient(responses: [
+            "session_list": .foundSession,
+            "preview_configure": .daemonError("invalid trait combination"),
+        ])
+
+        await expectDaemonToolError(contains: "invalid trait combination") {
+            try await command.execute(on: client)
+        }
+    }
 }

--- a/previewsmcp/Tests/PreviewsCLITests/ElementsCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/ElementsCommandLogicTests.swift
@@ -20,4 +20,30 @@ struct ElementsCommandLogicTests {
 
         #expect(client.calls.map(\.name) == ["session_list"])
     }
+
+    @Test("elements surfaces a daemon-reported tool error")
+    func elementsDaemonError() async throws {
+        let command = try ElementsCommand.parse([])
+        let client = FakeDaemonClient(responses: [
+            "session_list": .foundSession,
+            "preview_elements": .daemonError("only available for iOS simulator previews"),
+        ])
+
+        await expectDaemonToolError(contains: "only available for iOS simulator previews") {
+            try await command.execute(on: client)
+        }
+    }
+
+    @Test("elements --json errors when the response has no structuredContent")
+    func elementsJSONMissingStructuredContent() async throws {
+        let command = try ElementsCommand.parse(["--json"])
+        let client = FakeDaemonClient(responses: [
+            "session_list": .foundSession,
+            "preview_elements": CallTool.Result(content: [.text("[]")]),
+        ])
+
+        await expectDaemonToolError(contains: "missing structuredContent") {
+            try await command.execute(on: client)
+        }
+    }
 }

--- a/previewsmcp/Tests/PreviewsCLITests/FakeDaemonClient.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/FakeDaemonClient.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MCP
 @testable import PreviewsCLI
+import Testing
 
 /// Test double for `DaemonToolCalling`. Scripted with one canned
 /// `CallTool.Result` per tool name — no socket, no spawned daemon. Records
@@ -44,4 +45,32 @@ enum FakeDaemonClientError: Error, CustomStringConvertible {
 extension CallTool.Result {
     /// An empty `session_list` response — no active sessions.
     static let noSessions = CallTool.Result(content: [.text("")])
+
+    /// A `session_list` response with exactly one active session (id
+    /// "test-session"), matching `SessionResolver.parseSessionList`'s
+    /// tab-delimited format (`<sessionID>\t<platform>\t<sourceFilePath>`).
+    static let foundSession = CallTool.Result(
+        content: [.text("test-session\tmacos\t/tmp/previewsmcp-logic-test.swift")]
+    )
+
+    /// A daemon-reported tool error — `isError == true` with a message.
+    static func daemonError(_ message: String) -> CallTool.Result {
+        CallTool.Result(content: [.text(message)], isError: true)
+    }
+}
+
+/// Runs `run`, expecting it to throw a `DaemonToolError` whose description
+/// contains `substring`.
+func expectDaemonToolError(
+    contains substring: String,
+    run: () async throws -> Void
+) async {
+    do {
+        try await run()
+        Issue.record("expected a DaemonToolError, but run() succeeded")
+    } catch let error as DaemonToolError {
+        #expect(error.description.contains(substring), "unexpected message: \(error.description)")
+    } catch {
+        Issue.record("expected a DaemonToolError, got \(error)")
+    }
 }

--- a/previewsmcp/Tests/PreviewsCLITests/SimulatorsCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SimulatorsCommandLogicTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import MCP
+@testable import PreviewsCLI
+import Testing
+
+/// `simulators`'s daemon-relay logic (`SimulatorsCommand.execute(on:)`),
+/// tested against a `FakeDaemonClient` — no daemon spawn, no simulator.
+/// Real subprocess coverage (device-line formatting against actual
+/// CoreSimulator state, which needs real device data) stays in
+/// `CLIIntegrationTests/SimulatorsCommandTests.swift`.
+@Suite("simulators daemon-relay logic")
+struct SimulatorsCommandLogicTests {
+    @Test("simulators surfaces a daemon-reported tool error")
+    func simulatorsDaemonError() async throws {
+        let command = try SimulatorsCommand.parse([])
+        let client = FakeDaemonClient(responses: [
+            "simulator_list": .daemonError("CoreSimulator unavailable"),
+        ])
+
+        await expectDaemonToolError(contains: "CoreSimulator unavailable") {
+            try await command.execute(on: client)
+        }
+    }
+
+    @Test("simulators --json errors when the response has no structuredContent")
+    func simulatorsJSONMissingStructuredContent() async throws {
+        let command = try SimulatorsCommand.parse(["--json"])
+        let client = FakeDaemonClient(responses: [
+            "simulator_list": CallTool.Result(content: [.text("iPhone 16 — AAAA")]),
+        ])
+
+        await expectDaemonToolError(contains: "missing structuredContent") {
+            try await command.execute(on: client)
+        }
+    }
+}

--- a/previewsmcp/Tests/PreviewsCLITests/SwitchCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SwitchCommandLogicTests.swift
@@ -21,4 +21,17 @@ struct SwitchCommandLogicTests {
 
         #expect(client.calls.map(\.name) == ["session_list"])
     }
+
+    @Test("switch surfaces a daemon-reported tool error")
+    func switchDaemonError() async throws {
+        let command = try SwitchCommand.parse(["0"])
+        let client = FakeDaemonClient(responses: [
+            "session_list": .foundSession,
+            "preview_switch": .daemonError("preview index out of range"),
+        ])
+
+        await expectDaemonToolError(contains: "preview index out of range") {
+            try await command.execute(on: client)
+        }
+    }
 }

--- a/previewsmcp/Tests/PreviewsCLITests/TouchCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/TouchCommandLogicTests.swift
@@ -20,4 +20,17 @@ struct TouchCommandLogicTests {
 
         #expect(client.calls.map(\.name) == ["session_list"])
     }
+
+    @Test("touch surfaces a daemon-reported tool error")
+    func touchDaemonError() async throws {
+        let command = try TouchCommand.parse(["100", "200"])
+        let client = FakeDaemonClient(responses: [
+            "session_list": .foundSession,
+            "preview_touch": .daemonError("simulator not booted"),
+        ])
+
+        await expectDaemonToolError(contains: "simulator not booted") {
+            try await command.execute(on: client)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Closes the daemon-error and missing-structuredContent coverage gap identically across all 5 single-call commands (`Touch`, `Switch`, `Elements`, `Configure`, `Simulators`) — deferred from step 5d specifically to avoid doing it piecemeal (an altitude review at the time flagged that closing it only for `Simulators` would leave an unexplained inconsistent coverage bar vs. its siblings, which have the identical untested branches).
- `Elements` and `Simulators` are the only two with a `--json`/`structuredContent` branch, so they get two new tests each (`*DaemonError`, `*JSONMissingStructuredContent`); the other three get one (`isError` only).
- New shared fixtures in `FakeDaemonClient.swift`: `.foundSession` (a `session_list` response with one active session, matching `SessionResolver.parseSessionList`'s tab-delimited format) and `.daemonError(_:)` (`isError=true` with a message), plus a promoted `expectDaemonToolError` helper — file-local would've made sense at 1 consumer, but this now serves 5 files, matching the existing precedent of `expectValidationError`.
- `foundSession` started parameterized (`id:platform:sourceFilePath:`) but every call site used the defaults — `/simplify` caught the unused configurability and it's now a bare `static let`, matching `.noSessions`'s shape.

## Follow-up noted, not addressed here
The altitude `/simplify` pass flagged that `SnapshotCommand` (converted in step 5e, immediately before this one) has the identical `isError`/missing-`structuredContent` gaps, untested. Correctly out of scope for this diff — this chunk was scoped to "the five single-call commands," and Snapshot is multi-call — but it's the next place this pattern will surface if left unaddressed.

## Gates run
- `bazel build //...` — clean
- `bazel run //tools/lint:check` — clean
- `/simplify` — 2 parallel review agents (reuse+simplification, altitude): reuse+simplification caught the `foundSession` over-parameterization (fixed); altitude independently confirmed the same finding, verified coverage is genuinely complete and uniform across exactly the right 5 commands (grepped every `callToolStructured` call site in `previewsmcp/PreviewsCLI` to confirm no other single-call-shaped command was silently skipped), and flagged the `SnapshotCommand` follow-up above
- `/code-review` (workflow, high effort) — 0 findings, including independent re-derivation that each new test's targeted branch actually exists and is reached in the scripted order, and that `.foundSession`'s tab-delimited format actually parses through `SessionResolver.parseSessionList`
- Full local suite (`bazel test //previewsmcp/Tests/...`, 9 targets): hit 2 `MCPIntegrationTests` timeouts on a run that happened to overlap with a `/simplify` agent's own concurrent `bazel test` invocation in the same worktree — traced to that resource contention (plus a zombied `PreviewsMCPShell.app` process from the timeout itself, cleaned up), not a regression. A subsequent uncontended run passed clean: `MCPIntegrationTests` in 69.1s, all 9 targets green.

## Test plan
- [x] All 7 new tests pass in milliseconds against `FakeDaemonClient`
- [x] Full local bazel suite green (uncontended run)
- [x] `/simplify` + `/code-review` gates applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPF6gjyr2BBuz31yRSnMvG