### PR TITLE
Disable the SDK transport-level heartbeat on the daemon channel

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -54,3 +54,11 @@ cyclomatic_complexity:
 nesting:
   type_level: 2
   function_level: 3
+
+custom_rules:
+  daemon_channel_transport_factory:
+    name: "Daemon-channel transport factory"
+    regex: 'NetworkTransport\('
+    excluded: '.*/DaemonChannelTransport\.swift'
+    message: "Construct daemon-channel transports via daemonChannelTransport(connection:) — the SDK's default transport heartbeat corrupts framing (see NetworkTransportHeartbeatTests)."
+    severity: error

--- a/previewsmcp/PreviewsCLI/DaemonChannelTransport.swift
+++ b/previewsmcp/PreviewsCLI/DaemonChannelTransport.swift
@@ -1,0 +1,10 @@
+import MCP
+import Network
+
+/// Every transport on the daemon's UDS channel must be built here: the SDK's
+/// transport-level heartbeat is sent unframed and the receive loop discards
+/// any read chunk that starts with it (see NetworkTransportHeartbeatTests),
+/// so no peer on this channel may emit heartbeats.
+public func daemonChannelTransport(connection: NWConnection) -> NetworkTransport {
+    NetworkTransport(connection: connection, heartbeatConfig: .disabled)
+}

--- a/previewsmcp/PreviewsCLI/DaemonClient.swift
+++ b/previewsmcp/PreviewsCLI/DaemonClient.swift
@@ -126,7 +126,7 @@ enum DaemonClient {
             to: NWEndpoint.unix(path: DaemonPaths.socket.path),
             using: .tcp
         )
-        let transport = NetworkTransport(connection: connection)
+        let transport = NetworkTransport(connection: connection, heartbeatConfig: .disabled)
         let client = Client(name: clientName, version: PreviewsMCPCommand.version)
         await configure?(client)
         let initResult = try await client.connect(transport: transport)

--- a/previewsmcp/PreviewsCLI/DaemonClient.swift
+++ b/previewsmcp/PreviewsCLI/DaemonClient.swift
@@ -126,7 +126,7 @@ enum DaemonClient {
             to: NWEndpoint.unix(path: DaemonPaths.socket.path),
             using: .tcp
         )
-        let transport = NetworkTransport(connection: connection, heartbeatConfig: .disabled)
+        let transport = daemonChannelTransport(connection: connection)
         let client = Client(name: clientName, version: PreviewsMCPCommand.version)
         await configure?(client)
         let initResult = try await client.connect(transport: transport)

