### PR TITLE
Test restructure step 5i: Snapshot+Variants uniform isError/structuredContent coverage

### DIFF
--- a/previewsmcp/PreviewsCLI/SnapshotCommand.swift
+++ b/previewsmcp/PreviewsCLI/SnapshotCommand.swift
@@ -332,7 +332,7 @@ struct SnapshotCommand: AsyncParsableCommand {
     /// Write the image returned in the snapshot response to the output path.
     /// Prints either a bare path or a JSON document (when `--json` is set) to
     /// stdout on success.
-    private func handleSnapshotResponse(
+    func handleSnapshotResponse(
         _ response: CallTool.Result,
         sessionID: String
     ) throws {

--- a/previewsmcp/PreviewsCLI/VariantsCommand.swift
+++ b/previewsmcp/PreviewsCLI/VariantsCommand.swift
@@ -271,7 +271,7 @@ struct VariantsCommand: AsyncParsableCommand {
     /// Call `preview_variants`, decode each variant's outcome from the
     /// daemon's `structuredContent`, write successful images to disk, and
     /// surface per-variant errors to stderr.
-    private func captureVariants(
+    func captureVariants(
         sessionID: String,
         labels: [String],
         outputDir: URL,

--- a/previewsmcp/Tests/PreviewsCLITests/SnapshotCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SnapshotCommandLogicTests.swift
@@ -10,10 +10,13 @@ import Testing
 /// real rendering or real build-system behavior (PNG/JPEG validity,
 /// generated-source handling, live-session reuse) — none of that is
 /// convertible here. What *is* covered: the two previously-untested pure
-/// helpers (`resolvedQuality`, `resolvePlatform`), and `snapshotEphemeral`'s
-/// cleanup-on-throw path, which no integration test reaches (the only
-/// error case there, an out-of-range `--preview` index, is rejected by
-/// `preview_start` itself, never by the mid-flow `preview_snapshot` call).
+/// helpers (`resolvedQuality`, `resolvePlatform`), `snapshotEphemeral`'s
+/// cleanup-on-throw path (no integration test reaches it — the only error
+/// case there, an out-of-range `--preview` index, is rejected by
+/// `preview_start` itself, never by the mid-flow `preview_snapshot` call),
+/// and `handleSnapshotResponse`'s three response-handling branches
+/// (daemon-reported error, no image content, invalid image data) — a pure
+/// function needing no daemon/fake at all.
 @Suite("snapshot CLI-glue logic")
 struct SnapshotCommandLogicTests {
     // MARK: - resolvedQuality
@@ -126,5 +129,39 @@ struct SnapshotCommandLogicTests {
 
         #expect(client.calls.map(\.name) == ["preview_start", "preview_snapshot", "preview_stop"])
         #expect(client.calls.last?.arguments?["sessionID"] == .string("test-session"))
+    }
+
+    // MARK: - handleSnapshotResponse
+
+    @Test("handleSnapshotResponse: surfaces a daemon-reported tool error")
+    func handleSnapshotResponseDaemonError() async throws {
+        let command = try SnapshotCommand.parse(["a.swift"])
+        let response = CallTool.Result(content: [.text("simulator not booted")], isError: true)
+
+        await expectDaemonToolError(contains: "simulator not booted") {
+            try command.handleSnapshotResponse(response, sessionID: "test-session")
+        }
+    }
+
+    @Test("handleSnapshotResponse: throws when the response has no image content")
+    func handleSnapshotResponseNoImageContent() throws {
+        let command = try SnapshotCommand.parse(["a.swift"])
+        let response = CallTool.Result(content: [.text("no image here")])
+
+        #expect(throws: SnapshotCommandError.self) {
+            try command.handleSnapshotResponse(response, sessionID: "test-session")
+        }
+    }
+
+    @Test("handleSnapshotResponse: throws when the image data is not valid base64")
+    func handleSnapshotResponseInvalidBase64() throws {
+        let command = try SnapshotCommand.parse(["a.swift"])
+        let response = CallTool.Result(
+            content: [.image(data: "not valid base64!!", mimeType: "image/png", metadata: nil)]
+        )
+
+        #expect(throws: SnapshotCommandError.self) {
+            try command.handleSnapshotResponse(response, sessionID: "test-session")
+        }
     }
 }

--- a/previewsmcp/Tests/PreviewsCLITests/VariantsCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/VariantsCommandLogicTests.swift
@@ -9,12 +9,16 @@ import Testing
 /// real rendering or real build-system behavior — none of that is
 /// convertible here. `VariantsCommand.exitCode(successCount:failCount:)` is
 /// already unit-tested directly in `VariantsExitCodeTests.swift`. What's
-/// covered here: the previously-untested `resolvedQuality()`, and
+/// covered here: the previously-untested `resolvedQuality()`,
 /// `captureEphemeral`'s cleanup-on-throw path (mirrors
 /// `SnapshotCommand.snapshotEphemeral`'s equivalent test) — genuine
 /// daemon-relay logic no integration test reaches, since forcing a
 /// mid-flow `preview_variants` failure after a real session already
-/// started would require injecting a daemon-side fault.
+/// started would require injecting a daemon-side fault — and
+/// `captureVariants`' missing-`structuredContent` guard. Unlike
+/// `SnapshotCommand`, `captureVariants` has no top-level daemon-`isError`
+/// check at all: per-variant failures are reported via each outcome's
+/// `status` field inside `structuredContent`, not a response-level flag.
 @Suite("variants CLI-glue logic")
 struct VariantsCommandLogicTests {
     // MARK: - resolvedQuality
@@ -65,5 +69,24 @@ struct VariantsCommandLogicTests {
 
         #expect(client.calls.map(\.name) == ["preview_start", "preview_variants", "preview_stop"])
         #expect(client.calls.last?.arguments?["sessionID"] == .string("test-session"))
+    }
+
+    // MARK: - captureVariants
+
+    @Test("captureVariants errors when the response has no structuredContent")
+    func captureVariantsMissingStructuredContent() async throws {
+        let command = try VariantsCommand.parse(["a.swift", "--variant", "light"])
+        let client = FakeDaemonClient(responses: [
+            "preview_variants": CallTool.Result(content: [.text("no structured payload")]),
+        ])
+
+        await expectDaemonToolError(contains: "missing structuredContent") {
+            _ = try await command.captureVariants(
+                sessionID: "test-session",
+                labels: ["light"],
+                outputDir: URL(fileURLWithPath: "/tmp"),
+                client: client
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Widens `SnapshotCommand.handleSnapshotResponse` and `VariantsCommand.captureVariants` from `private` to `internal` so their response-handling branches are directly unit-testable via `@testable import`, mirroring the seam pattern used across steps 5a–5h.
- Adds unit tests covering each command's actual branches — the two commands turned out to have genuinely different response shapes, not forced parity: `handleSnapshotResponse` has 3 branches (daemon-reported `isError`, no image content, invalid base64), all now covered; `captureVariants` has no top-level `isError` check at all (per-variant failures come through each outcome's own `status` field inside `structuredContent`), so its only branch — missing `structuredContent` — is now covered.
- Applied one confirmed `/code-review` finding: `handleSnapshotResponseDaemonError` now uses the suite's shared `expectDaemonToolError(contains:)` helper instead of a bare `#expect(throws:)`, so the interpolated daemon-error message is actually verified, matching every other `DaemonToolError` test in the file.

## Test plan
- [x] `bazel build //...`
- [x] `bazel run //tools/lint:check` (no new warnings)
- [x] Full local suite: `bazel test //previewsmcp/Tests/... --nocache_test_results` — 9/9 targets pass
- [x] `/simplify` (reuse+simplification, altitude) — clean, no findings
- [x] `/code-review` (high) — 1 confirmed finding, applied and reverified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPF6gjyr2BBuz31yRSnMvG