### PR TITLE
Rewrite stage 3: UDS channel on the same framing core

### DIFF
--- a/previewsmcp/PreviewsCLI/DaemonSocket.swift
+++ b/previewsmcp/PreviewsCLI/DaemonSocket.swift
@@ -1,0 +1,112 @@
+import Darwin
+import System
+
+/// POSIX plumbing for the daemon's Unix-domain-socket channel (rewrite
+/// stage 3). Produces plain file descriptors that `FramedTransport` carries
+/// as-is, replacing `NWListener`/`NWConnection` + the SDK `NetworkTransport`
+/// at cutover.
+///
+/// Callers own every returned descriptor and must close it. All descriptors
+/// are close-on-exec so daemon children (compilers, simulators) never
+/// inherit the channel.
+enum DaemonSocket {
+    /// Bind and listen on `path`. The listener is non-blocking so
+    /// `accept(on:)` polls cancellably. Stale-socket-file cleanup stays
+    /// with the caller (it must first verify no live daemon is listening).
+    static func listen(at path: String, backlog: Int32 = 16) throws -> FileDescriptor {
+        let listener = try makeSocket()
+        do {
+            try withSockaddrUn(path) { address, length in
+                guard Darwin.bind(listener.rawValue, address, length) == 0 else {
+                    throw Errno(rawValue: errno)
+                }
+            }
+            guard Darwin.listen(listener.rawValue, backlog) == 0 else {
+                throw Errno(rawValue: errno)
+            }
+            try listener.setNonBlocking()
+        } catch {
+            try? listener.close()
+            throw error
+        }
+        return listener
+    }
+
+    /// Accept one connection, polling the non-blocking listener so the
+    /// call is cancellable (a blocking accept would park a cooperative
+    /// thread with no way to interrupt it).
+    static func accept(on listener: FileDescriptor) async throws -> FileDescriptor {
+        while true {
+            try Task.checkCancellation()
+            let raw = Darwin.accept(listener.rawValue, nil, nil)
+            if raw >= 0 {
+                let connection = FileDescriptor(rawValue: raw)
+                do {
+                    try connection.setCloseOnExec()
+                } catch {
+                    try? connection.close()
+                    throw error
+                }
+                return connection
+            }
+            switch Errno(rawValue: errno) {
+            case .wouldBlock, .resourceTemporarilyUnavailable:
+                try await Task.sleep(for: .milliseconds(10))
+            case .interrupted:
+                continue
+            case let failure:
+                throw failure
+            }
+        }
+    }
+
+    /// Dial the daemon at `path`. Blocking, but a UDS connect resolves
+    /// immediately: it either succeeds or fails with ENOENT/ECONNREFUSED.
+    static func connect(to path: String) throws -> FileDescriptor {
+        let socket = try makeSocket()
+        do {
+            try withSockaddrUn(path) { address, length in
+                guard Darwin.connect(socket.rawValue, address, length) == 0 else {
+                    throw Errno(rawValue: errno)
+                }
+            }
+        } catch {
+            try? socket.close()
+            throw error
+        }
+        return socket
+    }
+
+    private static func makeSocket() throws -> FileDescriptor {
+        let raw = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard raw >= 0 else { throw Errno(rawValue: errno) }
+        let socket = FileDescriptor(rawValue: raw)
+        do {
+            try socket.setCloseOnExec()
+        } catch {
+            try? socket.close()
+            throw error
+        }
+        return socket
+    }
+
+    private static func withSockaddrUn<T>(
+        _ path: String,
+        _ body: (UnsafePointer<sockaddr>, socklen_t) throws -> T
+    ) throws -> T {
+        var address = sockaddr_un()
+        let capacity = MemoryLayout.size(ofValue: address.sun_path) - 1
+        let bytes = Array(path.utf8)
+        guard bytes.count <= capacity else { throw Errno(rawValue: ENAMETOOLONG) }
+        address.sun_family = sa_family_t(AF_UNIX)
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+        withUnsafeMutableBytes(of: &address.sun_path) { destination in
+            destination.copyBytes(from: bytes)
+        }
+        return try withUnsafePointer(to: &address) { pointer in
+            try pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { rebound in
+                try body(rebound, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+    }
+}

--- a/previewsmcp/PreviewsCLI/DaemonSocket.swift
+++ b/previewsmcp/PreviewsCLI/DaemonSocket.swift
@@ -15,7 +15,7 @@ enum DaemonSocket {
     /// with the caller (it must first verify no live daemon is listening).
     static func listen(at path: String, backlog: Int32 = 16) throws -> FileDescriptor {
         let listener = try makeSocket()
-        do {
+        try closingOnThrow(listener) {
             try withSockaddrUn(path) { address, length in
                 guard Darwin.bind(listener.rawValue, address, length) == 0 else {
                     throw Errno(rawValue: errno)
@@ -25,9 +25,6 @@ enum DaemonSocket {
                 throw Errno(rawValue: errno)
             }
             try listener.setNonBlocking()
-        } catch {
-            try? listener.close()
-            throw error
         }
         return listener
     }
@@ -41,16 +38,13 @@ enum DaemonSocket {
             let raw = Darwin.accept(listener.rawValue, nil, nil)
             if raw >= 0 {
                 let connection = FileDescriptor(rawValue: raw)
-                do {
+                try closingOnThrow(connection) {
                     try connection.setCloseOnExec()
-                } catch {
-                    try? connection.close()
-                    throw error
                 }
                 return connection
             }
             switch Errno(rawValue: errno) {
-            case .wouldBlock, .resourceTemporarilyUnavailable:
+            case .wouldBlock:
                 try await Task.sleep(for: .milliseconds(10))
             case .interrupted:
                 continue
@@ -64,15 +58,12 @@ enum DaemonSocket {
     /// immediately: it either succeeds or fails with ENOENT/ECONNREFUSED.
     static func connect(to path: String) throws -> FileDescriptor {
         let socket = try makeSocket()
-        do {
+        try closingOnThrow(socket) {
             try withSockaddrUn(path) { address, length in
                 guard Darwin.connect(socket.rawValue, address, length) == 0 else {
                     throw Errno(rawValue: errno)
                 }
             }
-        } catch {
-            try? socket.close()
-            throw error
         }
         return socket
     }
@@ -81,13 +72,21 @@ enum DaemonSocket {
         let raw = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
         guard raw >= 0 else { throw Errno(rawValue: errno) }
         let socket = FileDescriptor(rawValue: raw)
-        do {
+        try closingOnThrow(socket) {
             try socket.setCloseOnExec()
-        } catch {
-            try? socket.close()
-            throw error
         }
         return socket
+    }
+
+    private static func closingOnThrow(
+        _ descriptor: FileDescriptor, _ body: () throws -> Void
+    ) throws {
+        do {
+            try body()
+        } catch {
+            try? descriptor.close()
+            throw error
+        }
     }
 
     private static func withSockaddrUn<T>(

--- a/previewsmcp/PreviewsCLI/DaemonSocket.swift
+++ b/previewsmcp/PreviewsCLI/DaemonSocket.swift
@@ -7,8 +7,10 @@ import System
 /// at cutover.
 ///
 /// Callers own every returned descriptor and must close it. All descriptors
-/// are close-on-exec so daemon children (compilers, simulators) never
-/// inherit the channel.
+/// are marked close-on-exec so daemon children (compilers, simulators) do
+/// not inherit the channel — best effort: Darwin has no atomic SOCK_CLOEXEC
+/// or accept4, so a spawn racing the fcntl can inherit the descriptor for
+/// that window.
 enum DaemonSocket {
     /// Bind and listen on `path`. The listener is non-blocking so
     /// `accept(on:)` polls cancellably. Stale-socket-file cleanup stays
@@ -46,7 +48,7 @@ enum DaemonSocket {
             switch Errno(rawValue: errno) {
             case .wouldBlock:
                 try await Task.sleep(for: .milliseconds(10))
-            case .interrupted:
+            case .interrupted, .connectionAbort:
                 continue
             case let failure:
                 throw failure
@@ -89,10 +91,10 @@ enum DaemonSocket {
         }
     }
 
-    private static func withSockaddrUn<T>(
+    private static func withSockaddrUn(
         _ path: String,
-        _ body: (UnsafePointer<sockaddr>, socklen_t) throws -> T
-    ) throws -> T {
+        _ body: (UnsafePointer<sockaddr>, socklen_t) throws -> Void
+    ) throws {
         var address = sockaddr_un()
         let capacity = MemoryLayout.size(ofValue: address.sun_path) - 1
         let bytes = Array(path.utf8)

--- a/previewsmcp/PreviewsCLI/FileDescriptorModes.swift
+++ b/previewsmcp/PreviewsCLI/FileDescriptorModes.swift
@@ -1,0 +1,24 @@
+import Darwin
+import System
+
+extension FileDescriptor {
+    func setNonBlocking() throws {
+        let flags = fcntl(rawValue, F_GETFL)
+        guard flags >= 0 else { throw Errno(rawValue: errno) }
+        guard fcntl(rawValue, F_SETFL, flags | O_NONBLOCK) >= 0 else {
+            throw Errno(rawValue: errno)
+        }
+    }
+
+    func setNoSigPipe() throws {
+        guard fcntl(rawValue, F_SETNOSIGPIPE, 1) >= 0 else {
+            throw Errno(rawValue: errno)
+        }
+    }
+
+    func setCloseOnExec() throws {
+        guard fcntl(rawValue, F_SETFD, FD_CLOEXEC) >= 0 else {
+            throw Errno(rawValue: errno)
+        }
+    }
+}

--- a/previewsmcp/PreviewsCLI/FramedTransport.swift
+++ b/previewsmcp/PreviewsCLI/FramedTransport.swift
@@ -4,10 +4,24 @@ import MCP
 import os
 import System
 
-enum FramedTransportError: Swift.Error, Equatable {
+enum FramedTransportError: Swift.Error, Equatable, LocalizedError {
+    case notConnected
     case disconnected
     case poisoned
     case truncatedFinalFrame
+
+    var errorDescription: String? {
+        switch self {
+        case .notConnected:
+            "the transport was used before connect()"
+        case .disconnected:
+            "the transport is disconnected"
+        case .poisoned:
+            "an earlier send failed mid-frame; the stream is unrecoverable"
+        case .truncatedFinalFrame:
+            "the peer closed the stream in the middle of a frame"
+        }
+    }
 }
 
 /// In-house newline-framed JSON-RPC transport over plain file descriptors
@@ -53,7 +67,9 @@ actor FramedTransport: Transport {
     private var sendChain: Task<Void, Swift.Error>?
     private var pendingSends: Set<Task<Void, Swift.Error>> = []
     private var reader: Task<Void, Never>?
+    private var isConnected = false
     private var isDisconnected = false
+    private var disconnectRendezvous: Task<Void, Never>?
     private let poisoned = OSAllocatedUnfairLock(initialState: false)
 
     init(
@@ -80,31 +96,40 @@ actor FramedTransport: Transport {
         reader = Task { [input, messageContinuation] in
             await Self.readLoop(input: input, continuation: messageContinuation)
         }
+        isConnected = true
     }
 
     func disconnect() async {
-        guard !isDisconnected else { return }
-        isDisconnected = true
-        // Cancel every queued/in-flight send, not just the chain tail: a
-        // peer that stops draining leaves the head send retrying EAGAIN
-        // forever, and everything queued behind it retains its message.
-        let sends = pendingSends
-        for task in sends {
-            task.cancel()
+        if disconnectRendezvous == nil {
+            isDisconnected = true
+            // Cancel every queued/in-flight send, not just the chain tail:
+            // a peer that stops draining leaves the head send retrying
+            // EAGAIN forever, and everything queued behind it retains its
+            // message.
+            let sends = pendingSends
+            for task in sends {
+                task.cancel()
+            }
+            pendingSends.removeAll()
+            sendChain = nil
+            reader?.cancel()
+            // Rendezvous with everything that touches the descriptors: the
+            // owner may close them the moment disconnect returns. Shared by
+            // every disconnect caller, so a re-entrant call cannot return
+            // before the descriptors are quiescent.
+            disconnectRendezvous = Task { [reader] in
+                for task in sends {
+                    _ = try? await task.value
+                }
+                await reader?.value
+            }
         }
-        pendingSends.removeAll()
-        sendChain = nil
-        reader?.cancel()
-        // Rendezvous with everything that touches the descriptors before
-        // returning: the owner may close them the moment we're done.
-        for task in sends {
-            _ = try? await task.value
-        }
-        await reader?.value
+        await disconnectRendezvous?.value
         messageContinuation.finish()
     }
 
     func send(_ message: Data) async throws {
+        guard isConnected else { throw FramedTransportError.notConnected }
         guard !isDisconnected else { throw FramedTransportError.disconnected }
         // No suspension between reading and updating `sendChain` — the
         // serialization invariant everything above depends on.
@@ -229,19 +254,23 @@ actor FramedTransport: Transport {
         var newline = UInt8(ascii: "\n")
         return try payload.withUnsafeBytes { raw in
             try withUnsafeMutableBytes(of: &newline) { newlineRaw in
-                var vectors = [iovec]()
-                if offset < payload.count {
-                    vectors.append(iovec(
-                        iov_base: UnsafeMutableRawPointer(
-                            mutating: raw.baseAddress!.advanced(by: offset)
-                        ),
-                        iov_len: payload.count - offset
-                    ))
+                try withUnsafeTemporaryAllocation(of: iovec.self, capacity: 2) { vectors in
+                    var count = 0
+                    if offset < payload.count {
+                        vectors[count] = iovec(
+                            iov_base: UnsafeMutableRawPointer(
+                                mutating: raw.baseAddress!.advanced(by: offset)
+                            ),
+                            iov_len: payload.count - offset
+                        )
+                        count += 1
+                    }
+                    vectors[count] = iovec(iov_base: newlineRaw.baseAddress, iov_len: 1)
+                    count += 1
+                    let written = writev(output.rawValue, vectors.baseAddress, Int32(count))
+                    guard written >= 0 else { throw Errno(rawValue: errno) }
+                    return written
                 }
-                vectors.append(iovec(iov_base: newlineRaw.baseAddress, iov_len: 1))
-                let written = writev(output.rawValue, &vectors, Int32(vectors.count))
-                guard written >= 0 else { throw Errno(rawValue: errno) }
-                return written
             }
         }
     }

--- a/previewsmcp/PreviewsCLI/FramedTransport.swift
+++ b/previewsmcp/PreviewsCLI/FramedTransport.swift
@@ -4,16 +4,19 @@ import MCP
 import os
 import System
 
-enum FramedStdioTransportError: Swift.Error, Equatable {
+enum FramedTransportError: Swift.Error, Equatable {
     case disconnected
     case poisoned
     case truncatedFinalFrame
 }
 
-/// In-house newline-framed JSON-RPC stdio transport (rewrite stage 2).
+/// In-house newline-framed JSON-RPC transport over plain file descriptors
+/// (rewrite stages 2-3): stdio for the MCP channel, a Unix domain socket
+/// for the daemon channel (see `DaemonSocket`).
 ///
-/// Replaces the SDK's `StdioTransport` and the `SerializedStdioTransport`
-/// wrapper at cutover, fixing their defect class by construction:
+/// Replaces the SDK's `StdioTransport`, the `SerializedStdioTransport`
+/// wrapper, and `NetworkTransport` at cutover, fixing their defect classes
+/// by construction:
 ///
 /// - Sends are chained, never concurrent: there is no suspension between
 ///   reading and updating `sendChain`, so re-entrant callers each queue
@@ -34,10 +37,12 @@ enum FramedStdioTransportError: Swift.Error, Equatable {
 /// The transport does not own its file descriptors and never closes them,
 /// but `connect()` switches both to non-blocking, disables SIGPIPE delivery
 /// on the output (a dead peer surfaces as EPIPE, not process death), and
-/// leaves both that way.
-actor FramedStdioTransport: Transport {
+/// leaves both that way. `disconnect()` returns only after the read loop
+/// and every send task have finished, so an owner may close the
+/// descriptors immediately afterwards without racing them.
+actor FramedTransport: Transport {
     nonisolated let logger = Logger(
-        label: "previewsmcp.framed-stdio",
+        label: "previewsmcp.framed-transport",
         factory: { _ in SwiftLogNoOpLogHandler() }
     )
 
@@ -62,10 +67,14 @@ actor FramedStdioTransport: Transport {
         messageContinuation = continuation
     }
 
+    init(socket: FileDescriptor) {
+        self.init(input: socket, output: socket)
+    }
+
     func connect() async throws {
-        try Self.setNonBlocking(input)
-        try Self.setNonBlocking(output)
-        try Self.setNoSigPipe(output)
+        try input.setNonBlocking()
+        try output.setNonBlocking()
+        try output.setNoSigPipe()
         reader = Task { [input, messageContinuation] in
             await Self.readLoop(input: input, continuation: messageContinuation)
         }
@@ -77,17 +86,24 @@ actor FramedStdioTransport: Transport {
         // Cancel every queued/in-flight send, not just the chain tail: a
         // peer that stops draining leaves the head send retrying EAGAIN
         // forever, and everything queued behind it retains its message.
-        for task in pendingSends {
+        let sends = pendingSends
+        for task in sends {
             task.cancel()
         }
         pendingSends.removeAll()
         sendChain = nil
         reader?.cancel()
+        // Rendezvous with everything that touches the descriptors before
+        // returning: the owner may close them the moment we're done.
+        for task in sends {
+            _ = try? await task.value
+        }
+        await reader?.value
         messageContinuation.finish()
     }
 
     func send(_ message: Data) async throws {
-        guard !isDisconnected else { throw FramedStdioTransportError.disconnected }
+        guard !isDisconnected else { throw FramedTransportError.disconnected }
         // No suspension between reading and updating `sendChain` — the
         // serialization invariant everything above depends on. The newline
         // goes out as its own write rather than appending to `message`,
@@ -97,7 +113,7 @@ actor FramedStdioTransport: Transport {
             _ = try? await previous?.value
             try Task.checkCancellation()
             guard !poisoned.withLock({ $0 }) else {
-                throw FramedStdioTransportError.poisoned
+                throw FramedTransportError.poisoned
             }
             do {
                 try await Self.write(message, to: output)
@@ -136,7 +152,7 @@ actor FramedStdioTransport: Transport {
                         continuation.finish()
                     } else {
                         continuation.finish(
-                            throwing: FramedStdioTransportError.truncatedFinalFrame
+                            throwing: FramedTransportError.truncatedFinalFrame
                         )
                     }
                     return
@@ -206,20 +222,6 @@ actor FramedStdioTransport: Transport {
                     throw errno
                 }
             }
-        }
-    }
-
-    private static func setNonBlocking(_ descriptor: FileDescriptor) throws {
-        let flags = fcntl(descriptor.rawValue, F_GETFL)
-        guard flags >= 0 else { throw Errno(rawValue: errno) }
-        guard fcntl(descriptor.rawValue, F_SETFL, flags | O_NONBLOCK) >= 0 else {
-            throw Errno(rawValue: errno)
-        }
-    }
-
-    private static func setNoSigPipe(_ descriptor: FileDescriptor) throws {
-        guard fcntl(descriptor.rawValue, F_SETNOSIGPIPE, 1) >= 0 else {
-            throw Errno(rawValue: errno)
         }
     }
 }

--- a/previewsmcp/PreviewsCLI/FramedTransport.swift
+++ b/previewsmcp/PreviewsCLI/FramedTransport.swift
@@ -73,7 +73,9 @@ actor FramedTransport: Transport {
 
     func connect() async throws {
         try input.setNonBlocking()
-        try output.setNonBlocking()
+        if output.rawValue != input.rawValue {
+            try output.setNonBlocking()
+        }
         try output.setNoSigPipe()
         reader = Task { [input, messageContinuation] in
             await Self.readLoop(input: input, continuation: messageContinuation)
@@ -105,9 +107,7 @@ actor FramedTransport: Transport {
     func send(_ message: Data) async throws {
         guard !isDisconnected else { throw FramedTransportError.disconnected }
         // No suspension between reading and updating `sendChain` — the
-        // serialization invariant everything above depends on. The newline
-        // goes out as its own write rather than appending to `message`,
-        // which would copy every multi-hundred-KB frame just to add a byte.
+        // serialization invariant everything above depends on.
         let previous = sendChain
         let task = Task { [output, poisoned] in
             _ = try? await previous?.value
@@ -116,8 +116,7 @@ actor FramedTransport: Transport {
                 throw FramedTransportError.poisoned
             }
             do {
-                try await Self.write(message, to: output)
-                try await Self.write(Self.newlineFrame, to: output)
+                try await Self.writeFrame(message, to: output)
             } catch {
                 poisoned.withLock { $0 = true }
                 throw error
@@ -180,7 +179,7 @@ actor FramedTransport: Transport {
                 scanFrom = buffer.endIndex
             } catch let errno as Errno {
                 switch errno {
-                case .wouldBlock, .resourceTemporarilyUnavailable:
+                case .wouldBlock:
                     try? await Task.sleep(for: pollInterval)
                 case .interrupted:
                     continue
@@ -198,29 +197,51 @@ actor FramedTransport: Transport {
 
     // MARK: - Write side
 
-    private static let newlineFrame = Data([UInt8(ascii: "\n")])
     private static let pollInterval: Duration = .milliseconds(10)
 
     /// Static so the retry suspension never suspends the actor mid-write;
-    /// ordering comes from the send chain, not isolation.
-    private static func write(_ data: Data, to output: FileDescriptor) async throws {
+    /// ordering comes from the send chain, not isolation. One `writev` per
+    /// attempt carries payload + newline: no payload copy, no second
+    /// syscall for the delimiter.
+    private static func writeFrame(_ payload: Data, to output: FileDescriptor) async throws {
         var offset = 0
-        while offset < data.count {
+        let total = payload.count + 1
+        while offset < total {
             try Task.checkCancellation()
             do {
-                let written = try data.withUnsafeBytes { raw in
-                    try output.write(UnsafeRawBufferPointer(rebasing: raw[offset...]))
-                }
-                offset += written
+                offset += try writeFrameChunk(payload, from: offset, to: output)
             } catch let errno as Errno {
                 switch errno {
-                case .wouldBlock, .resourceTemporarilyUnavailable:
+                case .wouldBlock:
                     try await Task.sleep(for: pollInterval)
                 case .interrupted:
                     continue
                 default:
                     throw errno
                 }
+            }
+        }
+    }
+
+    private static func writeFrameChunk(
+        _ payload: Data, from offset: Int, to output: FileDescriptor
+    ) throws -> Int {
+        var newline = UInt8(ascii: "\n")
+        return try payload.withUnsafeBytes { raw in
+            try withUnsafeMutableBytes(of: &newline) { newlineRaw in
+                var vectors = [iovec]()
+                if offset < payload.count {
+                    vectors.append(iovec(
+                        iov_base: UnsafeMutableRawPointer(
+                            mutating: raw.baseAddress!.advanced(by: offset)
+                        ),
+                        iov_len: payload.count - offset
+                    ))
+                }
+                vectors.append(iovec(iov_base: newlineRaw.baseAddress, iov_len: 1))
+                let written = writev(output.rawValue, &vectors, Int32(vectors.count))
+                guard written >= 0 else { throw Errno(rawValue: errno) }
+                return written
             }
         }
     }

--- a/previewsmcp/Tests/PreviewsCLITests/DaemonSocketTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/DaemonSocketTests.swift
@@ -191,17 +191,4 @@ struct DaemonSocketTests {
             _ = try DaemonSocket.listen(at: path)
         }
     }
-
-    private func makeSocketPath() throws -> String {
-        let directory = "/tmp/pmcp-\(UUID().uuidString.prefix(8))"
-        try FileManager.default.createDirectory(
-            atPath: directory, withIntermediateDirectories: true
-        )
-        return directory + "/daemon.sock"
-    }
-
-    private func removeSocketDirectory(_ socketPath: String) {
-        let directory = (socketPath as NSString).deletingLastPathComponent
-        try? FileManager.default.removeItem(atPath: directory)
-    }
 }

--- a/previewsmcp/Tests/PreviewsCLITests/DaemonSocketTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/DaemonSocketTests.swift
@@ -71,24 +71,12 @@ struct DaemonSocketTests {
         let serverSocket = try await DaemonSocket.accept(on: listener)
         defer { try? serverSocket.close() }
 
-        let server = Server(
-            name: "uds-differential", version: "1",
-            capabilities: .init(tools: .init(listChanged: false))
-        )
-        await server.withMethodHandler(CallTool.self) { params in
-            CallTool.Result(content: [.text("echo:\(params.name)")])
-        }
+        let server = await makeEchoServer(named: "uds-differential")
         try await server.start(transport: FramedTransport(socket: serverSocket))
 
         let client = Client(name: "uds-differential", version: "1")
         _ = try await client.connect(transport: FramedTransport(socket: clientSocket))
-
-        let result = try await client.callToolStructured(name: "probe")
-        guard case let .text(text)? = result.content.first else {
-            Issue.record("unexpected content: \(result.content)")
-            return
-        }
-        #expect(text == "echo:probe")
+        try await expectEchoProbe(client)
 
         await client.disconnect()
         await server.stop()
@@ -101,13 +89,7 @@ struct DaemonSocketTests {
         let listener = try DaemonSocket.listen(at: path)
         defer { try? listener.close() }
 
-        let server = Server(
-            name: "uds-interop", version: "1",
-            capabilities: .init(tools: .init(listChanged: false))
-        )
-        await server.withMethodHandler(CallTool.self) { params in
-            CallTool.Result(content: [.text("echo:\(params.name)")])
-        }
+        let server = await makeEchoServer(named: "uds-interop")
         let accepted = OSAllocatedUnfairLock(initialState: FileDescriptor?.none)
         let serving = Task {
             let serverSocket = try await DaemonSocket.accept(on: listener)
@@ -122,13 +104,42 @@ struct DaemonSocketTests {
         let connection = NWConnection(to: NWEndpoint.unix(path: path), using: .tcp)
         let client = Client(name: "uds-interop", version: "1")
         _ = try await client.connect(transport: daemonChannelTransport(connection: connection))
+        try await expectEchoProbe(client)
 
-        let result = try await client.callToolStructured(name: "probe")
-        guard case let .text(text)? = result.content.first else {
-            Issue.record("unexpected content: \(result.content)")
-            return
+        await client.disconnect()
+        await server.stop()
+    }
+
+    @Test("a framed client interoperates with an SDK NetworkTransport server")
+    func interopWithSDKNetworkTransportServer() async throws {
+        // The other half of the staged cutover: an upgraded CLI dialing a
+        // stale pre-cutover daemon must still complete the handshake, or
+        // the version-mismatch respawn can never run.
+        let path = try makeSocketPath()
+        defer { removeSocketDirectory(path) }
+
+        let params = NWParameters.tcp
+        params.requiredLocalEndpoint = NWEndpoint.unix(path: path)
+        let nwListener = try NWListener(using: params)
+        let acceptedConnection = OSAllocatedUnfairLock(initialState: NWConnection?.none)
+        nwListener.newConnectionHandler = { connection in
+            acceptedConnection.withLock { $0 = connection }
         }
-        #expect(text == "echo:probe")
+        try await awaitListenerReady(nwListener)
+        defer { nwListener.cancel() }
+
+        let clientSocket = try DaemonSocket.connect(to: path)
+        defer { try? clientSocket.close() }
+        let serverSide = try await pollUntil(
+            { acceptedConnection.withLock { $0 } },
+            failure: "NWListener never accepted the framed client"
+        )
+        let server = await makeEchoServer(named: "uds-interop-reverse")
+        try await server.start(transport: daemonChannelTransport(connection: serverSide))
+
+        let client = Client(name: "uds-interop-reverse", version: "1")
+        _ = try await client.connect(transport: FramedTransport(socket: clientSocket))
+        try await expectEchoProbe(client)
 
         await client.disconnect()
         await server.stop()

--- a/previewsmcp/Tests/PreviewsCLITests/DaemonSocketTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/DaemonSocketTests.swift
@@ -1,0 +1,196 @@
+import Foundation
+import MCP
+import Network
+import os
+@testable import PreviewsCLI
+import System
+import Testing
+
+/// The UDS channel (rewrite stage 3): raw POSIX sockets carried by the same
+/// `FramedTransport` the stdio channel uses. The interop test runs the SDK's
+/// `NetworkTransport` as the dialing side because that is exactly the
+/// stage-5→6 window: our listener serving a CLI still on the SDK transport.
+@Suite("DaemonSocket channel")
+struct DaemonSocketTests {
+    @Test("framed transports complete a round trip over a real UDS socket")
+    func roundTripOverSocket() async throws {
+        let path = try makeSocketPath()
+        defer { removeSocketDirectory(path) }
+        let listener = try DaemonSocket.listen(at: path)
+        defer { try? listener.close() }
+        let clientSocket = try DaemonSocket.connect(to: path)
+        defer { try? clientSocket.close() }
+        let serverSocket = try await DaemonSocket.accept(on: listener)
+        defer { try? serverSocket.close() }
+
+        let serverEnd = FramedTransport(socket: serverSocket)
+        let clientEnd = FramedTransport(socket: clientSocket)
+        try await serverEnd.connect()
+        try await clientEnd.connect()
+
+        let request = Data(#"{"blob":"\#(String(repeating: "u", count: 500_000))"}"#.utf8)
+        let reply = Data(#"{"ok":true}"#.utf8)
+        let seen = OSAllocatedUnfairLock(initialState: (request: Data?.none, reply: Data?.none))
+        let serverReader = Task {
+            for try await message in await serverEnd.receive() {
+                seen.withLock { $0.request = message }
+                break
+            }
+        }
+        let clientReader = Task {
+            for try await message in await clientEnd.receive() {
+                seen.withLock { $0.reply = message }
+                break
+            }
+        }
+        defer {
+            serverReader.cancel()
+            clientReader.cancel()
+        }
+
+        try await clientEnd.send(request)
+        try await serverEnd.send(reply)
+        let delivered = try await pollUntil(
+            { seen.withLock { $0.request != nil && $0.reply != nil ? $0 : nil } },
+            failure: "socket round trip never completed"
+        )
+        #expect(delivered.request == request)
+        #expect(delivered.reply == reply)
+        await clientEnd.disconnect()
+        await serverEnd.disconnect()
+    }
+
+    @Test("the SDK Client and Server complete a tool call over the socket channel")
+    func differentialSDKOverSocket() async throws {
+        let path = try makeSocketPath()
+        defer { removeSocketDirectory(path) }
+        let listener = try DaemonSocket.listen(at: path)
+        defer { try? listener.close() }
+        let clientSocket = try DaemonSocket.connect(to: path)
+        defer { try? clientSocket.close() }
+        let serverSocket = try await DaemonSocket.accept(on: listener)
+        defer { try? serverSocket.close() }
+
+        let server = Server(
+            name: "uds-differential", version: "1",
+            capabilities: .init(tools: .init(listChanged: false))
+        )
+        await server.withMethodHandler(CallTool.self) { params in
+            CallTool.Result(content: [.text("echo:\(params.name)")])
+        }
+        try await server.start(transport: FramedTransport(socket: serverSocket))
+
+        let client = Client(name: "uds-differential", version: "1")
+        _ = try await client.connect(transport: FramedTransport(socket: clientSocket))
+
+        let result = try await client.callToolStructured(name: "probe")
+        guard case let .text(text)? = result.content.first else {
+            Issue.record("unexpected content: \(result.content)")
+            return
+        }
+        #expect(text == "echo:probe")
+
+        await client.disconnect()
+        await server.stop()
+    }
+
+    @Test("an SDK NetworkTransport client interoperates with the framed listener")
+    func interopWithSDKNetworkTransportClient() async throws {
+        let path = try makeSocketPath()
+        defer { removeSocketDirectory(path) }
+        let listener = try DaemonSocket.listen(at: path)
+        defer { try? listener.close() }
+
+        let server = Server(
+            name: "uds-interop", version: "1",
+            capabilities: .init(tools: .init(listChanged: false))
+        )
+        await server.withMethodHandler(CallTool.self) { params in
+            CallTool.Result(content: [.text("echo:\(params.name)")])
+        }
+        let accepted = OSAllocatedUnfairLock(initialState: FileDescriptor?.none)
+        let serving = Task {
+            let serverSocket = try await DaemonSocket.accept(on: listener)
+            accepted.withLock { $0 = serverSocket }
+            try await server.start(transport: FramedTransport(socket: serverSocket))
+        }
+        defer {
+            serving.cancel()
+            if let socket = accepted.withLock({ $0 }) { try? socket.close() }
+        }
+
+        let connection = NWConnection(to: NWEndpoint.unix(path: path), using: .tcp)
+        let client = Client(name: "uds-interop", version: "1")
+        _ = try await client.connect(transport: daemonChannelTransport(connection: connection))
+
+        let result = try await client.callToolStructured(name: "probe")
+        guard case let .text(text)? = result.content.first else {
+            Issue.record("unexpected content: \(result.content)")
+            return
+        }
+        #expect(text == "echo:probe")
+
+        await client.disconnect()
+        await server.stop()
+    }
+
+    @Test("accept is cancellable while the listener is idle")
+    func acceptIsCancellable() async throws {
+        let path = try makeSocketPath()
+        defer { removeSocketDirectory(path) }
+        let listener = try DaemonSocket.listen(at: path)
+        defer { try? listener.close() }
+
+        let outcome = OSAllocatedUnfairLock(initialState: Result<Void, Swift.Error>?.none)
+        let accepting = Task {
+            do {
+                _ = try await DaemonSocket.accept(on: listener)
+                outcome.withLock { $0 = .success(()) }
+            } catch {
+                outcome.withLock { $0 = .failure(error) }
+            }
+        }
+        try await Task.sleep(for: .milliseconds(50))
+        accepting.cancel()
+
+        let result = try await pollUntil(
+            { outcome.withLock { $0 } },
+            failure: "cancelled accept never returned"
+        )
+        guard case let .failure(error) = result else {
+            Issue.record("accept returned a connection nobody dialed")
+            return
+        }
+        #expect(error is CancellationError)
+    }
+
+    @Test("connecting to a missing socket path throws")
+    func connectToMissingPathThrows() throws {
+        let path = try makeSocketPath()
+        defer { removeSocketDirectory(path) }
+        #expect(throws: Errno.self) {
+            _ = try DaemonSocket.connect(to: path)
+        }
+    }
+
+    @Test("an over-long socket path is rejected up front")
+    func pathTooLongThrows() {
+        let path = "/tmp/" + String(repeating: "p", count: 200)
+        #expect(throws: Errno(rawValue: ENAMETOOLONG)) {
+            _ = try DaemonSocket.listen(at: path)
+        }
+    }
+
+    private func makeSocketPath() throws -> String {
+        let directory = "/tmp/pmcp-\(UUID().uuidString.prefix(8))"
+        try FileManager.default.createDirectory(
+            atPath: directory, withIntermediateDirectories: true
+        )
+        return directory + "/daemon.sock"
+    }
+
+    private func removeSocketDirectory(_ socketPath: String) {
+        let directory = (socketPath as NSString).deletingLastPathComponent
+        try? FileManager.default.removeItem(atPath: directory)
+    }
+}

--- a/previewsmcp/Tests/PreviewsCLITests/FramedTransportTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/FramedTransportTests.swift
@@ -169,6 +169,55 @@ struct FramedTransportTests {
         }
     }
 
+    @Test("send before connect throws instead of blocking a raw fd")
+    func sendBeforeConnectThrows() async throws {
+        let devNull = try FileDescriptor.open("/dev/null", .readWrite)
+        defer { try? devNull.close() }
+        let transport = FramedTransport(input: devNull, output: devNull)
+
+        await #expect(throws: FramedTransportError.notConnected) {
+            try await transport.send(Data(#"{"early":1}"#.utf8))
+        }
+    }
+
+    @Test("re-entrant disconnects share the quiescence rendezvous")
+    func reentrantDisconnectWaits() async throws {
+        let pipe = Pipe()
+        let input = try FileDescriptor.open("/dev/null", .readWrite)
+        defer { try? input.close() }
+        let transport = FramedTransport(
+            input: input,
+            output: .init(rawValue: pipe.fileHandleForWriting.fileDescriptor)
+        )
+        try await transport.connect()
+
+        let outcome = OSAllocatedUnfairLock(initialState: Result<Void, Swift.Error>?.none)
+        let wedged = Task {
+            do {
+                try await transport.send(Data(repeating: UInt8(ascii: "z"), count: 300_000))
+                outcome.withLock { $0 = .success(()) }
+            } catch {
+                outcome.withLock { $0 = .failure(error) }
+            }
+        }
+        defer { wedged.cancel() }
+        try await Task.sleep(for: .milliseconds(200))
+
+        async let first: Void = transport.disconnect()
+        async let second: Void = transport.disconnect()
+        _ = await (first, second)
+
+        let result = try await pollUntil(
+            { outcome.withLock { $0 } },
+            failure: "wedged send survived concurrent disconnects"
+        )
+        guard case .failure = result else {
+            Issue.record("send of an undrained frame reported success")
+            return
+        }
+        withExtendedLifetime(pipe) {}
+    }
+
     @Test("disconnect cancels a send wedged on a full pipe")
     func disconnectCancelsWedgedSend() async throws {
         // Nobody drains the pipe, so a frame larger than its buffer parks

--- a/previewsmcp/Tests/PreviewsCLITests/FramedTransportTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/FramedTransportTests.swift
@@ -12,12 +12,12 @@ import Testing
 /// The differential test runs the real SDK Client and Server over two of
 /// these transports, keeping the SDK as the independent protocol
 /// implementation.
-@Suite("FramedStdioTransport")
-struct FramedStdioTransportTests {
+@Suite("FramedTransport")
+struct FramedTransportTests {
     @Test("concurrent sends under pipe backpressure never interleave frames")
     func concurrentSendsPreserveFraming() async throws {
         try await assertConcurrentSendsPreserveFraming { input, output in
-            FramedStdioTransport(input: input, output: output)
+            FramedTransport(input: input, output: output)
         }
     }
 
@@ -28,11 +28,11 @@ struct FramedStdioTransportTests {
         defer { try? senderNull.close() }
         let receiverNull = try FileDescriptor.open("/dev/null", .readWrite)
         defer { try? receiverNull.close() }
-        let sender = FramedStdioTransport(
+        let sender = FramedTransport(
             input: senderNull,
             output: .init(rawValue: pipe.fileHandleForWriting.fileDescriptor)
         )
-        let receiver = FramedStdioTransport(
+        let receiver = FramedTransport(
             input: .init(rawValue: pipe.fileHandleForReading.fileDescriptor),
             output: receiverNull
         )
@@ -70,7 +70,7 @@ struct FramedStdioTransportTests {
         defer { try? input.close() }
         let output = try FileDescriptor.open("/dev/null", .readWrite)
         defer { try? output.close() }
-        let transport = FramedStdioTransport(input: input, output: output)
+        let transport = FramedTransport(input: input, output: output)
         try await transport.connect()
 
         let result = try await receiveStreamOutcome(
@@ -89,7 +89,7 @@ struct FramedStdioTransportTests {
         let pipe = Pipe()
         let output = try FileDescriptor.open("/dev/null", .readWrite)
         defer { try? output.close() }
-        let transport = FramedStdioTransport(
+        let transport = FramedTransport(
             input: .init(rawValue: pipe.fileHandleForReading.fileDescriptor),
             output: output
         )
@@ -113,7 +113,7 @@ struct FramedStdioTransportTests {
         let pipe = Pipe()
         let output = try FileDescriptor.open("/dev/null", .readWrite)
         defer { try? output.close() }
-        let transport = FramedStdioTransport(
+        let transport = FramedTransport(
             input: .init(rawValue: pipe.fileHandleForReading.fileDescriptor),
             output: output
         )
@@ -129,7 +129,7 @@ struct FramedStdioTransportTests {
             Issue.record("truncated final frame was silently dropped")
             return
         }
-        #expect(error as? FramedStdioTransportError == .truncatedFinalFrame)
+        #expect(error as? FramedTransportError == .truncatedFinalFrame)
         await transport.disconnect()
         withExtendedLifetime(pipe) {}
     }
@@ -139,7 +139,7 @@ struct FramedStdioTransportTests {
         let pipe = Pipe()
         let input = try FileDescriptor.open("/dev/null", .readWrite)
         defer { try? input.close() }
-        let transport = FramedStdioTransport(
+        let transport = FramedTransport(
             input: input,
             output: .init(rawValue: pipe.fileHandleForWriting.fileDescriptor)
         )
@@ -149,7 +149,7 @@ struct FramedStdioTransportTests {
         await #expect(throws: Errno.brokenPipe) {
             try await transport.send(Data(#"{"a":1}"#.utf8))
         }
-        await #expect(throws: FramedStdioTransportError.poisoned) {
+        await #expect(throws: FramedTransportError.poisoned) {
             try await transport.send(Data(#"{"b":2}"#.utf8))
         }
         await transport.disconnect()
@@ -160,11 +160,11 @@ struct FramedStdioTransportTests {
     func sendAfterDisconnectThrows() async throws {
         let devNull = try FileDescriptor.open("/dev/null", .readWrite)
         defer { try? devNull.close() }
-        let transport = FramedStdioTransport(input: devNull, output: devNull)
+        let transport = FramedTransport(input: devNull, output: devNull)
         try await transport.connect()
         await transport.disconnect()
 
-        await #expect(throws: FramedStdioTransportError.disconnected) {
+        await #expect(throws: FramedTransportError.disconnected) {
             try await transport.send(Data(#"{"late":1}"#.utf8))
         }
     }
@@ -176,7 +176,7 @@ struct FramedStdioTransportTests {
         let pipe = Pipe()
         let input = try FileDescriptor.open("/dev/null", .readWrite)
         defer { try? input.close() }
-        let transport = FramedStdioTransport(
+        let transport = FramedTransport(
             input: input,
             output: .init(rawValue: pipe.fileHandleForWriting.fileDescriptor)
         )
@@ -213,11 +213,11 @@ struct FramedStdioTransportTests {
         // the SDK's, only the wire is ours.
         let clientToServer = Pipe()
         let serverToClient = Pipe()
-        let serverTransport = FramedStdioTransport(
+        let serverTransport = FramedTransport(
             input: .init(rawValue: clientToServer.fileHandleForReading.fileDescriptor),
             output: .init(rawValue: serverToClient.fileHandleForWriting.fileDescriptor)
         )
-        let clientTransport = FramedStdioTransport(
+        let clientTransport = FramedTransport(
             input: .init(rawValue: serverToClient.fileHandleForReading.fileDescriptor),
             output: .init(rawValue: clientToServer.fileHandleForWriting.fileDescriptor)
         )
@@ -248,7 +248,7 @@ struct FramedStdioTransportTests {
 
     /// Drains `receive()` on a child task and polls for how it ended.
     private func receiveStreamOutcome(
-        of transport: FramedStdioTransport,
+        of transport: FramedTransport,
         failure: Comment
     ) async throws -> Result<Void, Swift.Error> {
         let outcome = OSAllocatedUnfairLock(initialState: Result<Void, Swift.Error>?.none)

--- a/previewsmcp/Tests/PreviewsCLITests/FramedTransportTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/FramedTransportTests.swift
@@ -222,24 +222,12 @@ struct FramedTransportTests {
             output: .init(rawValue: clientToServer.fileHandleForWriting.fileDescriptor)
         )
 
-        let server = Server(
-            name: "framed-differential", version: "1",
-            capabilities: .init(tools: .init(listChanged: false))
-        )
-        await server.withMethodHandler(CallTool.self) { params in
-            CallTool.Result(content: [.text("echo:\(params.name)")])
-        }
+        let server = await makeEchoServer(named: "framed-differential")
         try await server.start(transport: serverTransport)
 
         let client = Client(name: "framed-differential", version: "1")
         _ = try await client.connect(transport: clientTransport)
-
-        let result = try await client.callToolStructured(name: "probe")
-        guard case let .text(text)? = result.content.first else {
-            Issue.record("unexpected content: \(result.content)")
-            return
-        }
-        #expect(text == "echo:probe")
+        try await expectEchoProbe(client)
 
         await client.disconnect()
         await server.stop()

--- a/previewsmcp/Tests/PreviewsCLITests/MCPWireTestSupport.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/MCPWireTestSupport.swift
@@ -1,0 +1,49 @@
+import Foundation
+import MCP
+import Network
+@testable import PreviewsCLI
+import Testing
+
+/// Shared fixtures for the wire-rewrite suites: the echo probe (an SDK
+/// Server answering CallTool with `echo:<name>`, and the client-side
+/// assertion) plus NWListener readiness for interop tests.
+func makeEchoServer(named name: String) async -> Server {
+    let server = Server(
+        name: name, version: "1",
+        capabilities: .init(tools: .init(listChanged: false))
+    )
+    await server.withMethodHandler(CallTool.self) { params in
+        CallTool.Result(content: [.text("echo:\(params.name)")])
+    }
+    return server
+}
+
+func expectEchoProbe(_ client: Client) async throws {
+    let result = try await client.callToolStructured(name: "probe")
+    guard case let .text(text)? = result.content.first else {
+        Issue.record("unexpected content: \(result.content)")
+        return
+    }
+    #expect(text == "echo:probe")
+}
+
+func awaitListenerReady(_ listener: NWListener) async throws {
+    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+        listener.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                cont.resume()
+                listener.stateUpdateHandler = nil
+            case let .failed(error), let .waiting(error):
+                cont.resume(throwing: error)
+                listener.stateUpdateHandler = nil
+            case .cancelled:
+                cont.resume(throwing: CancellationError())
+                listener.stateUpdateHandler = nil
+            default:
+                break
+            }
+        }
+        listener.start(queue: .global(qos: .userInitiated))
+    }
+}

--- a/previewsmcp/Tests/PreviewsCLITests/MCPWireTestSupport.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/MCPWireTestSupport.swift
@@ -27,6 +27,21 @@ func expectEchoProbe(_ client: Client) async throws {
     #expect(text == "echo:probe")
 }
 
+/// A unique short directory under /tmp: sun_path caps UDS paths at 104
+/// bytes, so bazel's deep TEST_TMPDIR is unusable for socket files.
+func makeSocketPath() throws -> String {
+    let directory = "/tmp/pmcp-\(UUID().uuidString.prefix(8))"
+    try FileManager.default.createDirectory(
+        atPath: directory, withIntermediateDirectories: true
+    )
+    return directory + "/daemon.sock"
+}
+
+func removeSocketDirectory(_ socketPath: String) {
+    let directory = (socketPath as NSString).deletingLastPathComponent
+    try? FileManager.default.removeItem(atPath: directory)
+}
+
 func awaitListenerReady(_ listener: NWListener) async throws {
     try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
         listener.stateUpdateHandler = { state in

--- a/previewsmcp/Tests/PreviewsCLITests/NetworkTransportHeartbeatTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/NetworkTransportHeartbeatTests.swift
@@ -17,9 +17,8 @@ import Testing
 struct NetworkTransportHeartbeatTests {
     @Test("a message coalesced behind a heartbeat is silently dropped")
     func coalescedHeartbeatDropsTheMessageBehindIt() async throws {
-        let socketPath = "/tmp/pmcp-hb-\(getpid()).sock"
-        try? FileManager.default.removeItem(atPath: socketPath)
-        defer { try? FileManager.default.removeItem(atPath: socketPath) }
+        let socketPath = try makeSocketPath()
+        defer { removeSocketDirectory(socketPath) }
 
         let params = NWParameters.tcp
         params.requiredLocalEndpoint = NWEndpoint.unix(path: socketPath)

--- a/previewsmcp/Tests/PreviewsCLITests/NetworkTransportHeartbeatTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/NetworkTransportHeartbeatTests.swift
@@ -29,7 +29,7 @@ struct NetworkTransportHeartbeatTests {
         listener.newConnectionHandler = { connection in
             accepted.withLock { $0 = connection }
         }
-        try await awaitReady(listener)
+        try await awaitListenerReady(listener)
         defer { listener.cancel() }
 
         let rawPeer = NWConnection(to: .unix(path: socketPath), using: .tcp)
@@ -100,27 +100,6 @@ struct NetworkTransportHeartbeatTests {
                 }
             }
             connection.start(queue: .global(qos: .userInitiated))
-        }
-    }
-
-    private func awaitReady(_ listener: NWListener) async throws {
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            listener.stateUpdateHandler = { state in
-                switch state {
-                case .ready:
-                    cont.resume()
-                    listener.stateUpdateHandler = nil
-                case let .failed(error), let .waiting(error):
-                    cont.resume(throwing: error)
-                    listener.stateUpdateHandler = nil
-                case .cancelled:
-                    cont.resume(throwing: CancellationError())
-                    listener.stateUpdateHandler = nil
-                default:
-                    break
-                }
-            }
-            listener.start(queue: .global(qos: .userInitiated))
         }
     }
 


### PR DESCRIPTION
Stage 3 of the MCP wire rewrite. The stage-2 transport is fd-based, and a Unix-domain-socket connection is just an fd — so the daemon channel reuses the identical framing core with **zero new wire code**. Not wired into the daemon; cutover is stage 5. Stage-1 characterization suite passes unchanged.

## What's here

- **`FramedStdioTransport` → `FramedTransport`** with `init(socket:)`: one framing/chaining/fail-stop core for both channels. Frames go out as a single `writev` (payload + newline iovecs, stack-allocated, partial-write resume across both).
- **`disconnect()` is a shared rendezvous**: the first caller cancels everything and creates one quiescence task; every caller (including re-entrant ones — a confirmed review finding) awaits it, so a descriptor owner may close fds the moment disconnect returns. `send()` before `connect()` or after disconnect throws instead of touching the fd.
- **`DaemonSocket`**: POSIX UDS listen/accept/connect producing owned `FileDescriptor`s; close-on-exec (best effort — Darwin has no `SOCK_CLOEXEC`/`accept4`), cancellable polling accept that retries `ECONNABORTED`, `sockaddr_un` length check.
- **`FramedTransportError` is `LocalizedError`** per AGENTS.md.

## Tests (8 new; suite total 117)

Framed round trip over a real UDS socket, SDK differential over the socket channel, **both interop directions with the SDK `NetworkTransport`** (forward: SDK client → framed listener = the stage-5→6 window; reverse: framed client → SDK server = upgraded CLI dialing a stale daemon, the path version-mismatch respawn depends on), cancellable accept, missing path, over-long path, send-before-connect, re-entrant disconnect. Shared fixtures (`makeEchoServer`/`expectEchoProbe`/`makeSocketPath`/`awaitListenerReady`) dedup three suites.

## Gates

- /simplify (4 agents): applied writev, closeOnThrow, echo-probe dedup, dead-pattern trim + the reverse interop test (altitude catch)
- /code-review (high, workflow): 2 confirmed fixed (re-entrant disconnect contract break, missing LocalizedError), 3 plausible hardened (send-before-connect hang, ECONNABORTED, CLOEXEC doc), 3 cleanups applied
- Determinism campaigns 15/15 × 3 across iterations; lint clean; full local suite 9/9 first try

## Stage-5 notes (documented, deliberate)

- 10ms sleep-polls (transport read loop + accept) must become kernel readiness (DispatchSource/kqueue) before cutover — the daemon is where idle-poll cost accrues.
- `DaemonProbe`'s NWConnection machinery collapses onto `DaemonSocket.connect` at cutover.
- Scoped accept ownership (`withAcceptedConnection` or an AsyncSequence of connections) gets designed with its real consumer, the stage-5 accept loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)