### PR TITLE
Test restructure step 5h: VariantsCommand pure logic + cleanup-on-throw

### DIFF
--- a/previewsmcp/PreviewsCLI/VariantsCommand.swift
+++ b/previewsmcp/PreviewsCLI/VariantsCommand.swift
@@ -202,7 +202,7 @@ struct VariantsCommand: AsyncParsableCommand {
 
     // MARK: - Execution paths
 
-    private func captureEphemeral(
+    func captureEphemeral(
         file: String,
         labels: [String],
         outputDir: URL,
@@ -397,7 +397,7 @@ struct VariantsCommand: AsyncParsableCommand {
 
     // MARK: - Helpers
 
-    private func resolvedQuality() -> Double {
+    func resolvedQuality() -> Double {
         // Explicit --format png overrides quality → ask daemon for PNG
         // (quality >= 1.0 is its PNG trigger).
         if format == .png { return 1.0 }

--- a/previewsmcp/Tests/PreviewsCLITests/FakeDaemonClient.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/FakeDaemonClient.swift
@@ -77,6 +77,22 @@ extension CallTool.Result {
     static func daemonError(_ message: String) -> CallTool.Result {
         CallTool.Result(content: [.text(message)], isError: true)
     }
+
+    /// A successful `preview_start` response for an ephemeral session,
+    /// decodable via `structuredContent.decode(DaemonProtocol.PreviewStartResult.self)`
+    /// the same way production code does. Used by cleanup-on-throw tests for
+    /// the ephemeral-session commands (`SnapshotCommand.snapshotEphemeral`,
+    /// `VariantsCommand.captureEphemeral`).
+    static func ephemeralStartResult(sessionID: String = "test-session") throws -> CallTool.Result {
+        try CallTool.Result(
+            structuredContent: DaemonProtocol.PreviewStartResult(
+                sessionID: sessionID, platform: "macos",
+                sourceFilePath: "/nonexistent/previewsmcp-logic-test/File.swift",
+                deviceUDID: nil, pid: nil, traits: nil, previews: [],
+                activeIndex: 0, setupWarning: nil, appServerPort: nil
+            )
+        )
+    }
 }
 
 /// Runs `run`, expecting it to throw a `DaemonToolError` whose description

--- a/previewsmcp/Tests/PreviewsCLITests/SnapshotCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SnapshotCommandLogicTests.swift
@@ -107,14 +107,7 @@ struct SnapshotCommandLogicTests {
         let command = try SnapshotCommand.parse([
             "/nonexistent/previewsmcp-logic-test/File.swift", "--platform", "macos",
         ])
-        let startResult = try CallTool.Result(
-            structuredContent: DaemonProtocol.PreviewStartResult(
-                sessionID: "test-session", platform: "macos",
-                sourceFilePath: "/nonexistent/previewsmcp-logic-test/File.swift",
-                deviceUDID: nil, pid: nil, traits: nil, previews: [],
-                activeIndex: 0, setupWarning: nil, appServerPort: nil
-            )
-        )
+        let startResult = try CallTool.Result.ephemeralStartResult()
         // preview_snapshot is deliberately unscripted — FakeDaemonClient
         // throws for it, simulating a mid-flow daemon failure after the
         // session already started. preview_stop IS scripted so the

--- a/previewsmcp/Tests/PreviewsCLITests/VariantsCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/VariantsCommandLogicTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import MCP
+@testable import PreviewsCLI
+import Testing
+
+/// `variants`'s CLI-side logic, tested without a real daemon or renderer.
+///
+/// Every test in `CLIIntegrationTests/VariantsCommandTests.swift` exercises
+/// real rendering or real build-system behavior — none of that is
+/// convertible here. `VariantsCommand.exitCode(successCount:failCount:)` is
+/// already unit-tested directly in `VariantsExitCodeTests.swift`. What's
+/// covered here: the previously-untested `resolvedQuality()`, and
+/// `captureEphemeral`'s cleanup-on-throw path (mirrors
+/// `SnapshotCommand.snapshotEphemeral`'s equivalent test) — genuine
+/// daemon-relay logic no integration test reaches, since forcing a
+/// mid-flow `preview_variants` failure after a real session already
+/// started would require injecting a daemon-side fault.
+@Suite("variants CLI-glue logic")
+struct VariantsCommandLogicTests {
+    // MARK: - resolvedQuality
+
+    @Test("resolvedQuality: --format png always requests 1.0")
+    func pngFormatForcesMaxQuality() throws {
+        let command = try VariantsCommand.parse(["a.swift", "--variant", "light", "--format", "png"])
+        #expect(command.resolvedQuality() == 1.0)
+    }
+
+    @Test("resolvedQuality: explicit --quality wins for jpeg")
+    func explicitQualityWins() throws {
+        let command = try VariantsCommand.parse([
+            "a.swift", "--variant", "light", "--quality", "0.5",
+        ])
+        #expect(command.resolvedQuality() == 0.5)
+    }
+
+    @Test("resolvedQuality: defaults to 0.85 for jpeg with no --quality")
+    func jpegDefaultsTo085() throws {
+        let command = try VariantsCommand.parse(["a.swift", "--variant", "light"])
+        #expect(command.resolvedQuality() == 0.85)
+    }
+
+    // MARK: - captureEphemeral cleanup-on-throw
+
+    @Test("captureEphemeral stops the session it started even when the capture call fails")
+    func ephemeralSessionStoppedAfterCaptureFailure() async throws {
+        let command = try VariantsCommand.parse(["a.swift", "--variant", "light"])
+        let startResult = try CallTool.Result.ephemeralStartResult()
+        // preview_variants is deliberately unscripted — FakeDaemonClient
+        // throws for it, simulating a mid-flow daemon failure after the
+        // session already started. preview_stop IS scripted so the
+        // assertion below proves cleanup actually succeeds.
+        let client = FakeDaemonClient(responses: [
+            "preview_start": startResult,
+            "preview_stop": CallTool.Result(content: []),
+        ])
+
+        await #expect(throws: FakeDaemonClientError.self) {
+            _ = try await command.captureEphemeral(
+                file: "/nonexistent/previewsmcp-logic-test/File.swift",
+                labels: ["light"],
+                outputDir: URL(fileURLWithPath: "/tmp"),
+                client: client
+            )
+        }
+
+        #expect(client.calls.map(\.name) == ["preview_start", "preview_variants", "preview_stop"])
+        #expect(client.calls.last?.arguments?["sessionID"] == .string("test-session"))
+    }
+}


### PR DESCRIPTION
## Summary
- Completes the original 6-command conversion list (Touch/Switch/Elements/Configure/Simulators/Stop already converted; SnapshotCommand handled earlier via the same pattern this diff repeats for VariantsCommand).
- `VariantsCommandTests.swift` has no daemon-relay test convertible the way the other commands were — every test needs real rendering or real build-system behavior — and `VariantsCommand.exitCode(successCount:failCount:)` is already unit-tested separately in `VariantsExitCodeTests.swift`.
- `resolvedQuality()` and `captureEphemeral(file:labels:outputDir:client:)` widened from `private` to internal (pure visibility change). New tests cover `resolvedQuality`'s three branches and `captureEphemeral`'s cleanup-on-throw path — genuine daemon-relay logic (`preview_start` succeeds, `preview_variants` fails mid-flow, the ephemeral session still gets torn down) that no integration test reaches.
- Extracted a shared `CallTool.Result.ephemeralStartResult()` factory into `FakeDaemonClient.swift` after a `/simplify` review found the exact same `PreviewStartResult` construction duplicated verbatim between the new `VariantsCommandLogicTests.swift` and `SnapshotCommandLogicTests.swift` — both now share it, closing a silent-drift risk on any future field change to `PreviewStartResult`.
- `captureVariants` (the method processing `preview_variants`'s response, analogous to `SnapshotCommand.handleSnapshotResponse`) stays `private` and untested here, matching Snapshot's own scope decision — an altitude review confirmed this is symmetric, not a gap this diff introduced.
- The isError/structuredContent coverage gap on both Snapshot and Variants remains open, correctly deferred to the separate uniform-pass chunk already agreed with mergequeue-lead.

## Gates run
- `bazel build //...` — clean
- `bazel run //tools/lint:check` — clean
- `/simplify` — 2 parallel review agents (reuse+simplification, altitude): reuse+simplification caught the `PreviewStartResult` duplication (fixed via the shared factory); altitude confirmed this is genuinely the last conversion, confirmed `captureVariants` was correctly left out of scope, confirmed no accidental narrowing of the deferred isError/structuredContent gap, and caught a stray doc comment that both violated the no-comments convention and was factually inaccurate (nothing was "factored out" — fixed to match `SnapshotCommand`'s precedent of adding no comment for the equivalent widening)
- `/code-review` (workflow, high effort) — 0 findings, including independent re-derivation that the shared factory produces byte-identical behavior to both files' original inline constructions
- Full local suite (`bazel test //previewsmcp/Tests/...`, 9 targets): all green (confirmed genuinely active via live subprocess inspection during a slower-than-typical run, not stuck)

## Test plan
- [x] All 4 new tests pass in milliseconds against `FakeDaemonClient`
- [x] Both `ephemeralStartResult()` consumers (Snapshot + Variants) still pass after the shared-factory refactor
- [x] Full local bazel suite green
- [x] `/simplify` + `/code-review` gates applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPF6gjyr2BBuz31yRSnMvG