### PR TITLE
Stage 1 addendum: ping round-trip characterization for the liveness design

### DIFF
--- a/previewsmcp/Tests/PreviewsCLITests/SDKClientCharacterizationTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SDKClientCharacterizationTests.swift
@@ -71,16 +71,62 @@ struct SDKClientCharacterizationTests {
         }
     }
 
+    // MARK: - Liveness (bidirectional MCP ping)
+
+    @Test("a server-initiated ping is answered with methodNotFound when no handler is registered")
+    func serverPingWithoutHandlerGetsMethodNotFound() async throws {
+        // The SDK client registers NO default ping handler, so the pong is
+        // an ERROR response. The daemon's dead-client detection must accept
+        // any response — result or error — as proof of life while SDK
+        // clients are on the wire (stage 5-6 window, MCPTestServer forever).
+        try await Self.withConnectedClient { _, responder in
+            try await responder.send(#"{"id":"srv-ping-1","jsonrpc":"2.0","method":"ping"}"#)
+            let reply = try await pollUntil(
+                { responder.collector.frame(forID: "srv-ping-1") },
+                failure: "client never responded to the server-initiated ping"
+            )
+            let error = try #require(reply["error"] as? [String: Any])
+            #expect(error["code"] as? Int == -32601, "expected methodNotFound: \(error)")
+        }
+    }
+
+    @Test("a registered Ping handler answers a server-initiated ping with an empty result")
+    func serverPingWithHandlerAnswersCleanly() async throws {
+        try await Self.withConnectedClient(
+            configure: { client in
+                _ = await client.withMethodHandler(Ping.self) { _ in Empty() }
+            }
+        ) { _, responder in
+            try await responder.send(#"{"id":"srv-ping-2","jsonrpc":"2.0","method":"ping"}"#)
+            let reply = try await pollUntil(
+                { responder.collector.frame(forID: "srv-ping-2") },
+                failure: "client never answered the ping despite a registered handler"
+            )
+            #expect(reply["error"] == nil)
+            #expect(reply["result"] != nil)
+        }
+    }
+
+    @Test("Client.ping() completes against a server that answers ping")
+    func clientPingRoundTrip() async throws {
+        try await Self.withConnectedClient(answerPings: true) { client, _ in
+            try await client.ping()
+        }
+    }
+
     /// Scopes a connected client + raw responder so disconnect/stop run on
     /// every path; `configure` runs before connect, like DaemonClient's.
     private static func withConnectedClient(
         notifyImmediatelyAfterInitialize: Bool = false,
+        answerPings: Bool = false,
         configure: (Client) async -> Void = { _ in },
         _ body: (Client, RawResponder) async throws -> Void
     ) async throws {
         let (clientSide, serverSide) = await InMemoryTransport.createConnectedPair()
         let responder = try await RawResponder.start(
-            on: serverSide, notifyImmediatelyAfterInitialize: notifyImmediatelyAfterInitialize
+            on: serverSide,
+            notifyImmediatelyAfterInitialize: notifyImmediatelyAfterInitialize,
+            answerPings: answerPings
         )
         defer { responder.stop() }
 
@@ -97,49 +143,62 @@ struct SDKClientCharacterizationTests {
     }
 
     /// Plays the server end of the pair in raw JSON-RPC: answers initialize
-    /// (echoing the client's id verbatim), records every frame via its
-    /// collector, and ignores everything else.
+    /// (echoing the client's id verbatim) and, optionally, ping; records
+    /// every frame via its collector and ignores everything else.
     private struct RawResponder {
         let collector: FrameCollector
+        private let transport: InMemoryTransport
 
         static func start(
             on transport: InMemoryTransport,
-            notifyImmediatelyAfterInitialize: Bool = false
+            notifyImmediatelyAfterInitialize: Bool = false,
+            answerPings: Bool = false
         ) async throws -> RawResponder {
             try await transport.connect()
             let collector = FrameCollector(reading: transport) { frame in
                 guard
                     let object = FrameCollector.object(frame),
-                    object["method"] as? String == "initialize",
                     let id = object["id"]
                 else { return }
-                let response: [String: Any] = [
-                    "jsonrpc": "2.0",
-                    "id": id,
-                    "result": [
-                        "capabilities": ["logging": [:]],
-                        "protocolVersion": Version.latest,
-                        "serverInfo": ["name": "raw", "version": "1"],
-                    ],
-                ]
-                guard
-                    let data = try? JSONSerialization.data(
-                        withJSONObject: response, options: [.sortedKeys]
-                    )
-                else { return }
-                try? await transport.send(data)
-                if notifyImmediatelyAfterInitialize {
-                    try? await transport.send(Data(
-                        #"{"jsonrpc":"2.0","method":"notifications/message","params":{"data":"early","level":"debug","logger":"probe"}}"#
-                            .utf8
-                    ))
+                switch object["method"] as? String {
+                case "initialize":
+                    await respond(on: transport, [
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": [
+                            "capabilities": ["logging": [:]],
+                            "protocolVersion": Version.latest,
+                            "serverInfo": ["name": "raw", "version": "1"],
+                        ],
+                    ])
+                    if notifyImmediatelyAfterInitialize {
+                        try? await transport.send(Data(
+                            #"{"jsonrpc":"2.0","method":"notifications/message","params":{"data":"early","level":"debug","logger":"probe"}}"#
+                                .utf8
+                        ))
+                    }
+                case "ping" where answerPings:
+                    await respond(on: transport, ["jsonrpc": "2.0", "id": id, "result": [:]])
+                default:
+                    break
                 }
             }
-            return RawResponder(collector: collector)
+            return RawResponder(collector: collector, transport: transport)
+        }
+
+        func send(_ raw: String) async throws {
+            try await transport.send(Data(raw.utf8))
         }
 
         func stop() {
             collector.stop()
+        }
+
+        private static func respond(on transport: InMemoryTransport, _ object: [String: Any]) async {
+            guard
+                let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+            else { return }
+            try? await transport.send(data)
         }
     }
 }

--- a/previewsmcp/Tests/PreviewsCLITests/SDKClientCharacterizationTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SDKClientCharacterizationTests.swift
@@ -113,11 +113,7 @@ struct SDKClientCharacterizationTests {
     @Test("Client.ping() completes against a server that answers ping")
     func clientPingRoundTrip() async throws {
         try await Self.withConnectedClient { client, _ in
-            let result = try await Self.boundedPing(client, failure: "ping never completed")
-            guard case .success = result else {
-                Issue.record("ping failed against an answering server: \(result)")
-                return
-            }
+            try await Self.expectPingCompletes(client, failure: "ping never completed")
         }
     }
 
@@ -127,19 +123,14 @@ struct SDKClientCharacterizationTests {
         // is in flight — so the pong must not serialize behind the client's
         // pending request.
         try await Self.withConnectedClient { client, responder in
-            let pending = Task { try await client.callToolStructured(name: "never-answered") }
-            defer { pending.cancel() }
-            try await pollUntil(
-                { responder.collector.sawMethod("tools/call") },
-                failure: "tools/call never reached the wire"
-            )
-
-            try await responder.send(#"{"id":"srv-ping-3","jsonrpc":"2.0","method":"ping"}"#)
-            let reply = try await pollUntil(
-                { responder.collector.frame(forID: "srv-ping-3") },
-                failure: "no pong while the client's callTool was pending"
-            )
-            #expect(reply["error"] != nil || reply["result"] != nil)
+            try await Self.withPendingCallTool(client, responder) {
+                try await responder.send(#"{"id":"srv-ping-3","jsonrpc":"2.0","method":"ping"}"#)
+                let reply = try await pollUntil(
+                    { responder.collector.frame(forID: "srv-ping-3") },
+                    failure: "no pong while the client's callTool was pending"
+                )
+                #expect(reply["method"] == nil, "expected a response frame, got a request: \(reply)")
+            }
         }
     }
 
@@ -149,28 +140,34 @@ struct SDKClientCharacterizationTests {
         // render, so the client must multiplex an outstanding ping
         // alongside the pending callTool and correlate both responses.
         try await Self.withConnectedClient { client, responder in
-            let pending = Task { try await client.callToolStructured(name: "never-answered") }
-            defer { pending.cancel() }
-            try await pollUntil(
-                { responder.collector.sawMethod("tools/call") },
-                failure: "tools/call never reached the wire"
-            )
-
-            let result = try await Self.boundedPing(
-                client, failure: "ping never completed while the callTool was pending"
-            )
-            guard case .success = result else {
-                Issue.record("ping failed while the callTool was pending: \(result)")
-                return
+            try await Self.withPendingCallTool(client, responder) {
+                try await Self.expectPingCompletes(
+                    client, failure: "ping never completed while the callTool was pending"
+                )
             }
         }
     }
 
+    /// Holds a callTool pending (the responder never answers tools/call),
+    /// confirmed on the wire, for the duration of `body`.
+    private static func withPendingCallTool(
+        _ client: Client, _ responder: RawResponder,
+        _ body: () async throws -> Void
+    ) async throws {
+        let pending = Task { try await client.callToolStructured(name: "never-answered") }
+        defer { pending.cancel() }
+        try await pollUntil(
+            { responder.collector.sawMethod("tools/call") },
+            failure: "tools/call never reached the wire"
+        )
+        try await body()
+    }
+
     /// Runs `client.ping()` on a child task and polls for the outcome, so a
     /// regression polls out red instead of wedging the suite.
-    private static func boundedPing(
+    private static func expectPingCompletes(
         _ client: Client, failure: Comment
-    ) async throws -> Result<Void, Swift.Error> {
+    ) async throws {
         let outcome = OSAllocatedUnfairLock(initialState: Result<Void, Swift.Error>?.none)
         let pinging = Task {
             do {
@@ -181,7 +178,10 @@ struct SDKClientCharacterizationTests {
             }
         }
         defer { pinging.cancel() }
-        return try await pollUntil({ outcome.withLock { $0 } }, failure: failure)
+        let result = try await pollUntil({ outcome.withLock { $0 } }, failure: failure)
+        if case let .failure(error) = result {
+            Issue.record("ping failed: \(error)")
+        }
     }
 
     /// Scopes a connected client + raw responder so disconnect/stop run on

--- a/previewsmcp/Tests/PreviewsCLITests/SDKClientCharacterizationTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SDKClientCharacterizationTests.swift
@@ -32,6 +32,9 @@ struct SDKClientCharacterizationTests {
 
     @Test("disconnect drains a pending callTool with an error instead of hanging")
     func disconnectDrainsPendingCallTool() async throws {
+        // The pinned contract is the METHOD-AGNOSTIC pending-request drain:
+        // the SDK keeps one request table for every method, so this covers
+        // an abandoned ping() (the liveness death path) as much as callTool.
         try await Self.withConnectedClient { client, responder in
             // The responder never answers tools/call, so this call can only
             // end via disconnect's drain — the StallTimer's entire safety
@@ -109,24 +112,88 @@ struct SDKClientCharacterizationTests {
 
     @Test("Client.ping() completes against a server that answers ping")
     func clientPingRoundTrip() async throws {
-        try await Self.withConnectedClient(answerPings: true) { client, _ in
-            try await client.ping()
+        try await Self.withConnectedClient { client, _ in
+            let result = try await Self.boundedPing(client, failure: "ping never completed")
+            guard case .success = result else {
+                Issue.record("ping failed against an answering server: \(result)")
+                return
+            }
         }
+    }
+
+    @Test("a server-initiated ping is answered while the client's own callTool is pending")
+    func serverPingAnsweredDuringClientInFlightCall() async throws {
+        // The daemon only needs dead-client detection while a long render
+        // is in flight — so the pong must not serialize behind the client's
+        // pending request.
+        try await Self.withConnectedClient { client, responder in
+            let pending = Task { try await client.callToolStructured(name: "never-answered") }
+            defer { pending.cancel() }
+            try await pollUntil(
+                { responder.collector.sawMethod("tools/call") },
+                failure: "tools/call never reached the wire"
+            )
+
+            try await responder.send(#"{"id":"srv-ping-3","jsonrpc":"2.0","method":"ping"}"#)
+            let reply = try await pollUntil(
+                { responder.collector.frame(forID: "srv-ping-3") },
+                failure: "no pong while the client's callTool was pending"
+            )
+            #expect(reply["error"] != nil || reply["result"] != nil)
+        }
+    }
+
+    @Test("Client.ping() completes while the client's own callTool is pending")
+    func clientPingCompletesDuringInFlightCall() async throws {
+        // StallTimer's rewrite keys off pong latency measured DURING a
+        // render, so the client must multiplex an outstanding ping
+        // alongside the pending callTool and correlate both responses.
+        try await Self.withConnectedClient { client, responder in
+            let pending = Task { try await client.callToolStructured(name: "never-answered") }
+            defer { pending.cancel() }
+            try await pollUntil(
+                { responder.collector.sawMethod("tools/call") },
+                failure: "tools/call never reached the wire"
+            )
+
+            let result = try await Self.boundedPing(
+                client, failure: "ping never completed while the callTool was pending"
+            )
+            guard case .success = result else {
+                Issue.record("ping failed while the callTool was pending: \(result)")
+                return
+            }
+        }
+    }
+
+    /// Runs `client.ping()` on a child task and polls for the outcome, so a
+    /// regression polls out red instead of wedging the suite.
+    private static func boundedPing(
+        _ client: Client, failure: Comment
+    ) async throws -> Result<Void, Swift.Error> {
+        let outcome = OSAllocatedUnfairLock(initialState: Result<Void, Swift.Error>?.none)
+        let pinging = Task {
+            do {
+                try await client.ping()
+                outcome.withLock { $0 = .success(()) }
+            } catch {
+                outcome.withLock { $0 = .failure(error) }
+            }
+        }
+        defer { pinging.cancel() }
+        return try await pollUntil({ outcome.withLock { $0 } }, failure: failure)
     }
 
     /// Scopes a connected client + raw responder so disconnect/stop run on
     /// every path; `configure` runs before connect, like DaemonClient's.
     private static func withConnectedClient(
         notifyImmediatelyAfterInitialize: Bool = false,
-        answerPings: Bool = false,
         configure: (Client) async -> Void = { _ in },
         _ body: (Client, RawResponder) async throws -> Void
     ) async throws {
         let (clientSide, serverSide) = await InMemoryTransport.createConnectedPair()
         let responder = try await RawResponder.start(
-            on: serverSide,
-            notifyImmediatelyAfterInitialize: notifyImmediatelyAfterInitialize,
-            answerPings: answerPings
+            on: serverSide, notifyImmediatelyAfterInitialize: notifyImmediatelyAfterInitialize
         )
         defer { responder.stop() }
 
@@ -143,16 +210,16 @@ struct SDKClientCharacterizationTests {
     }
 
     /// Plays the server end of the pair in raw JSON-RPC: answers initialize
-    /// (echoing the client's id verbatim) and, optionally, ping; records
-    /// every frame via its collector and ignores everything else.
+    /// (echoing the client's id verbatim) and ping; records every frame via
+    /// its collector and ignores everything else — tools/call deliberately
+    /// never gets an answer, so tests can hold a request pending.
     private struct RawResponder {
         let collector: FrameCollector
         private let transport: InMemoryTransport
 
         static func start(
             on transport: InMemoryTransport,
-            notifyImmediatelyAfterInitialize: Bool = false,
-            answerPings: Bool = false
+            notifyImmediatelyAfterInitialize: Bool = false
         ) async throws -> RawResponder {
             try await transport.connect()
             let collector = FrameCollector(reading: transport) { frame in
@@ -177,7 +244,7 @@ struct SDKClientCharacterizationTests {
                                 .utf8
                         ))
                     }
-                case "ping" where answerPings:
+                case "ping":
                     await respond(on: transport, ["jsonrpc": "2.0", "id": id, "result": [:]])
                 default:
                     break

--- a/previewsmcp/Tests/PreviewsCLITests/SDKServerCharacterizationTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SDKServerCharacterizationTests.swift
@@ -101,6 +101,39 @@ struct SDKServerCharacterizationTests {
         }
     }
 
+    @Test("ping is answered while a CallTool handler is still in flight")
+    func pingAnsweredDuringInFlightCall() async throws {
+        // The liveness rewrite keys StallTimer off pong latency, so a pong
+        // must not queue behind a long render.
+        let release = OSAllocatedUnfairLock(initialState: false)
+        try await Wire.with { server in
+            await server.withMethodHandler(CallTool.self) { _ in
+                while !release.withLock({ $0 }) {
+                    try await Task.sleep(for: .milliseconds(10))
+                }
+                return CallTool.Result(content: [.text("done")])
+            }
+        } _: { wire in
+            defer { release.withLock { $0 = true } }
+            try await wire.handshake()
+            try await wire.send(
+                #"{"id":21,"jsonrpc":"2.0","method":"tools/call","params":{"arguments":{},"name":"slow"}}"#
+            )
+            let pong = try await wire.roundTrip(id: 22, #"{"id":22,"jsonrpc":"2.0","method":"ping"}"#)
+            #expect(pong["error"] == nil)
+            #expect(pong["result"] != nil)
+            #expect(
+                wire.collector.frame(forID: 21) == nil,
+                "the slow call must still be pending when the pong arrives"
+            )
+            release.withLock { $0 = true }
+            _ = try await pollUntil(
+                { wire.collector.frame(forID: 21) },
+                failure: "the released CallTool never completed"
+            )
+        }
+    }
+
     @Test("string request ids are echoed verbatim")
     func stringIDRoundTrip() async throws {
         // The SDK Client (the daemon's actual peer) generates random STRING

--- a/previewsmcp/Tests/PreviewsCLITests/SDKServerCharacterizationTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SDKServerCharacterizationTests.swift
@@ -105,9 +105,11 @@ struct SDKServerCharacterizationTests {
     func pingAnsweredDuringInFlightCall() async throws {
         // The liveness rewrite keys StallTimer off pong latency, so a pong
         // must not queue behind a long render.
+        let started = OSAllocatedUnfairLock(initialState: false)
         let release = OSAllocatedUnfairLock(initialState: false)
         try await Wire.with { server in
             await server.withMethodHandler(CallTool.self) { _ in
+                started.withLock { $0 = true }
                 while !release.withLock({ $0 }) {
                     try await Task.sleep(for: .milliseconds(10))
                 }
@@ -118,6 +120,13 @@ struct SDKServerCharacterizationTests {
             try await wire.handshake()
             try await wire.send(
                 #"{"id":21,"jsonrpc":"2.0","method":"tools/call","params":{"arguments":{},"name":"slow"}}"#
+            )
+            // The premise: the handler must be RUNNING when the ping goes
+            // out, or a server that answers pings before dispatching queued
+            // calls would pass vacuously.
+            try await pollUntil(
+                { started.withLock { $0 } },
+                failure: "the CallTool handler never started"
             )
             let pong = try await wire.roundTrip(id: 22, #"{"id":22,"jsonrpc":"2.0","method":"ping"}"#)
             #expect(pong["error"] == nil)


### PR DESCRIPTION
The owner's liveness correction made a functioning bidirectional MCP-ping heartbeat a first-class rewrite requirement (stage 4 ping-responder + dead-client detection, stage 6 pinger + pong-fed StallTimer). This addendum grows the stage-1 characterization suite (the rewrite's acceptance bar) with the six facts that design builds on, all verified against the real SDK:

- **Server answers ping while a CallTool handler is running** — with the premise established (a started flag polled before the ping goes out), so a rewrite server that queues pongs behind renders cannot pass vacuously. StallTimer keys off pong latency; this is the fact that makes that sound.
- **The SDK Client has NO default ping handler**: a server-initiated ping gets a `methodNotFound` ERROR response. The daemon's dead-client detection must accept any response — result or error — as proof of life while SDK clients are on the wire (the stage 5-6 window, and MCPTestServer permanently).
- **A registered `Ping` handler** upgrades the pong to an empty result.
- **The client answers a server-initiated ping while its own callTool is pending** — the actual dead-client-detection window; an idle-only pin would miss a client that serializes pongs behind pending requests.
- **`Client.ping()` multiplexes alongside a pending callTool** — the CLI pings *during* renders.
- **`Client.ping()` completes when idle**; all ping awaits are bounded (regressions poll out red instead of wedging the suite).

Harness: RawResponder now answers initialize + ping and exposes raw send; `withPendingCallTool`/`expectPingCompletes` helpers; `disconnectDrainsPendingCallTool` documents that its pinned drain contract is method-agnostic (ping included — the death path's cleanup).

Gates: /simplify (4 agents — the altitude reviewer caught the two missing client-side in-flight facts), /code-review high (4 findings fixed, including the vacuity hole), determinism 10/10 × 3, lint clean, full suite 9/9 first try.

🤖 Generated with [Claude Code](https://claude.com/claude-code)