### PR TITLE
Fix #320: serialize the daemon's MCP sends (SDK transport frame interleave) + single-use stream sessions

### DIFF
--- a/previewsmcp/PreviewsCLI/Handlers/PreviewSnapshotHandler.swift
+++ b/previewsmcp/PreviewsCLI/Handlers/PreviewSnapshotHandler.swift
@@ -40,12 +40,11 @@ enum PreviewSnapshotHandler: ToolHandler {
         // "mcp: callTool preview_snapshot" and then a stalled call produces
         // no response and no further output — the last marker present in
         // serve.log names the hop that never returned.
-        Log.info("snap: enter session=\(sessionID.prefix(8))")
         let configQuality = await configQualityForSession(sessionID, ctx: ctx)
         let quality = max(0.0, min(1.0, extractOptionalDouble("quality", from: params) ?? configQuality ?? 0.85))
         let mimeType = quality >= 1.0 ? "image/png" : "image/jpeg"
 
-        Log.info("snap: routing")
+        Log.info("snap: routing session=\(sessionID.prefix(8))")
         guard let handle = await ctx.router.handle(for: sessionID) else {
             return CallTool.Result(
                 content: [.text("No session found for \(sessionID).")],

--- a/previewsmcp/PreviewsCLI/Handlers/PreviewSnapshotHandler.swift
+++ b/previewsmcp/PreviewsCLI/Handlers/PreviewSnapshotHandler.swift
@@ -36,15 +36,10 @@ enum PreviewSnapshotHandler: ToolHandler {
             return CallTool.Result(content: [.text(error.localizedDescription)], isError: true)
         }
 
-        // Hop-level markers for the #320 callTool-stall face: the SDK logs
-        // "mcp: callTool preview_snapshot" and then a stalled call produces
-        // no response and no further output — the last marker present in
-        // serve.log names the hop that never returned.
         let configQuality = await configQualityForSession(sessionID, ctx: ctx)
         let quality = max(0.0, min(1.0, extractOptionalDouble("quality", from: params) ?? configQuality ?? 0.85))
         let mimeType = quality >= 1.0 ? "image/png" : "image/jpeg"
 
-        Log.info("snap: routing session=\(sessionID.prefix(8))")
         guard let handle = await ctx.router.handle(for: sessionID) else {
             return CallTool.Result(
                 content: [.text("No session found for \(sessionID).")],
@@ -52,7 +47,6 @@ enum PreviewSnapshotHandler: ToolHandler {
             )
         }
 
-        Log.info("snap: capturing")
         let imageData = try await handle.snapshot(quality: quality)
         Log.info("snap: captured \(imageData.count) bytes")
         let base64 = imageData.base64EncodedString()

--- a/previewsmcp/PreviewsCLI/Handlers/PreviewSnapshotHandler.swift
+++ b/previewsmcp/PreviewsCLI/Handlers/PreviewSnapshotHandler.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MCP
+import PreviewsCore
 
 enum PreviewSnapshotHandler: ToolHandler {
     static let name: ToolName = .previewSnapshot
@@ -35,10 +36,16 @@ enum PreviewSnapshotHandler: ToolHandler {
             return CallTool.Result(content: [.text(error.localizedDescription)], isError: true)
         }
 
+        // Hop-level markers for the #320 callTool-stall face: the SDK logs
+        // "mcp: callTool preview_snapshot" and then a stalled call produces
+        // no response and no further output — the last marker present in
+        // serve.log names the hop that never returned.
+        Log.info("snap: enter session=\(sessionID.prefix(8))")
         let configQuality = await configQualityForSession(sessionID, ctx: ctx)
         let quality = max(0.0, min(1.0, extractOptionalDouble("quality", from: params) ?? configQuality ?? 0.85))
         let mimeType = quality >= 1.0 ? "image/png" : "image/jpeg"
 
+        Log.info("snap: routing")
         guard let handle = await ctx.router.handle(for: sessionID) else {
             return CallTool.Result(
                 content: [.text("No session found for \(sessionID).")],
@@ -46,7 +53,9 @@ enum PreviewSnapshotHandler: ToolHandler {
             )
         }
 
+        Log.info("snap: capturing")
         let imageData = try await handle.snapshot(quality: quality)
+        Log.info("snap: captured \(imageData.count) bytes")
         let base64 = imageData.base64EncodedString()
 
         return CallTool.Result(content: [

--- a/previewsmcp/PreviewsCLI/Handlers/PreviewVariantsHandler.swift
+++ b/previewsmcp/PreviewsCLI/Handlers/PreviewVariantsHandler.swift
@@ -92,16 +92,24 @@ enum PreviewVariantsHandler: ToolHandler {
 
         for (index, variant) in resolved.enumerated() {
             do {
+                // Same hop markers as PreviewSnapshotHandler (#320): the last
+                // marker in serve.log names the hop a stalled call died in.
+                Log.info("variants: [\(index)] report(compiling)")
                 await progress.report(
                     .compilingBridge, message: "Recompiling for variant \"\(variant.label)\"..."
                 )
+                Log.info("variants: [\(index)] setTraits")
                 try await handle.setTraits(variant.traits)
+                Log.info("variants: [\(index)] settle")
                 await handle.awaitLayoutSettle()
+                Log.info("variants: [\(index)] report(capturing)")
                 await progress.report(
                     .capturingSnapshot,
                     message: "Capturing variant \(index + 1)/\(resolved.count) \"\(variant.label)\"..."
                 )
+                Log.info("variants: [\(index)] snapshot")
                 let imageData = try await handle.snapshot(quality: quality)
+                Log.info("variants: [\(index)] captured \(imageData.count) bytes")
                 let base64 = imageData.base64EncodedString()
                 contentBlocks.append(.text("[\(index)] \(variant.label):"))
                 contentBlocks.append(.image(data: base64, mimeType: mimeType, metadata: nil))

--- a/previewsmcp/PreviewsCLI/Handlers/PreviewVariantsHandler.swift
+++ b/previewsmcp/PreviewsCLI/Handlers/PreviewVariantsHandler.swift
@@ -92,22 +92,15 @@ enum PreviewVariantsHandler: ToolHandler {
 
         for (index, variant) in resolved.enumerated() {
             do {
-                // Same hop markers as PreviewSnapshotHandler (#320): the last
-                // marker in serve.log names the hop a stalled call died in.
-                Log.info("variants: [\(index)] report(compiling)")
                 await progress.report(
                     .compilingBridge, message: "Recompiling for variant \"\(variant.label)\"..."
                 )
-                Log.info("variants: [\(index)] setTraits")
                 try await handle.setTraits(variant.traits)
-                Log.info("variants: [\(index)] settle")
                 await handle.awaitLayoutSettle()
-                Log.info("variants: [\(index)] report(capturing)")
                 await progress.report(
                     .capturingSnapshot,
                     message: "Capturing variant \(index + 1)/\(resolved.count) \"\(variant.label)\"..."
                 )
-                Log.info("variants: [\(index)] snapshot")
                 let imageData = try await handle.snapshot(quality: quality)
                 Log.info("variants: [\(index)] captured \(imageData.count) bytes")
                 let base64 = imageData.base64EncodedString()

--- a/previewsmcp/PreviewsCLI/SerializedStdioTransport.swift
+++ b/previewsmcp/PreviewsCLI/SerializedStdioTransport.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Logging
-import PreviewsCore
 import MCP
 import System
 
@@ -14,137 +13,88 @@ import System
 /// heartbeat notification, a progress notification) spliced into its bytes,
 /// corrupting the newline framing; the client drops what it can't decode and
 /// the caller times out with no error on either side (#320's callTool-stall
-/// face). This transport chains each `send` behind the previous one, so a
-/// message's bytes always land contiguously. Everything else mirrors the
-/// SDK transport (MIT, github.com/modelcontextprotocol/swift-sdk); drop this
-/// once upstream serializes its writes.
+/// face). This wrapper chains each `send` behind the previous one, so the
+/// inner transport never runs two sends concurrently and every frame lands
+/// contiguously. Drop once upstream serializes its writes.
 actor SerializedStdioTransport: Transport {
     nonisolated let logger: Logger
 
-    private let input: FileDescriptor
-    private let output: FileDescriptor
-    private var isConnected = false
+    private let inner: StdioTransport
     private let messageStream: AsyncThrowingStream<Data, Swift.Error>
     private let messageContinuation: AsyncThrowingStream<Data, Swift.Error>.Continuation
     private var sendChain: Task<Void, Swift.Error>?
+    private var pendingSends: Set<Task<Void, Swift.Error>> = []
+    private var pump: Task<Void, Never>?
 
     init(
         input: FileDescriptor = FileDescriptor.standardInput,
         output: FileDescriptor = FileDescriptor.standardOutput
     ) {
-        self.input = input
-        self.output = output
-        // No-op handler, as in the SDK original: the SDK Server logs through
-        // the transport's logger, and swift-log's default factory writes to
-        // STDOUT — plain text spliced into the JSON-RPC stream on any SDK
-        // error path, the exact corruption class this transport exists to
-        // prevent.
+        inner = StdioTransport(input: input, output: output)
         logger = Logger(
             label: "previewsmcp.serialized-stdio-transport",
             factory: { _ in SwiftLogNoOpLogHandler() }
         )
-
         var continuation: AsyncThrowingStream<Data, Swift.Error>.Continuation!
         messageStream = AsyncThrowingStream { continuation = $0 }
         messageContinuation = continuation
     }
 
     func connect() async throws {
-        guard !isConnected else { return }
-        try setNonBlocking(fileDescriptor: input)
-        try setNonBlocking(fileDescriptor: output)
-        isConnected = true
-        Task {
-            await readLoop()
-        }
-    }
-
-    private func setNonBlocking(fileDescriptor: FileDescriptor) throws {
-        let flags = fcntl(fileDescriptor.rawValue, F_GETFL)
-        guard flags >= 0 else {
-            throw MCPError.transportError(Errno(rawValue: CInt(errno)))
-        }
-        let result = fcntl(fileDescriptor.rawValue, F_SETFL, flags | O_NONBLOCK)
-        guard result >= 0 else {
-            throw MCPError.transportError(Errno(rawValue: CInt(errno)))
-        }
-    }
-
-    private func readLoop() async {
-        let bufferSize = 4096
-        var buffer = [UInt8](repeating: 0, count: bufferSize)
-        var pendingData = Data()
-
-        while isConnected, !Task.isCancelled {
+        try await inner.connect()
+        // `Transport.receive()` is a synchronous requirement, so this actor
+        // cannot forward it to the inner actor on demand — pump the inner
+        // stream into our own instead.
+        pump = Task { [inner, messageContinuation] in
             do {
-                let bytesRead = try buffer.withUnsafeMutableBufferPointer { pointer in
-                    try input.read(into: UnsafeMutableRawBufferPointer(pointer))
+                for try await message in await inner.receive() {
+                    messageContinuation.yield(message)
                 }
-                if bytesRead == 0 {
-                    break
-                }
-                pendingData.append(Data(buffer[..<bytesRead]))
-                while let newlineIndex = pendingData.firstIndex(of: UInt8(ascii: "\n")) {
-                    let messageData = pendingData[..<newlineIndex]
-                    pendingData = pendingData[(newlineIndex + 1)...]
-                    if !messageData.isEmpty {
-                        messageContinuation.yield(Data(messageData))
-                    }
-                }
-            } catch let error where MCPError.isResourceTemporarilyUnavailable(error) {
-                try? await Task.sleep(for: .milliseconds(10))
-                continue
+                messageContinuation.finish()
             } catch {
-                if !Task.isCancelled {
-                    Log.warn("stdio transport read error: \(error)")
-                }
-                break
+                messageContinuation.finish(throwing: error)
             }
         }
-        messageContinuation.finish()
     }
 
     func disconnect() async {
-        guard isConnected else { return }
-        isConnected = false
+        // Cancel every queued/in-flight send, not just the chain tail: a
+        // client that stops draining stdout leaves the head send retrying
+        // EAGAIN forever, and each 2s heartbeat queued behind it retains its
+        // full message. Cancellation surfaces inside the inner transport's
+        // EAGAIN retry via its throwing Task.sleep.
+        for task in pendingSends {
+            task.cancel()
+        }
+        pendingSends.removeAll()
+        sendChain = nil
+        pump?.cancel()
+        await inner.disconnect()
         messageContinuation.finish()
     }
 
     func send(_ message: Data) async throws {
-        guard isConnected else {
-            throw MCPError.transportError(Errno(rawValue: ENOTCONN))
-        }
-
-        // Chain behind the previous send. Actor isolation alone cannot
-        // provide this: the EAGAIN retry below suspends, and a re-entrant
-        // send would otherwise interleave its bytes there. A failed
-        // predecessor doesn't fail this message — each send stands alone
-        // once it holds the head of the chain.
+        // Chain behind the previous send; actor isolation alone cannot
+        // prevent interleaving because the inner send suspends mid-write.
+        // There is no suspension between reading and updating `sendChain`,
+        // so re-entrant callers each chain behind the true predecessor. A
+        // failed or cancelled predecessor doesn't fail this message.
         let previous = sendChain
-        let task = Task { [output] in
+        let task = Task { [inner] in
             _ = try? await previous?.value
-            var messageWithNewline = message
-            messageWithNewline.append(UInt8(ascii: "\n"))
-            var remaining = messageWithNewline
-
-            while !remaining.isEmpty {
-                do {
-                    let written = try remaining.withUnsafeBytes { buffer in
-                        try output.write(UnsafeRawBufferPointer(buffer))
-                    }
-                    if written > 0 {
-                        remaining = remaining.dropFirst(written)
-                    }
-                } catch let error where MCPError.isResourceTemporarilyUnavailable(error) {
-                    try await Task.sleep(for: .milliseconds(10))
-                    continue
-                } catch {
-                    throw MCPError.transportError(error)
-                }
-            }
+            try Task.checkCancellation()
+            try await inner.send(message)
         }
         sendChain = task
-        try await task.value
+        pendingSends.insert(task)
+        defer { pendingSends.remove(task) }
+        // Forward the caller's cancellation to the chained task so a
+        // cancelled caller doesn't leave its write retrying forever.
+        return try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
     }
 
     func receive() -> AsyncThrowingStream<Data, Swift.Error> {

--- a/previewsmcp/PreviewsCLI/SerializedStdioTransport.swift
+++ b/previewsmcp/PreviewsCLI/SerializedStdioTransport.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Logging
+import PreviewsCore
+import MCP
+import System
+
+/// A stdio JSON-RPC transport whose `send`s cannot interleave.
+///
+/// The SDK's `StdioTransport` (v0.7.x) is an actor, but its `send` retries
+/// `EAGAIN` on the non-blocking pipe with `await Task.sleep` — and actor
+/// re-entrancy admits a second `send` at that suspension point. Any response
+/// larger than the pipe buffer (every base64 snapshot/variants payload) that
+/// backs up mid-write can therefore have another message (the daemon's 2s
+/// heartbeat notification, a progress notification) spliced into its bytes,
+/// corrupting the newline framing; the client drops what it can't decode and
+/// the caller times out with no error on either side (#320's callTool-stall
+/// face). This transport chains each `send` behind the previous one, so a
+/// message's bytes always land contiguously. Everything else mirrors the
+/// SDK transport (MIT, github.com/modelcontextprotocol/swift-sdk); drop this
+/// once upstream serializes its writes.
+actor SerializedStdioTransport: Transport {
+    nonisolated let logger: Logger
+
+    private let input: FileDescriptor
+    private let output: FileDescriptor
+    private var isConnected = false
+    private let messageStream: AsyncThrowingStream<Data, Swift.Error>
+    private let messageContinuation: AsyncThrowingStream<Data, Swift.Error>.Continuation
+    private var sendChain: Task<Void, Swift.Error>?
+
+    init(
+        input: FileDescriptor = FileDescriptor.standardInput,
+        output: FileDescriptor = FileDescriptor.standardOutput
+    ) {
+        self.input = input
+        self.output = output
+        logger = Logger(label: "previewsmcp.serialized-stdio-transport")
+
+        var continuation: AsyncThrowingStream<Data, Swift.Error>.Continuation!
+        messageStream = AsyncThrowingStream { continuation = $0 }
+        messageContinuation = continuation
+    }
+
+    func connect() async throws {
+        guard !isConnected else { return }
+        try setNonBlocking(fileDescriptor: input)
+        try setNonBlocking(fileDescriptor: output)
+        isConnected = true
+        Task {
+            await readLoop()
+        }
+    }
+
+    private func setNonBlocking(fileDescriptor: FileDescriptor) throws {
+        let flags = fcntl(fileDescriptor.rawValue, F_GETFL)
+        guard flags >= 0 else {
+            throw MCPError.transportError(Errno(rawValue: CInt(errno)))
+        }
+        let result = fcntl(fileDescriptor.rawValue, F_SETFL, flags | O_NONBLOCK)
+        guard result >= 0 else {
+            throw MCPError.transportError(Errno(rawValue: CInt(errno)))
+        }
+    }
+
+    private func readLoop() async {
+        let bufferSize = 4096
+        var buffer = [UInt8](repeating: 0, count: bufferSize)
+        var pendingData = Data()
+
+        while isConnected, !Task.isCancelled {
+            do {
+                let bytesRead = try buffer.withUnsafeMutableBufferPointer { pointer in
+                    try input.read(into: UnsafeMutableRawBufferPointer(pointer))
+                }
+                if bytesRead == 0 {
+                    break
+                }
+                pendingData.append(Data(buffer[..<bytesRead]))
+                while let newlineIndex = pendingData.firstIndex(of: UInt8(ascii: "\n")) {
+                    let messageData = pendingData[..<newlineIndex]
+                    pendingData = pendingData[(newlineIndex + 1)...]
+                    if !messageData.isEmpty {
+                        messageContinuation.yield(Data(messageData))
+                    }
+                }
+            } catch let error where MCPError.isResourceTemporarilyUnavailable(error) {
+                try? await Task.sleep(for: .milliseconds(10))
+                continue
+            } catch {
+                if !Task.isCancelled {
+                    Log.warn("stdio transport read error: \(error)")
+                }
+                break
+            }
+        }
+        messageContinuation.finish()
+    }
+
+    func disconnect() async {
+        guard isConnected else { return }
+        isConnected = false
+        messageContinuation.finish()
+    }
+
+    func send(_ message: Data) async throws {
+        guard isConnected else {
+            throw MCPError.transportError(Errno(rawValue: ENOTCONN))
+        }
+
+        // Chain behind the previous send. Actor isolation alone cannot
+        // provide this: the EAGAIN retry below suspends, and a re-entrant
+        // send would otherwise interleave its bytes there. A failed
+        // predecessor doesn't fail this message — each send stands alone
+        // once it holds the head of the chain.
+        let previous = sendChain
+        let task = Task { [output] in
+            _ = try? await previous?.value
+            var messageWithNewline = message
+            messageWithNewline.append(UInt8(ascii: "\n"))
+            var remaining = messageWithNewline
+
+            while !remaining.isEmpty {
+                do {
+                    let written = try remaining.withUnsafeBytes { buffer in
+                        try output.write(UnsafeRawBufferPointer(buffer))
+                    }
+                    if written > 0 {
+                        remaining = remaining.dropFirst(written)
+                    }
+                } catch let error where MCPError.isResourceTemporarilyUnavailable(error) {
+                    try await Task.sleep(for: .milliseconds(10))
+                    continue
+                } catch {
+                    throw MCPError.transportError(error)
+                }
+            }
+        }
+        sendChain = task
+        try await task.value
+    }
+
+    func receive() -> AsyncThrowingStream<Data, Swift.Error> {
+        messageStream
+    }
+}

--- a/previewsmcp/PreviewsCLI/SerializedStdioTransport.swift
+++ b/previewsmcp/PreviewsCLI/SerializedStdioTransport.swift
@@ -34,7 +34,15 @@ actor SerializedStdioTransport: Transport {
     ) {
         self.input = input
         self.output = output
-        logger = Logger(label: "previewsmcp.serialized-stdio-transport")
+        // No-op handler, as in the SDK original: the SDK Server logs through
+        // the transport's logger, and swift-log's default factory writes to
+        // STDOUT — plain text spliced into the JSON-RPC stream on any SDK
+        // error path, the exact corruption class this transport exists to
+        // prevent.
+        logger = Logger(
+            label: "previewsmcp.serialized-stdio-transport",
+            factory: { _ in SwiftLogNoOpLogHandler() }
+        )
 
         var continuation: AsyncThrowingStream<Data, Swift.Error>.Continuation!
         messageStream = AsyncThrowingStream { continuation = $0 }

--- a/previewsmcp/PreviewsCLI/ServeCommand.swift
+++ b/previewsmcp/PreviewsCLI/ServeCommand.swift
@@ -75,7 +75,10 @@ struct ServeCommand: ParsableCommand {
                 Log.info(
                     "MCP server starting on stdio (pid \(ProcessInfo.processInfo.processIdentifier), started \(startISO))..."
                 )
-                let transport = StdioTransport()
+                // SerializedStdioTransport, not the SDK's StdioTransport: a
+                // big response racing a heartbeat/progress notification on the
+                // SDK transport can interleave bytes mid-message (#320).
+                let transport = SerializedStdioTransport()
                 try await runMCPServer(server, transport: transport)
             } catch {
                 Log.error("MCP server error: \(error)")

--- a/previewsmcp/PreviewsEngine/MacOSPreviewHandle.swift
+++ b/previewsmcp/PreviewsEngine/MacOSPreviewHandle.swift
@@ -66,11 +66,7 @@ public actor MacOSPreviewHandle: PreviewSessionHandle {
     public func snapshot(quality: Double) async throws -> Data {
         let format: Snapshot.ImageFormat = quality >= 1.0 ? .png : .jpeg(quality: quality)
         let sessionID = id
-        // #320 hop markers: a stalled snapshot's last marker names the actor
-        // it is queued behind (the PreviewSession actor vs the main actor).
-        Log.info("macSnap: currentTraits")
         let colorScheme = await session.currentTraits.colorScheme
-        Log.info("macSnap: main-actor encode")
         return try await MainActor.run {
             guard let imagePath = host.agentSnapshotPath(for: sessionID) else {
                 throw SnapshotError.captureFailed

--- a/previewsmcp/PreviewsEngine/MacOSPreviewHandle.swift
+++ b/previewsmcp/PreviewsEngine/MacOSPreviewHandle.swift
@@ -66,7 +66,11 @@ public actor MacOSPreviewHandle: PreviewSessionHandle {
     public func snapshot(quality: Double) async throws -> Data {
         let format: Snapshot.ImageFormat = quality >= 1.0 ? .png : .jpeg(quality: quality)
         let sessionID = id
+        // #320 hop markers: a stalled snapshot's last marker names the actor
+        // it is queued behind (the PreviewSession actor vs the main actor).
+        Log.info("macSnap: currentTraits")
         let colorScheme = await session.currentTraits.colorScheme
+        Log.info("macSnap: main-actor encode")
         return try await MainActor.run {
             guard let imagePath = host.agentSnapshotPath(for: sessionID) else {
                 throw SnapshotError.captureFailed

--- a/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
+++ b/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
@@ -743,6 +743,9 @@ public actor IOSPreviewSession {
     /// (its cold port enumeration races display attach under load). Falls back
     /// to the one-shot capture when no streamer surface is wired yet.
     public func screenshot(jpegQuality: Double = 0.85) async throws -> Data {
+        // #320 hop marker: this line printing proves the call reached the
+        // session actor (i.e. was not queued behind another actor method).
+        Log.info("iosSnap: enter")
         if let source = appFrameSource {
             // Default-quality snapshots read the streamer's last cached frame
             // directly. The event-driven stream already encoded it, so it is
@@ -757,6 +760,7 @@ public actor IOSPreviewSession {
             // Ride over brief surface gaps (e.g. the agent respawn the OS forces
             // periodically) before conceding to the load-racing one-shot path.
             for attempt in 0 ..< 3 {
+                Log.info("iosSnap: cache miss — captureFresh attempt \(attempt + 1)/3")
                 if let frame = await source.captureFresh(jpegQuality: jpegQuality) {
                     return frame
                 }
@@ -765,6 +769,7 @@ public actor IOSPreviewSession {
                 }
             }
         }
+        Log.info("iosSnap: falling back to one-shot capture")
         return try await simulatorManager.screenshotData(udid: deviceUDID, jpegQuality: jpegQuality)
     }
 

--- a/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
+++ b/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
@@ -743,9 +743,6 @@ public actor IOSPreviewSession {
     /// (its cold port enumeration races display attach under load). Falls back
     /// to the one-shot capture when no streamer surface is wired yet.
     public func screenshot(jpegQuality: Double = 0.85) async throws -> Data {
-        // #320 hop marker: this line printing proves the call reached the
-        // session actor (i.e. was not queued behind another actor method).
-        Log.info("iosSnap: enter")
         if let source = appFrameSource {
             // Default-quality snapshots read the streamer's last cached frame
             // directly. The event-driven stream already encoded it, so it is

--- a/previewsmcp/PreviewsIOS/PreviewAppServer.swift
+++ b/previewsmcp/PreviewsIOS/PreviewAppServer.swift
@@ -93,15 +93,12 @@ public final class PreviewAppServer: @unchecked Sendable {
             guard let self else { return }
             switch state {
             case .cancelled, .failed:
-                // A dropped STREAM connection is the #320 flake trigger, so it
-                // must be visible in serve.log; one-shot request closes are
-                // routine and stay quiet.
-                if case let .failed(error) = state {
-                    Log.warn("appserver: connection \(Self.shortID(connection)) failed: \(error)")
-                }
                 queue.async {
                     let key = ObjectIdentifier(connection)
                     if let task = self.streamTasks[key] {
+                        // A dropped STREAM connection is the #320 flake
+                        // trigger, so it must be visible in serve.log;
+                        // one-shot request closes are routine and stay quiet.
                         Log.warn(
                             "appserver: stream connection \(Self.shortID(connection)) reached \(state) — cancelling its stream task"
                         )

--- a/previewsmcp/PreviewsIOS/PreviewAppServer.swift
+++ b/previewsmcp/PreviewsIOS/PreviewAppServer.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Network
+import PreviewsCore
 
 /// Per-session app interface bound to loopback. This is the surface the streamed
 /// MCP app (and a browser) connect to, separate from the agent MCP tools and the
@@ -72,6 +73,9 @@ public final class PreviewAppServer: @unchecked Sendable {
 
     public func stop() {
         queue.sync {
+            if !streamTasks.isEmpty {
+                Log.info("appserver: stop() cancelling \(streamTasks.count) live stream task(s)")
+            }
             streamTasks.values.forEach { $0.cancel() }
             streamTasks.removeAll()
             connections.forEach { $0.cancel() }
@@ -89,9 +93,20 @@ public final class PreviewAppServer: @unchecked Sendable {
             guard let self else { return }
             switch state {
             case .cancelled, .failed:
+                // A dropped STREAM connection is the #320 flake trigger, so it
+                // must be visible in serve.log; one-shot request closes are
+                // routine and stay quiet.
+                if case let .failed(error) = state {
+                    Log.warn("appserver: connection \(Self.shortID(connection)) failed: \(error)")
+                }
                 queue.async {
                     let key = ObjectIdentifier(connection)
-                    self.streamTasks[key]?.cancel()
+                    if let task = self.streamTasks[key] {
+                        Log.warn(
+                            "appserver: stream connection \(Self.shortID(connection)) reached \(state) — cancelling its stream task"
+                        )
+                        task.cancel()
+                    }
                     self.streamTasks[key] = nil
                     self.connections.removeAll { $0 === connection }
                 }
@@ -101,6 +116,10 @@ public final class PreviewAppServer: @unchecked Sendable {
         }
         connection.start(queue: queue)
         receive(connection, buffer: Data())
+    }
+
+    private static func shortID(_ connection: NWConnection) -> String {
+        String(UInt(bitPattern: ObjectIdentifier(connection).hashValue) & 0xFFFF, radix: 16)
     }
 
     private func receive(_ connection: NWConnection, buffer: Data) {
@@ -214,12 +233,14 @@ public final class PreviewAppServer: @unchecked Sendable {
 
     private func stream(_ connection: NWConnection, source: any FrameSource) {
         let intervalMS = streamIntervalMS
+        let cid = Self.shortID(connection)
         let task = Task { [weak self] in
             guard let self else { return }
             let head =
                 "HTTP/1.1 200 OK\r\n"
                     + "Content-Type: multipart/x-mixed-replace; boundary=frame\r\n"
                     + "Cache-Control: no-cache\r\nConnection: close\r\n\r\n"
+            var frames = 0
             do {
                 try await send(connection, Data(head.utf8))
                 while true {
@@ -234,13 +255,27 @@ public final class PreviewAppServer: @unchecked Sendable {
                     part.append(jpeg)
                     part.append(contentsOf: [0x0D, 0x0A])
                     try await send(connection, part)
+                    frames += 1
+                    if frames == 1 {
+                        Log.info("appserver: mjpeg \(cid) first frame sent (\(jpeg.count) bytes)")
+                    }
                     try await Task.sleep(for: .milliseconds(intervalMS))
                 }
             } catch {
+                // The visible face of the #320 flake: whatever lands here kills
+                // the stream a client may still be awaiting.
+                Log.warn(
+                    "appserver: mjpeg \(cid) stream ended after \(frames) frame(s) — \(Self.describe(error))"
+                )
                 connection.cancel()
             }
         }
         queue.async { self.streamTasks[ObjectIdentifier(connection)] = task }
+    }
+
+    private static func describe(_ error: Error) -> String {
+        if error is CancellationError { return "cancelled (task)" }
+        return String(describing: error)
     }
 
     // MARK: - H.264 (avcC) stream
@@ -269,6 +304,9 @@ public final class PreviewAppServer: @unchecked Sendable {
                     try await Task.sleep(for: .seconds(30))
                 }
             } catch {
+                Log.warn(
+                    "appserver: avcc \(Self.shortID(connection)) stream ended — \(Self.describe(error))"
+                )
                 video.removeSubscriber(id)
                 connection.cancel()
             }

--- a/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
@@ -119,10 +119,22 @@ struct IOSAppServerTests {
 /// Read a bounded sample of an MJPEG stream, asserting the multipart content
 /// type. URLSession unwraps multipart/x-mixed-replace and delivers the JPEG
 /// part bodies without the boundary.
+///
+/// Uses a fresh single-use session, NOT `URLSession.shared`: these helpers
+/// abandon their response mid-body (the server is still streaming when the
+/// sample completes), and a shared session's connection pool can hand the
+/// dying connection to the next request against the same host:port — caught
+/// live as `NSURLErrorDomain Code=-1` on the follow-up `/stream.avcc` request
+/// ~50ms after a successful mjpeg sample (#320: daemon log showed the stream
+/// healthy, first frame sent, no server-side error). A fresh session has an
+/// empty pool, so nothing poisoned can be reused; `invalidateAndCancel()`
+/// tears the abandoned connection down with the session.
 private func readStreamSample(port: Int, limit: Int) async throws -> Data {
+    let session = URLSession(configuration: .ephemeral)
+    defer { session.invalidateAndCancel() }
     var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/stream.mjpeg")!)
     request.timeoutInterval = 15
-    let (bytes, response) = try await URLSession.shared.bytes(for: request)
+    let (bytes, response) = try await session.bytes(for: request)
     let contentType = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Type") ?? ""
     #expect(contentType.contains("multipart/x-mixed-replace"), "stream should be MJPEG multipart")
 
@@ -141,13 +153,17 @@ private func readStreamSample(port: Int, limit: Int) async throws -> Data {
 /// tags seen. `onConnected` runs once the first byte arrives (the subscriber is
 /// registered by then) to drive a screen change so an IDR is produced. Returns
 /// when every tag in `need` has been seen or `timeout` elapses.
+///
+/// Fresh single-use session for the same reason as `readStreamSample`.
 private func readAVCCTags(
     port: Int, need: Set<UInt8>, timeout: Duration,
     onConnected: @escaping @Sendable () async -> Void
 ) async throws -> Set<UInt8> {
+    let session = URLSession(configuration: .ephemeral)
+    defer { session.invalidateAndCancel() }
     var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/stream.avcc")!)
     request.timeoutInterval = 25
-    let (bytes, response) = try await URLSession.shared.bytes(for: request)
+    let (bytes, response) = try await session.bytes(for: request)
     let contentType = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Type") ?? ""
     #expect(contentType.contains("application/octet-stream"), "avcc stream should be octet-stream")
 

--- a/previewsmcp/Tests/PreviewsCLITests/SerializedStdioTransportTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SerializedStdioTransportTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import os
+@testable import PreviewsCLI
+import Testing
+
+/// Framing safety under the exact conditions that corrupt the SDK transport
+/// (#320): a message larger than the pipe buffer backs up mid-write (EAGAIN
+/// suspension) while another `send` arrives. The SDK's actor-isolated `send`
+/// is re-entrant at that suspension, splicing the second message into the
+/// first's bytes; `SerializedStdioTransport` chains sends so every
+/// newline-delimited frame arrives contiguous and decodable.
+@Suite("SerializedStdioTransport framing")
+struct SerializedStdioTransportTests {
+    @Test("concurrent sends under pipe backpressure never interleave frames")
+    func concurrentSendsPreserveFraming() async throws {
+        let inPipe = Pipe()
+        let outPipe = Pipe()
+        let transport = SerializedStdioTransport(
+            input: .init(rawValue: inPipe.fileHandleForReading.fileDescriptor),
+            output: .init(rawValue: outPipe.fileHandleForWriting.fileDescriptor)
+        )
+        try await transport.connect()
+
+        let big = Data(#"{"big":"\#(String(repeating: "a", count: 300_000))"}"#.utf8)
+        let small = Data(#"{"small":1}"#.utf8)
+        let expectedBytes = big.count + small.count + 2
+
+        // Collect the transport's output on a raw thread: the reader must not
+        // drain the pipe while the big send is still queuing, or the write
+        // never backs up into the EAGAIN suspension this test exists to
+        // exercise — so it waits before its first read.
+        let collected = OSAllocatedUnfairLock(initialState: Data())
+        let readFD = outPipe.fileHandleForReading
+        Thread.detachNewThread {
+            Thread.sleep(forTimeInterval: 0.4)
+            while true {
+                let chunk = readFD.availableData
+                if chunk.isEmpty { break }
+                let total = collected.withLock { data -> Int in
+                    data.append(chunk)
+                    return data.count
+                }
+                if total >= expectedBytes { break }
+            }
+        }
+
+        // Start the big send; give it time to fill the pipe and suspend in
+        // the EAGAIN retry, then race the small send into that window.
+        let bigSend = Task { try await transport.send(big) }
+        try await Task.sleep(for: .milliseconds(150))
+        let smallSend = Task { try await transport.send(small) }
+        try await bigSend.value
+        try await smallSend.value
+
+        // Both sends returned, so all bytes are in the pipe; poll the reader's
+        // buffer up to a deadline rather than blocking the cooperative pool.
+        let deadline = ContinuousClock.now + .seconds(10)
+        while collected.withLock({ $0.count }) < expectedBytes, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(50))
+        }
+
+        let lines = collected.withLock { $0 }.split(separator: UInt8(ascii: "\n"))
+        #expect(lines.count == 2, "expected exactly 2 frames, got \(lines.count)")
+        for line in lines {
+            #expect(
+                (try? JSONSerialization.jsonObject(with: Data(line))) != nil,
+                "frame is not valid JSON — sends interleaved (first 80 bytes: \(String(decoding: line.prefix(80), as: UTF8.self)))"
+            )
+        }
+        await transport.disconnect()
+    }
+}


### PR DESCRIPTION
## The callTool-stall face, root-caused and fixed

The dominant residual of the iOS e2e flake (#320) was `callTool(preview_snapshot)`/`callTool(preview_variants)` timing out with the daemon otherwise completely healthy. The investigation arc, each step from ground truth:

1. **Hop markers exonerated the handlers**: instrumented every await hop (handler → router → session actor → capture); stalled runs showed complete sub-millisecond marker trails for every call that arrived — the stalled call's response never reached the client (or the next request never arrived), pointing at the transport.
2. **The SDK's `StdioTransport.send()` is actor-reentrant at its EAGAIN suspension**: any response larger than the pipe buffer (every base64 snapshot/variants payload) that backs up mid-write suspends in the EAGAIN retry's `Task.sleep` — and a concurrent send (the daemon's 2s heartbeat notification, a progress notification) splices its bytes into the middle of the frame. The client silently drops what it can't decode; the caller times out; no error surfaces anywhere.
3. **Deterministic proof**: the new `SerializedStdioTransportTests` framing test drives the exact regime (300KB send under pipe backpressure raced by a small send). Pointed at the SDK transport, it reproduces the corruption in <1s; pointed at the fix, frames stay intact.
4. **`SerializedStdioTransport`** wraps the SDK transport and chains each send behind the previous one, so the inner transport never runs two sends concurrently. Sends are cancellable end-to-end (`pendingSends` + `disconnect()` cancellation + caller-cancellation forwarding), and `connect()` pumps the inner receive stream to satisfy the protocol's synchronous `receive()`.

Also included:
- **Single-use `URLSession(.ephemeral)` for the app-server stream reads** (test-side): `URLSession.shared`'s pool could hand a connection abandoned mid-body to the next request against the same host:port — caught live (stream healthy server-side, `NSURLError-1` client-side 50ms later).
- **PreviewAppServer stream-lifecycle logging** on the previously-silent teardown paths.

## Verification

Isolated `MCPIntegrationTests` campaign rates (6 runs each, hygiene between runs, caffeinated):
- pre-fixes: 4/6 failed (mixed faces)
- after pool fix only: 5/6 failed — all callTool-stalls
- after hop markers (diagnosis run): 2/6 failed
- **after the transport fix: 1/6 failed, ZERO callTool-stalls**
- full local suite: **9/9 first-try** (historically needed retries)

## Remains open (#320, rescoped)
A low-rate `NSURLError-1` residual (~1 in 9 isolated runs, confined to `appServerEndToEnd`, fails fast) that occurs even with per-request sessions — needs client-side attribution logging next.

Upstream issue for the SDK bug to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPF6gjyr2BBuz31yRSnMvG