### PR TITLE
Pin the MCP swift-sdk to exact 0.11.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.1"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
-        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.7.1"),
+        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", exact: "0.11.0"),
     ],
     targets: [
         .target(name: "PreviewsSetupKit"),


### PR DESCRIPTION
## Why

`from: "0.7.1"` already resolves to 0.11.0 (Package.resolved revision `6112a39`). The manifest now says so exactly, so no future re-resolution can silently float the dependency while the `SerializedStdioTransport` workaround (#320/#321) and the wire-layer rewrite depend on its exact behavior. Requested by mergequeue-lead as immediate hardening regardless of the rewrite timeline.

## What

One line: `from: "0.7.1"` → `exact: "0.11.0"` in Package.swift. Package.resolved intentionally untouched (`swift package resolve` and `swift build` verified as no-ops on it).

## Known trade-off (accepted)

`exact:` in the published manifest would make downstream resolution unsolvable if a published target ever links an MCP product. Today none does, and SwiftPM prunes the unused dependency for PreviewsSetupKit consumers (SE-0226). If PreviewsSetupKit ever gains an MCP dependency, revisit this pin.

## Verification

- `swift package resolve` and `swift build`: no-ops on Package.resolved
- `bazel build //previewsmcp/cli:previewsmcp`: green, fully cached (resolved revision unchanged)
- /simplify: 4 angles, clean (one efficiency claim about originHash regeneration empirically refuted on this toolchain)
- /code-review (high): one PLAUSIBLE finding = the accepted trade-off above
- Full suite `bazel test //previewsmcp/Tests/... --nocache_test_results`: 9/9 green first try

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPF6gjyr2BBuz31yRSnMvG