--- a/previewsmcp/PreviewsCLI/DaemonListener.swift
+++ b/previewsmcp/PreviewsCLI/DaemonListener.swift
@@ -84,7 +84,7 @@ enum DaemonListener {
         registry: SessionRegistry
     ) async {
         do {
-            let transport = NetworkTransport(connection: connection)
+            let transport = NetworkTransport(connection: connection, heartbeatConfig: .disabled)
             let (server, _) = try await configureMCPServer(
                 host: host, iosManager: iosManager,
                 configCache: configCache, registry: registry,

--- a/previewsmcp/PreviewsCLI/DaemonListener.swift
+++ b/previewsmcp/PreviewsCLI/DaemonListener.swift
@@ -84,7 +84,7 @@ enum DaemonListener {
         registry: SessionRegistry
     ) async {
         do {
-            let transport = NetworkTransport(connection: connection, heartbeatConfig: .disabled)
+            let transport = daemonChannelTransport(connection: connection)
             let (server, _) = try await configureMCPServer(
                 host: host, iosManager: iosManager,
                 configCache: configCache, registry: registry,

--- a/previewsmcp/Tests/MCPIntegrationTests/DaemonLifecycleTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/DaemonLifecycleTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MCP
 import Network
+import PreviewsCLI
 import Testing
 
 /// Integration tests for `previewsmcp serve --daemon` / `status` / `kill-daemon`.
@@ -117,7 +118,7 @@ struct DaemonLifecycleTests {
                 to: NWEndpoint.unix(path: Self.socketPath),
                 using: .tcp
             )
-            let transport = NetworkTransport(connection: connection)
+            let transport = daemonChannelTransport(connection: connection)
             let client = Client(name: "daemon-lifecycle-test", version: "1.0")
             _ = try await client.connect(transport: transport)
             defer {
@@ -244,7 +245,7 @@ struct DaemonLifecycleTests {
                 to: NWEndpoint.unix(path: Self.socketPath),
                 using: .tcp
             )
-            let transport = NetworkTransport(connection: connection)
+            let transport = daemonChannelTransport(connection: connection)
             let client = Client(name: "race-test", version: "1.0")
             _ = try await client.connect(transport: transport)
             await client.disconnect()

--- a/previewsmcp/Tests/PreviewsCLITests/NetworkTransportHeartbeatTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/NetworkTransportHeartbeatTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+import MCP
+import Network
+import os
+import Testing
+
+/// Documents why both daemon-channel `NetworkTransport`s are constructed with
+/// `heartbeatConfig: .disabled`: the SDK sends heartbeats WITHOUT the newline
+/// delimiter its messages use, and its receive loop classifies whole read
+/// chunks — a chunk that starts with the 4 heartbeat magic bytes is discarded
+/// entirely, so a JSON-RPC message coalesced into the same read as a preceding
+/// heartbeat is silently lost. The classification is unconditional, so a
+/// receiver cannot defend itself; the only safe topology is one where no peer
+/// emits transport-level heartbeats.
+@Suite("NetworkTransport heartbeat framing")
+struct NetworkTransportHeartbeatTests {
+    @Test("a message coalesced behind a heartbeat is silently dropped")
+    func coalescedHeartbeatDropsTheMessageBehindIt() async throws {
+        let socketPath = "/tmp/pmcp-hb-\(getpid()).sock"
+        try? FileManager.default.removeItem(atPath: socketPath)
+        defer { try? FileManager.default.removeItem(atPath: socketPath) }
+
+        let params = NWParameters.tcp
+        params.requiredLocalEndpoint = NWEndpoint.unix(path: socketPath)
+        params.allowLocalEndpointReuse = true
+        let listener = try NWListener(using: params)
+
+        let accepted = OSAllocatedUnfairLock(initialState: NWConnection?.none)
+        listener.newConnectionHandler = { connection in
+            accepted.withLock { $0 = connection }
+        }
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            listener.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    cont.resume()
+                    listener.stateUpdateHandler = nil
+                case let .failed(error):
+                    cont.resume(throwing: error)
+                    listener.stateUpdateHandler = nil
+                default:
+                    break
+                }
+            }
+            listener.start(queue: .global(qos: .userInitiated))
+        }
+        defer { listener.cancel() }
+
+        let rawPeer = NWConnection(to: .unix(path: socketPath), using: .tcp)
+        try await awaitReady(rawPeer)
+        defer { rawPeer.cancel() }
+
+        let serverSide = try await poll(
+            until: { accepted.withLock { $0 } },
+            failure: "listener never accepted the connection"
+        )
+        let transport = NetworkTransport(connection: serverSide, heartbeatConfig: .disabled)
+        try await transport.connect()
+        defer { Task { await transport.disconnect() } }
+
+        let received = OSAllocatedUnfairLock(initialState: [Data]())
+        let collector = Task {
+            for try await message in await transport.receive() {
+                received.withLock { $0.append(message) }
+            }
+        }
+        defer { collector.cancel() }
+
+        // Sentinel first: once it is yielded, the receive loop has drained the
+        // socket, so the next raw send arrives as its own fresh read chunk.
+        let sentinel = Data(#"{"sentinel":0}"#.utf8)
+        let dropped = Data(#"{"dropped":1}"#.utf8)
+        let survivor = Data(#"{"survivor":2}"#.utf8)
+        let newline = Data([UInt8(ascii: "\n")])
+
+        try await rawSend(rawPeer, sentinel + newline)
+        _ = try await poll(
+            until: { received.withLock { $0.count >= 1 } ? true : nil },
+            failure: "sentinel message never arrived"
+        )
+
+        // The defect: heartbeat and message written as ONE chunk. The receive
+        // loop sees the heartbeat magic at the chunk head and discards the
+        // whole read, message included. Give the loop time to consume it
+        // before the survivor lands, so the two sends cannot coalesce into a
+        // single (also fully discarded) read.
+        try await rawSend(rawPeer, NetworkTransport.Heartbeat().data + dropped + newline)
+        try await Task.sleep(for: .milliseconds(500))
+        try await rawSend(rawPeer, survivor + newline)
+
+        _ = try await poll(
+            until: { received.withLock { $0.count >= 2 } ? true : nil },
+            failure: "survivor message never arrived"
+        )
+        let messages = received.withLock { $0 }
+        #expect(messages == [sentinel, survivor], "expected the coalesced message to be dropped")
+        #expect(!messages.contains(dropped))
+    }
+
+    private func awaitReady(_ connection: NWConnection) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            connection.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    cont.resume()
+                    connection.stateUpdateHandler = nil
+                case let .failed(error):
+                    cont.resume(throwing: error)
+                    connection.stateUpdateHandler = nil
+                default:
+                    break
+                }
+            }
+            connection.start(queue: .global(qos: .userInitiated))
+        }
+    }
+
+    private func rawSend(_ connection: NWConnection, _ data: Data) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            connection.send(
+                content: data,
+                completion: .contentProcessed { error in
+                    if let error {
+                        cont.resume(throwing: error)
+                    } else {
+                        cont.resume()
+                    }
+                }
+            )
+        }
+    }
+
+    private func poll<T>(
+        until value: () -> T?,
+        failure: String,
+        deadline: Duration = .seconds(10)
+    ) async throws -> T {
+        let clock = ContinuousClock()
+        let limit = clock.now + deadline
+        while clock.now < limit {
+            if let found = value() { return found }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        Issue.record(Comment(rawValue: failure))
+        throw CancellationError()
+    }
+}

--- a/previewsmcp/Tests/PreviewsCLITests/NetworkTransportHeartbeatTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/NetworkTransportHeartbeatTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import MCP
 import Network
 import os
+import PreviewsCLI
 import Testing
 
 /// Documents why both daemon-channel `NetworkTransport`s are constructed with
@@ -28,21 +29,7 @@ struct NetworkTransportHeartbeatTests {
         listener.newConnectionHandler = { connection in
             accepted.withLock { $0 = connection }
         }
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            listener.stateUpdateHandler = { state in
-                switch state {
-                case .ready:
-                    cont.resume()
-                    listener.stateUpdateHandler = nil
-                case let .failed(error):
-                    cont.resume(throwing: error)
-                    listener.stateUpdateHandler = nil
-                default:
-                    break
-                }
-            }
-            listener.start(queue: .global(qos: .userInitiated))
-        }
+        try await awaitReady(listener)
         defer { listener.cancel() }
 
         let rawPeer = NWConnection(to: .unix(path: socketPath), using: .tcp)
@@ -53,9 +40,8 @@ struct NetworkTransportHeartbeatTests {
             until: { accepted.withLock { $0 } },
             failure: "listener never accepted the connection"
         )
-        let transport = NetworkTransport(connection: serverSide, heartbeatConfig: .disabled)
+        let transport = daemonChannelTransport(connection: serverSide)
         try await transport.connect()
-        defer { Task { await transport.disconnect() } }
 
         let received = OSAllocatedUnfairLock(initialState: [Data]())
         let collector = Task {
@@ -88,10 +74,12 @@ struct NetworkTransportHeartbeatTests {
         try await rawSend(rawPeer, survivor + newline)
 
         let messages = try await poll(
-            until: { received.withLock { $0.count >= 2 ? $0 : nil } },
+            until: { received.withLock { $0.contains(survivor) ? $0 : nil } },
             failure: "survivor message never arrived"
         )
-        #expect(messages == [sentinel, survivor], "expected the coalesced message to be dropped")
+        #expect(messages.first == sentinel)
+        #expect(!messages.contains(dropped), "expected the coalesced message to be dropped")
+        await transport.disconnect()
     }
 
     private func awaitReady(_ connection: NWConnection) async throws {
@@ -101,14 +89,38 @@ struct NetworkTransportHeartbeatTests {
                 case .ready:
                     cont.resume()
                     connection.stateUpdateHandler = nil
-                case let .failed(error):
+                case let .failed(error), let .waiting(error):
                     cont.resume(throwing: error)
+                    connection.stateUpdateHandler = nil
+                case .cancelled:
+                    cont.resume(throwing: CancellationError())
                     connection.stateUpdateHandler = nil
                 default:
                     break
                 }
             }
             connection.start(queue: .global(qos: .userInitiated))
+        }
+    }
+
+    private func awaitReady(_ listener: NWListener) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            listener.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    cont.resume()
+                    listener.stateUpdateHandler = nil
+                case let .failed(error), let .waiting(error):
+                    cont.resume(throwing: error)
+                    listener.stateUpdateHandler = nil
+                case .cancelled:
+                    cont.resume(throwing: CancellationError())
+                    listener.stateUpdateHandler = nil
+                default:
+                    break
+                }
+            }
+            listener.start(queue: .global(qos: .userInitiated))
         }
     }
 

