### PR TITLE
docs: merge-bar pipeline runs bazel test + hermetic //tools/lint:check (#245 wrap-up)

### DIFF
--- a/docs/local-merge-queue.md
+++ b/docs/local-merge-queue.md
@@ -75,9 +75,9 @@ replacement for CI cache, with no silent eviction.
 
 The pipeline matches the documented merge bar:
 
-- `swift-format lint --strict --recursive` over Swift sources
-- unit tests
-- example integration tests
+- `bazel test //...`
+- `bazel run //tools/lint:check` (hermetic, Bazel-pinned SwiftFormat,
+  SwiftLint, clang-format, and buildifier)
 
 ### 3. Attestation: SSH commit signing
 

--- a/docs/local-merge-queue.md
+++ b/docs/local-merge-queue.md
@@ -73,11 +73,15 @@ example projects' dependencies. Per run the VM only fetches commits, builds,
 and tests. Refreshing the snapshot is an explicit, versioned event — the
 replacement for CI cache, with no silent eviction.
 
-The pipeline matches the documented merge bar:
+The in-VM pipeline runs:
 
 - `bazel test //...`
 - `bazel run //tools/lint:check` (hermetic, Bazel-pinned SwiftFormat,
   SwiftLint, clang-format, and buildifier)
+
+The documented merge bar also requires the example integration tests;
+those are not yet part of the in-VM pipeline (`examples/` is excluded
+from the Bazel graph).
 
 ### 3. Attestation: SSH commit signing
 


### PR DESCRIPTION
Last remaining piece of #245: `docs/local-merge-queue.md` still described the pre-Bazel merge bar (`swift-format lint --strict --recursive`). The bar actually runs `bazel test //...` and the hermetic `bazel run //tools/lint:check` (see `merge-queue/scripts/bar.swift`).

Everything else in #245 already shipped on main:
- 4 lint/format tools pinned as prebuilt Bazel externals (`//tools/lint`)
- `bazel run //tools/lint:{check,format,staged}`
- pre-commit hook runs the hermetic `:staged` target
- Brewfile slimmed to `bash`/`bazelisk`/`xcodes` (no Homebrew lint tools)
- merge bar gates on `//tools/lint:check`

Docs-only change, no runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)