### PR TITLE
Enroll CLIIntegrationTests in CoreSimulatorHygiene before its iOS boots

### DIFF
--- a/previewsmcp/Tests/CLIIntegrationTests/CoreSimulatorHygiene.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/CoreSimulatorHygiene.swift
@@ -1,4 +1,3 @@
-import Foundation
 import os
 
 /// Host-global CoreSimulator hygiene for the iOS-booting CLI suite.
@@ -21,9 +20,10 @@ enum CoreSimulatorHygiene {
     private static let didReset = OSAllocatedUnfairLock(initialState: false)
 
     /// Reset host-global CoreSimulator state once per process. Subsequent calls
-    /// are no-ops. Best-effort: a failed reset is logged, not thrown — it must
+    /// are no-ops. Best-effort: spawn failures are swallowed — the reset must
     /// not fail an otherwise-healthy test, and the next `simctl` call respawns
-    /// the service regardless.
+    /// the service regardless. Each command is bounded by `runExternal`'s
+    /// timeout so a wedged `simctl` cannot park the suite's time limit.
     static func resetOnce() async {
         let shouldRun = didReset.withLock { done -> Bool in
             if done { return false }
@@ -35,27 +35,13 @@ enum CoreSimulatorHygiene {
         // Shut down every booted simulator, then bounce the service. `killall`
         // is domain-agnostic (CoreSimulatorService runs in the GUI session, not
         // a fixed launchd domain) and the service auto-respawns on the next
-        // simctl invocation — pickUDID, moments later, brings it back clean.
-        await run(["/usr/bin/xcrun", "simctl", "shutdown", "all"])
-        await run(["/usr/bin/killall", "-9", "com.apple.CoreSimulator.CoreSimulatorService"])
-    }
-
-    private static func run(_ args: [String]) async {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let process = Process()
-                process.executableURL = URL(fileURLWithPath: args[0])
-                process.arguments = Array(args.dropFirst())
-                process.standardOutput = FileHandle.nullDevice
-                process.standardError = FileHandle.nullDevice
-                do {
-                    try process.run()
-                    process.waitUntilExit()
-                } catch {
-                    print("CoreSimulatorHygiene: \(args.joined(separator: " ")) failed: \(error)")
-                }
-                continuation.resume()
-            }
-        }
+        // simctl invocation — the daemon's session boot brings it back clean.
+        _ = try? await CLIRunner.runExternal(
+            "/usr/bin/xcrun", arguments: ["simctl", "shutdown", "all"]
+        )
+        _ = try? await CLIRunner.runExternal(
+            "/usr/bin/killall",
+            arguments: ["-9", "com.apple.CoreSimulator.CoreSimulatorService"]
+        )
     }
 }

--- a/previewsmcp/Tests/CLIIntegrationTests/CoreSimulatorHygiene.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/CoreSimulatorHygiene.swift
@@ -14,34 +14,39 @@ import os
 ///
 /// Reset that state ONCE per test process, before the first iOS preview boots:
 /// shut every simulator down and bounce CoreSimulatorService so the next boot
-/// starts from a clean service. Call while holding `DaemonTestLock` so the reset
-/// never races a concurrent suite's simulator use.
+/// starts from a clean service. Call while holding `DaemonTestLock`, which
+/// serializes the sim-touching suites WITHIN this target (its flock path is
+/// per-target); across targets the only guard is this target's `exclusive`
+/// tag, which holds within a single bazel invocation — concurrent separate
+/// invocations are already forbidden by the repo's test-hygiene rules.
 enum CoreSimulatorHygiene {
     private static let didReset = OSAllocatedUnfairLock(initialState: false)
 
     /// Reset host-global CoreSimulator state once per process. Subsequent calls
     /// are no-ops. Best-effort: spawn failures are swallowed — the reset must
     /// not fail an otherwise-healthy test, and the next `simctl` call respawns
-    /// the service regardless. Each command is bounded by `runExternal`'s
-    /// timeout so a wedged `simctl` cannot park the suite's time limit.
+    /// the service regardless. Each command is bounded well below the suites'
+    /// time limits so a wedged `simctl` cannot eat the budget this reset
+    /// exists to protect. The done-flag is only set after both commands
+    /// finish, so a reset interrupted mid-flight (time-limit cancellation)
+    /// is retried by the next enrolled test; callers hold `DaemonTestLock`,
+    /// which is what serializes the check-then-run.
     static func resetOnce() async {
-        let shouldRun = didReset.withLock { done -> Bool in
-            if done { return false }
-            done = true
-            return true
-        }
-        guard shouldRun else { return }
+        guard !didReset.withLock({ $0 }) else { return }
 
         // Shut down every booted simulator, then bounce the service. `killall`
         // is domain-agnostic (CoreSimulatorService runs in the GUI session, not
         // a fixed launchd domain) and the service auto-respawns on the next
         // simctl invocation — the daemon's session boot brings it back clean.
         _ = try? await CLIRunner.runExternal(
-            "/usr/bin/xcrun", arguments: ["simctl", "shutdown", "all"]
+            "/usr/bin/xcrun", arguments: ["simctl", "shutdown", "all"],
+            timeout: .seconds(60)
         )
         _ = try? await CLIRunner.runExternal(
             "/usr/bin/killall",
-            arguments: ["-9", "com.apple.CoreSimulator.CoreSimulatorService"]
+            arguments: ["-9", "com.apple.CoreSimulator.CoreSimulatorService"],
+            timeout: .seconds(15)
         )
+        didReset.withLock { $0 = true }
     }
 }

