### PR TITLE
Hero icon: filled arrowheads matching assets/agent-icon.svg

### DIFF
--- a/assets/hero-icon.svg
+++ b/assets/hero-icon.svg
@@ -39,10 +39,10 @@
   <rect x="162" y="176" width="34" height="10" rx="5" fill="#67B7A4"/>
 
   <!-- Refresh arrows (top pink, bottom cyan) on the seam -->
-  <g>
-    <path d="M 119 144 A 9 9 0 0 1 135 140" fill="none" stroke="#FF7AB2" stroke-width="3" stroke-linecap="round"/>
-    <path d="M -5 -4 L 0 0 L -5 4" fill="none" stroke="#FF7AB2" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" transform="translate(135 140) rotate(30)"/>
-    <path d="M 137 148 A 9 9 0 0 1 121 152" fill="none" stroke="#5DD8FF" stroke-width="3" stroke-linecap="round"/>
-    <path d="M -5 -4 L 0 0 L -5 4" fill="none" stroke="#5DD8FF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" transform="translate(121 152) rotate(-150)"/>
+  <g stroke-linecap="round" stroke-linejoin="round">
+    <path d="M 117.86 150.72 A 10.5 10.5 0 0 1 134.02 139.4" fill="none" stroke="#FF7AB2" stroke-width="3"/>
+    <path d="M 137.23 141.65 L 129.52 142.43 L 135.37 134.53 Z" fill="#FF7AB2" stroke="#FF7AB2" stroke-width="1.5"/>
+    <path d="M 138.14 145.28 A 10.5 10.5 0 0 1 121.98 156.6" fill="none" stroke="#5DD8FF" stroke-width="3"/>
+    <path d="M 118.9 154.85 L 125.9 153.58 L 120.77 161.3 Z" fill="#5DD8FF" stroke="#5DD8FF" stroke-width="1.5"/>
   </g>
 </svg>


### PR DESCRIPTION
The README hero icon's refresh arrows were hand-placed: the arc wasn't concentric with its center point and the arrowhead proportions didn't match the agent icon's filled style (a prior attempt in this direction stalled).

This replaces the arrow group with an exact 0.1875-scale copy of `assets/agent-icon.svg`'s arc + arrowhead geometry (16-unit stroke → 3, radius 56 → 10.5), translated onto the seam at (128,148). No badge circle behind the arrows — they sit directly on the seam. Verified by rendering both icons plus a 2048px close-up crop of the motif.

🤖 Generated with [Claude Code](https://claude.com/claude-code)