### PR TITLE
Rewrite stage 4: in-house PreviewsMCPServer loop + dead-client detection

### DIFF
--- a/previewsmcp/PreviewsCLI/Handlers/HandlerContext.swift
+++ b/previewsmcp/PreviewsCLI/Handlers/HandlerContext.swift
@@ -19,5 +19,5 @@ struct HandlerContext {
     let simulatorLister: any SimulatorLister
     let registry: SessionRegistry
     let macCompiler: Compiler
-    let server: Server
+    let server: any MCPServing
 }

--- a/previewsmcp/PreviewsCLI/MCPServer.swift
+++ b/previewsmcp/PreviewsCLI/MCPServer.swift
@@ -52,7 +52,7 @@ func configureMCPServer(
     configCache cache: ConfigCache,
     registry: SessionRegistry,
     sharedCompiler: Compiler? = nil
-) async throws -> (Server, Compiler) {
+) async throws -> (any MCPServing, Compiler) {
     cleanupStaleTempDirs()
 
     let compiler: Compiler = if let sharedCompiler {

--- a/previewsmcp/PreviewsCLI/MCPServerSupport.swift
+++ b/previewsmcp/PreviewsCLI/MCPServerSupport.swift
@@ -8,12 +8,12 @@ import PreviewsEngine
 
 /// MCP progress reporter that sends progress notifications and log messages to the client.
 final class MCPProgressReporter: ProgressReporter, @unchecked Sendable {
-    private let server: Server
+    private let server: any MCPServing
     private let progressToken: ProgressToken?
     private let totalSteps: Int
     private let stepCounter: OSAllocatedUnfairLock<Int>
 
-    init(server: Server, progressToken: ProgressToken?, totalSteps: Int) {
+    init(server: any MCPServing, progressToken: ProgressToken?, totalSteps: Int) {
         self.server = server
         self.progressToken = progressToken
         self.totalSteps = totalSteps
@@ -46,7 +46,7 @@ final class MCPProgressReporter: ProgressReporter, @unchecked Sendable {
 
 /// Create an MCP progress reporter for the given tool call parameters.
 func mcpReporter(
-    server: Server, params: CallTool.Parameters, totalSteps: Int
+    server: any MCPServing, params: CallTool.Parameters, totalSteps: Int
 ) -> MCPProgressReporter {
     MCPProgressReporter(
         server: server,
@@ -98,7 +98,7 @@ func advertisedServerVersion() -> String {
 /// first ping fires at T+2s relative to `server.start`, not T+0. A
 /// client-side liveness timer should grant at least one full heartbeat
 /// interval of grace on connect before declaring the daemon wedged.
-func runMCPServer(_ server: Server, transport: any Transport) async throws {
+func runMCPServer(_ server: any MCPServing, transport: any Transport) async throws {
     let heartbeat = Task.detached {
         while !Task.isCancelled {
             try? await Task.sleep(for: .seconds(2))

--- a/previewsmcp/PreviewsCLI/MCPServing.swift
+++ b/previewsmcp/PreviewsCLI/MCPServing.swift
@@ -1,0 +1,24 @@
+import MCP
+
+/// The SDK `Server` surface the daemon and the stage-1 characterization
+/// suite actually consume. Both the SDK server and `PreviewsMCPServer`
+/// conform, so the suite gates the rewrite differentially and the stage-5
+/// cutover is a construction-site swap.
+protocol MCPServing: Actor {
+    @discardableResult
+    func withMethodHandler<M: MCP.Method>(
+        _ type: M.Type,
+        handler: @escaping @Sendable (M.Parameters) async throws -> M.Result
+    ) -> Self
+    func start(transport: any Transport) async throws
+    func stop() async
+    func waitUntilCompleted() async
+    func notify(_ notification: Message<some MCP.Notification>) async throws
+    func log(level: LogLevel, logger: String?, data: Value) async throws
+}
+
+extension Server: MCPServing {
+    func start(transport: any Transport) async throws {
+        try await start(transport: transport, initializeHook: nil)
+    }
+}

--- a/previewsmcp/PreviewsCLI/PreviewsMCPServer.swift
+++ b/previewsmcp/PreviewsCLI/PreviewsMCPServer.swift
@@ -56,7 +56,7 @@ actor PreviewsMCPServer: MCPServing {
     private var transport: (any Transport)?
     private var receiveLoop: Task<Void, Never>?
     private var pinger: Task<Void, Never>?
-    private var inFlightRequests: [ID: Task<Data, Swift.Error>] = [:]
+    private var inFlightRequests: [UUID: (id: ID, task: Task<Data, Swift.Error>)] = [:]
     private var isInitialized = false
     private var missedPongs = 0
 
@@ -125,30 +125,31 @@ actor PreviewsMCPServer: MCPServing {
                 // The receive loop is the liveness ground truth: ANY inbound
                 // frame proves the peer's process is alive and writing.
                 missedPongs = 0
-                if let request = try? Self.wireDecoder.decode(Request<ErasedMethod>.self, from: raw) {
+                if (try? Self.wireDecoder.decode(Response<ErasedMethod>.self, from: raw)) != nil {
+                    continue
+                } else if let request = try? Self.wireDecoder.decode(
+                    Request<ErasedMethod>.self, from: raw
+                ) {
                     dispatch(request, raw: raw, on: transport)
-                } else if (try? Self.wireDecoder.decode(Response<ErasedMethod>.self, from: raw)) != nil {
-                    // A pong (or a stray response); counted above.
                 } else if let note = try? Self.wireDecoder.decode(
                     Message<ErasedNotification>.self, from: raw
                 ) {
                     handleNotification(note, raw: raw)
                 } else {
-                    await send(Self.parseErrorResponse(for: raw), on: transport)
+                    let reply = Self.parseErrorResponse(for: raw)
+                    Task { await send(reply, on: transport) }
                 }
             }
-        } catch {
-            // A stream error ends the connection; teardown is the owner's.
-        }
-        // The connection is gone: a dead client's in-flight renders must not
-        // keep burning compiler/simulator resources.
-        cancelInFlight()
+        } catch {}
+        // In-flight handlers run to completion after peer disconnect, like
+        // the SDK: daemon sessions persist across CLI invocations, so a
+        // killed client's finishing render is a warm session, not waste.
         pinger?.cancel()
     }
 
     private func cancelInFlight() {
-        for task in inFlightRequests.values {
-            task.cancel()
+        for entry in inFlightRequests.values {
+            entry.task.cancel()
         }
         inFlightRequests.removeAll()
     }
@@ -162,15 +163,19 @@ actor PreviewsMCPServer: MCPServing {
             try Task.checkCancellation()
             return try await handler(raw)
         }
-        inFlightRequests[request.id] = work
-        Task { await complete(request.id, of: work, on: transport) }
+        // Keyed by token, not request id: a colliding id must neither orphan
+        // the first task from cancellation nor deregister the second when
+        // the first completes.
+        let token = UUID()
+        inFlightRequests[token] = (request.id, work)
+        Task { await complete(token, id: request.id, of: work, on: transport) }
     }
 
     private func complete(
-        _ id: ID, of work: Task<Data, Swift.Error>, on transport: any Transport
+        _ token: UUID, id: ID, of work: Task<Data, Swift.Error>, on transport: any Transport
     ) async {
         let outcome = await work.result
-        inFlightRequests.removeValue(forKey: id)
+        inFlightRequests.removeValue(forKey: token)
         switch outcome {
         case let .success(frame):
             await send(frame, on: transport)
@@ -191,7 +196,10 @@ actor PreviewsMCPServer: MCPServing {
                 Message<CancelledNotification>.self, from: raw
             )
         else { return }
-        inFlightRequests.removeValue(forKey: cancelled.params.requestId)?.cancel()
+        for (token, entry) in inFlightRequests where entry.id == cancelled.params.requestId {
+            entry.task.cancel()
+            inFlightRequests.removeValue(forKey: token)
+        }
     }
 
     // MARK: - Built-in methods
@@ -241,8 +249,13 @@ actor PreviewsMCPServer: MCPServing {
                 return
             }
             missedPongs += 1
-            if let frame = try? Self.encode(Ping.request()) {
-                await send(frame, on: transport)
+            guard let frame = try? Self.encode(Ping.request()) else { continue }
+            do {
+                try await transport.send(frame)
+            } catch {
+                Log.info("liveness ping send failed (\(error)); closing the connection")
+                await transport.disconnect()
+                return
             }
         }
     }
@@ -264,16 +277,12 @@ actor PreviewsMCPServer: MCPServing {
         try wireEncoder.encode(value)
     }
 
+    private struct IDEnvelope: Codable {
+        let id: ID?
+    }
+
     private static func parseErrorResponse(for raw: Data) -> Data {
-        let object = (try? JSONSerialization.jsonObject(with: raw)) as? [String: Any]
-        let id: ID =
-            if let string = object?["id"] as? String {
-                .string(string)
-            } else if let number = object?["id"] as? Int {
-                .number(number)
-            } else {
-                .random
-            }
+        let id = (try? wireDecoder.decode(IDEnvelope.self, from: raw))?.id ?? .random
         let reply = ErasedMethod.response(id: id, error: .parseError("Invalid message format"))
         return (try? encode(reply)) ?? Data()
     }

--- a/previewsmcp/PreviewsCLI/PreviewsMCPServer.swift
+++ b/previewsmcp/PreviewsCLI/PreviewsMCPServer.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MCP
+import PreviewsCore
 
 /// In-house MCP server loop (rewrite stage 4). Replaces the SDK `Server` at
 /// the stage-5 cutover; the SDK's data types (Method/Request/Response/Value)
@@ -27,18 +28,25 @@ actor PreviewsMCPServer: MCPServing {
     }
 
     /// Type-erased shapes for the first decode pass (the SDK's own AnyMethod
-    /// and AnyNotification are internal). `Value` is `NotRequired`, so
-    /// frames without params decode; the decoder does not validate the
-    /// method name against `name`.
+    /// and AnyNotification are internal). Payload fields decode as `Ignored`,
+    /// which accepts any shape while reading nothing — classification must
+    /// not build a throwaway tree from a several-hundred-KB params blob the
+    /// typed handler decodes again. The decoder does not validate the method
+    /// name against `name`.
+    private struct Ignored: NotRequired, Hashable, Codable {
+        init() {}
+        init(from _: Decoder) throws {}
+    }
+
     private struct ErasedMethod: MCP.Method {
         static let name = ""
-        typealias Parameters = Value
-        typealias Result = Value
+        typealias Parameters = Ignored
+        typealias Result = Ignored
     }
 
     private struct ErasedNotification: MCP.Notification {
         static let name = ""
-        typealias Parameters = Value
+        typealias Parameters = Ignored
     }
 
     private let serverInfo: Server.Info
@@ -68,7 +76,7 @@ actor PreviewsMCPServer: MCPServing {
         handler: @escaping @Sendable (M.Parameters) async throws -> M.Result
     ) -> Self {
         methodHandlers[M.name] = { raw in
-            let request = try JSONDecoder().decode(Request<M>.self, from: raw)
+            let request = try Self.wireDecoder.decode(Request<M>.self, from: raw)
             let result = try await handler(request.params)
             return try Self.encode(M.response(id: request.id, result: result))
         }
@@ -85,6 +93,7 @@ actor PreviewsMCPServer: MCPServing {
     }
 
     func stop() async {
+        cancelInFlight()
         pinger?.cancel()
         pinger = nil
         receiveLoop?.cancel()
@@ -113,11 +122,16 @@ actor PreviewsMCPServer: MCPServing {
     private func run(on transport: any Transport) async {
         do {
             for try await raw in await transport.receive() {
-                if let request = try? JSONDecoder().decode(Request<ErasedMethod>.self, from: raw) {
+                // The receive loop is the liveness ground truth: ANY inbound
+                // frame proves the peer's process is alive and writing.
+                missedPongs = 0
+                if let request = try? Self.wireDecoder.decode(Request<ErasedMethod>.self, from: raw) {
                     dispatch(request, raw: raw, on: transport)
-                } else if (try? JSONDecoder().decode(Response<ErasedMethod>.self, from: raw)) != nil {
-                    missedPongs = 0
-                } else if let note = try? JSONDecoder().decode(Message<ErasedNotification>.self, from: raw) {
+                } else if (try? Self.wireDecoder.decode(Response<ErasedMethod>.self, from: raw)) != nil {
+                    // A pong (or a stray response); counted above.
+                } else if let note = try? Self.wireDecoder.decode(
+                    Message<ErasedNotification>.self, from: raw
+                ) {
                     handleNotification(note, raw: raw)
                 } else {
                     await send(Self.parseErrorResponse(for: raw), on: transport)
@@ -126,21 +140,24 @@ actor PreviewsMCPServer: MCPServing {
         } catch {
             // A stream error ends the connection; teardown is the owner's.
         }
+        // The connection is gone: a dead client's in-flight renders must not
+        // keep burning compiler/simulator resources.
+        cancelInFlight()
         pinger?.cancel()
     }
 
-    private func dispatch(_ request: Request<ErasedMethod>, raw: Data, on transport: any Transport) {
-        guard let handler = builtinHandler(for: request.method) ?? methodHandlers[request.method]
-        else {
-            let reply = ErasedMethod.response(
-                id: request.id,
-                error: .methodNotFound("Unknown method: \(request.method)")
-            )
-            if let frame = try? Self.encode(reply) {
-                Task { await send(frame, on: transport) }
-            }
-            return
+    private func cancelInFlight() {
+        for task in inFlightRequests.values {
+            task.cancel()
         }
+        inFlightRequests.removeAll()
+    }
+
+    private func dispatch(_ request: Request<ErasedMethod>, raw: Data, on transport: any Transport) {
+        let method = request.method
+        let handler = builtinHandler(for: method)
+            ?? methodHandlers[method]
+            ?? { _ in throw MCPError.methodNotFound("Unknown method: \(method)") }
         let work = Task<Data, Swift.Error> {
             try Task.checkCancellation()
             return try await handler(raw)
@@ -170,7 +187,7 @@ actor PreviewsMCPServer: MCPServing {
     private func handleNotification(_ note: Message<ErasedNotification>, raw: Data) {
         guard
             note.method == CancelledNotification.name,
-            let cancelled = try? JSONDecoder().decode(
+            let cancelled = try? Self.wireDecoder.decode(
                 Message<CancelledNotification>.self, from: raw
             )
         else { return }
@@ -182,13 +199,10 @@ actor PreviewsMCPServer: MCPServing {
     private func builtinHandler(for method: String) -> (@Sendable (Data) async throws -> Data)? {
         switch method {
         case Initialize.name:
-            { [weak self] raw in
-                guard let self else { throw MCPError.internalError("server gone") }
-                return try await processInitialize(raw)
-            }
+            { raw in try await self.processInitialize(raw) }
         case Ping.name:
             { raw in
-                let request = try JSONDecoder().decode(Request<Ping>.self, from: raw)
+                let request = try Self.wireDecoder.decode(Request<Ping>.self, from: raw)
                 return try Self.encode(Ping.response(id: request.id))
             }
         default:
@@ -197,7 +211,7 @@ actor PreviewsMCPServer: MCPServing {
     }
 
     private func processInitialize(_ raw: Data) throws -> Data {
-        let request = try JSONDecoder().decode(Request<Initialize>.self, from: raw)
+        let request = try Self.wireDecoder.decode(Request<Initialize>.self, from: raw)
         guard !isInitialized else {
             throw MCPError.invalidRequest("Server is already initialized")
         }
@@ -215,13 +229,14 @@ actor PreviewsMCPServer: MCPServing {
     // MARK: - Liveness
 
     private func pingLoop(on transport: any Transport, _ config: ClientLiveness) async {
-        while !Task.isCancelled {
+        while true {
             do {
                 try await Task.sleep(for: config.interval)
             } catch {
                 return
             }
             if missedPongs >= config.missedPongLimit {
+                Log.info("declaring the client dead: \(missedPongs) pings with no traffic")
                 await transport.disconnect()
                 return
             }
@@ -238,10 +253,15 @@ actor PreviewsMCPServer: MCPServing {
         try? await transport.send(frame)
     }
 
-    private static func encode(_ value: some Encodable) throws -> Data {
+    private static let wireDecoder = JSONDecoder()
+    private static let wireEncoder: JSONEncoder = {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
-        return try encoder.encode(value)
+        return encoder
+    }()
+
+    private static func encode(_ value: some Encodable) throws -> Data {
+        try wireEncoder.encode(value)
     }
 
     private static func parseErrorResponse(for raw: Data) -> Data {

--- a/previewsmcp/PreviewsCLI/PreviewsMCPServer.swift
+++ b/previewsmcp/PreviewsCLI/PreviewsMCPServer.swift
@@ -1,0 +1,260 @@
+import Foundation
+import MCP
+
+/// In-house MCP server loop (rewrite stage 4). Replaces the SDK `Server` at
+/// the stage-5 cutover; the SDK's data types (Method/Request/Response/Value)
+/// are kept. The stage-1 characterization suite runs against both servers,
+/// so every pinned behavior — version negotiation, methodNotFound, ping,
+/// id echo, cancellation, progress, wire shape, teardown — is enforced
+/// differentially.
+///
+/// Concurrency model, load-bearing: each REQUEST runs in its own task so a
+/// ping is answered while a render is in flight; NOTIFICATIONS are handled
+/// inline in the receive loop so notifications/cancelled can reach a
+/// running handler. A handler that throws CancellationError produces NO
+/// response frame (MCP spec); other errors produce an error response.
+///
+/// Liveness (the owner's rewrite requirement): with a `ClientLiveness`
+/// config the server pings its client on an interval and disconnects the
+/// transport after `missedPongLimit` pings with no response of any kind.
+/// Any inbound response counts as proof of life — an SDK client answers
+/// server pings with methodNotFound (characterized), and that is a live
+/// peer.
+actor PreviewsMCPServer: MCPServing {
+    struct ClientLiveness {
+        var interval: Duration = .seconds(15)
+        var missedPongLimit: Int = 2
+    }
+
+    /// Type-erased shapes for the first decode pass (the SDK's own AnyMethod
+    /// and AnyNotification are internal). `Value` is `NotRequired`, so
+    /// frames without params decode; the decoder does not validate the
+    /// method name against `name`.
+    private struct ErasedMethod: MCP.Method {
+        static let name = ""
+        typealias Parameters = Value
+        typealias Result = Value
+    }
+
+    private struct ErasedNotification: MCP.Notification {
+        static let name = ""
+        typealias Parameters = Value
+    }
+
+    private let serverInfo: Server.Info
+    private let capabilities: Server.Capabilities
+    private let liveness: ClientLiveness?
+    private var methodHandlers: [String: @Sendable (Data) async throws -> Data] = [:]
+    private var transport: (any Transport)?
+    private var receiveLoop: Task<Void, Never>?
+    private var pinger: Task<Void, Never>?
+    private var inFlightRequests: [ID: Task<Data, Swift.Error>] = [:]
+    private var isInitialized = false
+    private var missedPongs = 0
+
+    init(
+        name: String, version: String,
+        capabilities: Server.Capabilities = .init(),
+        liveness: ClientLiveness? = nil
+    ) {
+        serverInfo = Server.Info(name: name, version: version)
+        self.capabilities = capabilities
+        self.liveness = liveness
+    }
+
+    @discardableResult
+    func withMethodHandler<M: MCP.Method>(
+        _: M.Type,
+        handler: @escaping @Sendable (M.Parameters) async throws -> M.Result
+    ) -> Self {
+        methodHandlers[M.name] = { raw in
+            let request = try JSONDecoder().decode(Request<M>.self, from: raw)
+            let result = try await handler(request.params)
+            return try Self.encode(M.response(id: request.id, result: result))
+        }
+        return self
+    }
+
+    func start(transport: any Transport) async throws {
+        self.transport = transport
+        try await transport.connect()
+        receiveLoop = Task { await run(on: transport) }
+        if let liveness {
+            pinger = Task { await pingLoop(on: transport, liveness) }
+        }
+    }
+
+    func stop() async {
+        pinger?.cancel()
+        pinger = nil
+        receiveLoop?.cancel()
+        receiveLoop = nil
+        await transport?.disconnect()
+        transport = nil
+    }
+
+    func waitUntilCompleted() async {
+        await receiveLoop?.value
+    }
+
+    func notify(_ notification: Message<some MCP.Notification>) async throws {
+        guard let transport else {
+            throw MCPError.internalError("Server connection not initialized")
+        }
+        try await transport.send(try Self.encode(notification))
+    }
+
+    func log(level: LogLevel, logger: String? = nil, data: Value) async throws {
+        try await notify(LogMessageNotification.message(.init(level: level, logger: logger, data: data)))
+    }
+
+    // MARK: - Receive loop
+
+    private func run(on transport: any Transport) async {
+        do {
+            for try await raw in await transport.receive() {
+                if let request = try? JSONDecoder().decode(Request<ErasedMethod>.self, from: raw) {
+                    dispatch(request, raw: raw, on: transport)
+                } else if (try? JSONDecoder().decode(Response<ErasedMethod>.self, from: raw)) != nil {
+                    missedPongs = 0
+                } else if let note = try? JSONDecoder().decode(Message<ErasedNotification>.self, from: raw) {
+                    handleNotification(note, raw: raw)
+                } else {
+                    await send(Self.parseErrorResponse(for: raw), on: transport)
+                }
+            }
+        } catch {
+            // A stream error ends the connection; teardown is the owner's.
+        }
+        pinger?.cancel()
+    }
+
+    private func dispatch(_ request: Request<ErasedMethod>, raw: Data, on transport: any Transport) {
+        guard let handler = builtinHandler(for: request.method) ?? methodHandlers[request.method]
+        else {
+            let reply = ErasedMethod.response(
+                id: request.id,
+                error: .methodNotFound("Unknown method: \(request.method)")
+            )
+            if let frame = try? Self.encode(reply) {
+                Task { await send(frame, on: transport) }
+            }
+            return
+        }
+        let work = Task<Data, Swift.Error> {
+            try Task.checkCancellation()
+            return try await handler(raw)
+        }
+        inFlightRequests[request.id] = work
+        Task { await complete(request.id, of: work, on: transport) }
+    }
+
+    private func complete(
+        _ id: ID, of work: Task<Data, Swift.Error>, on transport: any Transport
+    ) async {
+        let outcome = await work.result
+        inFlightRequests.removeValue(forKey: id)
+        switch outcome {
+        case let .success(frame):
+            await send(frame, on: transport)
+        case .failure(is CancellationError):
+            break
+        case let .failure(error):
+            let mcpError = error as? MCPError ?? .internalError(error.localizedDescription)
+            if let frame = try? Self.encode(ErasedMethod.response(id: id, error: mcpError)) {
+                await send(frame, on: transport)
+            }
+        }
+    }
+
+    private func handleNotification(_ note: Message<ErasedNotification>, raw: Data) {
+        guard
+            note.method == CancelledNotification.name,
+            let cancelled = try? JSONDecoder().decode(
+                Message<CancelledNotification>.self, from: raw
+            )
+        else { return }
+        inFlightRequests.removeValue(forKey: cancelled.params.requestId)?.cancel()
+    }
+
+    // MARK: - Built-in methods
+
+    private func builtinHandler(for method: String) -> (@Sendable (Data) async throws -> Data)? {
+        switch method {
+        case Initialize.name:
+            { [weak self] raw in
+                guard let self else { throw MCPError.internalError("server gone") }
+                return try await processInitialize(raw)
+            }
+        case Ping.name:
+            { raw in
+                let request = try JSONDecoder().decode(Request<Ping>.self, from: raw)
+                return try Self.encode(Ping.response(id: request.id))
+            }
+        default:
+            nil
+        }
+    }
+
+    private func processInitialize(_ raw: Data) throws -> Data {
+        let request = try JSONDecoder().decode(Request<Initialize>.self, from: raw)
+        guard !isInitialized else {
+            throw MCPError.invalidRequest("Server is already initialized")
+        }
+        isInitialized = true
+        let requested = request.params.protocolVersion
+        let negotiated = Version.supported.contains(requested) ? requested : Version.latest
+        let result = Initialize.Result(
+            protocolVersion: negotiated,
+            capabilities: capabilities,
+            serverInfo: serverInfo
+        )
+        return try Self.encode(Initialize.response(id: request.id, result: result))
+    }
+
+    // MARK: - Liveness
+
+    private func pingLoop(on transport: any Transport, _ config: ClientLiveness) async {
+        while !Task.isCancelled {
+            do {
+                try await Task.sleep(for: config.interval)
+            } catch {
+                return
+            }
+            if missedPongs >= config.missedPongLimit {
+                await transport.disconnect()
+                return
+            }
+            missedPongs += 1
+            if let frame = try? Self.encode(Ping.request()) {
+                await send(frame, on: transport)
+            }
+        }
+    }
+
+    // MARK: - Wire
+
+    private func send(_ frame: Data, on transport: any Transport) async {
+        try? await transport.send(frame)
+    }
+
+    private static func encode(_ value: some Encodable) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(value)
+    }
+
+    private static func parseErrorResponse(for raw: Data) -> Data {
+        let object = (try? JSONSerialization.jsonObject(with: raw)) as? [String: Any]
+        let id: ID =
+            if let string = object?["id"] as? String {
+                .string(string)
+            } else if let number = object?["id"] as? Int {
+                .number(number)
+            } else {
+                .random
+            }
+        let reply = ErasedMethod.response(id: id, error: .parseError("Invalid message format"))
+        return (try? encode(reply)) ?? Data()
+    }
+}

--- a/previewsmcp/Tests/PreviewsCLITests/PreviewsMCPServerLivenessTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/PreviewsMCPServerLivenessTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import MCP
+import os
+@testable import PreviewsCLI
+import Testing
+
+/// The stage-4 dead-client detection: the server pings its client on an
+/// interval and disconnects after `missedPongLimit` pings with no response.
+/// Any response counts as life — the characterized SDK client answers
+/// server pings with methodNotFound, and that is a live peer.
+@Suite("PreviewsMCPServer client liveness")
+struct PreviewsMCPServerLivenessTests {
+    @Test("a silent client is disconnected after the missed-pong limit")
+    func silentClientIsDisconnected() async throws {
+        let (clientSide, serverSide) = await InMemoryTransport.createConnectedPair()
+        let server = PreviewsMCPServer(
+            name: "liveness", version: "1",
+            liveness: .init(interval: .milliseconds(50), missedPongLimit: 2)
+        )
+        try await server.start(transport: serverSide)
+        try await clientSide.connect()
+
+        let completed = OSAllocatedUnfairLock(initialState: false)
+        let waiter = Task {
+            await server.waitUntilCompleted()
+            completed.withLock { $0 = true }
+        }
+        defer { waiter.cancel() }
+
+        try await pollUntil(
+            { completed.withLock { $0 } },
+            failure: "a silent client was never declared dead"
+        )
+        await server.stop()
+    }
+
+    @Test("a client that answers pings, even with an error, stays connected")
+    func respondingClientStaysAlive() async throws {
+        let (clientSide, serverSide) = await InMemoryTransport.createConnectedPair()
+        let server = PreviewsMCPServer(
+            name: "liveness", version: "1",
+            liveness: .init(interval: .milliseconds(50), missedPongLimit: 5)
+        )
+        try await server.start(transport: serverSide)
+        try await clientSide.connect()
+
+        // Mimic the characterized SDK client: no ping handler, so every
+        // server ping gets a methodNotFound ERROR response.
+        let sawPing = OSAllocatedUnfairLock(initialState: false)
+        let responder = Task {
+            for try await raw in await clientSide.receive() {
+                guard
+                    let object = try? JSONSerialization.jsonObject(with: raw) as? [String: Any],
+                    object["method"] as? String == "ping",
+                    let id = object["id"]
+                else { continue }
+                sawPing.withLock { $0 = true }
+                let reply: [String: Any] = [
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": ["code": -32601, "message": "Method not found"],
+                ]
+                let data = try JSONSerialization.data(withJSONObject: reply, options: [.sortedKeys])
+                try await clientSide.send(data)
+            }
+        }
+        defer { responder.cancel() }
+
+        let completed = OSAllocatedUnfairLock(initialState: false)
+        let waiter = Task {
+            await server.waitUntilCompleted()
+            completed.withLock { $0 = true }
+        }
+        defer { waiter.cancel() }
+
+        try await pollUntil(
+            { sawPing.withLock { $0 } },
+            failure: "the server never pinged its client"
+        )
+        // Ten intervals of answered pings: the connection must survive.
+        try await Task.sleep(for: .milliseconds(500))
+        #expect(!completed.withLock { $0 }, "a responding client was declared dead")
+        await server.stop()
+    }
+}

--- a/previewsmcp/Tests/PreviewsCLITests/PreviewsMCPServerLivenessTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/PreviewsMCPServerLivenessTests.swift
@@ -5,9 +5,10 @@ import os
 import Testing
 
 /// The stage-4 dead-client detection: the server pings its client on an
-/// interval and disconnects after `missedPongLimit` pings with no response.
-/// Any response counts as life — the characterized SDK client answers
-/// server pings with methodNotFound, and that is a live peer.
+/// interval and disconnects after `missedPongLimit` pings with no inbound
+/// traffic of any kind. Any frame counts as life — the characterized SDK
+/// client answers server pings with methodNotFound, and that is a live
+/// peer.
 @Suite("PreviewsMCPServer client liveness")
 struct PreviewsMCPServerLivenessTests {
     @Test("a silent client is disconnected after the missed-pong limit")
@@ -20,15 +21,11 @@ struct PreviewsMCPServerLivenessTests {
         try await server.start(transport: serverSide)
         try await clientSide.connect()
 
-        let completed = OSAllocatedUnfairLock(initialState: false)
-        let waiter = Task {
-            await server.waitUntilCompleted()
-            completed.withLock { $0 = true }
-        }
-        defer { waiter.cancel() }
+        let completed = completionFlag(of: server)
+        defer { completed.waiter.cancel() }
 
         try await pollUntil(
-            { completed.withLock { $0 } },
+            { completed.flag.withLock { $0 } },
             failure: "a silent client was never declared dead"
         )
         await server.stop()
@@ -47,31 +44,27 @@ struct PreviewsMCPServerLivenessTests {
         // Mimic the characterized SDK client: no ping handler, so every
         // server ping gets a methodNotFound ERROR response.
         let sawPing = OSAllocatedUnfairLock(initialState: false)
-        let responder = Task {
-            for try await raw in await clientSide.receive() {
-                guard
-                    let object = try? JSONSerialization.jsonObject(with: raw) as? [String: Any],
-                    object["method"] as? String == "ping",
-                    let id = object["id"]
-                else { continue }
-                sawPing.withLock { $0 = true }
-                let reply: [String: Any] = [
-                    "jsonrpc": "2.0",
-                    "id": id,
-                    "error": ["code": -32601, "message": "Method not found"],
-                ]
-                let data = try JSONSerialization.data(withJSONObject: reply, options: [.sortedKeys])
-                try await clientSide.send(data)
-            }
+        let responder = FrameCollector(reading: clientSide) { frame in
+            guard
+                let object = FrameCollector.object(frame),
+                object["method"] as? String == "ping",
+                let id = object["id"]
+            else { return }
+            sawPing.withLock { $0 = true }
+            let reply: [String: Any] = [
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": ["code": -32601, "message": "Method not found"],
+            ]
+            guard
+                let data = try? JSONSerialization.data(withJSONObject: reply, options: [.sortedKeys])
+            else { return }
+            try? await clientSide.send(data)
         }
-        defer { responder.cancel() }
+        defer { responder.stop() }
 
-        let completed = OSAllocatedUnfairLock(initialState: false)
-        let waiter = Task {
-            await server.waitUntilCompleted()
-            completed.withLock { $0 = true }
-        }
-        defer { waiter.cancel() }
+        let completed = completionFlag(of: server)
+        defer { completed.waiter.cancel() }
 
         try await pollUntil(
             { sawPing.withLock { $0 } },
@@ -79,7 +72,18 @@ struct PreviewsMCPServerLivenessTests {
         )
         // Ten intervals of answered pings: the connection must survive.
         try await Task.sleep(for: .milliseconds(500))
-        #expect(!completed.withLock { $0 }, "a responding client was declared dead")
+        #expect(!completed.flag.withLock { $0 }, "a responding client was declared dead")
         await server.stop()
+    }
+
+    private func completionFlag(
+        of server: PreviewsMCPServer
+    ) -> (flag: OSAllocatedUnfairLock<Bool>, waiter: Task<Void, Never>) {
+        let flag = OSAllocatedUnfairLock(initialState: false)
+        let waiter = Task {
+            await server.waitUntilCompleted()
+            flag.withLock { $0 = true }
+        }
+        return (flag, waiter)
     }
 }

--- a/previewsmcp/Tests/PreviewsCLITests/PreviewsMCPServerLivenessTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/PreviewsMCPServerLivenessTests.swift
@@ -43,14 +43,13 @@ struct PreviewsMCPServerLivenessTests {
 
         // Mimic the characterized SDK client: no ping handler, so every
         // server ping gets a methodNotFound ERROR response.
-        let sawPing = OSAllocatedUnfairLock(initialState: false)
+        let answeredPings = OSAllocatedUnfairLock(initialState: 0)
         let responder = FrameCollector(reading: clientSide) { frame in
             guard
                 let object = FrameCollector.object(frame),
                 object["method"] as? String == "ping",
                 let id = object["id"]
             else { return }
-            sawPing.withLock { $0 = true }
             let reply: [String: Any] = [
                 "jsonrpc": "2.0",
                 "id": id,
@@ -60,18 +59,20 @@ struct PreviewsMCPServerLivenessTests {
                 let data = try? JSONSerialization.data(withJSONObject: reply, options: [.sortedKeys])
             else { return }
             try? await clientSide.send(data)
+            answeredPings.withLock { $0 += 1 }
         }
         defer { responder.stop() }
 
         let completed = completionFlag(of: server)
         defer { completed.waiter.cancel() }
 
+        // Event-based, not wall-clock: eight answered pings can only happen
+        // if the reset keeps working past the missed-pong limit; machine
+        // load delays the events instead of failing the test.
         try await pollUntil(
-            { sawPing.withLock { $0 } },
-            failure: "the server never pinged its client"
+            { answeredPings.withLock { $0 } >= 8 },
+            failure: "the server stopped pinging a responsive client"
         )
-        // Ten intervals of answered pings: the connection must survive.
-        try await Task.sleep(for: .milliseconds(500))
         #expect(!completed.flag.withLock { $0 }, "a responding client was declared dead")
         await server.stop()
     }

--- a/previewsmcp/Tests/PreviewsCLITests/SDKServerCharacterizationTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SDKServerCharacterizationTests.swift
@@ -186,6 +186,28 @@ struct SDKServerCharacterizationTests {
         }
     }
 
+    @Test(
+        "a frame with both method and result keys is consumed as a response, not dispatched",
+        arguments: ServerKind.allCases
+    )
+    func methodEchoingResponseIsNotDispatched(kind: ServerKind) async throws {
+        // Some peers echo the method name in response frames. Classifying
+        // request-first would dispatch such a pong as a fresh request and
+        // answer it — a spurious frame in the client's id space. The later
+        // id-992 round trip orders the assertion: the stream is processed
+        // in order, so by the time 992 is answered, 991 was classified.
+        try await Wire.with(kind) { wire in
+            try await wire.handshake()
+            try await wire.send(#"{"id":991,"jsonrpc":"2.0","method":"ping","result":{}}"#)
+            let after = try await wire.roundTrip(id: 992, #"{"id":992,"jsonrpc":"2.0","method":"ping"}"#)
+            #expect(after["error"] == nil)
+            #expect(
+                wire.collector.frame(forID: 991) == nil,
+                "a response-shaped frame must be consumed, not answered"
+            )
+        }
+    }
+
     @Test("string request ids are echoed verbatim", arguments: ServerKind.allCases)
     func stringIDRoundTrip(kind: ServerKind) async throws {
         // The SDK Client (the daemon's actual peer) generates random STRING

--- a/previewsmcp/Tests/PreviewsCLITests/SDKServerCharacterizationTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SDKServerCharacterizationTests.swift
@@ -1,37 +1,51 @@
 import Foundation
 import MCP
 import os
+@testable import PreviewsCLI
 import Testing
 
-/// Characterizes the SDK `Server` behaviors the daemon relies on. This suite
-/// is the acceptance bar for the in-house wire-layer rewrite: every test here
-/// must pass unchanged against the replacement server loop. Each test drives
-/// a server configured like `configureMCPServer` through the SDK's
-/// `InMemoryTransport` pair, speaking raw JSON-RPC frames from the client
-/// side.
+/// Characterizes the server behaviors the daemon relies on, and runs every
+/// test against BOTH implementations: the SDK `Server` (the original
+/// characterization subject) and the in-house `PreviewsMCPServer` (rewrite
+/// stage 4). The assertions are the acceptance bar for the rewrite — they
+/// were pinned against the SDK first and must hold unchanged for the
+/// replacement. Each test drives a server configured like
+/// `configureMCPServer` through the SDK's `InMemoryTransport` pair,
+/// speaking raw JSON-RPC frames from the client side.
 ///
 /// Deliberately out of scope: JSON-RPC batch requests. No client of the
 /// daemon sends them (Claude Code and the CLI both issue single requests),
 /// so the rewrite is not required to support batching; revisit if a batching
 /// client ever appears.
-@Suite("SDK Server characterization")
+@Suite("MCP server characterization (SDK + in-house)")
 struct SDKServerCharacterizationTests {
     private static let serverVersion = "0.0.1-characterization"
 
+    enum ServerKind: String, CaseIterable {
+        case sdk
+        case inHouse
+    }
+
     // MARK: - Version negotiation
 
-    @Test("initialize echoes every supported protocol version", arguments: Version.supported.sorted())
-    func initializeEchoesSupportedVersion(version: String) async throws {
-        try await Wire.with { wire in
+    @Test(
+        "initialize echoes every supported protocol version",
+        arguments: ServerKind.allCases, Version.supported.sorted()
+    )
+    func initializeEchoesSupportedVersion(kind: ServerKind, version: String) async throws {
+        try await Wire.with(kind) { wire in
             let reply = try await wire.roundTrip(id: 1, Self.initialize(version: version))
             let result = try #require(reply["result"] as? [String: Any])
             #expect(result["protocolVersion"] as? String == version)
         }
     }
 
-    @Test("initialize falls back to the latest version and advertises the server's own version")
-    func initializeFallsBackToLatest() async throws {
-        try await Wire.with { wire in
+    @Test(
+        "initialize falls back to the latest version and advertises the server's own version",
+        arguments: ServerKind.allCases
+    )
+    func initializeFallsBackToLatest(kind: ServerKind) async throws {
+        try await Wire.with(kind) { wire in
             let reply = try await wire.roundTrip(id: 1, Self.initialize(version: "1999-01-01"))
             let result = try #require(reply["result"] as? [String: Any])
             #expect(result["protocolVersion"] as? String == Version.latest)
@@ -44,9 +58,12 @@ struct SDKServerCharacterizationTests {
 
     // MARK: - Wire shape
 
-    @Test("responses encode with sorted keys and unescaped slashes")
-    func responseWireShape() async throws {
-        try await Wire.with { server in
+    @Test(
+        "responses encode with sorted keys and unescaped slashes",
+        arguments: ServerKind.allCases
+    )
+    func responseWireShape(kind: ServerKind) async throws {
+        try await Wire.with(kind) { server in
             await server.withMethodHandler(ListTools.self) { _ in
                 ListTools.Result(tools: [
                     Tool(
@@ -75,12 +92,15 @@ struct SDKServerCharacterizationTests {
 
     // MARK: - Request handling contracts
 
-    @Test("an unknown request method gets a methodNotFound error, not silence")
-    func unknownMethodGetsError() async throws {
+    @Test(
+        "an unknown request method gets a methodNotFound error, not silence",
+        arguments: ServerKind.allCases
+    )
+    func unknownMethodGetsError(kind: ServerKind) async throws {
         // withDaemonClient awaits `setLoggingLevel` BEFORE its stall watcher
         // starts, and the daemon registers no logging/setLevel handler — this
         // error response is the only thing that unblocks every CLI command.
-        try await Wire.with { wire in
+        try await Wire.with(kind) { wire in
             try await wire.handshake()
             let reply = try await wire.roundTrip(
                 id: 9,
@@ -91,9 +111,9 @@ struct SDKServerCharacterizationTests {
         }
     }
 
-    @Test("ping answers with an empty result")
-    func pingAnswers() async throws {
-        try await Wire.with { wire in
+    @Test("ping answers with an empty result", arguments: ServerKind.allCases)
+    func pingAnswers(kind: ServerKind) async throws {
+        try await Wire.with(kind) { wire in
             try await wire.handshake()
             let reply = try await wire.roundTrip(id: 4, #"{"id":4,"jsonrpc":"2.0","method":"ping"}"#)
             #expect(reply["error"] == nil)
@@ -101,13 +121,16 @@ struct SDKServerCharacterizationTests {
         }
     }
 
-    @Test("ping is answered while a CallTool handler is still in flight")
-    func pingAnsweredDuringInFlightCall() async throws {
+    @Test(
+        "ping is answered while a CallTool handler is still in flight",
+        arguments: ServerKind.allCases
+    )
+    func pingAnsweredDuringInFlightCall(kind: ServerKind) async throws {
         // The liveness rewrite keys StallTimer off pong latency, so a pong
         // must not queue behind a long render.
         let started = OSAllocatedUnfairLock(initialState: false)
         let release = OSAllocatedUnfairLock(initialState: false)
-        try await Wire.with { server in
+        try await Wire.with(kind) { server in
             await server.withMethodHandler(CallTool.self) { _ in
                 started.withLock { $0 = true }
                 while !release.withLock({ $0 }) {
@@ -143,12 +166,12 @@ struct SDKServerCharacterizationTests {
         }
     }
 
-    @Test("string request ids are echoed verbatim")
-    func stringIDRoundTrip() async throws {
+    @Test("string request ids are echoed verbatim", arguments: ServerKind.allCases)
+    func stringIDRoundTrip(kind: ServerKind) async throws {
         // The SDK Client (the daemon's actual peer) generates random STRING
         // ids; the integer ids used elsewhere in this suite are the less
         // common case.
-        try await Wire.with { wire in
+        try await Wire.with(kind) { wire in
             try await wire.handshake()
             try await wire.send(#"{"id":"req-abc","jsonrpc":"2.0","method":"ping"}"#)
             let reply = try await pollUntil(
@@ -161,11 +184,14 @@ struct SDKServerCharacterizationTests {
 
     // MARK: - Cancellation
 
-    @Test("notifications/cancelled cancels the in-flight CallTool handler")
-    func cancelledNotificationCancelsHandler() async throws {
+    @Test(
+        "notifications/cancelled cancels the in-flight CallTool handler",
+        arguments: ServerKind.allCases
+    )
+    func cancelledNotificationCancelsHandler(kind: ServerKind) async throws {
         let started = OSAllocatedUnfairLock(initialState: false)
         let cancelled = OSAllocatedUnfairLock(initialState: false)
-        try await Wire.with { server in
+        try await Wire.with(kind) { server in
             await server.withMethodHandler(CallTool.self) { _ in
                 started.withLock { $0 = true }
                 do {
@@ -217,9 +243,12 @@ struct SDKServerCharacterizationTests {
 
     // MARK: - Notifications
 
-    @Test("server.log reaches the wire as notifications/message")
-    func serverLogNotificationReachesWire() async throws {
-        try await Wire.with { wire in
+    @Test(
+        "server.log reaches the wire as notifications/message",
+        arguments: ServerKind.allCases
+    )
+    func serverLogNotificationReachesWire(kind: ServerKind) async throws {
+        try await Wire.with(kind) { wire in
             try await wire.handshake()
 
             try await wire.server.log(level: .debug, logger: "heartbeat", data: .string("alive"))
@@ -233,13 +262,16 @@ struct SDKServerCharacterizationTests {
         }
     }
 
-    @Test("progress tokens decode from _meta and notify as notifications/progress")
-    func progressTokenPlumbing() async throws {
+    @Test(
+        "progress tokens decode from _meta and notify as notifications/progress",
+        arguments: ServerKind.allCases
+    )
+    func progressTokenPlumbing(kind: ServerKind) async throws {
         // MCPProgressReporter depends on both halves: CallTool.Parameters
         // exposing _meta.progressToken, and server.notify(ProgressNotification)
         // reaching the wire tagged with that token.
         let token = OSAllocatedUnfairLock(initialState: String?.none)
-        try await Wire.with { server in
+        try await Wire.with(kind) { server in
             await server.withMethodHandler(CallTool.self) { params in
                 if case let .string(value) = params._meta?.progressToken {
                     token.withLock { $0 = value }
@@ -271,12 +303,15 @@ struct SDKServerCharacterizationTests {
 
     // MARK: - Lifecycle
 
-    @Test("waitUntilCompleted returns when the transport closes")
-    func waitUntilCompletedReturnsOnTransportClose() async throws {
+    @Test(
+        "waitUntilCompleted returns when the transport closes",
+        arguments: ServerKind.allCases
+    )
+    func waitUntilCompletedReturnsOnTransportClose(kind: ServerKind) async throws {
         // runMCPServer's entire per-connection teardown: start returns once
         // the receive loop is spawned, and waitUntilCompleted returns when
         // the peer goes away.
-        try await Wire.with { wire in
+        try await Wire.with(kind) { wire in
             let completed = OSAllocatedUnfairLock(initialState: false)
             let waiter = Task {
                 await wire.server.waitUntilCompleted()
@@ -297,24 +332,36 @@ struct SDKServerCharacterizationTests {
         #"{"id":1,"jsonrpc":"2.0","method":"initialize","params":{"capabilities":{},"clientInfo":{"name":"probe","version":"1"},"protocolVersion":"\#(version)"}}"#
     }
 
-    /// A started SDK server plus the raw client side of its transport.
-    /// `with` scopes the harness so teardown runs on every path, including
-    /// thrown polls.
+    /// A started server (SDK or in-house, per `kind`) plus the raw client
+    /// side of its transport. `with` scopes the harness so teardown runs on
+    /// every path, including thrown polls.
     struct Wire {
-        let server: Server
+        let server: any MCPServing
         let collector: FrameCollector
         private let testSide: InMemoryTransport
 
         static func with(
-            _ configure: (Server) async -> Void = { _ in },
+            _ kind: ServerKind,
+            _ configure: (any MCPServing) async -> Void = { _ in },
             _ body: (Wire) async throws -> Void
         ) async throws {
             let (testSide, serverSide) = await InMemoryTransport.createConnectedPair()
-            let server = Server(
-                name: "characterization",
-                version: serverVersion,
-                capabilities: .init(logging: .init(), tools: .init(listChanged: false))
+            let capabilities = Server.Capabilities(
+                logging: .init(), tools: .init(listChanged: false)
             )
+            let server: any MCPServing =
+                switch kind {
+                case .sdk:
+                    Server(
+                        name: "characterization", version: serverVersion,
+                        capabilities: capabilities
+                    )
+                case .inHouse:
+                    PreviewsMCPServer(
+                        name: "characterization", version: serverVersion,
+                        capabilities: capabilities
+                    )
+                }
             await configure(server)
             try await server.start(transport: serverSide)
             try await testSide.connect()

--- a/previewsmcp/Tests/PreviewsCLITests/SDKServerCharacterizationTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SDKServerCharacterizationTests.swift
@@ -166,6 +166,26 @@ struct SDKServerCharacterizationTests {
         }
     }
 
+    @Test(
+        "a malformed frame gets an error response echoing a recoverable id",
+        arguments: ServerKind.allCases
+    )
+    func malformedFrameEchoesIDInError(kind: ServerKind) async throws {
+        // Neither server may go silent on a frame that fails to decode: a
+        // client awaiting that id would hang forever. The error code is not
+        // pinned (the SDK says internalError, the in-house loop parseError);
+        // the pinned contract is an ERROR response carrying the sender's id.
+        try await Wire.with(kind) { wire in
+            try await wire.handshake()
+            try await wire.send(#"{"id":77,"jsonrpc":"1.0","method":"ping"}"#)
+            let reply = try await pollUntil(
+                { wire.collector.frame(forID: 77) },
+                failure: "no reply for the malformed frame"
+            )
+            #expect(reply["error"] != nil, "expected an error response: \(reply)")
+        }
+    }
+
     @Test("string request ids are echoed verbatim", arguments: ServerKind.allCases)
     func stringIDRoundTrip(kind: ServerKind) async throws {
         // The SDK Client (the daemon's actual peer) generates random STRING


### PR DESCRIPTION
Stage 4 of the MCP wire rewrite: an in-house server actor replacing the SDK `Server` at the stage-5 cutover (SDK data types stay). **The stage-1 characterization suite now runs every test against BOTH servers** via a `ServerKind` argument, and the in-house loop passed the entire acceptance bar on first exposure — that suite is doing exactly the job it was built for.

## What's here

- **`PreviewsMCPServer`**: receive loop with SDK-parity semantics — response-first frame classification, task-per-request dispatch (ping answered during in-flight renders), notifications inline (`notifications/cancelled` reaches running handlers), cancellation produces no response frame, `methodNotFound` via a throwing fallback through the one response pipeline, built-in initialize (negotiation over `Version.supported`, re-init rejection) and ping, sorted-keys/unescaped-slashes encoder, lenient lifecycle. In-flight tracking is keyed by a per-request token so id collisions can't orphan tasks from cancellation. Classification decodes payloads as a read-nothing `Ignored` type (no throwaway `Value` tree per multi-hundred-KB frame).
- **Dead-client detection** (the owner's liveness requirement, unwired until stage 5): a `ClientLiveness` config pings the client each interval; ANY inbound frame is proof of life (the characterized SDK client answers pings with `methodNotFound` — that's alive); after N intervals with no traffic the connection is closed with a daemon-side log. A failed ping send closes the connection honestly instead of blaming the peer.
- **`MCPServing` seam**: the exact consumed SDK surface; production signatures (`HandlerContext`, `MCPProgressReporter`, `runMCPServer`, `configureMCPServer`) already retyped, so **stage 5 becomes a one-line constructor swap** + liveness config.
- Two new differential pins beyond the original bar: malformed frames get an error response echoing a recoverable id; a response frame that echoes `method` is consumed, never dispatched.

## One deliberate SDK-behavior decision for owner visibility

In-flight handlers **run to completion after peer disconnect** (SDK parity). Review argued both directions; the tiebreaker is that daemon sessions persist across CLI invocations by design, so a killed CLI's finishing `preview_start` is a warm session for the next invocation, not leaked work. `stop()` (tests only) does cancel. If you'd rather reap in-flight work on dead-client disconnect, it's a two-line change in `run()`'s epilogue.

## Gates

- /simplify (4 agents): applied 10 findings incl. the altitude set (any-frame-is-life, production retype, kill logging)
- /code-review (high, workflow, 19 agents): 4 confirmed defects fixed (id-collision orphaning, request-first classification, inline parse-error send starving liveness, ping-send failure miscounted as dead peer) + judgment reversal above
- Determinism campaigns 15/15 × 3; lint clean; full local suite 9/9 first try

Remaining stages: 5 (daemon cutover + wedgecheck campaign; pre-stage-5 items: event-driven readiness, DaemonProbe collapse, scoped accept ownership), 6 (in-house client + pong-fed StallTimer, retiring the 2s log-heartbeat hack), 7 (retire SerializedStdioTransport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)