### PR TITLE
Pre-stage-5: kernel readiness replaces the 10ms idle polls

### DIFF
--- a/previewsmcp/PreviewsCLI/DaemonSocket.swift
+++ b/previewsmcp/PreviewsCLI/DaemonSocket.swift
@@ -48,7 +48,7 @@ enum DaemonSocket {
             }
             switch Errno(rawValue: errno) {
             case .wouldBlock:
-                try await FDReadiness.waitUntilReadable(listener)
+                await FDReadiness.waitUntilReadable(listener)
             case .interrupted, .connectionAbort:
                 continue
             case let failure:

--- a/previewsmcp/PreviewsCLI/DaemonSocket.swift
+++ b/previewsmcp/PreviewsCLI/DaemonSocket.swift
@@ -13,8 +13,9 @@ import System
 /// that window.
 enum DaemonSocket {
     /// Bind and listen on `path`. The listener is non-blocking so
-    /// `accept(on:)` polls cancellably. Stale-socket-file cleanup stays
-    /// with the caller (it must first verify no live daemon is listening).
+    /// `accept(on:)` waits on kernel readiness, cancellably. Stale-socket-
+    /// file cleanup stays with the caller (it must first verify no live
+    /// daemon is listening).
     static func listen(at path: String, backlog: Int32 = 16) throws -> FileDescriptor {
         let listener = try makeSocket()
         try closingOnThrow(listener) {
@@ -31,9 +32,9 @@ enum DaemonSocket {
         return listener
     }
 
-    /// Accept one connection, polling the non-blocking listener so the
-    /// call is cancellable (a blocking accept would park a cooperative
-    /// thread with no way to interrupt it).
+    /// Accept one connection, waiting on kernel readiness between attempts
+    /// so the call is cancellable and never parks a cooperative thread (a
+    /// blocking accept would) nor idle-polls the daemon's lifetime away.
     static func accept(on listener: FileDescriptor) async throws -> FileDescriptor {
         while true {
             try Task.checkCancellation()
@@ -47,7 +48,7 @@ enum DaemonSocket {
             }
             switch Errno(rawValue: errno) {
             case .wouldBlock:
-                try await Task.sleep(for: .milliseconds(10))
+                try await FDReadiness.waitUntilReadable(listener)
             case .interrupted, .connectionAbort:
                 continue
             case let failure:

--- a/previewsmcp/PreviewsCLI/FDReadiness.swift
+++ b/previewsmcp/PreviewsCLI/FDReadiness.swift
@@ -1,0 +1,42 @@
+import Dispatch
+import os
+import System
+
+/// Kernel readiness for non-blocking descriptors (pre-stage-5 requirement:
+/// the daemon must not idle-poll at 100Hz per connection). Callers attempt
+/// the syscall first and wait only on EAGAIN, so descriptors that cannot
+/// EAGAIN (regular files, /dev/null) and error paths (EBADF) never reach
+/// the source machinery; kqueue readiness is level-triggered, so bytes
+/// arriving between the EAGAIN and activation still fire the event.
+enum FDReadiness {
+    static func waitUntilReadable(_ descriptor: FileDescriptor) async throws {
+        let source = DispatchSource.makeReadSource(
+            fileDescriptor: descriptor.rawValue, queue: .global()
+        )
+        let resumed = OSAllocatedUnfairLock(initialState: false)
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                source.setEventHandler {
+                    guard resumed.withLock({ claimed in
+                        if claimed { return false }
+                        claimed = true
+                        return true
+                    }) else { return }
+                    source.cancel()
+                    cont.resume()
+                }
+                source.setCancelHandler {
+                    guard resumed.withLock({ claimed in
+                        if claimed { return false }
+                        claimed = true
+                        return true
+                    }) else { return }
+                    cont.resume(throwing: CancellationError())
+                }
+                source.activate()
+            }
+        } onCancel: {
+            source.cancel()
+        }
+    }
+}

--- a/previewsmcp/PreviewsCLI/FDReadiness.swift
+++ b/previewsmcp/PreviewsCLI/FDReadiness.swift
@@ -1,13 +1,19 @@
 import Dispatch
-import os
 import System
 
 /// Kernel readiness for non-blocking descriptors (pre-stage-5 requirement:
 /// the daemon must not idle-poll at 100Hz per connection). Callers attempt
-/// the syscall first and wait only on EAGAIN, so descriptors that cannot
-/// EAGAIN (regular files, /dev/null) and error paths (EBADF) never reach
-/// the source machinery; kqueue readiness is level-triggered, so bytes
-/// arriving between the EAGAIN and activation still fire the event.
+/// the syscall first and wait only on EAGAIN; the wait returns — without
+/// signalling why — when the descriptor is ready, when the surrounding
+/// task is cancelled, or after a 1s safety interval, and the caller's
+/// re-attempted syscall plus its own cancellation checks decide what
+/// happened. kqueue readiness is level-triggered, so bytes arriving
+/// between the EAGAIN and activation still fire the event.
+///
+/// The 1s re-attempt bounds every failure kqueue cannot report: an fd
+/// closed mid-wait drops its knote silently (the old 10ms poll surfaced
+/// EBADF; this wakes and re-reads within a second), and device fds kqueue
+/// cannot watch degrade to a 1Hz poll instead of hanging.
 ///
 /// The source's cancellation handler is the ONLY resume point: Dispatch
 /// runs it after the kqueue registration is torn down, so when the wait
@@ -15,33 +21,32 @@ import System
 /// transport's owner-may-close-after-disconnect contract depends on that
 /// ordering.
 enum FDReadiness {
-    static func waitUntilReadable(_ descriptor: FileDescriptor) async throws {
-        try await wait(on: DispatchSource.makeReadSource(fileDescriptor: descriptor.rawValue))
+    static func waitUntilReadable(_ descriptor: FileDescriptor) async {
+        await wait(on: DispatchSource.makeReadSource(fileDescriptor: descriptor.rawValue))
     }
 
-    static func waitUntilWritable(_ descriptor: FileDescriptor) async throws {
-        try await wait(on: DispatchSource.makeWriteSource(fileDescriptor: descriptor.rawValue))
+    static func waitUntilWritable(_ descriptor: FileDescriptor) async {
+        await wait(on: DispatchSource.makeWriteSource(fileDescriptor: descriptor.rawValue))
     }
 
-    private static func wait(on source: some DispatchSourceProtocol) async throws {
+    private static let reattemptInterval: DispatchTimeInterval = .seconds(1)
+
+    private static func wait(on source: some DispatchSourceProtocol) async {
         nonisolated(unsafe) let source = source
-        let taskCancelled = OSAllocatedUnfairLock(initialState: false)
-        try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
                 source.setEventHandler {
                     source.cancel()
                 }
                 source.setCancelHandler {
-                    if taskCancelled.withLock({ $0 }) {
-                        cont.resume(throwing: CancellationError())
-                    } else {
-                        cont.resume()
-                    }
+                    cont.resume()
                 }
                 source.activate()
+                DispatchQueue.global().asyncAfter(deadline: .now() + reattemptInterval) {
+                    source.cancel()
+                }
             }
         } onCancel: {
-            taskCancelled.withLock { $0 = true }
             source.cancel()
         }
     }

--- a/previewsmcp/PreviewsCLI/FDReadiness.swift
+++ b/previewsmcp/PreviewsCLI/FDReadiness.swift
@@ -8,34 +8,40 @@ import System
 /// EAGAIN (regular files, /dev/null) and error paths (EBADF) never reach
 /// the source machinery; kqueue readiness is level-triggered, so bytes
 /// arriving between the EAGAIN and activation still fire the event.
+///
+/// The source's cancellation handler is the ONLY resume point: Dispatch
+/// runs it after the kqueue registration is torn down, so when the wait
+/// returns, nothing kernel-side still references the descriptor — the
+/// transport's owner-may-close-after-disconnect contract depends on that
+/// ordering.
 enum FDReadiness {
     static func waitUntilReadable(_ descriptor: FileDescriptor) async throws {
-        let source = DispatchSource.makeReadSource(
-            fileDescriptor: descriptor.rawValue, queue: .global()
-        )
-        let resumed = OSAllocatedUnfairLock(initialState: false)
+        try await wait(on: DispatchSource.makeReadSource(fileDescriptor: descriptor.rawValue))
+    }
+
+    static func waitUntilWritable(_ descriptor: FileDescriptor) async throws {
+        try await wait(on: DispatchSource.makeWriteSource(fileDescriptor: descriptor.rawValue))
+    }
+
+    private static func wait(on source: some DispatchSourceProtocol) async throws {
+        nonisolated(unsafe) let source = source
+        let taskCancelled = OSAllocatedUnfairLock(initialState: false)
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
                 source.setEventHandler {
-                    guard resumed.withLock({ claimed in
-                        if claimed { return false }
-                        claimed = true
-                        return true
-                    }) else { return }
                     source.cancel()
-                    cont.resume()
                 }
                 source.setCancelHandler {
-                    guard resumed.withLock({ claimed in
-                        if claimed { return false }
-                        claimed = true
-                        return true
-                    }) else { return }
-                    cont.resume(throwing: CancellationError())
+                    if taskCancelled.withLock({ $0 }) {
+                        cont.resume(throwing: CancellationError())
+                    } else {
+                        cont.resume()
+                    }
                 }
                 source.activate()
             }
         } onCancel: {
+            taskCancelled.withLock { $0 = true }
             source.cancel()
         }
     }

--- a/previewsmcp/PreviewsCLI/FramedTransport.swift
+++ b/previewsmcp/PreviewsCLI/FramedTransport.swift
@@ -207,8 +207,11 @@ actor FramedTransport: Transport {
                 case .wouldBlock:
                     do {
                         try await FDReadiness.waitUntilReadable(input)
-                    } catch {
+                    } catch is CancellationError {
                         continuation.finish()
+                        return
+                    } catch {
+                        continuation.finish(throwing: error)
                         return
                     }
                 case .interrupted:
@@ -227,8 +230,6 @@ actor FramedTransport: Transport {
 
     // MARK: - Write side
 
-    private static let pollInterval: Duration = .milliseconds(10)
-
     /// Static so the retry suspension never suspends the actor mid-write;
     /// ordering comes from the send chain, not isolation. One `writev` per
     /// attempt carries payload + newline: no payload copy, no second
@@ -243,7 +244,7 @@ actor FramedTransport: Transport {
             } catch let errno as Errno {
                 switch errno {
                 case .wouldBlock:
-                    try await Task.sleep(for: pollInterval)
+                    try await FDReadiness.waitUntilWritable(output)
                 case .interrupted:
                     continue
                 default:

--- a/previewsmcp/PreviewsCLI/FramedTransport.swift
+++ b/previewsmcp/PreviewsCLI/FramedTransport.swift
@@ -205,15 +205,7 @@ actor FramedTransport: Transport {
             } catch let errno as Errno {
                 switch errno {
                 case .wouldBlock:
-                    do {
-                        try await FDReadiness.waitUntilReadable(input)
-                    } catch is CancellationError {
-                        continuation.finish()
-                        return
-                    } catch {
-                        continuation.finish(throwing: error)
-                        return
-                    }
+                    await FDReadiness.waitUntilReadable(input)
                 case .interrupted:
                     continue
                 default:
@@ -244,7 +236,7 @@ actor FramedTransport: Transport {
             } catch let errno as Errno {
                 switch errno {
                 case .wouldBlock:
-                    try await FDReadiness.waitUntilWritable(output)
+                    await FDReadiness.waitUntilWritable(output)
                 case .interrupted:
                     continue
                 default:

--- a/previewsmcp/PreviewsCLI/FramedTransport.swift
+++ b/previewsmcp/PreviewsCLI/FramedTransport.swift
@@ -205,7 +205,12 @@ actor FramedTransport: Transport {
             } catch let errno as Errno {
                 switch errno {
                 case .wouldBlock:
-                    try? await Task.sleep(for: pollInterval)
+                    do {
+                        try await FDReadiness.waitUntilReadable(input)
+                    } catch {
+                        continuation.finish()
+                        return
+                    }
                 case .interrupted:
                     continue
                 default:


### PR DESCRIPTION
The documented pre-stage-5 requirement: the daemon must not wake 100 times a second per idle connection for its lifetime. `FDReadiness.waitUntilReadable`/`waitUntilWritable` suspend on a DispatchSource until the descriptor is ready; `FramedTransport`'s read loop and write retry, and `DaemonSocket.accept`, wait on them after EAGAIN instead of sleeping 10ms.

## Design points (each survived a reviewer trying to break it)

- **Syscall-first, wait-on-EAGAIN-only**: error paths (EBADF) and instant-EOF fds never touch the source machinery; kqueue readiness is level-triggered, so no lost wakeups between the EAGAIN and activation.
- **The cancellation handler is the only resume point**: Dispatch runs it after kqueue unregistration, exactly once — so when the wait returns, nothing kernel-side references the fd, preserving the transport's owner-may-close-after-disconnect contract (an event-handler resume would race fd close against knote teardown).
- **A 1s re-attempt heartbeat bounds what kqueue can't report**: an fd closed mid-wait drops its knote silently (the old poll surfaced EBADF within 10ms; without this, the waiter leaks forever — confirmed review finding, reachable from test failure paths), and unwatchable device fds degrade to a 1Hz poll instead of hanging. The timer just cancels the source, so the single-resume-point ordering holds.
- **The wait is non-throwing**: it returns on readiness, cancellation, or the safety interval; the caller's re-attempted syscall and its own cancellation checks decide what happened. No flag races, no unreachable catch branches; `writeFrame` still poisons via `checkCancellation`, `accept` still throws `CancellationError`.
- The write side matters too: the 10ms backpressure poll capped drain-limited throughput at ~sockbuf/10ms (~6.4MB/s) — a real tax on multi-MB render frames — and it's gone.

## Gates

/simplify (4 agents — altitude caught the event-handler-resume teardown escape), /code-review high (confirmed fd-close continuation leak fixed via the heartbeat; unreachable catch removed structurally), determinism 20/20 × 3, lint clean, full suite 9/9 first try.

With this merged, stage 5 (daemon cutover) needs only: the `configureMCPServer` constructor swap + liveness config, `DaemonListener`'s accept loop on `DaemonSocket`, the DaemonProbe collapse, and the wedgecheck campaign gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)