### PR TITLE
Rewrite stage 2: in-house FramedStdioTransport

### DIFF
--- a/previewsmcp/PreviewsCLI/FramedStdioTransport.swift
+++ b/previewsmcp/PreviewsCLI/FramedStdioTransport.swift
@@ -17,7 +17,8 @@ import System
 /// - The logger is a no-op by construction, so nothing can write prose
 ///   into the JSON stream the daemon serves on stdout.
 ///
-/// The transport does not own its file descriptors and never closes them.
+/// The transport does not own its file descriptors and never closes them,
+/// but `connect()` switches both to non-blocking and leaves them that way.
 actor FramedStdioTransport: Transport {
     nonisolated let logger = Logger(
         label: "previewsmcp.framed-stdio",
@@ -46,7 +47,9 @@ actor FramedStdioTransport: Transport {
     func connect() async throws {
         try Self.setNonBlocking(input)
         try Self.setNonBlocking(output)
-        reader = Task { await readLoop() }
+        reader = Task { [input, messageContinuation] in
+            await Self.readLoop(input: input, continuation: messageContinuation)
+        }
     }
 
     func disconnect() async {
@@ -63,15 +66,16 @@ actor FramedStdioTransport: Transport {
     }
 
     func send(_ message: Data) async throws {
-        var frame = message
-        frame.append(UInt8(ascii: "\n"))
         // No suspension between reading and updating `sendChain` — the
-        // serialization invariant everything above depends on.
+        // serialization invariant everything above depends on. The newline
+        // goes out as its own write rather than appending to `message`,
+        // which would copy every multi-hundred-KB frame just to add a byte.
         let previous = sendChain
         let task = Task { [output] in
             _ = try? await previous?.value
             try Task.checkCancellation()
-            try await Self.write(frame, to: output)
+            try await Self.write(message, to: output)
+            try await Self.write(Self.newlineFrame, to: output)
         }
         sendChain = task
         pendingSends.insert(task)
@@ -91,50 +95,64 @@ actor FramedStdioTransport: Transport {
 
     // MARK: - Read side
 
-    private func readLoop() async {
+    /// Static like `write`: it touches no actor state, so running it
+    /// isolated would only make senders and the reader contend.
+    private static func readLoop(
+        input: FileDescriptor,
+        continuation: AsyncThrowingStream<Data, Swift.Error>.Continuation
+    ) async {
         var buffer = Data()
+        var scanFrom = buffer.startIndex
         var chunk = [UInt8](repeating: 0, count: 64 * 1024)
         while !Task.isCancelled {
             do {
                 let count = try chunk.withUnsafeMutableBytes { try input.read(into: $0) }
                 if count == 0 {
-                    messageContinuation.finish()
+                    continuation.finish()
                     return
                 }
-                buffer.append(contentsOf: chunk[0 ..< count])
-                while let newline = buffer.firstIndex(of: UInt8(ascii: "\n")) {
+                chunk.withUnsafeBytes { raw in
+                    buffer.append(contentsOf: UnsafeRawBufferPointer(rebasing: raw[0 ..< count]))
+                }
+                // `scanFrom` marks how far the newline scan has gotten, so
+                // a large frame arriving in many chunks is scanned once,
+                // not once per chunk; slicing instead of re-wrapping in
+                // Data() keeps frame extraction copy-free.
+                while let newline = buffer[scanFrom...].firstIndex(of: UInt8(ascii: "\n")) {
                     let line = buffer[buffer.startIndex ..< newline]
                     if !line.isEmpty {
-                        messageContinuation.yield(Data(line))
+                        continuation.yield(Data(line))
                     }
-                    buffer = Data(buffer[buffer.index(after: newline)...])
+                    buffer = buffer[buffer.index(after: newline)...]
+                    scanFrom = buffer.startIndex
                 }
-                // Keep the actor fair to senders during sustained input.
-                await Task.yield()
+                scanFrom = buffer.endIndex
+                if buffer.isEmpty {
+                    buffer = Data()
+                    scanFrom = buffer.startIndex
+                }
             } catch let errno as Errno {
                 switch errno {
                 case .wouldBlock, .resourceTemporarilyUnavailable:
-                    do {
-                        try await Task.sleep(for: .milliseconds(10))
-                    } catch {
-                        messageContinuation.finish()
-                        return
-                    }
+                    try? await Task.sleep(for: pollInterval)
                 case .interrupted:
                     continue
                 default:
-                    messageContinuation.finish(throwing: errno)
+                    continuation.finish(throwing: errno)
                     return
                 }
             } catch {
-                messageContinuation.finish(throwing: error)
+                continuation.finish(throwing: error)
                 return
             }
         }
-        messageContinuation.finish()
+        continuation.finish()
     }
 
     // MARK: - Write side
+
+    private static let newlineFrame = Data([UInt8(ascii: "\n")])
+    private static let pollInterval: Duration = .milliseconds(10)
 
     /// Static so the retry suspension never suspends the actor mid-write;
     /// ordering comes from the send chain, not isolation.
@@ -149,7 +167,7 @@ actor FramedStdioTransport: Transport {
             } catch let errno as Errno {
                 switch errno {
                 case .wouldBlock, .resourceTemporarilyUnavailable:
-                    try await Task.sleep(for: .milliseconds(10))
+                    try await Task.sleep(for: pollInterval)
                 case .interrupted:
                     continue
                 default:

--- a/previewsmcp/PreviewsCLI/FramedStdioTransport.swift
+++ b/previewsmcp/PreviewsCLI/FramedStdioTransport.swift
@@ -1,7 +1,14 @@
 import Foundation
 import Logging
 import MCP
+import os
 import System
+
+enum FramedStdioTransportError: Swift.Error, Equatable {
+    case disconnected
+    case poisoned
+    case truncatedFinalFrame
+}
 
 /// In-house newline-framed JSON-RPC stdio transport (rewrite stage 2).
 ///
@@ -11,14 +18,23 @@ import System
 /// - Sends are chained, never concurrent: there is no suspension between
 ///   reading and updating `sendChain`, so re-entrant callers each queue
 ///   behind the true predecessor and frames land contiguously (#320).
+/// - A started frame always finishes: caller cancellation is NOT forwarded
+///   into an in-flight write, because aborting mid-frame leaves partial
+///   bytes on the wire that would corrupt every later frame. Only
+///   `disconnect()` aborts writes, and any write that fails or aborts
+///   poisons the transport so later sends fail loudly instead of gluing
+///   onto a torn frame.
 /// - Read errors PROPAGATE: a real errno finishes the receive stream
-///   throwing, EOF finishes it cleanly, and EINTR is retried — the SDK
-///   broke its loop silently on both.
+///   throwing, EOF with a buffered partial frame finishes it throwing
+///   `truncatedFinalFrame`, clean EOF finishes it cleanly, and EINTR is
+///   retried — the SDK broke its loop silently on all of these.
 /// - The logger is a no-op by construction, so nothing can write prose
 ///   into the JSON stream the daemon serves on stdout.
 ///
 /// The transport does not own its file descriptors and never closes them,
-/// but `connect()` switches both to non-blocking and leaves them that way.
+/// but `connect()` switches both to non-blocking, disables SIGPIPE delivery
+/// on the output (a dead peer surfaces as EPIPE, not process death), and
+/// leaves both that way.
 actor FramedStdioTransport: Transport {
     nonisolated let logger = Logger(
         label: "previewsmcp.framed-stdio",
@@ -32,6 +48,8 @@ actor FramedStdioTransport: Transport {
     private var sendChain: Task<Void, Swift.Error>?
     private var pendingSends: Set<Task<Void, Swift.Error>> = []
     private var reader: Task<Void, Never>?
+    private var isDisconnected = false
+    private let poisoned = OSAllocatedUnfairLock(initialState: false)
 
     init(
         input: FileDescriptor = .standardInput,
@@ -47,12 +65,15 @@ actor FramedStdioTransport: Transport {
     func connect() async throws {
         try Self.setNonBlocking(input)
         try Self.setNonBlocking(output)
+        try Self.setNoSigPipe(output)
         reader = Task { [input, messageContinuation] in
             await Self.readLoop(input: input, continuation: messageContinuation)
         }
     }
 
     func disconnect() async {
+        guard !isDisconnected else { return }
+        isDisconnected = true
         // Cancel every queued/in-flight send, not just the chain tail: a
         // peer that stops draining leaves the head send retrying EAGAIN
         // forever, and everything queued behind it retains its message.
@@ -66,27 +87,30 @@ actor FramedStdioTransport: Transport {
     }
 
     func send(_ message: Data) async throws {
+        guard !isDisconnected else { throw FramedStdioTransportError.disconnected }
         // No suspension between reading and updating `sendChain` — the
         // serialization invariant everything above depends on. The newline
         // goes out as its own write rather than appending to `message`,
         // which would copy every multi-hundred-KB frame just to add a byte.
         let previous = sendChain
-        let task = Task { [output] in
+        let task = Task { [output, poisoned] in
             _ = try? await previous?.value
             try Task.checkCancellation()
-            try await Self.write(message, to: output)
-            try await Self.write(Self.newlineFrame, to: output)
+            guard !poisoned.withLock({ $0 }) else {
+                throw FramedStdioTransportError.poisoned
+            }
+            do {
+                try await Self.write(message, to: output)
+                try await Self.write(Self.newlineFrame, to: output)
+            } catch {
+                poisoned.withLock { $0 = true }
+                throw error
+            }
         }
         sendChain = task
         pendingSends.insert(task)
         defer { pendingSends.remove(task) }
-        // Forward the caller's cancellation so a cancelled caller doesn't
-        // leave its write retrying forever.
-        return try await withTaskCancellationHandler {
-            try await task.value
-        } onCancel: {
-            task.cancel()
-        }
+        try await task.value
     }
 
     func receive() -> AsyncThrowingStream<Data, Swift.Error> {
@@ -108,7 +132,13 @@ actor FramedStdioTransport: Transport {
             do {
                 let count = try chunk.withUnsafeMutableBytes { try input.read(into: $0) }
                 if count == 0 {
-                    continuation.finish()
+                    if buffer.isEmpty {
+                        continuation.finish()
+                    } else {
+                        continuation.finish(
+                            throwing: FramedStdioTransportError.truncatedFinalFrame
+                        )
+                    }
                     return
                 }
                 chunk.withUnsafeBytes { raw in
@@ -116,8 +146,10 @@ actor FramedStdioTransport: Transport {
                 }
                 // `scanFrom` marks how far the newline scan has gotten, so
                 // a large frame arriving in many chunks is scanned once,
-                // not once per chunk; slicing instead of re-wrapping in
-                // Data() keeps frame extraction copy-free.
+                // not once per chunk; frame extraction slices (no copy),
+                // then one compaction per iteration that extracted frames
+                // releases the consumed prefix's backing storage.
+                let preExtraction = buffer.startIndex
                 while let newline = buffer[scanFrom...].firstIndex(of: UInt8(ascii: "\n")) {
                     let line = buffer[buffer.startIndex ..< newline]
                     if !line.isEmpty {
@@ -126,11 +158,10 @@ actor FramedStdioTransport: Transport {
                     buffer = buffer[buffer.index(after: newline)...]
                     scanFrom = buffer.startIndex
                 }
-                scanFrom = buffer.endIndex
-                if buffer.isEmpty {
-                    buffer = Data()
-                    scanFrom = buffer.startIndex
+                if buffer.startIndex != preExtraction {
+                    buffer = Data(buffer)
                 }
+                scanFrom = buffer.endIndex
             } catch let errno as Errno {
                 switch errno {
                 case .wouldBlock, .resourceTemporarilyUnavailable:
@@ -159,6 +190,7 @@ actor FramedStdioTransport: Transport {
     private static func write(_ data: Data, to output: FileDescriptor) async throws {
         var offset = 0
         while offset < data.count {
+            try Task.checkCancellation()
             do {
                 let written = try data.withUnsafeBytes { raw in
                     try output.write(UnsafeRawBufferPointer(rebasing: raw[offset...]))
@@ -181,6 +213,12 @@ actor FramedStdioTransport: Transport {
         let flags = fcntl(descriptor.rawValue, F_GETFL)
         guard flags >= 0 else { throw Errno(rawValue: errno) }
         guard fcntl(descriptor.rawValue, F_SETFL, flags | O_NONBLOCK) >= 0 else {
+            throw Errno(rawValue: errno)
+        }
+    }
+
+    private static func setNoSigPipe(_ descriptor: FileDescriptor) throws {
+        guard fcntl(descriptor.rawValue, F_SETNOSIGPIPE, 1) >= 0 else {
             throw Errno(rawValue: errno)
         }
     }

--- a/previewsmcp/PreviewsCLI/FramedStdioTransport.swift
+++ b/previewsmcp/PreviewsCLI/FramedStdioTransport.swift
@@ -1,0 +1,169 @@
+import Foundation
+import Logging
+import MCP
+import System
+
+/// In-house newline-framed JSON-RPC stdio transport (rewrite stage 2).
+///
+/// Replaces the SDK's `StdioTransport` and the `SerializedStdioTransport`
+/// wrapper at cutover, fixing their defect class by construction:
+///
+/// - Sends are chained, never concurrent: there is no suspension between
+///   reading and updating `sendChain`, so re-entrant callers each queue
+///   behind the true predecessor and frames land contiguously (#320).
+/// - Read errors PROPAGATE: a real errno finishes the receive stream
+///   throwing, EOF finishes it cleanly, and EINTR is retried — the SDK
+///   broke its loop silently on both.
+/// - The logger is a no-op by construction, so nothing can write prose
+///   into the JSON stream the daemon serves on stdout.
+///
+/// The transport does not own its file descriptors and never closes them.
+actor FramedStdioTransport: Transport {
+    nonisolated let logger = Logger(
+        label: "previewsmcp.framed-stdio",
+        factory: { _ in SwiftLogNoOpLogHandler() }
+    )
+
+    private let input: FileDescriptor
+    private let output: FileDescriptor
+    private let messageStream: AsyncThrowingStream<Data, Swift.Error>
+    private let messageContinuation: AsyncThrowingStream<Data, Swift.Error>.Continuation
+    private var sendChain: Task<Void, Swift.Error>?
+    private var pendingSends: Set<Task<Void, Swift.Error>> = []
+    private var reader: Task<Void, Never>?
+
+    init(
+        input: FileDescriptor = .standardInput,
+        output: FileDescriptor = .standardOutput
+    ) {
+        self.input = input
+        self.output = output
+        var continuation: AsyncThrowingStream<Data, Swift.Error>.Continuation!
+        messageStream = AsyncThrowingStream { continuation = $0 }
+        messageContinuation = continuation
+    }
+
+    func connect() async throws {
+        try Self.setNonBlocking(input)
+        try Self.setNonBlocking(output)
+        reader = Task { await readLoop() }
+    }
+
+    func disconnect() async {
+        // Cancel every queued/in-flight send, not just the chain tail: a
+        // peer that stops draining leaves the head send retrying EAGAIN
+        // forever, and everything queued behind it retains its message.
+        for task in pendingSends {
+            task.cancel()
+        }
+        pendingSends.removeAll()
+        sendChain = nil
+        reader?.cancel()
+        messageContinuation.finish()
+    }
+
+    func send(_ message: Data) async throws {
+        var frame = message
+        frame.append(UInt8(ascii: "\n"))
+        // No suspension between reading and updating `sendChain` — the
+        // serialization invariant everything above depends on.
+        let previous = sendChain
+        let task = Task { [output] in
+            _ = try? await previous?.value
+            try Task.checkCancellation()
+            try await Self.write(frame, to: output)
+        }
+        sendChain = task
+        pendingSends.insert(task)
+        defer { pendingSends.remove(task) }
+        // Forward the caller's cancellation so a cancelled caller doesn't
+        // leave its write retrying forever.
+        return try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
+    func receive() -> AsyncThrowingStream<Data, Swift.Error> {
+        messageStream
+    }
+
+    // MARK: - Read side
+
+    private func readLoop() async {
+        var buffer = Data()
+        var chunk = [UInt8](repeating: 0, count: 64 * 1024)
+        while !Task.isCancelled {
+            do {
+                let count = try chunk.withUnsafeMutableBytes { try input.read(into: $0) }
+                if count == 0 {
+                    messageContinuation.finish()
+                    return
+                }
+                buffer.append(contentsOf: chunk[0 ..< count])
+                while let newline = buffer.firstIndex(of: UInt8(ascii: "\n")) {
+                    let line = buffer[buffer.startIndex ..< newline]
+                    if !line.isEmpty {
+                        messageContinuation.yield(Data(line))
+                    }
+                    buffer = Data(buffer[buffer.index(after: newline)...])
+                }
+                // Keep the actor fair to senders during sustained input.
+                await Task.yield()
+            } catch let errno as Errno {
+                switch errno {
+                case .wouldBlock, .resourceTemporarilyUnavailable:
+                    do {
+                        try await Task.sleep(for: .milliseconds(10))
+                    } catch {
+                        messageContinuation.finish()
+                        return
+                    }
+                case .interrupted:
+                    continue
+                default:
+                    messageContinuation.finish(throwing: errno)
+                    return
+                }
+            } catch {
+                messageContinuation.finish(throwing: error)
+                return
+            }
+        }
+        messageContinuation.finish()
+    }
+
+    // MARK: - Write side
+
+    /// Static so the retry suspension never suspends the actor mid-write;
+    /// ordering comes from the send chain, not isolation.
+    private static func write(_ data: Data, to output: FileDescriptor) async throws {
+        var offset = 0
+        while offset < data.count {
+            do {
+                let written = try data.withUnsafeBytes { raw in
+                    try output.write(UnsafeRawBufferPointer(rebasing: raw[offset...]))
+                }
+                offset += written
+            } catch let errno as Errno {
+                switch errno {
+                case .wouldBlock, .resourceTemporarilyUnavailable:
+                    try await Task.sleep(for: .milliseconds(10))
+                case .interrupted:
+                    continue
+                default:
+                    throw errno
+                }
+            }
+        }
+    }
+
+    private static func setNonBlocking(_ descriptor: FileDescriptor) throws {
+        let flags = fcntl(descriptor.rawValue, F_GETFL)
+        guard flags >= 0 else { throw Errno(rawValue: errno) }
+        guard fcntl(descriptor.rawValue, F_SETFL, flags | O_NONBLOCK) >= 0 else {
+            throw Errno(rawValue: errno)
+        }
+    }
+}

--- a/previewsmcp/Tests/PreviewsCLITests/FramedStdioTransportTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/FramedStdioTransportTests.swift
@@ -15,55 +15,9 @@ import Testing
 struct FramedStdioTransportTests {
     @Test("concurrent sends under pipe backpressure never interleave frames")
     func concurrentSendsPreserveFraming() async throws {
-        let inPipe = Pipe()
-        let outPipe = Pipe()
-        let transport = FramedStdioTransport(
-            input: .init(rawValue: inPipe.fileHandleForReading.fileDescriptor),
-            output: .init(rawValue: outPipe.fileHandleForWriting.fileDescriptor)
-        )
-        try await transport.connect()
-
-        let big = Data(#"{"big":"\#(String(repeating: "a", count: 300_000))"}"#.utf8)
-        let small = Data(#"{"small":1}"#.utf8)
-        let expectedBytes = big.count + small.count + 2
-
-        // Collect the transport's output on a raw thread: the reader must not
-        // drain the pipe while the big send is still queuing, or the write
-        // never backs up into the EAGAIN retry this test exists to exercise.
-        let collected = OSAllocatedUnfairLock(initialState: Data())
-        let readFD = outPipe.fileHandleForReading
-        Thread.detachNewThread {
-            Thread.sleep(forTimeInterval: 0.4)
-            while true {
-                let chunk = readFD.availableData
-                if chunk.isEmpty { break }
-                let total = collected.withLock { data -> Int in
-                    data.append(chunk)
-                    return data.count
-                }
-                if total >= expectedBytes { break }
-            }
+        try await assertConcurrentSendsPreserveFraming { input, output in
+            FramedStdioTransport(input: input, output: output)
         }
-
-        let bigSend = Task { try await transport.send(big) }
-        try await Task.sleep(for: .milliseconds(150))
-        let smallSend = Task { try await transport.send(small) }
-        try await bigSend.value
-        try await smallSend.value
-
-        _ = try await pollUntil(
-            { collected.withLock { $0.count } >= expectedBytes },
-            failure: "collector never saw both frames"
-        )
-        let lines = collected.withLock { $0 }.split(separator: UInt8(ascii: "\n"))
-        #expect(lines.count == 2, "expected exactly 2 frames, got \(lines.count)")
-        for line in lines {
-            #expect(
-                (try? JSONSerialization.jsonObject(with: Data(line))) != nil,
-                "frame is not valid JSON — sends interleaved (first 80 bytes: \(String(decoding: line.prefix(80), as: UTF8.self)))"
-            )
-        }
-        await transport.disconnect()
     }
 
     @Test("a frame larger than the pipe buffer arrives intact")
@@ -112,19 +66,8 @@ struct FramedStdioTransportTests {
         )
         try await transport.connect()
 
-        let outcome = OSAllocatedUnfairLock(initialState: Result<Void, Swift.Error>?.none)
-        let consumer = Task {
-            do {
-                for try await _ in await transport.receive() {}
-                outcome.withLock { $0 = .success(()) }
-            } catch {
-                outcome.withLock { $0 = .failure(error) }
-            }
-        }
-        defer { consumer.cancel() }
-
-        let result = try await pollUntil(
-            { outcome.withLock { $0 } },
+        let result = try await receiveStreamOutcome(
+            of: transport,
             failure: "stream neither finished nor threw on an unreadable input"
         )
         guard case .failure = result else {
@@ -142,7 +85,24 @@ struct FramedStdioTransportTests {
             output: try FileDescriptor.open("/dev/null", .readWrite)
         )
         try await transport.connect()
+        try pipe.fileHandleForWriting.close()
 
+        let result = try await receiveStreamOutcome(
+            of: transport,
+            failure: "stream never finished after peer EOF"
+        )
+        guard case .success = result else {
+            Issue.record("EOF surfaced as an error: \(result)")
+            return
+        }
+        await transport.disconnect()
+    }
+
+    /// Drains `receive()` on a child task and polls for how it ended.
+    private func receiveStreamOutcome(
+        of transport: FramedStdioTransport,
+        failure: Comment
+    ) async throws -> Result<Void, Swift.Error> {
         let outcome = OSAllocatedUnfairLock(initialState: Result<Void, Swift.Error>?.none)
         let consumer = Task {
             do {
@@ -153,18 +113,7 @@ struct FramedStdioTransportTests {
             }
         }
         defer { consumer.cancel() }
-
-        try pipe.fileHandleForWriting.close()
-
-        let result = try await pollUntil(
-            { outcome.withLock { $0 } },
-            failure: "stream never finished after peer EOF"
-        )
-        guard case .success = result else {
-            Issue.record("EOF surfaced as an error: \(result)")
-            return
-        }
-        await transport.disconnect()
+        return try await pollUntil({ outcome.withLock { $0 } }, failure: failure)
     }
 
     @Test("disconnect cancels a send wedged on a full pipe")

--- a/previewsmcp/Tests/PreviewsCLITests/FramedStdioTransportTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/FramedStdioTransportTests.swift
@@ -1,0 +1,242 @@
+import Foundation
+import MCP
+import os
+@testable import PreviewsCLI
+import System
+import Testing
+
+/// The in-house stdio transport must beat the SDK's on its three known
+/// defect classes: interleaved sends under backpressure, silent read-loop
+/// death, and prose on stdout (structurally impossible — the logger is
+/// hard-wired no-op). The differential test runs the real SDK Client and
+/// Server over two of these transports, keeping the SDK as the independent
+/// protocol implementation.
+@Suite("FramedStdioTransport")
+struct FramedStdioTransportTests {
+    @Test("concurrent sends under pipe backpressure never interleave frames")
+    func concurrentSendsPreserveFraming() async throws {
+        let inPipe = Pipe()
+        let outPipe = Pipe()
+        let transport = FramedStdioTransport(
+            input: .init(rawValue: inPipe.fileHandleForReading.fileDescriptor),
+            output: .init(rawValue: outPipe.fileHandleForWriting.fileDescriptor)
+        )
+        try await transport.connect()
+
+        let big = Data(#"{"big":"\#(String(repeating: "a", count: 300_000))"}"#.utf8)
+        let small = Data(#"{"small":1}"#.utf8)
+        let expectedBytes = big.count + small.count + 2
+
+        // Collect the transport's output on a raw thread: the reader must not
+        // drain the pipe while the big send is still queuing, or the write
+        // never backs up into the EAGAIN retry this test exists to exercise.
+        let collected = OSAllocatedUnfairLock(initialState: Data())
+        let readFD = outPipe.fileHandleForReading
+        Thread.detachNewThread {
+            Thread.sleep(forTimeInterval: 0.4)
+            while true {
+                let chunk = readFD.availableData
+                if chunk.isEmpty { break }
+                let total = collected.withLock { data -> Int in
+                    data.append(chunk)
+                    return data.count
+                }
+                if total >= expectedBytes { break }
+            }
+        }
+
+        let bigSend = Task { try await transport.send(big) }
+        try await Task.sleep(for: .milliseconds(150))
+        let smallSend = Task { try await transport.send(small) }
+        try await bigSend.value
+        try await smallSend.value
+
+        _ = try await pollUntil(
+            { collected.withLock { $0.count } >= expectedBytes },
+            failure: "collector never saw both frames"
+        )
+        let lines = collected.withLock { $0 }.split(separator: UInt8(ascii: "\n"))
+        #expect(lines.count == 2, "expected exactly 2 frames, got \(lines.count)")
+        for line in lines {
+            #expect(
+                (try? JSONSerialization.jsonObject(with: Data(line))) != nil,
+                "frame is not valid JSON — sends interleaved (first 80 bytes: \(String(decoding: line.prefix(80), as: UTF8.self)))"
+            )
+        }
+        await transport.disconnect()
+    }
+
+    @Test("a frame larger than the pipe buffer arrives intact")
+    func largeFrameRoundTrip() async throws {
+        let pipe = Pipe()
+        let sender = FramedStdioTransport(
+            input: try FileDescriptor.open("/dev/null", .readWrite),
+            output: .init(rawValue: pipe.fileHandleForWriting.fileDescriptor)
+        )
+        let receiver = FramedStdioTransport(
+            input: .init(rawValue: pipe.fileHandleForReading.fileDescriptor),
+            output: try FileDescriptor.open("/dev/null", .readWrite)
+        )
+        try await sender.connect()
+        try await receiver.connect()
+
+        let payload = Data(#"{"blob":"\#(String(repeating: "x", count: 1_000_000))"}"#.utf8)
+        let received = OSAllocatedUnfairLock(initialState: Data?.none)
+        let collector = Task {
+            for try await message in await receiver.receive() {
+                received.withLock { $0 = message }
+                break
+            }
+        }
+        defer { collector.cancel() }
+
+        try await sender.send(payload)
+        let message = try await pollUntil(
+            { received.withLock { $0 } },
+            failure: "large frame never arrived"
+        )
+        #expect(message == payload)
+        await sender.disconnect()
+        await receiver.disconnect()
+    }
+
+    @Test("a real read error finishes the stream throwing, not silently")
+    func readErrorPropagates() async throws {
+        // A write-only input fails every read with EBADF, the errno the
+        // SDK's loop would swallow silently. Closing a live fd mid-run
+        // would race parallel tests: the number gets reused and the loop
+        // reads someone else's descriptor.
+        let transport = FramedStdioTransport(
+            input: try FileDescriptor.open("/dev/null", .writeOnly),
+            output: try FileDescriptor.open("/dev/null", .readWrite)
+        )
+        try await transport.connect()
+
+        let outcome = OSAllocatedUnfairLock(initialState: Result<Void, Swift.Error>?.none)
+        let consumer = Task {
+            do {
+                for try await _ in await transport.receive() {}
+                outcome.withLock { $0 = .success(()) }
+            } catch {
+                outcome.withLock { $0 = .failure(error) }
+            }
+        }
+        defer { consumer.cancel() }
+
+        let result = try await pollUntil(
+            { outcome.withLock { $0 } },
+            failure: "stream neither finished nor threw on an unreadable input"
+        )
+        guard case .failure = result else {
+            Issue.record("read error was swallowed: stream finished cleanly")
+            return
+        }
+        await transport.disconnect()
+    }
+
+    @Test("peer EOF finishes the stream cleanly")
+    func eofFinishesCleanly() async throws {
+        let pipe = Pipe()
+        let transport = FramedStdioTransport(
+            input: .init(rawValue: pipe.fileHandleForReading.fileDescriptor),
+            output: try FileDescriptor.open("/dev/null", .readWrite)
+        )
+        try await transport.connect()
+
+        let outcome = OSAllocatedUnfairLock(initialState: Result<Void, Swift.Error>?.none)
+        let consumer = Task {
+            do {
+                for try await _ in await transport.receive() {}
+                outcome.withLock { $0 = .success(()) }
+            } catch {
+                outcome.withLock { $0 = .failure(error) }
+            }
+        }
+        defer { consumer.cancel() }
+
+        try pipe.fileHandleForWriting.close()
+
+        let result = try await pollUntil(
+            { outcome.withLock { $0 } },
+            failure: "stream never finished after peer EOF"
+        )
+        guard case .success = result else {
+            Issue.record("EOF surfaced as an error: \(result)")
+            return
+        }
+        await transport.disconnect()
+    }
+
+    @Test("disconnect cancels a send wedged on a full pipe")
+    func disconnectCancelsWedgedSend() async throws {
+        // Nobody drains the pipe, so a frame larger than its buffer parks
+        // the send in the EAGAIN retry forever unless disconnect frees it.
+        let pipe = Pipe()
+        let transport = FramedStdioTransport(
+            input: try FileDescriptor.open("/dev/null", .readWrite),
+            output: .init(rawValue: pipe.fileHandleForWriting.fileDescriptor)
+        )
+        try await transport.connect()
+
+        let outcome = OSAllocatedUnfairLock(initialState: Result<Void, Swift.Error>?.none)
+        let wedged = Task {
+            do {
+                try await transport.send(Data(repeating: UInt8(ascii: "y"), count: 300_000))
+                outcome.withLock { $0 = .success(()) }
+            } catch {
+                outcome.withLock { $0 = .failure(error) }
+            }
+        }
+        defer { wedged.cancel() }
+
+        try await Task.sleep(for: .milliseconds(200))
+        await transport.disconnect()
+
+        let result = try await pollUntil(
+            { outcome.withLock { $0 } },
+            failure: "wedged send was not released by disconnect"
+        )
+        guard case .failure = result else {
+            Issue.record("send of an undrained frame reported success")
+            return
+        }
+    }
+
+    @Test("the SDK Client and Server complete a tool call over two framed transports")
+    func differentialUnderSDKClientAndServer() async throws {
+        // The independent-implementation cross-check: both protocol ends are
+        // the SDK's, only the wire is ours.
+        let clientToServer = Pipe()
+        let serverToClient = Pipe()
+        let serverTransport = FramedStdioTransport(
+            input: .init(rawValue: clientToServer.fileHandleForReading.fileDescriptor),
+            output: .init(rawValue: serverToClient.fileHandleForWriting.fileDescriptor)
+        )
+        let clientTransport = FramedStdioTransport(
+            input: .init(rawValue: serverToClient.fileHandleForReading.fileDescriptor),
+            output: .init(rawValue: clientToServer.fileHandleForWriting.fileDescriptor)
+        )
+
+        let server = Server(
+            name: "framed-differential", version: "1",
+            capabilities: .init(tools: .init(listChanged: false))
+        )
+        await server.withMethodHandler(CallTool.self) { params in
+            CallTool.Result(content: [.text("echo:\(params.name)")])
+        }
+        try await server.start(transport: serverTransport)
+
+        let client = Client(name: "framed-differential", version: "1")
+        _ = try await client.connect(transport: clientTransport)
+
+        let result = try await client.callToolStructured(name: "probe")
+        guard case let .text(text)? = result.content.first else {
+            Issue.record("unexpected content: \(result.content)")
+            return
+        }
+        #expect(text == "echo:probe")
+
+        await client.disconnect()
+        await server.stop()
+    }
+}

--- a/previewsmcp/Tests/PreviewsCLITests/FramedStdioTransportTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/FramedStdioTransportTests.swift
@@ -5,12 +5,13 @@ import os
 import System
 import Testing
 
-/// The in-house stdio transport must beat the SDK's on its three known
-/// defect classes: interleaved sends under backpressure, silent read-loop
-/// death, and prose on stdout (structurally impossible — the logger is
-/// hard-wired no-op). The differential test runs the real SDK Client and
-/// Server over two of these transports, keeping the SDK as the independent
-/// protocol implementation.
+/// The in-house stdio transport must beat the SDK's on its known defect
+/// classes: interleaved sends under backpressure, silent read-loop death,
+/// prose on stdout (structurally impossible — the logger is hard-wired
+/// no-op), SIGPIPE process death, and silently dropped truncated frames.
+/// The differential test runs the real SDK Client and Server over two of
+/// these transports, keeping the SDK as the independent protocol
+/// implementation.
 @Suite("FramedStdioTransport")
 struct FramedStdioTransportTests {
     @Test("concurrent sends under pipe backpressure never interleave frames")
@@ -23,13 +24,17 @@ struct FramedStdioTransportTests {
     @Test("a frame larger than the pipe buffer arrives intact")
     func largeFrameRoundTrip() async throws {
         let pipe = Pipe()
+        let senderNull = try FileDescriptor.open("/dev/null", .readWrite)
+        defer { try? senderNull.close() }
+        let receiverNull = try FileDescriptor.open("/dev/null", .readWrite)
+        defer { try? receiverNull.close() }
         let sender = FramedStdioTransport(
-            input: try FileDescriptor.open("/dev/null", .readWrite),
+            input: senderNull,
             output: .init(rawValue: pipe.fileHandleForWriting.fileDescriptor)
         )
         let receiver = FramedStdioTransport(
             input: .init(rawValue: pipe.fileHandleForReading.fileDescriptor),
-            output: try FileDescriptor.open("/dev/null", .readWrite)
+            output: receiverNull
         )
         try await sender.connect()
         try await receiver.connect()
@@ -52,6 +57,7 @@ struct FramedStdioTransportTests {
         #expect(message == payload)
         await sender.disconnect()
         await receiver.disconnect()
+        withExtendedLifetime(pipe) {}
     }
 
     @Test("a real read error finishes the stream throwing, not silently")
@@ -60,10 +66,11 @@ struct FramedStdioTransportTests {
         // SDK's loop would swallow silently. Closing a live fd mid-run
         // would race parallel tests: the number gets reused and the loop
         // reads someone else's descriptor.
-        let transport = FramedStdioTransport(
-            input: try FileDescriptor.open("/dev/null", .writeOnly),
-            output: try FileDescriptor.open("/dev/null", .readWrite)
-        )
+        let input = try FileDescriptor.open("/dev/null", .writeOnly)
+        defer { try? input.close() }
+        let output = try FileDescriptor.open("/dev/null", .readWrite)
+        defer { try? output.close() }
+        let transport = FramedStdioTransport(input: input, output: output)
         try await transport.connect()
 
         let result = try await receiveStreamOutcome(
@@ -80,9 +87,11 @@ struct FramedStdioTransportTests {
     @Test("peer EOF finishes the stream cleanly")
     func eofFinishesCleanly() async throws {
         let pipe = Pipe()
+        let output = try FileDescriptor.open("/dev/null", .readWrite)
+        defer { try? output.close() }
         let transport = FramedStdioTransport(
             input: .init(rawValue: pipe.fileHandleForReading.fileDescriptor),
-            output: try FileDescriptor.open("/dev/null", .readWrite)
+            output: output
         )
         try await transport.connect()
         try pipe.fileHandleForWriting.close()
@@ -96,24 +105,68 @@ struct FramedStdioTransportTests {
             return
         }
         await transport.disconnect()
+        withExtendedLifetime(pipe) {}
     }
 
-    /// Drains `receive()` on a child task and polls for how it ended.
-    private func receiveStreamOutcome(
-        of transport: FramedStdioTransport,
-        failure: Comment
-    ) async throws -> Result<Void, Swift.Error> {
-        let outcome = OSAllocatedUnfairLock(initialState: Result<Void, Swift.Error>?.none)
-        let consumer = Task {
-            do {
-                for try await _ in await transport.receive() {}
-                outcome.withLock { $0 = .success(()) }
-            } catch {
-                outcome.withLock { $0 = .failure(error) }
-            }
+    @Test("EOF with a buffered partial frame finishes the stream throwing")
+    func truncatedFinalFrameThrows() async throws {
+        let pipe = Pipe()
+        let output = try FileDescriptor.open("/dev/null", .readWrite)
+        defer { try? output.close() }
+        let transport = FramedStdioTransport(
+            input: .init(rawValue: pipe.fileHandleForReading.fileDescriptor),
+            output: output
+        )
+        try await transport.connect()
+        try pipe.fileHandleForWriting.write(contentsOf: Data(#"{"cut"#.utf8))
+        try pipe.fileHandleForWriting.close()
+
+        let result = try await receiveStreamOutcome(
+            of: transport,
+            failure: "stream never finished after a truncated EOF"
+        )
+        guard case let .failure(error) = result else {
+            Issue.record("truncated final frame was silently dropped")
+            return
         }
-        defer { consumer.cancel() }
-        return try await pollUntil({ outcome.withLock { $0 } }, failure: failure)
+        #expect(error as? FramedStdioTransportError == .truncatedFinalFrame)
+        await transport.disconnect()
+        withExtendedLifetime(pipe) {}
+    }
+
+    @Test("a dead peer surfaces as EPIPE and poisons later sends, not SIGPIPE")
+    func deadPeerPoisonsInsteadOfKilling() async throws {
+        let pipe = Pipe()
+        let input = try FileDescriptor.open("/dev/null", .readWrite)
+        defer { try? input.close() }
+        let transport = FramedStdioTransport(
+            input: input,
+            output: .init(rawValue: pipe.fileHandleForWriting.fileDescriptor)
+        )
+        try await transport.connect()
+        try pipe.fileHandleForReading.close()
+
+        await #expect(throws: Errno.brokenPipe) {
+            try await transport.send(Data(#"{"a":1}"#.utf8))
+        }
+        await #expect(throws: FramedStdioTransportError.poisoned) {
+            try await transport.send(Data(#"{"b":2}"#.utf8))
+        }
+        await transport.disconnect()
+        withExtendedLifetime(pipe) {}
+    }
+
+    @Test("send after disconnect throws instead of writing")
+    func sendAfterDisconnectThrows() async throws {
+        let devNull = try FileDescriptor.open("/dev/null", .readWrite)
+        defer { try? devNull.close() }
+        let transport = FramedStdioTransport(input: devNull, output: devNull)
+        try await transport.connect()
+        await transport.disconnect()
+
+        await #expect(throws: FramedStdioTransportError.disconnected) {
+            try await transport.send(Data(#"{"late":1}"#.utf8))
+        }
     }
 
     @Test("disconnect cancels a send wedged on a full pipe")
@@ -121,8 +174,10 @@ struct FramedStdioTransportTests {
         // Nobody drains the pipe, so a frame larger than its buffer parks
         // the send in the EAGAIN retry forever unless disconnect frees it.
         let pipe = Pipe()
+        let input = try FileDescriptor.open("/dev/null", .readWrite)
+        defer { try? input.close() }
         let transport = FramedStdioTransport(
-            input: try FileDescriptor.open("/dev/null", .readWrite),
+            input: input,
             output: .init(rawValue: pipe.fileHandleForWriting.fileDescriptor)
         )
         try await transport.connect()
@@ -149,6 +204,7 @@ struct FramedStdioTransportTests {
             Issue.record("send of an undrained frame reported success")
             return
         }
+        withExtendedLifetime(pipe) {}
     }
 
     @Test("the SDK Client and Server complete a tool call over two framed transports")
@@ -187,5 +243,24 @@ struct FramedStdioTransportTests {
 
         await client.disconnect()
         await server.stop()
+        withExtendedLifetime((clientToServer, serverToClient)) {}
+    }
+
+    /// Drains `receive()` on a child task and polls for how it ended.
+    private func receiveStreamOutcome(
+        of transport: FramedStdioTransport,
+        failure: Comment
+    ) async throws -> Result<Void, Swift.Error> {
+        let outcome = OSAllocatedUnfairLock(initialState: Result<Void, Swift.Error>?.none)
+        let consumer = Task {
+            do {
+                for try await _ in await transport.receive() {}
+                outcome.withLock { $0 = .success(()) }
+            } catch {
+                outcome.withLock { $0 = .failure(error) }
+            }
+        }
+        defer { consumer.cancel() }
+        return try await pollUntil({ outcome.withLock { $0 } }, failure: failure)
     }
 }

--- a/previewsmcp/Tests/PreviewsCLITests/FramingAssertions.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/FramingAssertions.swift
@@ -50,10 +50,15 @@ func assertConcurrentSendsPreserveFraming(
     try await bigSend.value
     try await smallSend.value
 
-    try await pollUntil(
-        { collected.withLock { $0.count } >= expectedBytes },
-        failure: "collector never saw both frames"
-    )
+    do {
+        try await pollUntil(
+            { collected.withLock { $0.count } >= expectedBytes },
+            failure: "collector never saw both frames"
+        )
+    } catch {
+        await transport.disconnect()
+        throw error
+    }
     let lines = collected.withLock { $0 }.split(separator: UInt8(ascii: "\n"))
     #expect(lines.count == 2, "expected exactly 2 frames, got \(lines.count)")
     for line in lines {
@@ -63,4 +68,7 @@ func assertConcurrentSendsPreserveFraming(
         )
     }
     await transport.disconnect()
+    // The Pipes must outlive the transport traffic: releasing them closes
+    // their fds under the still-running transport (fd-number reuse).
+    withExtendedLifetime((inPipe, outPipe)) {}
 }

--- a/previewsmcp/Tests/PreviewsCLITests/FramingAssertions.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/FramingAssertions.swift
@@ -1,0 +1,66 @@
+import Foundation
+import MCP
+import os
+import System
+import Testing
+
+/// Shared repro for the #320 defect class: a frame larger than the pipe
+/// buffer backs up mid-write (EAGAIN suspension) while another `send` races
+/// into that window. A safe transport delivers both newline-delimited frames
+/// contiguous and decodable.
+func assertConcurrentSendsPreserveFraming(
+    makeTransport: (FileDescriptor, FileDescriptor) -> some Transport
+) async throws {
+    let inPipe = Pipe()
+    let outPipe = Pipe()
+    let transport = makeTransport(
+        FileDescriptor(rawValue: inPipe.fileHandleForReading.fileDescriptor),
+        FileDescriptor(rawValue: outPipe.fileHandleForWriting.fileDescriptor)
+    )
+    try await transport.connect()
+
+    let big = Data(#"{"big":"\#(String(repeating: "a", count: 300_000))"}"#.utf8)
+    let small = Data(#"{"small":1}"#.utf8)
+    let expectedBytes = big.count + small.count + 2
+
+    // Collect the transport's output on a raw thread: the reader must not
+    // drain the pipe while the big send is still queuing, or the write
+    // never backs up into the EAGAIN suspension this assertion exists to
+    // exercise — so it waits before its first read.
+    let collected = OSAllocatedUnfairLock(initialState: Data())
+    let readFD = outPipe.fileHandleForReading
+    Thread.detachNewThread {
+        Thread.sleep(forTimeInterval: 0.4)
+        while true {
+            let chunk = readFD.availableData
+            if chunk.isEmpty { break }
+            let total = collected.withLock { data -> Int in
+                data.append(chunk)
+                return data.count
+            }
+            if total >= expectedBytes { break }
+        }
+    }
+
+    // Start the big send; give it time to fill the pipe and suspend in
+    // the EAGAIN retry, then race the small send into that window.
+    let bigSend = Task { try await transport.send(big) }
+    try await Task.sleep(for: .milliseconds(150))
+    let smallSend = Task { try await transport.send(small) }
+    try await bigSend.value
+    try await smallSend.value
+
+    try await pollUntil(
+        { collected.withLock { $0.count } >= expectedBytes },
+        failure: "collector never saw both frames"
+    )
+    let lines = collected.withLock { $0 }.split(separator: UInt8(ascii: "\n"))
+    #expect(lines.count == 2, "expected exactly 2 frames, got \(lines.count)")
+    for line in lines {
+        #expect(
+            (try? JSONSerialization.jsonObject(with: Data(line))) != nil,
+            "frame is not valid JSON — sends interleaved (first 80 bytes: \(String(decoding: line.prefix(80), as: UTF8.self)))"
+        )
+    }
+    await transport.disconnect()
+}

--- a/previewsmcp/Tests/PreviewsCLITests/SerializedStdioTransportTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SerializedStdioTransportTests.swift
@@ -1,5 +1,3 @@
-import Foundation
-import os
 @testable import PreviewsCLI
 import Testing
 
@@ -13,60 +11,8 @@ import Testing
 struct SerializedStdioTransportTests {
     @Test("concurrent sends under pipe backpressure never interleave frames")
     func concurrentSendsPreserveFraming() async throws {
-        let inPipe = Pipe()
-        let outPipe = Pipe()
-        let transport = SerializedStdioTransport(
-            input: .init(rawValue: inPipe.fileHandleForReading.fileDescriptor),
-            output: .init(rawValue: outPipe.fileHandleForWriting.fileDescriptor)
-        )
-        try await transport.connect()
-
-        let big = Data(#"{"big":"\#(String(repeating: "a", count: 300_000))"}"#.utf8)
-        let small = Data(#"{"small":1}"#.utf8)
-        let expectedBytes = big.count + small.count + 2
-
-        // Collect the transport's output on a raw thread: the reader must not
-        // drain the pipe while the big send is still queuing, or the write
-        // never backs up into the EAGAIN suspension this test exists to
-        // exercise — so it waits before its first read.
-        let collected = OSAllocatedUnfairLock(initialState: Data())
-        let readFD = outPipe.fileHandleForReading
-        Thread.detachNewThread {
-            Thread.sleep(forTimeInterval: 0.4)
-            while true {
-                let chunk = readFD.availableData
-                if chunk.isEmpty { break }
-                let total = collected.withLock { data -> Int in
-                    data.append(chunk)
-                    return data.count
-                }
-                if total >= expectedBytes { break }
-            }
+        try await assertConcurrentSendsPreserveFraming { input, output in
+            SerializedStdioTransport(input: input, output: output)
         }
-
-        // Start the big send; give it time to fill the pipe and suspend in
-        // the EAGAIN retry, then race the small send into that window.
-        let bigSend = Task { try await transport.send(big) }
-        try await Task.sleep(for: .milliseconds(150))
-        let smallSend = Task { try await transport.send(small) }
-        try await bigSend.value
-        try await smallSend.value
-
-        // Both sends returned, so all bytes are in the pipe; poll the reader's
-        // buffer up to a deadline rather than blocking the cooperative pool.
-        let deadline = ContinuousClock.now + .seconds(10)
-        while collected.withLock({ $0.count }) < expectedBytes, ContinuousClock.now < deadline {
-            try await Task.sleep(for: .milliseconds(50))
-        }
-
-        let lines = collected.withLock { $0 }.split(separator: UInt8(ascii: "\n"))
-        #expect(lines.count == 2, "expected exactly 2 frames, got \(lines.count)")
-        for line in lines {
-            #expect(
-                (try? JSONSerialization.jsonObject(with: Data(line))) != nil,
-                "frame is not valid JSON — sends interleaved (first 80 bytes: \(String(decoding: line.prefix(80), as: UTF8.self)))"
-            )
-        }
-        await transport.disconnect()
     }
 }


### PR DESCRIPTION
Stage 2 of the MCP wire rewrite (plan in #322/#323 lineage): an in-house newline-framed JSON-RPC stdio transport conforming to the SDK's `Transport` protocol. Not wired into production yet — cutover is stage 5; stage 1's 13-test SDK characterization suite passes unchanged.

## Design (fixes the SDK's defect classes by construction)

- **Chained sends, never concurrent** — no suspension between reading and updating `sendChain`, so re-entrant callers queue behind the true predecessor and frames land contiguously (#320's class).
- **A started frame always finishes** — caller cancellation is not forwarded into an in-flight write (mid-frame aborts tear the wire); only `disconnect()` aborts, and any failed/aborted write **poisons** the transport so later sends throw instead of gluing onto a torn frame.
- **Fail-stop error surface** — read errnos finish the receive stream throwing; EOF with a buffered partial frame throws `truncatedFinalFrame`; clean EOF finishes cleanly; EINTR retried; dead peer surfaces as EPIPE (`F_SETNOSIGPIPE`), not SIGPIPE process death.
- **No prose on stdout** — the logger is hard-wired no-op.
- Hot-path: incremental newline scan, copy-free frame extraction with per-iteration compaction, no per-frame payload copy (newline written separately).

## Tests (9, all deterministic — no fd-close races)

Framing under backpressure (shared `assertConcurrentSendsPreserveFraming`, also used by the SerializedStdioTransport suite), 1MB round trip, EBADF propagation via write-only fd, clean EOF, truncated final frame, EPIPE + poison (would previously have killed the test process via SIGPIPE), send-after-disconnect, disconnect frees a wedged send, and a differential SDK-Client↔SDK-Server tool call over two framed transports.

## Gates

- /simplify (4-agent): 8 findings applied
- /code-review (high, workflow): 4 confirmed correctness defects fixed (mid-frame abort corruption, SIGPIPE, disconnect/send race, dropped truncated frame) + test fd hygiene
- Determinism campaigns 15/15 + 10/15 + 15/15 across iterations; final 15/15
- Lint clean; full local suite 9/9 (MCPIntegrationTests failed once with the pre-existing #320 NSURLError-1 residual, passed on rerun — not this change: the transport is unwired)

## Deferred (documented)

- Event-driven read readiness (DispatchSource/kqueue) replaces the 10ms idle poll **before stage-5 cutover**.
- Send-chain duplication with `SerializedStdioTransport` is intentional; the wrapper dies at stage 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)