### PR TITLE
Fix #336: host-level SimulatorTestLock serializes sim-booting tests across workspaces

### DIFF
--- a/previewsmcp/Tests/CLIIntegrationTests/BUILD.bazel
+++ b/previewsmcp/Tests/CLIIntegrationTests/BUILD.bazel
@@ -30,4 +30,5 @@ swift_test(
         "local",
     ],
     visibility = ["//visibility:public"],
+    deps = ["//previewsmcp/Tests/TestSupport"],
 )

--- a/previewsmcp/Tests/CLIIntegrationTests/CoreSimulatorHygiene.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/CoreSimulatorHygiene.swift
@@ -14,11 +14,12 @@ import os
 ///
 /// Reset that state ONCE per test process, before the first iOS preview boots:
 /// shut every simulator down and bounce CoreSimulatorService so the next boot
-/// starts from a clean service. Call while holding `DaemonTestLock`, which
-/// serializes the sim-touching suites WITHIN this target (its flock path is
-/// per-target); across targets the only guard is this target's `exclusive`
-/// tag, which holds within a single bazel invocation — concurrent separate
-/// invocations are already forbidden by the repo's test-hygiene rules.
+/// starts from a clean service. Call while holding `SimulatorTestLock` (which
+/// serializes sim-booting tests host-wide, so this reset cannot kill another
+/// workspace's live run — #336) and `DaemonTestLock`, which serializes the
+/// sim-touching suites WITHIN this target (its flock path is per-target);
+/// across targets within one invocation the guard is this target's
+/// `exclusive` tag.
 enum CoreSimulatorHygiene {
     private static let didReset = OSAllocatedUnfairLock(initialState: false)
 

--- a/previewsmcp/Tests/CLIIntegrationTests/IOSCLIWorkflowTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/IOSCLIWorkflowTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PreviewsTestSupport
 import Testing
 
 /// Combined iOS CLI workflow test. Boots one iOS session and exercises
@@ -20,6 +21,8 @@ struct IOSCLIWorkflowTests {
         .timeLimit(.minutes(10))
     )
     func iosCLIWorkflow() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         try await DaemonTestLock.run {
             let simResult = try await CLIRunner.runExternal(
                 "/usr/bin/xcrun",

--- a/previewsmcp/Tests/CLIIntegrationTests/SnapshotCommandTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/SnapshotCommandTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PreviewsTestSupport
 import Testing
 
 @Suite("CLI snapshot command", .serialized)
@@ -349,6 +350,8 @@ struct SnapshotCommandTests {
             print("iOS JIT resources not bundled — skipping iOS snapshot test")
             return
         }
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         try await DaemonTestLock.run {
             try await Self.cleanSlate()
             let simResult = try await CLIRunner.runExternal(

--- a/previewsmcp/Tests/MCPIntegrationTests/CoreSimulatorHygiene.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/CoreSimulatorHygiene.swift
@@ -14,11 +14,12 @@ import os
 ///
 /// Reset that state ONCE per test process, before the first iOS preview boots:
 /// shut every simulator down and bounce CoreSimulatorService so the next boot
-/// starts from a clean service. Call while holding `DaemonTestLock`, which
-/// serializes the sim-touching suites WITHIN this target (its flock path is
-/// per-target); across targets the only guard is this target's `exclusive`
-/// tag, which holds within a single bazel invocation — concurrent separate
-/// invocations are already forbidden by the repo's test-hygiene rules.
+/// starts from a clean service. Call while holding `SimulatorTestLock` (which
+/// serializes sim-booting tests host-wide, so this reset cannot kill another
+/// workspace's live run — #336) and `DaemonTestLock`, which serializes the
+/// sim-touching suites WITHIN this target (its flock path is per-target);
+/// across targets within one invocation the guard is this target's
+/// `exclusive` tag.
 enum CoreSimulatorHygiene {
     private static let didReset = OSAllocatedUnfairLock(initialState: false)
 

--- a/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import MCP
 import os
 import PreviewsIOS
+import PreviewsTestSupport
 import Testing
 
 /// Verifies the per-session app interface that the daemon hosts in-process:
@@ -27,6 +28,10 @@ struct IOSAppServerTests {
         // are .disabled on CI) three sims booting and driving their displays at
         // once starve the single host GPU/window-server, so whichever loses the
         // race flakes. One sim at a time keeps each render/capture healthy.
+        // The host lock extends that to sim-booting runs from other
+        // checkouts (#336).
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let lock = try await DaemonTestLock.acquire()
         defer { lock.release() }
 

--- a/previewsmcp/Tests/MCPIntegrationTests/IOSHIDInputTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSHIDInputTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MCP
 import PreviewsIOS
+import PreviewsTestSupport
 @preconcurrency import SimulatorBridge
 import Testing
 
@@ -20,7 +21,10 @@ struct IOSHIDInputTests {
     )
     func tapAndDrag() async throws {
         // Serialized against the other heavy iOS e2e suites — see the note in
-        // IOSAppServerTests.appServerEndToEnd.
+        // IOSAppServerTests.appServerEndToEnd — and against sim-booting runs
+        // from other checkouts (#336).
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let lock = try await DaemonTestLock.acquire()
         defer { lock.release() }
 

--- a/previewsmcp/Tests/MCPIntegrationTests/IOSMCPTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSMCPTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MCP
+import PreviewsTestSupport
 import Testing
 
 /// All iOS MCP tests share a single server process and session to avoid
@@ -62,7 +63,10 @@ struct IOSMCPTests {
     )
     func fullIOSWorkflow() async throws {
         // Serialized against the other heavy iOS e2e suites — see the note in
-        // IOSAppServerTests.appServerEndToEnd.
+        // IOSAppServerTests.appServerEndToEnd — and against sim-booting runs
+        // from other checkouts (#336).
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let lock = try await DaemonTestLock.acquire()
         defer { lock.release() }
 

--- a/previewsmcp/Tests/MCPIntegrationTests/IOSSimulatorPicker.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSSimulatorPicker.swift
@@ -26,11 +26,13 @@ enum IOSSimulatorPicker {
     ///
     /// Current assignments (grep for `IOSSimulatorPicker.pickUDID(index:` to audit):
     ///
-    /// - index 0: `SimulatorManagerTests.bootAndShutdown`
-    /// - index 1: `IOSPreviewSessionTests.endToEnd`
-    /// - index 1: `IOSMCPTests.fullIOSWorkflow`
+    /// - index 0: `SimulatorManagerTests.bootAndShutdown` (PreviewsIOS target)
+    /// - index 1: `IOSMCPTests.fullIOSWorkflow`; shared with
+    ///   `SimulatorManagerTests.makeFramebufferStreamer` (PreviewsIOS
+    ///   target — different targets never run concurrently)
     /// - index 2: `IOSHIDInputTests.tapAndDrag`
     /// - index 3: `IOSAppServerTests.appServerEndToEnd`
+    /// - index 4: `SimulatorManagerTests.makeHIDClient` (PreviewsIOS target)
     static func pickUDID(index: Int) async throws -> String? {
         // Must drain stdout concurrently: `simctl list devices --json` on a
         // CI runner with 100+ simulators produces >64KB of JSON, filling

--- a/previewsmcp/Tests/PreviewsIOSTests/BUILD.bazel
+++ b/previewsmcp/Tests/PreviewsIOSTests/BUILD.bazel
@@ -11,5 +11,8 @@ swift_test(
     env = {"PREVIEWSMCP_IOS_JIT_DIR": "$(rlocationpath //:ios_jit_resources)"},
     tags = ["local"],
     visibility = ["//visibility:public"],
-    deps = ["//previewsmcp/PreviewsIOS"],
+    deps = [
+        "//previewsmcp/PreviewsIOS",
+        "//previewsmcp/Tests/TestSupport",
+    ],
 )

--- a/previewsmcp/Tests/PreviewsIOSTests/IOSSimulatorPicker.swift
+++ b/previewsmcp/Tests/PreviewsIOSTests/IOSSimulatorPicker.swift
@@ -25,10 +25,11 @@ enum IOSSimulatorPicker {
     /// Current assignments (grep for `IOSSimulatorPicker.pick(index:` to audit):
     ///
     /// - index 0: `SimulatorManagerTests.bootAndShutdown`
-    /// - index 1: `IOSPreviewSessionTests.endToEnd`
-    /// - index 2: `IOSMCPTests.fullIOSWorkflow` (in MCP target; uses UDID
-    ///   via preview_start's `deviceUDID` arg)
-    /// - index 3: `IOSPreviewSessionTests.endToEndUIViewBodyKindProbe`
+    /// - index 1: `SimulatorManagerTests.makeFramebufferStreamer`; shared
+    ///   with `IOSMCPTests.fullIOSWorkflow` (MCP target, via `pickUDID` —
+    ///   different targets never run concurrently)
+    /// - index 2: `IOSHIDInputTests.tapAndDrag` (MCP target)
+    /// - index 3: `IOSAppServerTests.appServerEndToEnd` (MCP target)
     /// - index 4: `SimulatorManagerTests.makeHIDClient`
     ///
     /// Sort order matches the MCP-target sibling's

--- a/previewsmcp/Tests/PreviewsIOSTests/SimulatorManagerTests.swift
+++ b/previewsmcp/Tests/PreviewsIOSTests/SimulatorManagerTests.swift
@@ -64,8 +64,6 @@ struct SimulatorManagerTests {
 
     @Test("Boot and shutdown a device")
     func bootAndShutdown() async throws {
-        let simLock = try await SimulatorTestLock.acquire()
-        defer { simLock.release() }
         // Each test that boots a simulator gets its OWN device (distinct
         // IOSSimulatorPicker index) so the three iOS test suites don't
         // contend for the same device when Swift Testing runs them in
@@ -84,6 +82,8 @@ struct SimulatorManagerTests {
             print("No iOS simulator at picker index 0 — skipping")
             return
         }
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let manager = SimulatorManager()
 
         // Boot, test, then always shutdown — even if assertions fail.
@@ -119,12 +119,12 @@ struct SimulatorManagerTests {
 
     @Test("Create a daemon-side HID client against a booted device")
     func makeHIDClient() async throws {
-        let simLock = try await SimulatorTestLock.acquire()
-        defer { simLock.release() }
         guard let target = try await IOSSimulatorPicker.pick(index: 4) else {
             print("No iOS simulator at picker index 4 — skipping")
             return
         }
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let manager = SimulatorManager()
 
         // Boot only if needed, and shut down only what we booted, so the test
@@ -155,12 +155,12 @@ struct SimulatorManagerTests {
 
     @Test("Create a daemon-side framebuffer streamer against a booted device")
     func makeFramebufferStreamer() async throws {
-        let simLock = try await SimulatorTestLock.acquire()
-        defer { simLock.release() }
         guard let target = try await IOSSimulatorPicker.pick(index: 1) else {
             print("No iOS simulator at picker index 1 — skipping")
             return
         }
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let manager = SimulatorManager()
 
         let initial = try await manager.findDevice(udid: target.udid)

--- a/previewsmcp/Tests/PreviewsIOSTests/SimulatorManagerTests.swift
+++ b/previewsmcp/Tests/PreviewsIOSTests/SimulatorManagerTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 @testable import PreviewsIOS
+import PreviewsTestSupport
 @preconcurrency import SimulatorBridge
 import Testing
 
@@ -63,6 +64,8 @@ struct SimulatorManagerTests {
 
     @Test("Boot and shutdown a device")
     func bootAndShutdown() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         // Each test that boots a simulator gets its OWN device (distinct
         // IOSSimulatorPicker index) so the three iOS test suites don't
         // contend for the same device when Swift Testing runs them in
@@ -116,6 +119,8 @@ struct SimulatorManagerTests {
 
     @Test("Create a daemon-side HID client against a booted device")
     func makeHIDClient() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         guard let target = try await IOSSimulatorPicker.pick(index: 4) else {
             print("No iOS simulator at picker index 4 — skipping")
             return
@@ -150,6 +155,8 @@ struct SimulatorManagerTests {
 
     @Test("Create a daemon-side framebuffer streamer against a booted device")
     func makeFramebufferStreamer() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         guard let target = try await IOSSimulatorPicker.pick(index: 1) else {
             print("No iOS simulator at picker index 1 — skipping")
             return

--- a/previewsmcp/Tests/PreviewsJITLinkTests/BUILD.bazel
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/BUILD.bazel
@@ -60,5 +60,6 @@ swift_test(
         "//previewsmcp/PreviewsCore",
         "//previewsmcp/PreviewsIOS",
         "//previewsmcp/PreviewsJITLink",
+        "//previewsmcp/Tests/TestSupport",
     ],
 )

--- a/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
@@ -2,6 +2,7 @@ import Foundation
 import PreviewsCore
 import PreviewsIOS
 import PreviewsJITLink
+import PreviewsTestSupport
 import Testing
 
 /// End-to-end iOS preview tests: the daemon builds the real agent app, boots the
@@ -32,6 +33,8 @@ struct IOSPreviewE2ETests {
     /// the termination handler, proving in-session spawn works without xcrun.
     @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(5)))
     func spawnInSessionRunsProgramAndReportsExit() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let udid = try IOSPreviewE2ESupport.bootSimulator()
         let exe = try IOSPreviewE2ESupport.compileExecutableForIOSSim(
             source: "int main(void) { return 0; }", name: "trivial_exit"
@@ -62,6 +65,8 @@ struct IOSPreviewE2ETests {
     /// the daemon-side spawn a viable launch primitive (the plan's fallback).
     @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(5)))
     func inSessionSpawnGetsHostLoopbackNetworking() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let udid = try IOSPreviewE2ESupport.bootSimulator()
         let exe = try IOSPreviewE2ESupport.compileExecutableForIOSSim(
             source: """
@@ -113,6 +118,8 @@ struct IOSPreviewE2ETests {
     /// mode needs no preview dylib, so the app launches with `--jit-port` alone.
     @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
     func hostsRemoteSessionInRealHostApp() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let udid = try IOSPreviewE2ESupport.bootSimulator()
         let object = try IOSPreviewE2ESupport.compileForIOSSim("answer.c")
         let appPath = try await IOSAgentBuilder().ensureAgentApp()
@@ -147,6 +154,8 @@ struct IOSPreviewE2ETests {
     /// (it links answer.c and runs 42 inside the closure).
     @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
     func productionSessionEstablishesJITOverSecondSocket() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let udid = try IOSPreviewE2ESupport.bootSimulator()
         let object = try IOSPreviewE2ESupport.compileForIOSSim("answer.c")
 
@@ -192,6 +201,8 @@ struct IOSPreviewE2ETests {
     /// must then contain the rendered text — proving the preview renders over JIT, not dylib.
     @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
     func endToEndRendersOverJIT() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let udid = try IOSPreviewE2ESupport.bootSimulator()
 
         let tempDir = FileManager.default.temporaryDirectory
@@ -242,6 +253,8 @@ struct IOSPreviewE2ETests {
     /// agent stays non-`active` across respawn, where the value is meaningful.
     @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
     func agentReportsForegroundLifecycleState() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let udid = try IOSPreviewE2ESupport.bootSimulator()
 
         let tempDir = FileManager.default.temporaryDirectory
@@ -290,6 +303,8 @@ struct IOSPreviewE2ETests {
     /// restart, which is how leaked `__swift5_*`/ObjC metadata is reclaimed.
     @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
     func relaunchReRendersCurrentPreview() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let udid = try IOSPreviewE2ESupport.bootSimulator()
 
         let tempDir = FileManager.default.temporaryDirectory
@@ -352,6 +367,8 @@ struct IOSPreviewE2ETests {
     /// assertion (the signal is visual); saves frames to /tmp/flashfree-gap.
     @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
     func flashFreeRespawnGap() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let udid = try IOSPreviewE2ESupport.bootSimulator()
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("previewsmcp-gap-\(UUID().uuidString)")
@@ -420,6 +437,8 @@ struct IOSPreviewE2ETests {
     /// red before it.
     @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
     func stopWaitsOutInFlightRespawn() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let udid = try IOSPreviewE2ESupport.bootSimulator()
 
         let tempDir = FileManager.default.temporaryDirectory
@@ -496,6 +515,8 @@ struct IOSPreviewE2ETests {
     /// tracking reloader asserts no two renders overlap when many edits fire at once.
     @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
     func concurrentEditsSerialize() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let udid = try IOSPreviewE2ESupport.bootSimulator()
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("previewsmcp-ios-jit-serialize-\(UUID().uuidString)")
@@ -552,6 +573,8 @@ struct IOSPreviewE2ETests {
     /// second render carried a fresh object path.
     @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
     func literalEditReSeedsSameObjectWithoutRecompile() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let udid = try IOSPreviewE2ESupport.bootSimulator()
 
         let tempDir = FileManager.default.temporaryDirectory
@@ -625,6 +648,8 @@ struct IOSPreviewE2ETests {
     /// After the fix the banner's `dev@example.com` appears in the a11y tree.
     @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
     func endToEndRendersSetupWrappedOverJIT() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let udid = try IOSPreviewE2ESupport.bootSimulator()
 
         let hot = Self.packageRoot

--- a/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
@@ -714,7 +714,9 @@ struct IOSPreviewE2ETests {
     /// see the bug. The probe reproduces the crash deterministically on any sub-26
     /// runtime by calling the exact selector ShellMain calls.
     @Test(.enabled(if: preIOS26RuntimePresent), .timeLimit(.minutes(5)))
-    func sceneHostingInitIsUnrecognizedSelectorOnPreIOS26() throws {
+    func sceneHostingInitIsUnrecognizedSelectorOnPreIOS26() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
         let udid = try IOSPreviewE2ESupport.bootLegacySimulator()
         let probe = try IOSPreviewE2ESupport.compileObjCExecutableForIOSSim(
             source: Self.sceneHostingProbeSource, name: "scene_host_sel_probe"

--- a/previewsmcp/Tests/TestSupport/SimulatorTestLock.swift
+++ b/previewsmcp/Tests/TestSupport/SimulatorTestLock.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Host-level serialization for simulator-booting tests (#336).
+///
+/// `DaemonTestLock` serializes suites within one workspace (its flock path is
+/// keyed by `$TEST_TMPDIR`) and Bazel's `exclusive` tag serializes targets
+/// within one invocation, but two checkouts/worktrees running sim-booting
+/// suites concurrently share the host's single CoreSimulator service and
+/// degrade it for both. This lock closes that gap: a blocking flock on a
+/// fixed per-user path, so any workspace's sim-booting tests queue behind
+/// each other machine-wide.
+///
+/// Ordering: acquire this lock BEFORE `DaemonTestLock`. Sim-booting daemon
+/// tests hold both; daemon-only tests hold only `DaemonTestLock`, so no
+/// cycle is possible. Waiting for the lock counts against a test's
+/// `.timeLimit`, which is the intent — queueing behind another workspace's
+/// sim work is strictly better than racing it.
+///
+/// Uses a blocking flock on a detached thread (same rationale as
+/// `DaemonTestLock`): non-blocking polling from Swift concurrency starves
+/// small cooperative pools.
+public enum SimulatorTestLock {
+    private static var lockPath: String {
+        (NSHomeDirectory() as NSString).appendingPathComponent(".previewsmcp/sim.lock")
+    }
+
+    /// A held exclusive lock. Call `release()` to let the next waiter proceed;
+    /// pair it with `defer` at the acquisition site.
+    public final class Guard: Sendable {
+        private let fd: Int32
+        fileprivate init(fd: Int32) {
+            self.fd = fd
+        }
+
+        public func release() {
+            _ = flock(fd, LOCK_UN)
+            close(fd)
+        }
+    }
+
+    /// Block until the host-wide simulator lock is held, then return a `Guard`
+    /// the caller releases (via `defer`) when its critical section ends.
+    public static func acquire() async throws -> Guard {
+        let path = lockPath
+        let fd = try await withCheckedThrowingContinuation {
+            (cont: CheckedContinuation<Int32, Error>) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let dir = (path as NSString).deletingLastPathComponent
+                try? FileManager.default.createDirectory(
+                    atPath: dir, withIntermediateDirectories: true
+                )
+                let fd = open(path, O_CREAT | O_RDWR, 0o644)
+                guard fd >= 0 else {
+                    cont.resume(
+                        throwing: NSError(
+                            domain: NSPOSIXErrorDomain, code: Int(errno),
+                            userInfo: [
+                                NSLocalizedDescriptionKey: "open(\(path)) failed",
+                            ]
+                        )
+                    )
+                    return
+                }
+                if flock(fd, LOCK_EX) != 0 {
+                    close(fd)
+                    cont.resume(
+                        throwing: NSError(
+                            domain: NSPOSIXErrorDomain, code: Int(errno),
+                            userInfo: [
+                                NSLocalizedDescriptionKey: "flock failed",
+                            ]
+                        )
+                    )
+                    return
+                }
+                cont.resume(returning: fd)
+            }
+        }
+        return Guard(fd: fd)
+    }
+}

--- a/previewsmcp/Tests/TestSupport/SimulatorTestLock.swift
+++ b/previewsmcp/Tests/TestSupport/SimulatorTestLock.swift
@@ -20,9 +20,8 @@ import Foundation
 /// `DaemonTestLock`): non-blocking polling from Swift concurrency starves
 /// small cooperative pools.
 public enum SimulatorTestLock {
-    private static var lockPath: String {
+    private static let lockPath =
         (NSHomeDirectory() as NSString).appendingPathComponent(".previewsmcp/sim.lock")
-    }
 
     /// A held exclusive lock. Call `release()` to let the next waiter proceed;
     /// pair it with `defer` at the acquisition site.
@@ -40,16 +39,20 @@ public enum SimulatorTestLock {
 
     /// Block until the host-wide simulator lock is held, then return a `Guard`
     /// the caller releases (via `defer`) when its critical section ends.
+    ///
+    /// `O_CLOEXEC` is load-bearing: tests spawn children (daemons, `simctl`,
+    /// sim executables) while holding the lock, and an inherited dup of the
+    /// fd would keep the kernel flock held after this process exits — see
+    /// `DaemonRestart.acquireRestartLock` and issue #142.
     public static func acquire() async throws -> Guard {
         let path = lockPath
-        let fd = try await withCheckedThrowingContinuation {
-            (cont: CheckedContinuation<Int32, Error>) in
+        let fd = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Int32, Error>) in
             DispatchQueue.global(qos: .userInitiated).async {
                 let dir = (path as NSString).deletingLastPathComponent
                 try? FileManager.default.createDirectory(
                     atPath: dir, withIntermediateDirectories: true
                 )
-                let fd = open(path, O_CREAT | O_RDWR, 0o644)
+                let fd = open(path, O_CREAT | O_RDWR | O_CLOEXEC, 0o644)
                 guard fd >= 0 else {
                     cont.resume(
                         throwing: NSError(


### PR DESCRIPTION
Fixes #336.

## What

`DaemonTestLock` serializes daemon-touching suites within one workspace (its flock path is keyed by `$TEST_TMPDIR`) and the `exclusive` tag serializes targets within one bazel invocation, but sim-booting suites from two checkouts/worktrees shared the host's single CoreSimulator service with nothing serializing them — three collisions on 2026-07-09 alone, each surfacing as a different iOS e2e flake face.

`SimulatorTestLock` (new, in `previewsmcp/Tests/TestSupport`) is a blocking flock on the fixed per-user path `~/.previewsmcp/sim.lock`. Every sim-booting test acquires it for the duration of the test, BEFORE `DaemonTestLock` where both are taken (consistent order, so no deadlock; daemon-only tests take only `DaemonTestLock`, sim-only tests take only this):

- `MCPIntegrationTests`: `fullIOSWorkflow`, `appServerEndToEnd`, `tapAndDrag`
- `CLIIntegrationTests`: `iosCLIWorkflow`, `snapshotIOS`
- `PreviewsIOSTests`: the three booting `SimulatorManagerTests` (acquired after the picker skip guard, so sim-less hosts never take the lock)
- `IOSPreviewE2ETests`: all 13 booting tests (12 `bootSimulator()` + the pre-iOS-26 `bootLegacySimulator()` repro)

The fd is opened `O_CLOEXEC` — children spawned under the lock (daemons, `simctl`, sim executables) must not inherit it, or a leaked child pins the machine-wide lock after the test process dies (same #142 lesson as `DaemonRestart.acquireRestartLock`). `CoreSimulatorHygiene.resetOnce()` (which `killall`s the shared service) now always runs under the host lock, and its doc no longer claims concurrent invocations are forbidden.

`CLIIntegrationTests`, `PreviewsIOSTests`, and `IOSPreviewE2ETests` gain a dep on `//previewsmcp/Tests/TestSupport`; for `CLIIntegrationTests` (previously dep-free) that transitively pulls the MCP types module — build-graph weight only.

## Verification

- Flock probe on `~/.previewsmcp/sim.lock`: held exactly during sim-booting test windows run from two separate worktrees (same fixed path resolved by both).
- Blocking proof: with an external process holding the lock, `bootAndShutdown` blocked ~35s and booted only after the release (41.9s total vs 5–7s unblocked), green both ways.
- Full `bazel test //previewsmcp/...` green from the feature worktree: 9/9 targets pass (CLIIntegrationTests 146s, MCPIntegrationTests 130s, IOSPreviewE2ETests 159s, rest unchanged).

## Known limits / follow-ups

- Per-test holding (matching `DaemonTestLock` granularity) means two workspaces' sim suites interleave per test: a peer can grab the lock between two e2e tests and run its hygiene reset, forcing a re-boot, and a short-`.timeLimit` test queueing behind a peer's long test can time out while waiting. Fixing that means target-level holding (process latch or a bazel `--run_under` flock wrapper) — queued with the test-helper consolidation follow-up rather than done here.
- The consolidation follow-up should fold the four flock copies (2× `DaemonTestLock`, `DaemonRestart.acquireRestartLock`, `SimulatorTestLock`) into one parametrized TestSupport primitive; the `DaemonTestLock` copies lack `O_CLOEXEC` today (benign for them only because their lock paths are per-run).
- With #336 mechanical, the interim mailbox sim-claim ceremony retires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