--- a/previewsmcp/Tests/CLIIntegrationTests/CoreSimulatorHygiene.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/CoreSimulatorHygiene.swift
@@ -1,0 +1,61 @@
+import Foundation
+import os
+
+/// Host-global CoreSimulator hygiene for the iOS-booting CLI suite.
+///
+/// In a full `bazel test //...` run this target executes after
+/// `PreviewsIOSTests` and `IOSPreviewE2ETests` have driven simulators for
+/// minutes. CoreSimulator is a host-global service, so by then its display
+/// subsystem is degraded: SimulatorKit display-port attach slows to tens of
+/// seconds and snapshot paths fall through to their slow bounded fallbacks,
+/// stretching the suite's serialized chain past its timeout. It never
+/// reproduces in isolation because nothing has degraded the service yet.
+/// (Per-target copy, like `DaemonTestLock` — swift_test targets don't share
+/// test sources, and the once-per-process guard is per-target by design.)
+///
+/// Reset that state ONCE per test process, before the first iOS preview boots:
+/// shut every simulator down and bounce CoreSimulatorService so the next boot
+/// starts from a clean service. Call while holding `DaemonTestLock` so the reset
+/// never races a concurrent suite's simulator use.
+enum CoreSimulatorHygiene {
+    private static let didReset = OSAllocatedUnfairLock(initialState: false)
+
+    /// Reset host-global CoreSimulator state once per process. Subsequent calls
+    /// are no-ops. Best-effort: a failed reset is logged, not thrown — it must
+    /// not fail an otherwise-healthy test, and the next `simctl` call respawns
+    /// the service regardless.
+    static func resetOnce() async {
+        let shouldRun = didReset.withLock { done -> Bool in
+            if done { return false }
+            done = true
+            return true
+        }
+        guard shouldRun else { return }
+
+        // Shut down every booted simulator, then bounce the service. `killall`
+        // is domain-agnostic (CoreSimulatorService runs in the GUI session, not
+        // a fixed launchd domain) and the service auto-respawns on the next
+        // simctl invocation — pickUDID, moments later, brings it back clean.
+        await run(["/usr/bin/xcrun", "simctl", "shutdown", "all"])
+        await run(["/usr/bin/killall", "-9", "com.apple.CoreSimulator.CoreSimulatorService"])
+    }
+
+    private static func run(_ args: [String]) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: args[0])
+                process.arguments = Array(args.dropFirst())
+                process.standardOutput = FileHandle.nullDevice
+                process.standardError = FileHandle.nullDevice
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+                } catch {
+                    print("CoreSimulatorHygiene: \(args.joined(separator: " ")) failed: \(error)")
+                }
+                continuation.resume()
+            }
+        }
+    }
+}

--- a/previewsmcp/Tests/CLIIntegrationTests/IOSCLIWorkflowTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/IOSCLIWorkflowTests.swift
@@ -30,12 +30,12 @@ struct IOSCLIWorkflowTests {
                 return
             }
 
+            try await Self.cleanSlate()
+
             // Reset host-global CoreSimulator state once before the first iOS
             // preview boots — earlier Bazel targets leave it degraded (see
             // CoreSimulatorHygiene).
             await CoreSimulatorHygiene.resetOnce()
-
-            try await Self.cleanSlate()
 
             let file = CLIRunner.spmExampleRoot
                 .appendingPathComponent("Sources/ToDo/ToDoView.swift").path

--- a/previewsmcp/Tests/CLIIntegrationTests/IOSCLIWorkflowTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/IOSCLIWorkflowTests.swift
@@ -30,6 +30,11 @@ struct IOSCLIWorkflowTests {
                 return
             }
 
+            // Reset host-global CoreSimulator state once before the first iOS
+            // preview boots — earlier Bazel targets leave it degraded (see
+            // CoreSimulatorHygiene).
+            await CoreSimulatorHygiene.resetOnce()
+
             try await Self.cleanSlate()
 
             let file = CLIRunner.spmExampleRoot

