### PR TITLE
Test restructure step 5g: StopCommand conversion + FakeDaemonClient FIFO queue

### DIFF
--- a/previewsmcp/PreviewsCLI/StopCommand.swift
+++ b/previewsmcp/PreviewsCLI/StopCommand.swift
@@ -46,7 +46,10 @@ struct StopCommand: AsyncParsableCommand {
         }
     }
 
-    private func stopOne(client: any DaemonToolCalling) async throws {
+    /// The daemon-relay body for stopping a single session, factored out so
+    /// tests can call it directly against a fake `DaemonToolCalling`
+    /// without a real daemon connection.
+    func stopOne(client: any DaemonToolCalling) async throws {
         let resolution = try await SessionResolver.resolve(
             session: target.session,
             file: target.file,
@@ -64,7 +67,12 @@ struct StopCommand: AsyncParsableCommand {
         try await sendStop(sessionID: sessionID, client: client)
     }
 
-    private func stopAll(client: any DaemonToolCalling) async throws {
+    /// The daemon-relay body for `--all`, factored out so tests can call it
+    /// directly against a fake `DaemonToolCalling` without a real daemon
+    /// connection. Sweeps every active session, stopping each in turn; one
+    /// session's failure doesn't stop the sweep, but the first failure is
+    /// still thrown once the sweep completes.
+    func stopAll(client: any DaemonToolCalling) async throws {
         let response = try await client.callToolStructured(name: "session_list", arguments: [:])
         if response.isError == true {
             throw DaemonToolError.daemonError(response.content.joinedText())

--- a/previewsmcp/Tests/CLIIntegrationTests/StopCommandTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/StopCommandTests.swift
@@ -43,35 +43,11 @@ struct StopCommandTests {
         }
     }
 
-    // MARK: - No-session paths
-
-    @Test("stop errors when no session is running")
-    func stopNoSession() async throws {
-        try await DaemonTestLock.run {
-            try await Self.cleanSlate()
-
-            let result = try await CLIRunner.run("stop")
-            #expect(result.exitCode != 0)
-            #expect(
-                result.stderr.contains("No session found to stop"),
-                "stderr: \(result.stderr)"
-            )
-        }
-    }
-
-    @Test("stop --all on an empty daemon is a no-op success")
-    func stopAllWithNoSessions() async throws {
-        try await DaemonTestLock.run {
-            try await Self.cleanSlate()
-
-            let result = try await CLIRunner.run("stop", arguments: ["--all"])
-            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
-            #expect(
-                result.stderr.contains("No active sessions to stop"),
-                "stderr: \(result.stderr)"
-            )
-        }
-    }
+    // "stop errors when no session is running" and "stop --all on an empty
+    // daemon is a no-op success" moved to PreviewsCLITests/
+    // StopCommandLogicTests.swift, which invokes StopCommand.stopOne(client:)
+    // / .stopAll(client:) against a FakeDaemonClient instead of spawning a
+    // subprocess + daemon.
 
     // MARK: - Happy paths
 

--- a/previewsmcp/Tests/PreviewsCLITests/FakeDaemonClient.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/FakeDaemonClient.swift
@@ -3,20 +3,28 @@ import MCP
 @testable import PreviewsCLI
 import Testing
 
-/// Test double for `DaemonToolCalling`. Scripted with one canned
-/// `CallTool.Result` per tool name — no socket, no spawned daemon. Records
+/// Test double for `DaemonToolCalling`. Scripted with canned
+/// `CallTool.Result`s per tool name — no socket, no spawned daemon. Records
 /// every call so tests can assert on what a command actually sent.
 ///
-/// One response per tool name only: a command that calls the same tool name
-/// more than once per `execute` (e.g. `StopCommand.stopAll`'s per-session
-/// `preview_stop` loop) can't yet script distinct results per call. Extend
-/// `responses` to a per-name queue if a future conversion needs that.
+/// Two ways to script a tool name: `responses` for a single repeatable
+/// result (the common case), and `sequences` for a command that calls the
+/// same tool name more than once per `execute` and needs a distinct result
+/// per call (e.g. `StopCommand.stopAll`'s per-session `preview_stop` loop —
+/// one session fails, the rest still get stopped). A tool name present in
+/// `sequences` is popped FIFO on each call; once exhausted, falls back to
+/// `responses`.
 final class FakeDaemonClient: DaemonToolCalling, @unchecked Sendable {
     private let responses: [String: CallTool.Result]
+    private var sequences: [String: [CallTool.Result]]
     private(set) var calls: [(name: String, arguments: [String: Value]?)] = []
 
-    init(responses: [String: CallTool.Result] = [:]) {
+    init(
+        responses: [String: CallTool.Result] = [:],
+        sequences: [String: [CallTool.Result]] = [:]
+    ) {
         self.responses = responses
+        self.sequences = sequences
     }
 
     func callToolStructured(
@@ -24,6 +32,11 @@ final class FakeDaemonClient: DaemonToolCalling, @unchecked Sendable {
         arguments: [String: Value]?
     ) async throws -> CallTool.Result {
         calls.append((name, arguments))
+        if var queue = sequences[name], !queue.isEmpty {
+            let result = queue.removeFirst()
+            sequences[name] = queue
+            return result
+        }
         guard let result = responses[name] else {
             throw FakeDaemonClientError.noCannedResponse(name)
         }
@@ -51,6 +64,13 @@ extension CallTool.Result {
     /// tab-delimited format (`<sessionID>\t<platform>\t<sourceFilePath>`).
     static let foundSession = CallTool.Result(
         content: [.text("test-session\tmacos\t/tmp/previewsmcp-logic-test.swift")]
+    )
+
+    /// A `session_list` response with two active sessions ("session-a",
+    /// "session-b"), for commands that sweep every session (e.g.
+    /// `StopCommand.stopAll`).
+    static let twoSessions = CallTool.Result(
+        content: [.text("session-a\tmacos\t/tmp/a.swift\nsession-b\tios\t/tmp/b.swift")]
     )
 
     /// A daemon-reported tool error — `isError == true` with a message.

--- a/previewsmcp/Tests/PreviewsCLITests/StopCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/StopCommandLogicTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import MCP
+@testable import PreviewsCLI
+import Testing
+
+/// `stop`'s daemon-relay logic (`StopCommand.stopOne(client:)` and
+/// `.stopAll(client:)`), tested against a `FakeDaemonClient` — no daemon
+/// spawn, no simulator. Real subprocess coverage (actually stopping a live
+/// session, which depends on the daemon's own behavior) stays in
+/// `CLIIntegrationTests/StopCommandTests.swift`.
+@Suite("stop daemon-relay logic")
+struct StopCommandLogicTests {
+    @Test("stop errors when no session is running")
+    func stopOneNoSession() async throws {
+        let command = try StopCommand.parse([])
+        let client = FakeDaemonClient(responses: ["session_list": .noSessions])
+
+        await expectValidationError(contains: "No session found to stop") {
+            try await command.stopOne(client: client)
+        }
+
+        #expect(client.calls.map(\.name) == ["session_list"])
+    }
+
+    @Test("stop surfaces a daemon-reported tool error")
+    func stopOneDaemonError() async throws {
+        let command = try StopCommand.parse([])
+        let client = FakeDaemonClient(responses: [
+            "session_list": .foundSession,
+            "preview_stop": .daemonError("session already stopped"),
+        ])
+
+        await expectDaemonToolError(contains: "session already stopped") {
+            try await command.stopOne(client: client)
+        }
+    }
+
+    @Test("stop --all is a no-op when no sessions are running")
+    func stopAllNoSessions() async throws {
+        let command = try StopCommand.parse(["--all"])
+        let client = FakeDaemonClient(responses: ["session_list": .noSessions])
+
+        try await command.stopAll(client: client)
+
+        #expect(client.calls.map(\.name) == ["session_list"])
+    }
+
+    @Test("stop --all stops every active session")
+    func stopAllStopsEverySession() async throws {
+        let command = try StopCommand.parse(["--all"])
+        let client = FakeDaemonClient(
+            responses: ["session_list": .twoSessions],
+            sequences: [
+                "preview_stop": [
+                    CallTool.Result(content: []),
+                    CallTool.Result(content: []),
+                ],
+            ]
+        )
+
+        try await command.stopAll(client: client)
+
+        #expect(client.calls.map(\.name) == ["session_list", "preview_stop", "preview_stop"])
+        let stoppedSessionIDs = client.calls.dropFirst().map { $0.arguments?["sessionID"] }
+        #expect(stoppedSessionIDs == [.string("session-a"), .string("session-b")])
+    }
+
+    @Test("stop --all keeps sweeping after one session fails, then throws the first failure")
+    func stopAllContinuesSweepAfterFailure() async throws {
+        let command = try StopCommand.parse(["--all"])
+        let client = FakeDaemonClient(
+            responses: ["session_list": .twoSessions],
+            sequences: [
+                // Both sessions fail, with distinct messages, so the
+                // assertion below can only pass if the FIRST failure is
+                // what's thrown — a last-failure-wins regression would
+                // surface "session-b boom" instead and fail this test.
+                "preview_stop": [
+                    .daemonError("session-a wedged"),
+                    .daemonError("session-b boom"),
+                ],
+            ]
+        )
+
+        await expectDaemonToolError(contains: "session-a wedged") {
+            try await command.stopAll(client: client)
+        }
+
+        // Both sessions were attempted even though the first one failed.
+        #expect(client.calls.map(\.name) == ["session_list", "preview_stop", "preview_stop"])
+    }
+}


### PR DESCRIPTION
## Summary
- Closes the "extend `FakeDaemonClient` to a per-name queue" item deferred since step 5b: `StopCommand.stopAll`'s `--all` sweep calls `preview_stop` once per session — a repeat-same-tool-name case the fake couldn't express with a single response per tool name.
- `FakeDaemonClient` gets a new additive `sequences: [String: [CallTool.Result]]` init parameter. A tool name present in it is popped FIFO on each call, falling back to the existing single-response `responses` dict once exhausted. All ~9 existing call sites across the other `*LogicTests.swift` files are untouched.
- `stopOne`/`stopAll` widened from `private` to internal (`sendStop`, the shared per-session RPC helper both call, stays `private`). Unlike the 5 previously-converted commands, `StopCommand` deliberately has no unified `execute(on:)` wrapper — `run()` branches directly between `stopOne`/`stopAll` rather than dispatching through one entry point, so there's no single body to extract.
- New `StopCommandLogicTests.swift`: 5 tests — the no-session and daemon-error paths mirror the established pattern from the other 5 commands; `stopAll`'s no-op-on-empty, all-succeed, and continues-sweep-after-failure paths are new coverage of behavior that was previously only reachable (and never actually exercised) via real daemon integration tests.
- The sweep-continuation test scripts **both** sessions to fail with **distinct** messages, so the assertion can discriminate first-failure-wins from last-failure-wins semantics — an altitude `/simplify` review caught that an earlier draft with only one failing session couldn't tell the two apart, since a buggy "last wins" implementation would've produced the identical observable result.
- 2 old subprocess tests removed from `CLIIntegrationTests/StopCommandTests.swift`, replaced with a pointer comment. Real subprocess coverage (actually stopping live sessions, `--session` targeting, `--all` closing multiple real sessions, the `--all`-combined-with-`--session`/`--file` validation rejections) is untouched.

## Gates run
- `bazel build //...` — clean
- `bazel run //tools/lint:check` — clean
- `/simplify` — 2 parallel review agents (reuse+simplification, altitude): reuse+simplification confirmed the `sequences` design matches exactly what was anticipated back when the limitation was first documented; altitude confirmed the conversion is complete and well-scoped, and caught the sweep-continuation test's weak discrimination between first-wins/last-wins semantics (fixed)
- `/code-review` (workflow, high effort) — 0 findings, including independent re-derivation of the FIFO-pop-then-fallback mutation logic and the strengthened test's discrimination power against `StopCommand.stopAll`'s actual `firstFailure` control flow
- Full local suite (`bazel test //previewsmcp/Tests/...`, 9 targets): all green (one run took longer than usual — confirmed genuinely progressing via live subprocess inspection, not stuck)

## Test plan
- [x] All 5 new tests pass in milliseconds against `FakeDaemonClient`
- [x] Full local bazel suite green
- [x] `/simplify` + `/code-review` gates applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPF6gjyr2BBuz31yRSnMvG