### PR TITLE
Fix #279: enclosing-Apple-bundle fallback for cross-config module redefinition

### DIFF
--- a/previewsmcp/PreviewsCore/BazelBuildSystem.swift
+++ b/previewsmcp/PreviewsCore/BazelBuildSystem.swift
@@ -75,16 +75,19 @@ public actor BazelBuildSystem: BuildSystem {
             // swiftc rejects the duplicate (#279). Building *through* the
             // enclosing Apple bundle applies the rule's 1:1 split transition,
             // which collapses the dep to a single config.
-            guard
-                let bundle = await findEnclosingAppleBundle(
-                    target: target, packagePath: packagePath
-                )
-            else {
-                throw error
+            for bundle in await findEnclosingAppleBundles(
+                target: target, packagePath: packagePath
+            ) {
+                guard
+                    let context = try? await buildViaAppleBundle(
+                        bundle: bundle, target: target, moduleName: moduleName
+                    )
+                else { continue }
+                return context
             }
-            return try await buildViaAppleBundle(
-                bundle: bundle, target: target, moduleName: moduleName
-            )
+            // No candidate worked: surface the actionable original diagnostic,
+            // not whichever candidate bundle happened to fail last.
+            throw error
         }
 
         let platformArgs = platformFlags(for: platform)
@@ -144,32 +147,49 @@ public actor BazelBuildSystem: BuildSystem {
         return stderr.contains("redefinition of module")
     }
 
-    /// Find an Apple bundle rule (application/framework/extension) that depends
-    /// on `target`, to rebuild through on the #279 fallback. Tries the target's
-    /// package subtree first (bundles are usually colocated, and `rdeps` over
-    /// `//...` loads every package in exactly the monorepos this fallback
-    /// targets), then widens to the whole workspace. Query failures (e.g.
-    /// unrelated broken packages under `//...`) resolve to nil so the caller
-    /// rethrows the original build error.
-    private func findEnclosingAppleBundle(
+    /// Apple bundle rules (application/framework/extension) that depend on
+    /// `target`, to rebuild through on the #279 fallback; capped at 3
+    /// candidates since each attempt is a full bundle build. Tries the
+    /// target's package subtree first (bundles are usually colocated, and
+    /// `rdeps` over `//...` loads every package in exactly the monorepos this
+    /// fallback targets), then widens to the whole workspace. The kind regex
+    /// is end-anchored so import rules (`apple_static_framework_import`, ...)
+    /// that merely contain "framework" do not match. Total query failure
+    /// resolves to [] so the caller rethrows the original build error.
+    private func findEnclosingAppleBundles(
         target: String, packagePath: String
-    ) async -> String? {
+    ) async -> [String] {
         var universes = ["//..."]
         if !packagePath.isEmpty {
             universes.insert("//\(packagePath)/...", at: 0)
         }
         for universe in universes {
             let query =
-                #"kind("(ios|apple)_.*(application|framework|extension)", "#
+                #"kind("^(ios|apple)_.*(application|framework|extension) rule$", "#
                     + "rdeps(\(universe), \(target)))"
-            let output = (try? await runBazelQuery(query)) ?? ""
-            if let bundle = output.split(separator: "\n").map(String.init)
-                .first(where: { $0.hasPrefix("//") })
-            {
-                return bundle
+            let bundles = await runPartialBazelQuery(query)
+                .split(separator: "\n").map(String.init)
+                .filter { $0.hasPrefix("//") }
+            if !bundles.isEmpty {
+                return Array(bundles.prefix(3))
             }
         }
-        return nil
+        return []
+    }
+
+    /// `bazel query --keep_going`, tolerating exit code 3 (valid partial
+    /// results after skipping broken packages in the universe) so one broken
+    /// unrelated package cannot hide an existing enclosing bundle.
+    private func runPartialBazelQuery(_ query: String) async -> String {
+        guard
+            let output = try? await runAsync(
+                "/usr/bin/env",
+                arguments: ["bazel", "query", query, "--keep_going"],
+                workingDirectory: projectRoot, discardStderr: true
+            ),
+            output.exitCode == 0 || output.exitCode == 3
+        else { return "" }
+        return output.stdout
     }
 
     /// #279 fallback: build `bundle` with the simulator split transition
@@ -185,9 +205,14 @@ public actor BazelBuildSystem: BuildSystem {
         let platformArgs = ["--ios_multi_cpus=sim_arm64", Self.iosMinimumOSFlag]
         try await runBazel(["bazel", "build", bundle] + platformArgs)
 
+        // filter(), not `intersect <target>`: a bare target pattern in the
+        // expression would be configured at TOP level (no rule transition) —
+        // the very analysis that fails on these graphs. filter() selects the
+        // library from inside the bundle's already-configured closure.
+        let escaped = NSRegularExpression.escapedPattern(for: target)
         return try await makeBuildContext(
             target: target,
-            expr: "deps(\(bundle)) intersect \(target)",
+            expr: "filter(\"^\(escaped)$\", deps(\(bundle)))",
             moduleName: moduleName,
             platformArgs: platformArgs
         )
@@ -305,11 +330,13 @@ public actor BazelBuildSystem: BuildSystem {
 
         let output = try await runBazel(args, discardStderr: true)
 
-        // Find the .swiftmodule file in the output
+        // Find the .swiftmodule file in the output, preferring a target-config
+        // one (the fallback closure can also carry an exec-config copy) but
+        // keeping the pre-#279 any-match behavior as the backstop.
         let files = output.split(separator: "\n").map(String.init)
-        let swiftmoduleFile = files.first {
-            $0.hasSuffix(".swiftmodule") && !Self.isExecConfigPath($0)
-        }
+        let swiftmodules = files.filter { $0.hasSuffix(".swiftmodule") }
+        let swiftmoduleFile =
+            swiftmodules.first { !Self.isExecConfigPath($0) } ?? swiftmodules.first
 
         if let swiftmodulePath = swiftmoduleFile {
             // Resolve to absolute path (cquery may return relative paths from execroot)
@@ -319,6 +346,15 @@ public actor BazelBuildSystem: BuildSystem {
                 projectRoot.appendingPathComponent(swiftmodulePath)
             }
             return ["-I", absolutePath.deletingLastPathComponent().path]
+        }
+
+        // The bazel-bin symlink tracks the default config; on the bundle
+        // fallback the artifacts live under the split-transition output dir,
+        // so a bazel-bin hit could only be a stale module from another config.
+        guard expr == target else {
+            throw BuildSystemError.missingArtifacts(
+                "Expected \(moduleName).swiftmodule in cquery output for \(expr)"
+            )
         }
 
         // Fallback: try bazel-bin symlink + package path

--- a/previewsmcp/PreviewsCore/BazelBuildSystem.swift
+++ b/previewsmcp/PreviewsCore/BazelBuildSystem.swift
@@ -66,29 +66,67 @@ public actor BazelBuildSystem: BuildSystem {
         let moduleName = try await queryModuleName(target: target)
 
         // 3. Build the target
-        try await runBazelBuild(target: target, platform: platform)
+        do {
+            try await runBazelBuild(target: target, platform: platform)
+        } catch where platform == .iOS && Self.isModuleRedefinition(error) {
+            // The top-level `--platforms` transition on a bare swift_library can
+            // resolve a shared dep into two configurations at once on some
+            // dependency graphs, and both emit the same unqualified modulemap —
+            // swiftc rejects the duplicate (#279). Building *through* the
+            // enclosing Apple bundle applies the rule's 1:1 split transition,
+            // which collapses the dep to a single config.
+            guard let bundle = await findEnclosingAppleBundle(target: target) else {
+                throw error
+            }
+            return try await buildViaAppleBundle(
+                bundle: bundle, target: target, moduleName: moduleName
+            )
+        }
 
-        // 4. Locate the .swiftmodule
+        return try await makeBuildContext(
+            target: target,
+            expr: target,
+            depsExpr: "deps(\(target))",
+            moduleName: moduleName,
+            platformArgs: platformFlags(for: platform),
+            buildDepArchives: true
+        )
+    }
+
+    /// Assemble the `BuildContext` for `target` after its build succeeded.
+    ///
+    /// `expr` is the cquery/aquery expression that selects the target in the
+    /// configuration it was built under: the target itself on the default
+    /// (bare-library) path, or `deps(<bundle>) intersect <target>` on the
+    /// enclosing-bundle fallback. `depsExpr` selects its dependency closure the
+    /// same way. `buildDepArchives` is false on the fallback path because the
+    /// bundle's link step already materialized every dependency archive.
+    private func makeBuildContext(
+        target: String, expr: String, depsExpr: String, moduleName: String,
+        platformArgs: [String], buildDepArchives: Bool
+    ) async throws -> BuildContext {
+        // Locate the .swiftmodule
         var compilerFlags = try await findCompilerFlags(
-            target: target, moduleName: moduleName, platform: platform
+            target: target, expr: expr, moduleName: moduleName, platformArgs: platformArgs
         )
 
-        // 4b. Add dependency module search paths (swift_library deps and
-        //     objc_library module maps) from the target's SwiftCompile action,
-        //     so the bridge's `import <Dep>` resolves.
+        // Add dependency module search paths (swift_library deps and
+        // objc_library module maps) from the target's SwiftCompile action,
+        // so the bridge's `import <Dep>` resolves.
         compilerFlags += try await findDependencyModuleFlags(
-            target: target, platform: platform
+            expr: expr, platformArgs: platformArgs
         )
 
-        // 4c. Add dependency archive link flags (`-L`/`-l`) for the target's
-        //     static-library deps, so the preview JIT link resolves their
-        //     cross-target symbols (`findDependencyModuleFlags` only covers the
-        //     compile-time module search).
+        // Add dependency archive link flags (`-L`/`-l`) for the target's
+        // static-library deps, so the preview JIT link resolves their
+        // cross-target symbols (`findDependencyModuleFlags` only covers the
+        // compile-time module search).
         compilerFlags += try await findDependencyArchiveFlags(
-            target: target, platform: platform
+            target: target, depsExpr: depsExpr, platformArgs: platformArgs,
+            buildDepArchives: buildDepArchives
         )
 
-        // 5. Collect source files for Tier 2
+        // Collect source files for Tier 2
         let sourceFiles = try await collectSourceFiles(target: target)
 
         return BuildContext(
@@ -97,6 +135,51 @@ public actor BazelBuildSystem: BuildSystem {
             projectRoot: projectRoot,
             targetName: moduleName,
             sourceFiles: sourceFiles
+        )
+    }
+
+    /// True if `error` is a build failure whose diagnostics contain swiftc's
+    /// cross-config duplicate-modulemap signature (#279).
+    static func isModuleRedefinition(_ error: Error) -> Bool {
+        guard case let BuildSystemError.buildFailed(stderr, _) = error else {
+            return false
+        }
+        return stderr.contains("redefinition of module")
+    }
+
+    /// Find an Apple bundle rule (application/framework/extension) that depends
+    /// on `target`, to rebuild through on the #279 fallback. Query failures
+    /// (e.g. unrelated broken packages under `//...`) resolve to nil so the
+    /// caller rethrows the original build error.
+    func findEnclosingAppleBundle(target: String) async -> String? {
+        let query = """
+        kind("(ios|apple)_.*(application|framework|extension)", rdeps(//..., \(target)))
+        """
+        let output = (try? await runBazelQuery(query)) ?? ""
+        return output.split(separator: "\n").map(String.init)
+            .first { $0.hasPrefix("//") }
+    }
+
+    /// #279 fallback: build `bundle` with the simulator split transition
+    /// (`--ios_multi_cpus`), which configures `target`'s dependency closure in
+    /// exactly one config, then derive all flags from that closure. The bare
+    /// library cannot take `--ios_multi_cpus` at top level itself (Apple rules
+    /// like `apple_dynamic_xcframework_import` need the platform from a rule
+    /// transition, not a CLI flag).
+    private func buildViaAppleBundle(
+        bundle: String, target: String, moduleName: String
+    ) async throws -> BuildContext {
+        let platformArgs = ["--ios_multi_cpus=sim_arm64"]
+        try await runBazel(["bazel", "build", bundle] + platformArgs)
+
+        let expr = "deps(\(bundle)) intersect \(target)"
+        return try await makeBuildContext(
+            target: target,
+            expr: expr,
+            depsExpr: "deps(\(expr))",
+            moduleName: moduleName,
+            platformArgs: platformArgs,
+            buildDepArchives: false
         )
     }
 
@@ -205,16 +288,18 @@ public actor BazelBuildSystem: BuildSystem {
 
     /// Locate the .swiftmodule and return compiler flags (`-I <dir>`).
     private func findCompilerFlags(
-        target: String, moduleName: String, platform: PreviewPlatform
+        target: String, expr: String, moduleName: String, platformArgs: [String]
     ) async throws -> [String] {
-        var args = ["bazel", "cquery", "--output=files", target]
-        args += platformFlags(for: platform)
+        var args = ["bazel", "cquery", "--output=files", expr]
+        args += platformArgs
 
         let output = try await runBazel(args, discardStderr: true)
 
         // Find the .swiftmodule file in the output
         let files = output.split(separator: "\n").map(String.init)
-        let swiftmoduleFile = files.first { $0.hasSuffix(".swiftmodule") }
+        let swiftmoduleFile = files.first {
+            $0.hasSuffix(".swiftmodule") && !Self.isExecConfigPath($0)
+        }
 
         if let swiftmodulePath = swiftmoduleFile {
             // Resolve to absolute path (cquery may return relative paths from execroot)
@@ -260,10 +345,10 @@ public actor BazelBuildSystem: BuildSystem {
     /// (`<pkg>/<name>_modulemap/_/module.modulemap`) that are not in
     /// `cquery --output=files`.
     private func findDependencyModuleFlags(
-        target: String, platform: PreviewPlatform
+        expr: String, platformArgs: [String]
     ) async throws -> [String] {
-        var args = ["bazel", "aquery", "mnemonic(\"SwiftCompile\", \(target))"]
-        args += platformFlags(for: platform)
+        var args = ["bazel", "aquery", "mnemonic(\"SwiftCompile\", \(expr))"]
+        args += platformArgs
         let output = (try? await runBazel(args, discardStderr: true)) ?? ""
 
         func resolve(_ path: String) -> String {
@@ -324,23 +409,24 @@ public actor BazelBuildSystem: BuildSystem {
     ///     file plus any `@main` object, both of which the JIT compiles fresh /
     ///     must not link.
     private func findDependencyArchiveFlags(
-        target: String, platform: PreviewPlatform
+        target: String, depsExpr: String, platformArgs: [String],
+        buildDepArchives: Bool
     ) async throws -> [String] {
-        let platformArgs = platformFlags(for: platform)
-
-        let depLibs =
-            (try? await runBazelQuery(
-                "kind(\"(swift|objc)_library\", deps(\(target)))"
-            )) ?? ""
-        let labels = depLibs.split(separator: "\n").map(String.init)
-            .filter { $0.hasPrefix("//") }
-        if !labels.isEmpty {
-            try await runBazel(["bazel", "build"] + labels + platformArgs)
+        if buildDepArchives {
+            let depLibs =
+                (try? await runBazelQuery(
+                    "kind(\"(swift|objc)_library\", deps(\(target)))"
+                )) ?? ""
+            let labels = depLibs.split(separator: "\n").map(String.init)
+                .filter { $0.hasPrefix("//") }
+            if !labels.isEmpty {
+                try await runBazel(["bazel", "build"] + labels + platformArgs)
+            }
         }
 
         let output =
             (try? await runBazel(
-                ["bazel", "cquery", "deps(\(target))", "--output=files"]
+                ["bazel", "cquery", depsExpr, "--output=files"]
                     + platformArgs, discardStderr: true
             )) ?? ""
 

--- a/previewsmcp/PreviewsCore/BazelBuildSystem.swift
+++ b/previewsmcp/PreviewsCore/BazelBuildSystem.swift
@@ -75,7 +75,11 @@ public actor BazelBuildSystem: BuildSystem {
             // swiftc rejects the duplicate (#279). Building *through* the
             // enclosing Apple bundle applies the rule's 1:1 split transition,
             // which collapses the dep to a single config.
-            guard let bundle = await findEnclosingAppleBundle(target: target) else {
+            guard
+                let bundle = await findEnclosingAppleBundle(
+                    target: target, packagePath: packagePath
+                )
+            else {
                 throw error
             }
             return try await buildViaAppleBundle(
@@ -83,13 +87,10 @@ public actor BazelBuildSystem: BuildSystem {
             )
         }
 
+        let platformArgs = platformFlags(for: platform)
+        try await buildDependencyArchives(target: target, platformArgs: platformArgs)
         return try await makeBuildContext(
-            target: target,
-            expr: target,
-            depsExpr: "deps(\(target))",
-            moduleName: moduleName,
-            platformArgs: platformFlags(for: platform),
-            buildDepArchives: true
+            target: target, expr: target, moduleName: moduleName, platformArgs: platformArgs
         )
     }
 
@@ -98,12 +99,9 @@ public actor BazelBuildSystem: BuildSystem {
     /// `expr` is the cquery/aquery expression that selects the target in the
     /// configuration it was built under: the target itself on the default
     /// (bare-library) path, or `deps(<bundle>) intersect <target>` on the
-    /// enclosing-bundle fallback. `depsExpr` selects its dependency closure the
-    /// same way. `buildDepArchives` is false on the fallback path because the
-    /// bundle's link step already materialized every dependency archive.
+    /// enclosing-bundle fallback.
     private func makeBuildContext(
-        target: String, expr: String, depsExpr: String, moduleName: String,
-        platformArgs: [String], buildDepArchives: Bool
+        target: String, expr: String, moduleName: String, platformArgs: [String]
     ) async throws -> BuildContext {
         // Locate the .swiftmodule
         var compilerFlags = try await findCompilerFlags(
@@ -122,8 +120,7 @@ public actor BazelBuildSystem: BuildSystem {
         // cross-target symbols (`findDependencyModuleFlags` only covers the
         // compile-time module search).
         compilerFlags += try await findDependencyArchiveFlags(
-            target: target, depsExpr: depsExpr, platformArgs: platformArgs,
-            buildDepArchives: buildDepArchives
+            target: target, expr: expr, platformArgs: platformArgs
         )
 
         // Collect source files for Tier 2
@@ -148,16 +145,31 @@ public actor BazelBuildSystem: BuildSystem {
     }
 
     /// Find an Apple bundle rule (application/framework/extension) that depends
-    /// on `target`, to rebuild through on the #279 fallback. Query failures
-    /// (e.g. unrelated broken packages under `//...`) resolve to nil so the
-    /// caller rethrows the original build error.
-    func findEnclosingAppleBundle(target: String) async -> String? {
-        let query = """
-        kind("(ios|apple)_.*(application|framework|extension)", rdeps(//..., \(target)))
-        """
-        let output = (try? await runBazelQuery(query)) ?? ""
-        return output.split(separator: "\n").map(String.init)
-            .first { $0.hasPrefix("//") }
+    /// on `target`, to rebuild through on the #279 fallback. Tries the target's
+    /// package subtree first (bundles are usually colocated, and `rdeps` over
+    /// `//...` loads every package in exactly the monorepos this fallback
+    /// targets), then widens to the whole workspace. Query failures (e.g.
+    /// unrelated broken packages under `//...`) resolve to nil so the caller
+    /// rethrows the original build error.
+    private func findEnclosingAppleBundle(
+        target: String, packagePath: String
+    ) async -> String? {
+        var universes = ["//..."]
+        if !packagePath.isEmpty {
+            universes.insert("//\(packagePath)/...", at: 0)
+        }
+        for universe in universes {
+            let query =
+                #"kind("(ios|apple)_.*(application|framework|extension)", "#
+                    + "rdeps(\(universe), \(target)))"
+            let output = (try? await runBazelQuery(query)) ?? ""
+            if let bundle = output.split(separator: "\n").map(String.init)
+                .first(where: { $0.hasPrefix("//") })
+            {
+                return bundle
+            }
+        }
+        return nil
     }
 
     /// #279 fallback: build `bundle` with the simulator split transition
@@ -165,21 +177,19 @@ public actor BazelBuildSystem: BuildSystem {
     /// exactly one config, then derive all flags from that closure. The bare
     /// library cannot take `--ios_multi_cpus` at top level itself (Apple rules
     /// like `apple_dynamic_xcframework_import` need the platform from a rule
-    /// transition, not a CLI flag).
+    /// transition, not a CLI flag). No `buildDependencyArchives` here: the
+    /// bundle's link step already materialized every dependency archive.
     private func buildViaAppleBundle(
         bundle: String, target: String, moduleName: String
     ) async throws -> BuildContext {
-        let platformArgs = ["--ios_multi_cpus=sim_arm64"]
+        let platformArgs = ["--ios_multi_cpus=sim_arm64", Self.iosMinimumOSFlag]
         try await runBazel(["bazel", "build", bundle] + platformArgs)
 
-        let expr = "deps(\(bundle)) intersect \(target)"
         return try await makeBuildContext(
             target: target,
-            expr: expr,
-            depsExpr: "deps(\(expr))",
+            expr: "deps(\(bundle)) intersect \(target)",
             moduleName: moduleName,
-            platformArgs: platformArgs,
-            buildDepArchives: false
+            platformArgs: platformArgs
         )
     }
 
@@ -393,15 +403,29 @@ public actor BazelBuildSystem: BuildSystem {
         return flags
     }
 
+    /// Build the target's dependency libraries so their static archives are on
+    /// disk before `findDependencyArchiveFlags` scans for them: building
+    /// `target` alone materializes its dependency swiftmodules but not their
+    /// archives (a `swift_library` build has no link step).
+    private func buildDependencyArchives(
+        target: String, platformArgs: [String]
+    ) async throws {
+        let depLibs =
+            (try? await runBazelQuery(
+                "kind(\"(swift|objc)_library\", deps(\(target)))"
+            )) ?? ""
+        let labels = depLibs.split(separator: "\n").map(String.init)
+            .filter { $0.hasPrefix("//") }
+        if !labels.isEmpty {
+            try await runBazel(["bazel", "build"] + labels + platformArgs)
+        }
+    }
+
     /// Extract `-L <dir>` / `-l<name>` link flags for the target's dependency
     /// static archives (`libSwiftLib.a`, `libObjCLib.a`), so the preview JIT
     /// link resolves their cross-target symbols.
     ///
-    /// Building `target` alone materializes its dependency swiftmodules but not
-    /// their static archives (a `swift_library` build has no link step), so this
-    /// first builds the dependency library targets to put their `.a` on disk.
-    ///
-    /// `deps(<target>)` also returns two kinds of archives that must NOT be
+    /// `deps(<expr>)` also returns two kinds of archives that must NOT be
     /// linked, filtered here:
     ///   * Build tooling in the exec configuration (see `isExecConfigPath`,
     ///     e.g. the rules_swift worker).
@@ -409,24 +433,11 @@ public actor BazelBuildSystem: BuildSystem {
     ///     file plus any `@main` object, both of which the JIT compiles fresh /
     ///     must not link.
     private func findDependencyArchiveFlags(
-        target: String, depsExpr: String, platformArgs: [String],
-        buildDepArchives: Bool
+        target: String, expr: String, platformArgs: [String]
     ) async throws -> [String] {
-        if buildDepArchives {
-            let depLibs =
-                (try? await runBazelQuery(
-                    "kind(\"(swift|objc)_library\", deps(\(target)))"
-                )) ?? ""
-            let labels = depLibs.split(separator: "\n").map(String.init)
-                .filter { $0.hasPrefix("//") }
-            if !labels.isEmpty {
-                try await runBazel(["bazel", "build"] + labels + platformArgs)
-            }
-        }
-
         let output =
             (try? await runBazel(
-                ["bazel", "cquery", depsExpr, "--output=files"]
+                ["bazel", "cquery", "deps(\(expr))", "--output=files"]
                     + platformArgs, discardStderr: true
             )) ?? ""
 
@@ -535,6 +546,14 @@ public actor BazelBuildSystem: BuildSystem {
 
     // MARK: - Private: Platform Flags
 
+    /// Deployment-target pin shared by both iOS build paths, matching the
+    /// bridge compile triple (`Platform.iOS` -> ios17.0): dependency modules
+    /// otherwise come out at the SDK-default min (e.g. 26.2) and fail to load
+    /// against the 17.0 bridge ("module has a minimum deployment target of
+    /// iOS 26.2"). On the bundle fallback, a bundle's own `minimum_os_version`
+    /// attribute still takes precedence over this flag.
+    private static let iosMinimumOSFlag = "--ios_minimum_os=17.0"
+
     private func platformFlags(for platform: PreviewPlatform) -> [String] {
         switch platform {
         case .macOS:
@@ -551,13 +570,9 @@ public actor BazelBuildSystem: BuildSystem {
             // the apple_support repo, whose name varies per project (default
             // `apple_support`, but e.g. the study uses `repo_name =
             // "build_bazel_apple_support"`), so resolve it from MODULE.bazel.
-            // Pin the deployment target to match the bridge compile triple
-            // (`Platform.iOS` -> ios17.0): a bare swift_library otherwise gets
-            // the SDK-default min (e.g. 26.2), which fails to load against the
-            // 17.0 bridge ("module has a minimum deployment target of iOS 26.2").
             [
                 "--platforms=@\(appleSupportRepoName())//platforms:ios_sim_arm64",
-                "--ios_minimum_os=17.0",
+                Self.iosMinimumOSFlag,
             ]
         }
     }

--- a/previewsmcp/Tests/PreviewsCoreTests/BuildSystemTests.swift
+++ b/previewsmcp/Tests/PreviewsCoreTests/BuildSystemTests.swift
@@ -239,6 +239,34 @@ struct BuildSystemTests {
         #expect(bazel.labelToPath("invalid") == nil)
     }
 
+    // MARK: - BazelBuildSystem module-redefinition classification (#279)
+
+    @Test("isModuleRedefinition matches the cross-config duplicate-modulemap failure")
+    func isModuleRedefinitionMatches() {
+        let error = BuildSystemError.buildFailed(
+            stderr: """
+            CombineSchedulers.rspm.__impl_modulemap/_/module.modulemap:1:8: \
+            error: redefinition of module 'CombineSchedulers'
+            <unknown>:0: error: could not build Objective-C module 'SwiftShims'
+            """,
+            exitCode: 1
+        )
+        #expect(BazelBuildSystem.isModuleRedefinition(error))
+    }
+
+    @Test("isModuleRedefinition rejects other failures and error types")
+    func isModuleRedefinitionRejects() {
+        let otherBuildFailure = BuildSystemError.buildFailed(
+            stderr: "error: no such module 'Foo'", exitCode: 1
+        )
+        #expect(!BazelBuildSystem.isModuleRedefinition(otherBuildFailure))
+
+        let otherError = BuildSystemError.targetNotFound(
+            sourceFile: "a.swift", project: "p"
+        )
+        #expect(!BazelBuildSystem.isModuleRedefinition(otherError))
+    }
+
     // MARK: - BuildSystemDetector with Bazel
 
     @Test("BuildSystemDetector prefers SPM when both Package.swift and MODULE.bazel exist")


### PR DESCRIPTION
Implements the fallback prescribed in #279. When a bare `swift_library` iOS build fails with swiftc's `redefinition of module` signature (a shared dep resolved into two configs at once, both emitting the same unqualified modulemap), `BazelBuildSystem` now finds Apple bundles that depend on the library (`rdeps`, package subtree first, then `//...`, `--keep_going`), rebuilds through the first workable one with `--ios_multi_cpus=sim_arm64` (the bundle rule's 1:1 split transition collapses the closure to a single config), and derives all compile/link flags from that closure via `filter("^<target>$", deps(<bundle>))` scoping. The bare-library path is behaviorally unchanged on success, and if no candidate bundle works the ORIGINAL redefinition diagnostic is rethrown.

## Verification
- Unit tests for the failure-signature classifier (`isModuleRedefinition`).
- Every bazel query/cquery/aquery form the fallback issues was executed against `examples/bazel` (`MixedApp` `ios_application`): the rdeps+kind query finds the bundle, the `filter()`-scoped cquery/aquery return exactly one (ios_sim split) config, and the archive closure matches the existing exec-config/own-archive filters.
- Full `bazel test //...` green; `//tools/lint:check` clean.
- **Not verified end-to-end**: the redefinition trigger itself — the minimal repro documented in #279 does not reproduce on a current clean stack (version/graph specific). Fallback e2e on a triggering monorepo remains open as #279's bisect step.

## Review notes
/simplify (4 agents) and /code-review high ran. The review's verify stage was cut short by a session limit (13/18 candidate findings unverified by agents), so all 18 candidates were triaged manually; fixes landed for: intersect→filter top-level-configuration hazard, candidate retry + original-error preservation, kind-regex end-anchoring (`... rule$`, excludes `*_import`), `--keep_going` universe queries, target-config swiftmodule preference with pre-#279 backstop, bazel-bin backstop gated to the bare path. Skipped with rationale: fallback-decision memoization (the build system is constructed per render — nothing lives to memoize; noted as possible follow-up), single-closure-evaluation config plumbing (bazel's warm analysis cache covers it), data-dep-only archive materialization edge, and the min-os limitation below.

## Known limitation
If the enclosing bundle pins `minimum_os_version` above 17.0, dependency swiftmodules build at that min-OS and the ios17.0 bridge triple may refuse to import them. The `--ios_minimum_os=17.0` pin is passed but a bundle attribute takes precedence. Fixing that means plumbing the bundle's min-OS into the bridge compile triple — out of scope here, noted on #279.

Closes #279 (the fallback half; the rules_swift bisect/regression-example step is noted there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)