--- a/previewsmcp/Tests/CLIIntegrationTests/SnapshotCommandTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/SnapshotCommandTests.swift
@@ -360,6 +360,11 @@ struct SnapshotCommandTests {
                 return
             }
 
+            // Reset host-global CoreSimulator state once before the first iOS
+            // preview boots — earlier Bazel targets leave it degraded (see
+            // CoreSimulatorHygiene).
+            await CoreSimulatorHygiene.resetOnce()
+
             let tempDir = try CLIRunner.makeTempDir()
             defer { try? FileManager.default.removeItem(at: tempDir) }
 

--- a/previewsmcp/Tests/MCPIntegrationTests/CoreSimulatorHygiene.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/CoreSimulatorHygiene.swift
@@ -14,22 +14,23 @@ import os
 ///
 /// Reset that state ONCE per test process, before the first iOS preview boots:
 /// shut every simulator down and bounce CoreSimulatorService so the next boot
-/// starts from a clean service. Call while holding `DaemonTestLock` so the reset
-/// never races a concurrent suite's simulator use.
+/// starts from a clean service. Call while holding `DaemonTestLock`, which
+/// serializes the sim-touching suites WITHIN this target (its flock path is
+/// per-target); across targets the only guard is this target's `exclusive`
+/// tag, which holds within a single bazel invocation — concurrent separate
+/// invocations are already forbidden by the repo's test-hygiene rules.
 enum CoreSimulatorHygiene {
     private static let didReset = OSAllocatedUnfairLock(initialState: false)
 
     /// Reset host-global CoreSimulator state once per process. Subsequent calls
     /// are no-ops. Best-effort: a failed reset is logged, not thrown — it must
     /// not fail an otherwise-healthy test, and the next `simctl` call respawns
-    /// the service regardless.
+    /// the service regardless. The done-flag is only set after both commands
+    /// finish, so a reset interrupted mid-flight (time-limit cancellation)
+    /// is retried by the next enrolled test; callers hold `DaemonTestLock`,
+    /// which is what serializes the check-then-run.
     static func resetOnce() async {
-        let shouldRun = didReset.withLock { done -> Bool in
-            if done { return false }
-            done = true
-            return true
-        }
-        guard shouldRun else { return }
+        guard !didReset.withLock({ $0 }) else { return }
 
         // Shut down every booted simulator, then bounce the service. `killall`
         // is domain-agnostic (CoreSimulatorService runs in the GUI session, not
@@ -37,6 +38,7 @@ enum CoreSimulatorHygiene {
         // simctl invocation — pickUDID, moments later, brings it back clean.
         await run(["/usr/bin/xcrun", "simctl", "shutdown", "all"])
         await run(["/usr/bin/killall", "-9", "com.apple.CoreSimulator.CoreSimulatorService"])
+        didReset.withLock { $0 = true }
     }
 
     private static func run(_ args: [String]) async {


### PR DESCRIPTION
## Why

The merge bar's full-graph VM run timed out `CLIIntegrationTests` at the 300s default ceiling while the same suite passes isolated in the same VM in 184s. The VM's per-suite progression tracked a healthy local run 1:1 for 112s, then the tail suites (Snapshot/Stop/Variants) consumed the remaining 187s without completing — the suite runs after `PreviewsIOSTests` and `IOSPreviewE2ETests` have degraded the host-global CoreSimulator service. This is the exact mechanism #319 root-caused and fixed for `MCPIntegrationTests` (which passed at 261s in the same failing bar run); `CLIIntegrationTests` is the target #319's enrollment missed.

## What

- Per-target copy of `CoreSimulatorHygiene` (like `DaemonTestLock` — test sources aren't shared across swift_test targets and the once-per-process guard is per-target by design), with its commands routed through `CLIRunner.runExternal` bounded at 60s/15s so a wedged `simctl` cannot eat the suite budget the reset protects.
- Both iOS-booting suites enrolled (`iosCLIWorkflow`, `snapshotIOS`) — suite lock order is nondeterministic, mirroring #319's all-suites pattern.
- Review hardening applied to **both** copies: the done-flag flips only after the commands complete (an interrupted reset re-arms instead of silently no-opping), and the headers now state the real serialization guarantees (per-target flock within the target, `exclusive` tag across targets within one invocation).

## Verification

- CLIIntegrationTests isolated: green 3x (~138-142s) across the change iterations
- /simplify (4 angles): applied — snapshotIOS enrollment and the runExternal reuse came out of it
- /code-review (high, workflow): 3 findings, all applied (re-armable guard, bounded commands, honest lock docs)
- Lint clean; full suite `bazel test //previewsmcp/Tests/... --nocache_test_results`: 9/9 green
- The falsification test is the bar itself: mergequeue-lead runs 3x full-graph bar next; if the tail still wedges with hygiene enrolled, the mechanism theory is wrong and we farm a live serve.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPF6gjyr2BBuz31yRSnMvG