--- a/previewsmcp/Tests/PreviewsCLITests/NetworkTransportHeartbeatTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/NetworkTransportHeartbeatTests.swift
@@ -22,7 +22,6 @@ struct NetworkTransportHeartbeatTests {
 
         let params = NWParameters.tcp
         params.requiredLocalEndpoint = NWEndpoint.unix(path: socketPath)
-        params.allowLocalEndpointReuse = true
         let listener = try NWListener(using: params)
 
         let accepted = OSAllocatedUnfairLock(initialState: NWConnection?.none)
@@ -75,7 +74,7 @@ struct NetworkTransportHeartbeatTests {
 
         try await rawSend(rawPeer, sentinel + newline)
         _ = try await poll(
-            until: { received.withLock { $0.count >= 1 } ? true : nil },
+            until: { received.withLock { $0.count >= 1 ? $0 : nil } },
             failure: "sentinel message never arrived"
         )
 
@@ -88,13 +87,11 @@ struct NetworkTransportHeartbeatTests {
         try await Task.sleep(for: .milliseconds(500))
         try await rawSend(rawPeer, survivor + newline)
 
-        _ = try await poll(
-            until: { received.withLock { $0.count >= 2 } ? true : nil },
+        let messages = try await poll(
+            until: { received.withLock { $0.count >= 2 ? $0 : nil } },
             failure: "survivor message never arrived"
         )
-        let messages = received.withLock { $0 }
         #expect(messages == [sentinel, survivor], "expected the coalesced message to be dropped")
-        #expect(!messages.contains(dropped))
     }
 
     private func awaitReady(_ connection: NWConnection) async throws {
@@ -132,7 +129,7 @@ struct NetworkTransportHeartbeatTests {
 
     private func poll<T>(
         until value: () -> T?,
-        failure: String,
+        failure: Comment,
         deadline: Duration = .seconds(10)
     ) async throws -> T {
         let clock = ContinuousClock()
@@ -141,7 +138,7 @@ struct NetworkTransportHeartbeatTests {
             if let found = value() { return found }
             try await Task.sleep(for: .milliseconds(25))
         }
-        Issue.record(Comment(rawValue: failure))
+        Issue.record(failure)
         throw CancellationError()
     }
 }


### PR DESCRIPTION
## Why

The MCP swift-sdk's `NetworkTransport` sends its 15s heartbeats **without** the newline delimiter its messages use, and its receive loop classifies whole read chunks: a chunk starting with the heartbeat magic bytes is discarded entirely (a JSON-RPC message coalesced behind a heartbeat is silently lost), and a mid-chunk heartbeat is appended raw into the framing buffer. Same defect class as #320's stdio interleave, sitting on the CLI↔daemon UDS channel. The receive-side classification is unconditional, so the only defense is that no peer emits heartbeats. Liveness is unaffected: the daemon already runs its own 2s MCP-level heartbeat feeding the client's StallTimer, and the SDK's reconnect logic was verified to never read heartbeat state.

Part of the approved immediate hardening while the wire-layer rewrite proceeds (stage 0).

## What

- `daemonChannelTransport(connection:)` — the single factory for daemon-channel transports, `heartbeatConfig: .disabled`. All four construction sites (DaemonClient, DaemonListener, two DaemonLifecycleTests clients that were still heartbeating at the real daemon) route through it.
- SwiftLint custom rule (probe-verified) forbids direct `NetworkTransport(` construction outside the factory file, so the invariant is structural, not conventional.
- `NetworkTransportHeartbeatTests` — deterministic repro pinning the SDK defect: sentinel, then heartbeat+message in one write, then survivor; the coalesced message never arrives. If an SDK upgrade ever fixes the framing, this test fails and prompts reconsideration.

## Accepted residual (documented, no code change)

A stale pre-fix daemon that passes the lenient release-vs-dev version handshake keeps heartbeating at a new client until restarted; the StallTimer bounds any resulting dropped-response hang at a loud 30s failure and one daemon restart heals it. Mid-message magic-byte false positives in SDK receive code are consciously deferred to the wire-layer rewrite.

## Verification

- Repro test: 10/10 green isolated (5x before + 5x after review fixes)
- /simplify (4 angles): applied — factory consolidation came from its altitude finding
- /code-review (high, workflow): applied — fail-fast ready waits, split-tolerant assertions, awaited teardown, lint enforcement; one CONFIRMED mixed-version finding accepted + documented above
- `bazel run //tools/lint:check` clean; custom rule verified to fire on a staged probe violation
- Full suite `bazel test //previewsmcp/Tests/... --nocache_test_results`: 9/9 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPF6gjyr2BBuz31yRSnMvG