### PR TITLE
#254: seamless macOS respawn handoff with focus and frame carry

### DIFF
--- a/previewsmcp/PreviewsCore/BridgeGenerator.swift
+++ b/previewsmcp/PreviewsCore/BridgeGenerator.swift
@@ -235,6 +235,7 @@ public enum BridgeGenerator {
                                 styleMask: [.titled, .closable, .miniaturizable, .resizable],
                                 backing: .buffered, defer: false)
                             created.title = "\(title)"
+                            created.animationBehavior = .none
             """
             // A visible window takes key status and activates the agent only when the spec
             // asks (a session's first window, or a handoff replacing the key window).

--- a/previewsmcp/PreviewsCore/BridgeGenerator.swift
+++ b/previewsmcp/PreviewsCore/BridgeGenerator.swift
@@ -5,6 +5,9 @@ import Foundation
 /// or a borderless off-screen window used only to render at the requested size (snapshots,
 /// headless daemons). Applied only when the agent creates the window, so a user's later drag or
 /// resize survives leaf edits. Nil means no spec at all — a borderless off-screen default size.
+/// `activate` selects whether a visible window takes key status and activates the app on
+/// creation: true for a session's first window, and on a respawn handoff only when the outgoing
+/// window was key — so an edit never steals focus from whatever the user was typing in (#254).
 public struct JITRenderWindow: Sendable {
     public let x: Double
     public let y: Double
@@ -12,9 +15,11 @@ public struct JITRenderWindow: Sendable {
     public let height: Double
     public let title: String
     public let headless: Bool
+    public let activate: Bool
 
     public init(
-        x: Double, y: Double, width: Double, height: Double, title: String, headless: Bool = false
+        x: Double, y: Double, width: Double, height: Double, title: String,
+        headless: Bool = false, activate: Bool = true
     ) {
         self.x = x
         self.y = y
@@ -22,6 +27,7 @@ public struct JITRenderWindow: Sendable {
         self.height = height
         self.title = title
         self.headless = headless
+        self.activate = activate
     }
 }
 
@@ -217,6 +223,7 @@ public enum BridgeGenerator {
         let createWindow: String
         let presentNewWindow: String
         let frameObservers: String
+        let firstFrameFlush: String
         if let window, !window.headless {
             let title = escapedForSwiftStringLiteral(window.title)
             createWindow = """
@@ -229,14 +236,26 @@ public enum BridgeGenerator {
                                 backing: .buffered, defer: false)
                             created.title = "\(title)"
             """
-            // A visible window takes key status and activates the agent once, at
-            // creation, matching what the daemon's dylib window start used to do.
-            // Re-renders use orderFrontRegardless so edits never steal focus.
-            presentNewWindow = """
-            window.makeKeyAndOrderFront(nil)
-                            NSApplication.shared.activate(ignoringOtherApps: true)
-            """
+            // A visible window takes key status and activates the agent only when the spec
+            // asks (a session's first window, or a handoff replacing the key window).
+            // Re-renders and non-key handoffs use orderFrontRegardless so edits never
+            // steal focus.
+            presentNewWindow = window.activate
+                ? """
+                window.makeKeyAndOrderFront(nil)
+                                NSApplication.shared.activate(ignoringOtherApps: true)
+                """
+                : "window.orderFrontRegardless()"
             frameObservers = frameSidecarPath.map(frameObserverCode) ?? ""
+            // The synchronous entry return is the daemon's handoff-ready signal: the old
+            // agent (and its window) dies right after. Push the first frame to the
+            // WindowServer before returning so the overlap never shows a blank window.
+            firstFrameFlush = """
+            if isNewWindow {
+                                window.displayIfNeeded()
+                                CATransaction.flush()
+                            }
+            """
         } else {
             // Headless spec or no spec: a borderless off-screen window used only to render at
             // the requested size, never shown or activated. Falls back to 400x600 with no spec.
@@ -250,6 +269,7 @@ public enum BridgeGenerator {
             """
             presentNewWindow = "window.orderFrontRegardless()"
             frameObservers = ""
+            firstFrameFlush = ""
         }
         return """
         @_cdecl("renderPreviewToFile")
@@ -278,6 +298,7 @@ public enum BridgeGenerator {
                     window.orderFrontRegardless()
                 }
                 hosting.layoutSubtreeIfNeeded()
+                \(firstFrameFlush)
                 let bounds = hosting.bounds
                 guard bounds.width > 0, bounds.height > 0,
                     let rep = NSBitmapImageRep(
@@ -335,9 +356,11 @@ public enum BridgeGenerator {
     }
 
     /// Code (run once when the agent creates its visible window) that records the window's frame
-    /// to `sidecarPath` on every move/resize. A respawned agent reads it back so the user's
-    /// dragged/resized window is restored across non-leaf structural edits (#195). Reads the frame
-    /// off the notification's window so the `@Sendable` observer closure captures only the path.
+    /// and key status to `sidecarPath` on every move/resize/key change. A respawned agent reads
+    /// it back so the user's dragged/resized window is restored across non-leaf structural edits
+    /// (#195) and the handoff replacement only takes key when the outgoing window had it (#254).
+    /// Reads the state off the notification's window so the `@Sendable` observer closure captures
+    /// only the path.
     private static func frameObserverCode(sidecarPath: String) -> String {
         """
         let __frameURL = URL(fileURLWithPath: "\(escapedForSwiftStringLiteral(sidecarPath))")
@@ -345,21 +368,23 @@ public enum BridgeGenerator {
                             MainActor.assumeIsolated {
                                 guard let __win = __note.object as? NSWindow else { return }
                                 let __f = __win.frame
-                                let __dict: [String: Double] = [
+                                let __dict: [String: Any] = [
                                     "x": __f.origin.x, "y": __f.origin.y,
                                     "width": __f.size.width, "height": __f.size.height,
+                                    "key": __win.isKeyWindow,
                                 ]
                                 if let __data = try? JSONSerialization.data(withJSONObject: __dict) {
                                     try? __data.write(to: __frameURL, options: .atomic)
                                 }
                             }
                         }
-                        NotificationCenter.default.addObserver(
-                            forName: NSWindow.didMoveNotification, object: window, queue: nil,
-                            using: __recordFrame)
-                        NotificationCenter.default.addObserver(
-                            forName: NSWindow.didResizeNotification, object: window, queue: nil,
-                            using: __recordFrame)
+                        for __name in [
+                            NSWindow.didMoveNotification, NSWindow.didResizeNotification,
+                            NSWindow.didBecomeKeyNotification, NSWindow.didResignKeyNotification,
+                        ] {
+                            NotificationCenter.default.addObserver(
+                                forName: __name, object: window, queue: nil, using: __recordFrame)
+                        }
         """
     }
 

--- a/previewsmcp/PreviewsCore/BridgeGenerator.swift
+++ b/previewsmcp/PreviewsCore/BridgeGenerator.swift
@@ -356,19 +356,20 @@ public enum BridgeGenerator {
         """
     }
 
-    /// Code (run once when the agent creates its visible window) that records the window's frame
-    /// and key status to `sidecarPath` on every move/resize/key change. A respawned agent reads
-    /// it back so the user's dragged/resized window is restored across non-leaf structural edits
-    /// (#195) and the handoff replacement only takes key when the outgoing window had it (#254).
-    /// Reads the state off the notification's window so the `@Sendable` observer closure captures
-    /// only the path.
+    /// Code (run once when the agent creates its visible window) that records the window's
+    /// content rect and key status to `sidecarPath` on every move/resize/key change. A respawned
+    /// agent reads it back so the user's dragged/resized window is restored across non-leaf
+    /// structural edits (#195) and the handoff replacement only takes key when the outgoing
+    /// window had it (#254). The content rect (not the frame) is recorded because that is what
+    /// window creation bakes, so readers never need the window's style mask. Reads the state off
+    /// the notification's window so the `@Sendable` observer closure captures only the path.
     private static func frameObserverCode(sidecarPath: String) -> String {
         """
         let __frameURL = URL(fileURLWithPath: "\(escapedForSwiftStringLiteral(sidecarPath))")
                         let __recordFrame: @Sendable (Notification) -> Void = { __note in
                             MainActor.assumeIsolated {
                                 guard let __win = __note.object as? NSWindow else { return }
-                                let __f = __win.frame
+                                let __f = __win.contentRect(forFrameRect: __win.frame)
                                 let __dict: [String: Any] = [
                                     "x": __f.origin.x, "y": __f.origin.y,
                                     "width": __f.size.width, "height": __f.size.height,

--- a/previewsmcp/PreviewsCore/BridgeGenerator.swift
+++ b/previewsmcp/PreviewsCore/BridgeGenerator.swift
@@ -5,9 +5,9 @@ import Foundation
 /// or a borderless off-screen window used only to render at the requested size (snapshots,
 /// headless daemons). Applied only when the agent creates the window, so a user's later drag or
 /// resize survives leaf edits. Nil means no spec at all — a borderless off-screen default size.
-/// `activate` selects whether a visible window takes key status and activates the app on
-/// creation: true for a session's first window, and on a respawn handoff only when the outgoing
-/// window was key — so an edit never steals focus from whatever the user was typing in (#254).
+/// Whether a new visible window takes key status is not baked: the generated entry decides at
+/// render time from the sidecar's live key record, so a focus change during the compile never
+/// steals or drops focus (#254).
 public struct JITRenderWindow: Sendable {
     public let x: Double
     public let y: Double
@@ -15,11 +15,9 @@ public struct JITRenderWindow: Sendable {
     public let height: Double
     public let title: String
     public let headless: Bool
-    public let activate: Bool
 
     public init(
-        x: Double, y: Double, width: Double, height: Double, title: String,
-        headless: Bool = false, activate: Bool = true
+        x: Double, y: Double, width: Double, height: Double, title: String, headless: Bool = false
     ) {
         self.x = x
         self.y = y
@@ -27,7 +25,6 @@ public struct JITRenderWindow: Sendable {
         self.height = height
         self.title = title
         self.headless = headless
-        self.activate = activate
     }
 }
 
@@ -221,9 +218,9 @@ public enum BridgeGenerator {
     ) -> String {
         let seed = designTimeSeed(valuesPath)
         let createWindow: String
-        let presentNewWindow: String
-        let frameObservers: String
-        let firstFrameFlush: String
+        let preRasterPresent: String
+        let postRasterPresent: String
+        let stateWriter: String
         if let window, !window.headless {
             let title = escapedForSwiftStringLiteral(window.title)
             createWindow = """
@@ -237,26 +234,35 @@ public enum BridgeGenerator {
                             created.title = "\(title)"
                             created.animationBehavior = .none
             """
-            // A visible window takes key status and activates the agent only when the spec
-            // asks (a session's first window, or a handoff replacing the key window).
-            // Re-renders and non-key handoffs use orderFrontRegardless so edits never
-            // steal focus.
-            presentNewWindow = window.activate
-                ? """
-                window.makeKeyAndOrderFront(nil)
-                                NSApplication.shared.activate(ignoringOtherApps: true)
-                """
-                : "window.orderFrontRegardless()"
-            frameObservers = frameSidecarPath.map(frameObserverCode) ?? ""
-            // The synchronous entry return is the daemon's handoff-ready signal: the old
-            // agent (and its window) dies right after. Push the first frame to the
-            // WindowServer before returning so the overlap never shows a blank window.
-            firstFrameFlush = """
+            // A new visible window is presented only after the raster succeeds, so a
+            // failing render never flashes a half-built window over the previous
+            // generation (the daemon keeps the old agent alive on failure). It takes key
+            // and activates only when the sidecar's live record says the outgoing window
+            // was key at this instant — decided at render time, not compile time, so a
+            // focus change during the compile never steals or drops focus. The trailing
+            // flush pushes the first frame to the WindowServer before the entry returns,
+            // because that return is the daemon's kill-the-old-agent signal.
+            preRasterPresent = """
+            if !isNewWindow {
+                                window.orderFrontRegardless()
+                            }
+            """
+            postRasterPresent = """
             if isNewWindow {
+                                \(frameSidecarPath.map(runtimeKeyDecisionCode) ?? "let __takeKey = true")
+                                if __takeKey {
+                                    window.makeKeyAndOrderFront(nil)
+                                    NSApplication.shared.activate(ignoringOtherApps: true)
+                                } else {
+                                    window.orderFrontRegardless()
+                                }
+                                \(frameSidecarPath != nil ? frameObserverCode() : "")
+                                \(frameSidecarPath != nil ? "__previewsmcpWriteWindowState(window)" : "")
                                 window.displayIfNeeded()
                                 CATransaction.flush()
                             }
             """
+            stateWriter = frameSidecarPath.map(windowStateWriterCode) ?? ""
         } else {
             // Headless spec or no spec: a borderless off-screen window used only to render at
             // the requested size, never shown or activated. Falls back to 400x600 with no spec.
@@ -268,11 +274,15 @@ public enum BridgeGenerator {
                                 styleMask: [.borderless], backing: .buffered, defer: false)
                             created.setFrameOrigin(NSPoint(x: -10_000, y: -10_000))
             """
-            presentNewWindow = "window.orderFrontRegardless()"
-            frameObservers = ""
-            firstFrameFlush = ""
+            preRasterPresent = """
+            window.orderFrontRegardless()
+                            _ = isNewWindow
+            """
+            postRasterPresent = ""
+            stateWriter = ""
         }
         return """
+        \(stateWriter)
         @_cdecl("renderPreviewToFile")
         public func renderPreviewToFile() -> Int32 {
             MainActor.assumeIsolated {
@@ -292,14 +302,8 @@ public enum BridgeGenerator {
                 let hosting = NSHostingView(rootView: view)
                 hosting.sizingOptions = []
                 window.contentView = hosting
-                if isNewWindow {
-                    \(presentNewWindow)
-                    \(frameObservers)
-                } else {
-                    window.orderFrontRegardless()
-                }
+                \(preRasterPresent)
                 hosting.layoutSubtreeIfNeeded()
-                \(firstFrameFlush)
                 let bounds = hosting.bounds
                 guard bounds.width > 0, bounds.height > 0,
                     let rep = NSBitmapImageRep(
@@ -325,9 +329,64 @@ public enum BridgeGenerator {
                 } catch {
                     return Int32(-3)
                 }
+                \(postRasterPresent)
                 return 0
             }
         }
+        """
+    }
+
+    /// Top-level helper (visible windows with a sidecar) that atomically records the window's
+    /// content rect and key status. Called by the frame/key observers, once at first
+    /// presentation, and by the `recordPreviewWindowState` entry the reloader runs after a
+    /// handoff kills the outgoing agent — the last write is then guaranteed to describe the
+    /// surviving window, without the daemon ever writing the sidecar itself.
+    private static func windowStateWriterCode(sidecarPath: String) -> String {
+        """
+        @MainActor
+        func __previewsmcpWriteWindowState(_ __win: NSWindow) {
+            let __f = __win.contentRect(forFrameRect: __win.frame)
+            let __dict: [String: Any] = [
+                "x": __f.origin.x, "y": __f.origin.y,
+                "width": __f.size.width, "height": __f.size.height,
+                "key": __win.isKeyWindow,
+            ]
+            if let __data = try? JSONSerialization.data(withJSONObject: __dict) {
+                try? __data.write(
+                    to: URL(fileURLWithPath: "\(escapedForSwiftStringLiteral(sidecarPath))"),
+                    options: .atomic)
+            }
+        }
+
+        @_cdecl("recordPreviewWindowState")
+        public func recordPreviewWindowState() -> Int32 {
+            MainActor.assumeIsolated {
+                let identifier = NSUserInterfaceItemIdentifier("previewsmcp-preview")
+                guard
+                    let window = NSApplication.shared.windows.first(where: {
+                        $0.identifier == identifier
+                    })
+                else { return Int32(-1) }
+                __previewsmcpWriteWindowState(window)
+                return 0
+            }
+        }
+        """
+    }
+
+    /// Reads the sidecar's live key record to decide whether the replacement window takes key.
+    /// Absent sidecar or key field means the window never reported otherwise: take key,
+    /// matching a session's first visible window.
+    private static func runtimeKeyDecisionCode(sidecarPath: String) -> String {
+        """
+        var __takeKey = true
+                            if let __data = try? Data(
+                                contentsOf: URL(fileURLWithPath: "\(escapedForSwiftStringLiteral(sidecarPath))")),
+                                let __obj = try? JSONSerialization.jsonObject(with: __data) as? [String: Any],
+                                let __key = __obj["key"] as? Bool
+                            {
+                                __takeKey = __key
+                            }
         """
     }
 
@@ -357,36 +416,26 @@ public enum BridgeGenerator {
     }
 
     /// Code (run once when the agent creates its visible window) that records the window's
-    /// content rect and key status to `sidecarPath` on every move/resize/key change. A respawned
+    /// state via `__previewsmcpWriteWindowState` on every move/resize/key change. A respawned
     /// agent reads it back so the user's dragged/resized window is restored across non-leaf
     /// structural edits (#195) and the handoff replacement only takes key when the outgoing
     /// window had it (#254). The content rect (not the frame) is recorded because that is what
-    /// window creation bakes, so readers never need the window's style mask. Reads the state off
-    /// the notification's window so the `@Sendable` observer closure captures only the path.
-    private static func frameObserverCode(sidecarPath: String) -> String {
+    /// window creation bakes, so readers never need the window's style mask.
+    private static func frameObserverCode() -> String {
         """
-        let __frameURL = URL(fileURLWithPath: "\(escapedForSwiftStringLiteral(sidecarPath))")
-                        let __recordFrame: @Sendable (Notification) -> Void = { __note in
-                            MainActor.assumeIsolated {
-                                guard let __win = __note.object as? NSWindow else { return }
-                                let __f = __win.contentRect(forFrameRect: __win.frame)
-                                let __dict: [String: Any] = [
-                                    "x": __f.origin.x, "y": __f.origin.y,
-                                    "width": __f.size.width, "height": __f.size.height,
-                                    "key": __win.isKeyWindow,
-                                ]
-                                if let __data = try? JSONSerialization.data(withJSONObject: __dict) {
-                                    try? __data.write(to: __frameURL, options: .atomic)
+        for __name in [
+                                NSWindow.didMoveNotification, NSWindow.didResizeNotification,
+                                NSWindow.didBecomeKeyNotification, NSWindow.didResignKeyNotification,
+                            ] {
+                                NotificationCenter.default.addObserver(
+                                    forName: __name, object: window, queue: nil
+                                ) { __note in
+                                    MainActor.assumeIsolated {
+                                        guard let __win = __note.object as? NSWindow else { return }
+                                        __previewsmcpWriteWindowState(__win)
+                                    }
                                 }
                             }
-                        }
-                        for __name in [
-                            NSWindow.didMoveNotification, NSWindow.didResizeNotification,
-                            NSWindow.didBecomeKeyNotification, NSWindow.didResignKeyNotification,
-                        ] {
-                            NotificationCenter.default.addObserver(
-                                forName: __name, object: window, queue: nil, using: __recordFrame)
-                        }
         """
     }
 

--- a/previewsmcp/PreviewsCore/PreviewSession.swift
+++ b/previewsmcp/PreviewsCore/PreviewSession.swift
@@ -166,10 +166,9 @@ public actor PreviewSession {
     /// Overwrite the recorded key status, keeping the recorded frame. The daemon calls this
     /// after a reload: the outgoing agent's dying window resigns key to the incoming one and
     /// records that loss, so the daemon reasserts the state it baked for the surviving window.
-    public nonisolated static func recordWindowKeyState(
-        _ isKey: Bool, for id: String, fallback: WindowFrame
-    ) {
-        let frame = storedWindowFrame(for: id) ?? fallback
+    /// No-op when the session never recorded a sidecar — there is nothing to correct.
+    public nonisolated static func recordWindowKeyState(_ isKey: Bool, for id: String) {
+        guard let frame = storedWindowFrame(for: id) else { return }
         let dict: [String: Any] = [
             "x": frame.x, "y": frame.y, "width": frame.width, "height": frame.height,
             "key": isKey,

--- a/previewsmcp/PreviewsCore/PreviewSession.swift
+++ b/previewsmcp/PreviewsCore/PreviewSession.swift
@@ -28,6 +28,10 @@ public struct JITRenderBuild: Sendable {
     /// The generated `@_cdecl` setup entry (`previewSetUp`), present when the session has a
     /// setup plugin. The reloader runs it once per agent process before the first render.
     public let setupEntrySymbol: String?
+    /// The generated `@_cdecl` window-state entry (`recordPreviewWindowState`), present for
+    /// visible macOS sessions. The reloader runs it after a respawn handoff kills the outgoing
+    /// agent, so the sidecar's last write describes the surviving window (#254).
+    public let windowStateEntrySymbol: String?
 
     public init(
         objectPath: URL,
@@ -39,7 +43,8 @@ public struct JITRenderBuild: Sendable {
         archivePaths: [URL] = [],
         dylibPaths: [URL] = [],
         requiresFreshAgent: Bool = false,
-        setupEntrySymbol: String? = nil
+        setupEntrySymbol: String? = nil,
+        windowStateEntrySymbol: String? = nil
     ) {
         self.objectPath = objectPath
         self.imagePath = imagePath
@@ -51,6 +56,7 @@ public struct JITRenderBuild: Sendable {
         self.dylibPaths = dylibPaths
         self.requiresFreshAgent = requiresFreshAgent
         self.setupEntrySymbol = setupEntrySymbol
+        self.windowStateEntrySymbol = windowStateEntrySymbol
     }
 }
 
@@ -132,16 +138,14 @@ public actor PreviewSession {
             .appendingPathComponent("previewsmcp-jit-frame-\(id).json")
     }
 
-    /// A window placement (content rect) and key status recorded by the agent for a session.
-    /// `isKey` carries focus across the respawn handoff (#254); absent in the sidecar it
-    /// defaults to key, matching the activate-on-creation behavior of a window that never
-    /// reported otherwise.
+    /// A window placement (content rect) recorded by the agent for a session. The sidecar also
+    /// carries a live key-status field, but that is written and read only by generated agent
+    /// code (#254); the daemon never interprets or writes it.
     public struct WindowFrame: Sendable {
         public let x: Double
         public let y: Double
         public let width: Double
         public let height: Double
-        public let isKey: Bool
     }
 
     /// The last window frame the agent recorded for this session, or nil when none was written.
@@ -151,25 +155,7 @@ public actor PreviewSession {
               let x = obj["x"] as? Double, let y = obj["y"] as? Double,
               let width = obj["width"] as? Double, let height = obj["height"] as? Double
         else { return nil }
-        return WindowFrame(
-            x: x, y: y, width: width, height: height, isKey: obj["key"] as? Bool ?? true
-        )
-    }
-
-    /// Patch the recorded key status in place, keeping every other recorded field. The daemon
-    /// calls this after a reload: the outgoing agent's dying window resigns key to the incoming
-    /// one and records that loss, so the daemon reasserts the state it baked for the surviving
-    /// window. No-op when the session never recorded a sidecar or the status already matches.
-    public nonisolated static func recordWindowKeyState(_ isKey: Bool, for id: String) {
-        let url = frameSidecarPath(for: id)
-        guard let data = try? Data(contentsOf: url),
-              var obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              (obj["key"] as? Bool ?? true) != isKey
-        else { return }
-        obj["key"] = isKey
-        if let patched = try? JSONSerialization.data(withJSONObject: obj) {
-            try? patched.write(to: url, options: .atomic)
-        }
+        return WindowFrame(x: x, y: y, width: width, height: height)
     }
 
     /// Compile the preview for the JIT structural-reload path. Generates a render bridge
@@ -319,7 +305,8 @@ public actor PreviewSession {
             archivePaths: archivePaths,
             dylibPaths: dylibPaths,
             requiresFreshAgent: requiresFreshAgent,
-            setupEntrySymbol: hasSetup ? "previewSetUp" : nil
+            setupEntrySymbol: hasSetup ? "previewSetUp" : nil,
+            windowStateEntrySymbol: window?.headless == false ? "recordPreviewWindowState" : nil
         )
         lastJITBuild = build
         return build

--- a/previewsmcp/PreviewsCore/PreviewSession.swift
+++ b/previewsmcp/PreviewsCore/PreviewSession.swift
@@ -132,23 +132,16 @@ public actor PreviewSession {
             .appendingPathComponent("previewsmcp-jit-frame-\(id).json")
     }
 
-    /// A window frame and key status recorded by the agent for a session. `isKey` carries
-    /// focus across the respawn handoff (#254); absent in the sidecar it defaults to key,
-    /// matching the activate-on-creation behavior of a window that never reported otherwise.
+    /// A window placement (content rect) and key status recorded by the agent for a session.
+    /// `isKey` carries focus across the respawn handoff (#254); absent in the sidecar it
+    /// defaults to key, matching the activate-on-creation behavior of a window that never
+    /// reported otherwise.
     public struct WindowFrame: Sendable {
         public let x: Double
         public let y: Double
         public let width: Double
         public let height: Double
         public let isKey: Bool
-
-        public init(x: Double, y: Double, width: Double, height: Double, isKey: Bool = true) {
-            self.x = x
-            self.y = y
-            self.width = width
-            self.height = height
-            self.isKey = isKey
-        }
     }
 
     /// The last window frame the agent recorded for this session, or nil when none was written.
@@ -163,18 +156,19 @@ public actor PreviewSession {
         )
     }
 
-    /// Overwrite the recorded key status, keeping the recorded frame. The daemon calls this
-    /// after a reload: the outgoing agent's dying window resigns key to the incoming one and
-    /// records that loss, so the daemon reasserts the state it baked for the surviving window.
-    /// No-op when the session never recorded a sidecar — there is nothing to correct.
+    /// Patch the recorded key status in place, keeping every other recorded field. The daemon
+    /// calls this after a reload: the outgoing agent's dying window resigns key to the incoming
+    /// one and records that loss, so the daemon reasserts the state it baked for the surviving
+    /// window. No-op when the session never recorded a sidecar or the status already matches.
     public nonisolated static func recordWindowKeyState(_ isKey: Bool, for id: String) {
-        guard let frame = storedWindowFrame(for: id) else { return }
-        let dict: [String: Any] = [
-            "x": frame.x, "y": frame.y, "width": frame.width, "height": frame.height,
-            "key": isKey,
-        ]
-        if let data = try? JSONSerialization.data(withJSONObject: dict) {
-            try? data.write(to: frameSidecarPath(for: id), options: .atomic)
+        let url = frameSidecarPath(for: id)
+        guard let data = try? Data(contentsOf: url),
+              var obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              (obj["key"] as? Bool ?? true) != isKey
+        else { return }
+        obj["key"] = isKey
+        if let patched = try? JSONSerialization.data(withJSONObject: obj) {
+            try? patched.write(to: url, options: .atomic)
         }
     }
 

--- a/previewsmcp/PreviewsCore/PreviewSession.swift
+++ b/previewsmcp/PreviewsCore/PreviewSession.swift
@@ -132,21 +132,51 @@ public actor PreviewSession {
             .appendingPathComponent("previewsmcp-jit-frame-\(id).json")
     }
 
-    /// A window frame recorded by the agent for a session.
+    /// A window frame and key status recorded by the agent for a session. `isKey` carries
+    /// focus across the respawn handoff (#254); absent in the sidecar it defaults to key,
+    /// matching the activate-on-creation behavior of a window that never reported otherwise.
     public struct WindowFrame: Sendable {
         public let x: Double
         public let y: Double
         public let width: Double
         public let height: Double
+        public let isKey: Bool
+
+        public init(x: Double, y: Double, width: Double, height: Double, isKey: Bool = true) {
+            self.x = x
+            self.y = y
+            self.width = width
+            self.height = height
+            self.isKey = isKey
+        }
     }
 
     /// The last window frame the agent recorded for this session, or nil when none was written.
     public nonisolated static func storedWindowFrame(for id: String) -> WindowFrame? {
         guard let data = try? Data(contentsOf: frameSidecarPath(for: id)),
-              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Double],
-              let x = obj["x"], let y = obj["y"], let width = obj["width"], let height = obj["height"]
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let x = obj["x"] as? Double, let y = obj["y"] as? Double,
+              let width = obj["width"] as? Double, let height = obj["height"] as? Double
         else { return nil }
-        return WindowFrame(x: x, y: y, width: width, height: height)
+        return WindowFrame(
+            x: x, y: y, width: width, height: height, isKey: obj["key"] as? Bool ?? true
+        )
+    }
+
+    /// Overwrite the recorded key status, keeping the recorded frame. The daemon calls this
+    /// after a reload: the outgoing agent's dying window resigns key to the incoming one and
+    /// records that loss, so the daemon reasserts the state it baked for the surviving window.
+    public nonisolated static func recordWindowKeyState(
+        _ isKey: Bool, for id: String, fallback: WindowFrame
+    ) {
+        let frame = storedWindowFrame(for: id) ?? fallback
+        let dict: [String: Any] = [
+            "x": frame.x, "y": frame.y, "width": frame.width, "height": frame.height,
+            "key": isKey,
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: dict) {
+            try? data.write(to: frameSidecarPath(for: id), options: .atomic)
+        }
     }
 
     /// Compile the preview for the JIT structural-reload path. Generates a render bridge

--- a/previewsmcp/PreviewsJITLink/JITStructuralReloader.swift
+++ b/previewsmcp/PreviewsJITLink/JITStructuralReloader.swift
@@ -49,13 +49,11 @@ public actor JITStructuralReloader: StructuralReloader {
                 _ = try session.runOnMain(symbol: setupEntry)
                 didRunSetUp = true
             }
-            let mark = ContinuousClock.now
-            try Self.run(session, build.entrySymbol)
-            Log.info("jit_latency: render-entry \(Log.millis(mark, ContinuousClock.now))ms")
+            try Self.runRenderEntry(session, build)
             return
         }
 
-        var mark = ContinuousClock.now
+        let mark = ContinuousClock.now
         let fresh = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
         Log.info(
             "jit_latency: agent-session force-fresh=\(build.requiresFreshAgent) "
@@ -65,9 +63,7 @@ public actor JITStructuralReloader: StructuralReloader {
         if let setupEntry = build.setupEntrySymbol {
             _ = try fresh.runOnMain(symbol: setupEntry)
         }
-        mark = ContinuousClock.now
-        try Self.run(fresh, build.entrySymbol)
-        Log.info("jit_latency: render-entry \(Log.millis(mark, ContinuousClock.now))ms")
+        try Self.runRenderEntry(fresh, build)
         // The fresh agent's window is up; replacing the session now kills the old agent.
         session = fresh
         generation = 1
@@ -96,6 +92,12 @@ public actor JITStructuralReloader: StructuralReloader {
             "jit_latency: add-objects \(build.supportObjectPaths.count + 1) "
                 + "\(Log.millis(mark, ContinuousClock.now))ms"
         )
+    }
+
+    private static func runRenderEntry(_ session: JITSession, _ build: JITRenderBuild) throws {
+        let mark = ContinuousClock.now
+        try run(session, build.entrySymbol)
+        Log.info("jit_latency: render-entry \(Log.millis(mark, ContinuousClock.now))ms")
     }
 
     private static func run(_ session: JITSession, _ entrySymbol: String) throws {

--- a/previewsmcp/PreviewsJITLink/JITStructuralReloader.swift
+++ b/previewsmcp/PreviewsJITLink/JITStructuralReloader.swift
@@ -10,8 +10,10 @@ import PreviewsCore
 /// A respawn is a seamless handoff (#254): the fresh agent is stood up completely — spawned,
 /// linked, first render, so its window is on screen at the baked frame — before the old
 /// session is replaced, whose `deinit` kills the old agent and closes its window. The reverse
-/// order shows the desktop in the gap. A failure anywhere leaves the old agent, its window,
-/// and this actor's state untouched, so the last good preview stays up.
+/// order shows the desktop in the gap. A failed respawn keeps the old agent (and its window)
+/// as the live session, and a failed render on either path leaves `lastObjectPath` on the
+/// last build that actually rendered, so the literal fast path can never re-run a build whose
+/// first full render failed.
 public actor JITStructuralReloader: StructuralReloader {
     private let generationCap: Int
     private var session: JITSession?
@@ -41,7 +43,6 @@ public actor JITStructuralReloader: StructuralReloader {
             generation += 1
             try session.newGeneration()
             try link(build, into: session)
-            lastObjectPath = build.objectPath
             // Setup runs once per agent process (its plugin state lives for the process's
             // lifetime), so re-run after a respawn but not per generation. The entry is
             // void; the wrapper's status word is meaningless for it.
@@ -50,6 +51,7 @@ public actor JITStructuralReloader: StructuralReloader {
                 didRunSetUp = true
             }
             try Self.runRenderEntry(session, build)
+            lastObjectPath = build.objectPath
             return
         }
 
@@ -69,6 +71,13 @@ public actor JITStructuralReloader: StructuralReloader {
         generation = 1
         didRunSetUp = build.setupEntrySymbol != nil
         lastObjectPath = build.objectPath
+        // With the outgoing agent dead and reaped, the fresh agent's record is guaranteed
+        // to be the sidecar's last write — settling the key status its dying predecessor
+        // recorded losing to us. Best-effort: a failure here only costs focus carry on
+        // the next handoff, which the window's own key observers heal on the next change.
+        if let stateEntry = build.windowStateEntrySymbol {
+            _ = try? fresh.runOnMain(symbol: stateEntry)
+        }
     }
 
     private func link(_ build: JITRenderBuild, into session: JITSession) throws {

--- a/previewsmcp/PreviewsJITLink/JITStructuralReloader.swift
+++ b/previewsmcp/PreviewsJITLink/JITStructuralReloader.swift
@@ -6,6 +6,12 @@ import PreviewsCore
 /// every `generationCap` edits. Respawn bounds the unreclaimable `__swift5_*` metadata that
 /// each generation leaks (it cannot be deregistered). The render entry runs on the agent's
 /// main thread and writes the preview PNG to the path baked into the object at compile time.
+///
+/// A respawn is a seamless handoff (#254): the fresh agent is stood up completely — spawned,
+/// linked, first render, so its window is on screen at the baked frame — before the old
+/// session is replaced, whose `deinit` kills the old agent and closes its window. The reverse
+/// order shows the desktop in the gap. A failure anywhere leaves the old agent, its window,
+/// and this actor's state untouched, so the last good preview stays up.
 public actor JITStructuralReloader: StructuralReloader {
     private let generationCap: Int
     private var session: JITSession?
@@ -28,13 +34,49 @@ public actor JITStructuralReloader: StructuralReloader {
             return
         }
 
+        // A fresh `JITDylib` on the live agent while under the cap. The first edit, each
+        // post-cap edit, and any `forceFresh` edit (the non-leaf incremental split, which
+        // reuses the target's stable module name) hand off to a new agent instead.
+        if let session, !build.requiresFreshAgent, generation < generationCap {
+            generation += 1
+            try session.newGeneration()
+            try link(build, into: session)
+            lastObjectPath = build.objectPath
+            // Setup runs once per agent process (its plugin state lives for the process's
+            // lifetime), so re-run after a respawn but not per generation. The entry is
+            // void; the wrapper's status word is meaningless for it.
+            if let setupEntry = build.setupEntrySymbol, !didRunSetUp {
+                _ = try session.runOnMain(symbol: setupEntry)
+                didRunSetUp = true
+            }
+            let mark = ContinuousClock.now
+            try Self.run(session, build.entrySymbol)
+            Log.info("jit_latency: render-entry \(Log.millis(mark, ContinuousClock.now))ms")
+            return
+        }
+
         var mark = ContinuousClock.now
-        let session = try nextSession(forceFresh: build.requiresFreshAgent)
+        let fresh = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
         Log.info(
             "jit_latency: agent-session force-fresh=\(build.requiresFreshAgent) "
                 + "\(Log.millis(mark, ContinuousClock.now))ms"
         )
+        try link(build, into: fresh)
+        if let setupEntry = build.setupEntrySymbol {
+            _ = try fresh.runOnMain(symbol: setupEntry)
+        }
         mark = ContinuousClock.now
+        try Self.run(fresh, build.entrySymbol)
+        Log.info("jit_latency: render-entry \(Log.millis(mark, ContinuousClock.now))ms")
+        // The fresh agent's window is up; replacing the session now kills the old agent.
+        session = fresh
+        generation = 1
+        didRunSetUp = build.setupEntrySymbol != nil
+        lastObjectPath = build.objectPath
+    }
+
+    private func link(_ build: JITRenderBuild, into session: JITSession) throws {
+        var mark = ContinuousClock.now
         for dylib in build.dylibPaths {
             try session.addDylib(path: dylib.path)
         }
@@ -54,17 +96,6 @@ public actor JITStructuralReloader: StructuralReloader {
             "jit_latency: add-objects \(build.supportObjectPaths.count + 1) "
                 + "\(Log.millis(mark, ContinuousClock.now))ms"
         )
-        lastObjectPath = build.objectPath
-        // Setup runs once per agent process (its plugin state lives for the process's
-        // lifetime), so re-run after a respawn but not per generation. The entry is
-        // void; the wrapper's status word is meaningless for it.
-        if let setupEntry = build.setupEntrySymbol, !didRunSetUp {
-            _ = try session.runOnMain(symbol: setupEntry)
-            didRunSetUp = true
-        }
-        mark = ContinuousClock.now
-        try Self.run(session, build.entrySymbol)
-        Log.info("jit_latency: render-entry \(Log.millis(mark, ContinuousClock.now))ms")
     }
 
     private static func run(_ session: JITSession, _ entrySymbol: String) throws {
@@ -72,23 +103,6 @@ public actor JITStructuralReloader: StructuralReloader {
         guard status == 0 else {
             throw JITReloadError.renderFailed(status: status)
         }
-    }
-
-    /// The session to link this edit into: a fresh `JITDylib` on the live agent while under
-    /// the cap, otherwise a freshly respawned agent (replacing the old one, whose `deinit`
-    /// kills its process). The first edit, each post-cap edit, and any `forceFresh` edit (the
-    /// non-leaf incremental split, which reuses the target's stable module name) start a new agent.
-    private func nextSession(forceFresh: Bool) throws -> JITSession {
-        if let session, !forceFresh, generation < generationCap {
-            generation += 1
-            try session.newGeneration()
-            return session
-        }
-        let fresh = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
-        session = fresh
-        generation = 1
-        didRunSetUp = false
-        return fresh
     }
 }
 

--- a/previewsmcp/PreviewsJITLink/JITStructuralReloader.swift
+++ b/previewsmcp/PreviewsJITLink/JITStructuralReloader.swift
@@ -73,8 +73,10 @@ public actor JITStructuralReloader: StructuralReloader {
         lastObjectPath = build.objectPath
         // With the outgoing agent dead and reaped, the fresh agent's record is guaranteed
         // to be the sidecar's last write — settling the key status its dying predecessor
-        // recorded losing to us. Best-effort: a failure here only costs focus carry on
-        // the next handoff, which the window's own key observers heal on the next change.
+        // recorded losing to us. Best-effort twice over: a failure here, or activation
+        // still in flight (the record can say key=false moments before the app finishes
+        // becoming active), only costs focus carry on the next handoff, which the
+        // window's own key observers heal on the next change.
         if let stateEntry = build.windowStateEntrySymbol {
             _ = try? fresh.runOnMain(symbol: stateEntry)
         }

--- a/previewsmcp/PreviewsMacOS/HostApp.swift
+++ b/previewsmcp/PreviewsMacOS/HostApp.swift
@@ -199,24 +199,18 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         return image
     }
 
-    /// Before a structural reload, bake the agent's last recorded window frame and key status
-    /// into the session's spec so a respawned agent restores the user's dragged/resized window
-    /// instead of recentering (#195) and only takes key when the outgoing window had it (#254).
-    /// Only for visible sessions; absent sidecar keeps the stored spec unchanged.
+    /// Before a structural reload, bake the agent's last recorded window placement and key
+    /// status into the session's spec so a respawned agent restores the user's dragged/resized
+    /// window instead of recentering (#195) and only takes key when the outgoing window had it
+    /// (#254). The sidecar records the content rect — the same space the spec bakes — so no
+    /// frame conversion happens here. Only for visible sessions; absent sidecar keeps the
+    /// stored spec unchanged.
     private func restoreAgentWindowFrame(sessionID: String, session: PreviewSession) {
         guard let spec = agentWindowSpecs[sessionID], !spec.headless,
               let frame = PreviewSession.storedWindowFrame(for: session.id)
         else { return }
-        // The sidecar records the window's frame; the bridge bakes a content rect. Convert
-        // (same style mask the bridge creates with) so a handoff reproduces the window
-        // exactly instead of growing by the title-bar height each respawn.
-        let content = NSWindow.contentRect(
-            forFrameRect: NSRect(x: frame.x, y: frame.y, width: frame.width, height: frame.height),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable]
-        )
         agentWindowSpecs[sessionID] = JITRenderWindow(
-            x: content.origin.x, y: content.origin.y,
-            width: content.width, height: content.height,
+            x: frame.x, y: frame.y, width: frame.width, height: frame.height,
             title: spec.title, headless: false, activate: frame.isKey
         )
     }

--- a/previewsmcp/PreviewsMacOS/HostApp.swift
+++ b/previewsmcp/PreviewsMacOS/HostApp.swift
@@ -192,26 +192,21 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     public func jitStructuralReload(sessionID: String, session: PreviewSession) async throws -> URL {
         restoreAgentWindowFrame(sessionID: sessionID, session: session)
         let build = try await session.compileObjectForJIT(window: agentWindowSpec(for: sessionID))
-        let image = try await jitRender(sessionID: sessionID, build: build)
-        if let spec = agentWindowSpecs[sessionID], !spec.headless {
-            PreviewSession.recordWindowKeyState(spec.activate, for: session.id)
-        }
-        return image
+        return try await jitRender(sessionID: sessionID, build: build)
     }
 
-    /// Before a structural reload, bake the agent's last recorded window placement and key
-    /// status into the session's spec so a respawned agent restores the user's dragged/resized
-    /// window instead of recentering (#195) and only takes key when the outgoing window had it
-    /// (#254). The sidecar records the content rect — the same space the spec bakes — so no
-    /// frame conversion happens here. Only for visible sessions; absent sidecar keeps the
-    /// stored spec unchanged.
+    /// Before a structural reload, bake the agent's last recorded window placement into the
+    /// session's spec so a respawned agent restores the user's dragged/resized window instead
+    /// of recentering (#195). The sidecar records the content rect — the same space the spec
+    /// bakes — so no frame conversion happens here. Only for visible sessions; absent sidecar
+    /// keeps the stored spec unchanged.
     private func restoreAgentWindowFrame(sessionID: String, session: PreviewSession) {
         guard let spec = agentWindowSpecs[sessionID], !spec.headless,
               let frame = PreviewSession.storedWindowFrame(for: session.id)
         else { return }
         agentWindowSpecs[sessionID] = JITRenderWindow(
             x: frame.x, y: frame.y, width: frame.width, height: frame.height,
-            title: spec.title, headless: false, activate: frame.isKey
+            title: spec.title, headless: false
         )
     }
 

--- a/previewsmcp/PreviewsMacOS/HostApp.swift
+++ b/previewsmcp/PreviewsMacOS/HostApp.swift
@@ -194,12 +194,7 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         let build = try await session.compileObjectForJIT(window: agentWindowSpec(for: sessionID))
         let image = try await jitRender(sessionID: sessionID, build: build)
         if let spec = agentWindowSpecs[sessionID], !spec.headless {
-            PreviewSession.recordWindowKeyState(
-                spec.activate, for: session.id,
-                fallback: PreviewSession.WindowFrame(
-                    x: spec.x, y: spec.y, width: spec.width, height: spec.height
-                )
-            )
+            PreviewSession.recordWindowKeyState(spec.activate, for: session.id)
         }
         return image
     }
@@ -212,8 +207,16 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         guard let spec = agentWindowSpecs[sessionID], !spec.headless,
               let frame = PreviewSession.storedWindowFrame(for: session.id)
         else { return }
+        // The sidecar records the window's frame; the bridge bakes a content rect. Convert
+        // (same style mask the bridge creates with) so a handoff reproduces the window
+        // exactly instead of growing by the title-bar height each respawn.
+        let content = NSWindow.contentRect(
+            forFrameRect: NSRect(x: frame.x, y: frame.y, width: frame.width, height: frame.height),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable]
+        )
         agentWindowSpecs[sessionID] = JITRenderWindow(
-            x: frame.x, y: frame.y, width: frame.width, height: frame.height,
+            x: content.origin.x, y: content.origin.y,
+            width: content.width, height: content.height,
             title: spec.title, headless: false, activate: frame.isKey
         )
     }

--- a/previewsmcp/PreviewsMacOS/HostApp.swift
+++ b/previewsmcp/PreviewsMacOS/HostApp.swift
@@ -192,19 +192,29 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
     public func jitStructuralReload(sessionID: String, session: PreviewSession) async throws -> URL {
         restoreAgentWindowFrame(sessionID: sessionID, session: session)
         let build = try await session.compileObjectForJIT(window: agentWindowSpec(for: sessionID))
-        return try await jitRender(sessionID: sessionID, build: build)
+        let image = try await jitRender(sessionID: sessionID, build: build)
+        if let spec = agentWindowSpecs[sessionID], !spec.headless {
+            PreviewSession.recordWindowKeyState(
+                spec.activate, for: session.id,
+                fallback: PreviewSession.WindowFrame(
+                    x: spec.x, y: spec.y, width: spec.width, height: spec.height
+                )
+            )
+        }
+        return image
     }
 
-    /// Before a structural reload, bake the agent's last recorded window frame into the session's
-    /// spec so a respawned agent restores the user's dragged/resized window instead of recentering
-    /// (#195). Only for visible sessions; absent sidecar keeps the stored spec unchanged.
+    /// Before a structural reload, bake the agent's last recorded window frame and key status
+    /// into the session's spec so a respawned agent restores the user's dragged/resized window
+    /// instead of recentering (#195) and only takes key when the outgoing window had it (#254).
+    /// Only for visible sessions; absent sidecar keeps the stored spec unchanged.
     private func restoreAgentWindowFrame(sessionID: String, session: PreviewSession) {
         guard let spec = agentWindowSpecs[sessionID], !spec.headless,
               let frame = PreviewSession.storedWindowFrame(for: session.id)
         else { return }
         agentWindowSpecs[sessionID] = JITRenderWindow(
             x: frame.x, y: frame.y, width: frame.width, height: frame.height,
-            title: spec.title, headless: false
+            title: spec.title, headless: false, activate: frame.isKey
         )
     }
 

--- a/previewsmcp/Tests/PreviewsCoreTests/BridgeGeneratorFrameHandoverTests.swift
+++ b/previewsmcp/Tests/PreviewsCoreTests/BridgeGeneratorFrameHandoverTests.swift
@@ -32,24 +32,10 @@ struct BridgeGeneratorFrameHandoverTests {
         #expect(generated.source.contains("didBecomeKeyNotification"))
         #expect(generated.source.contains("didResignKeyNotification"))
         #expect(generated.source.contains("/tmp/frame.json"))
+        #expect(generated.source.contains("recordPreviewWindowState"))
         #expect(generated.source.contains("makeKeyAndOrderFront"))
-        #expect(generated.source.contains("displayIfNeeded"))
-    }
-
-    @Test("non-activating render window orders front without taking key or activating")
-    func nonActivatingOrdersFrontWithoutKey() {
-        let generated = BridgeGenerator.generateCombinedSource(
-            originalSource: Self.source,
-            closureBody: "TestView()",
-            renderOutputPath: "/tmp/out.png",
-            renderWindow: JITRenderWindow(
-                x: 0, y: 0, width: 800, height: 1000, title: "t", headless: false, activate: false
-            ),
-            frameSidecarPath: "/tmp/frame.json"
-        )
-        #expect(!generated.source.contains("makeKeyAndOrderFront"))
-        #expect(!generated.source.contains("activate(ignoringOtherApps:"))
         #expect(generated.source.contains("orderFrontRegardless"))
+        #expect(generated.source.contains("displayIfNeeded"))
     }
 
     @Test("headless render window installs no frame observers")
@@ -65,5 +51,7 @@ struct BridgeGeneratorFrameHandoverTests {
         )
         #expect(!generated.source.contains("didMoveNotification"))
         #expect(!generated.source.contains("didResizeNotification"))
+        #expect(!generated.source.contains("recordPreviewWindowState"))
+        #expect(!generated.source.contains("makeKeyAndOrderFront"))
     }
 }

--- a/previewsmcp/Tests/PreviewsCoreTests/BridgeGeneratorFrameHandoverTests.swift
+++ b/previewsmcp/Tests/PreviewsCoreTests/BridgeGeneratorFrameHandoverTests.swift
@@ -29,7 +29,27 @@ struct BridgeGeneratorFrameHandoverTests {
         )
         #expect(generated.source.contains("didMoveNotification"))
         #expect(generated.source.contains("didResizeNotification"))
+        #expect(generated.source.contains("didBecomeKeyNotification"))
+        #expect(generated.source.contains("didResignKeyNotification"))
         #expect(generated.source.contains("/tmp/frame.json"))
+        #expect(generated.source.contains("makeKeyAndOrderFront"))
+        #expect(generated.source.contains("displayIfNeeded"))
+    }
+
+    @Test("non-activating render window orders front without taking key or activating")
+    func nonActivatingOrdersFrontWithoutKey() {
+        let generated = BridgeGenerator.generateCombinedSource(
+            originalSource: Self.source,
+            closureBody: "TestView()",
+            renderOutputPath: "/tmp/out.png",
+            renderWindow: JITRenderWindow(
+                x: 0, y: 0, width: 800, height: 1000, title: "t", headless: false, activate: false
+            ),
+            frameSidecarPath: "/tmp/frame.json"
+        )
+        #expect(!generated.source.contains("makeKeyAndOrderFront"))
+        #expect(!generated.source.contains("activate(ignoringOtherApps:"))
+        #expect(generated.source.contains("orderFrontRegardless"))
     }
 
     @Test("headless render window installs no frame observers")

--- a/previewsmcp/Tests/PreviewsCoreTests/PreviewSessionFrameSidecarTests.swift
+++ b/previewsmcp/Tests/PreviewsCoreTests/PreviewSessionFrameSidecarTests.swift
@@ -17,7 +17,7 @@ struct PreviewSessionFrameSidecarTests {
         #expect(PreviewSession.storedWindowFrame(for: "no-such-session-\(UUID().uuidString)") == nil)
     }
 
-    @Test("stored window frame round-trips a written sidecar")
+    @Test("stored window frame round-trips a written sidecar, tolerating agent-only fields")
     func roundTrips() throws {
         let id = "frame-test-\(UUID().uuidString)"
         let url = PreviewSession.frameSidecarPath(for: id)
@@ -30,39 +30,5 @@ struct PreviewSessionFrameSidecarTests {
         #expect(frame?.y == 34)
         #expect(frame?.width == 567)
         #expect(frame?.height == 890)
-        #expect(frame?.isKey == false)
-    }
-
-    @Test("stored window frame without key state defaults to key")
-    func missingKeyDefaultsToKey() throws {
-        let id = "frame-test-\(UUID().uuidString)"
-        let url = PreviewSession.frameSidecarPath(for: id)
-        let dict: [String: Double] = ["x": 12, "y": 34, "width": 567, "height": 890]
-        try JSONSerialization.data(withJSONObject: dict).write(to: url)
-        defer { try? FileManager.default.removeItem(at: url) }
-
-        #expect(PreviewSession.storedWindowFrame(for: id)?.isKey == true)
-    }
-
-    @Test("recording key state overwrites key and keeps the recorded frame")
-    func recordKeyStateKeepsFrame() throws {
-        let id = "frame-test-\(UUID().uuidString)"
-        let url = PreviewSession.frameSidecarPath(for: id)
-        let dict: [String: Any] = ["x": 12, "y": 34, "width": 567, "height": 890, "key": false]
-        try JSONSerialization.data(withJSONObject: dict).write(to: url)
-        defer { try? FileManager.default.removeItem(at: url) }
-
-        PreviewSession.recordWindowKeyState(true, for: id)
-        let frame = PreviewSession.storedWindowFrame(for: id)
-        #expect(frame?.isKey == true)
-        #expect(frame?.x == 12)
-        #expect(frame?.height == 890)
-    }
-
-    @Test("recording key state without a sidecar records nothing")
-    func recordKeyStateWithoutSidecarIsNoop() {
-        let id = "frame-test-\(UUID().uuidString)"
-        PreviewSession.recordWindowKeyState(true, for: id)
-        #expect(PreviewSession.storedWindowFrame(for: id) == nil)
     }
 }

--- a/previewsmcp/Tests/PreviewsCoreTests/PreviewSessionFrameSidecarTests.swift
+++ b/previewsmcp/Tests/PreviewsCoreTests/PreviewSessionFrameSidecarTests.swift
@@ -21,7 +21,7 @@ struct PreviewSessionFrameSidecarTests {
     func roundTrips() throws {
         let id = "frame-test-\(UUID().uuidString)"
         let url = PreviewSession.frameSidecarPath(for: id)
-        let dict: [String: Double] = ["x": 12, "y": 34, "width": 567, "height": 890]
+        let dict: [String: Any] = ["x": 12, "y": 34, "width": 567, "height": 890, "key": false]
         try JSONSerialization.data(withJSONObject: dict).write(to: url)
         defer { try? FileManager.default.removeItem(at: url) }
 
@@ -30,5 +30,17 @@ struct PreviewSessionFrameSidecarTests {
         #expect(frame?.y == 34)
         #expect(frame?.width == 567)
         #expect(frame?.height == 890)
+        #expect(frame?.isKey == false)
+    }
+
+    @Test("stored window frame without key state defaults to key")
+    func missingKeyDefaultsToKey() throws {
+        let id = "frame-test-\(UUID().uuidString)"
+        let url = PreviewSession.frameSidecarPath(for: id)
+        let dict: [String: Double] = ["x": 12, "y": 34, "width": 567, "height": 890]
+        try JSONSerialization.data(withJSONObject: dict).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(PreviewSession.storedWindowFrame(for: id)?.isKey == true)
     }
 }

--- a/previewsmcp/Tests/PreviewsCoreTests/PreviewSessionFrameSidecarTests.swift
+++ b/previewsmcp/Tests/PreviewsCoreTests/PreviewSessionFrameSidecarTests.swift
@@ -43,4 +43,26 @@ struct PreviewSessionFrameSidecarTests {
 
         #expect(PreviewSession.storedWindowFrame(for: id)?.isKey == true)
     }
+
+    @Test("recording key state overwrites key and keeps the recorded frame")
+    func recordKeyStateKeepsFrame() throws {
+        let id = "frame-test-\(UUID().uuidString)"
+        let url = PreviewSession.frameSidecarPath(for: id)
+        let dict: [String: Any] = ["x": 12, "y": 34, "width": 567, "height": 890, "key": false]
+        try JSONSerialization.data(withJSONObject: dict).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        PreviewSession.recordWindowKeyState(true, for: id)
+        let frame = PreviewSession.storedWindowFrame(for: id)
+        #expect(frame?.isKey == true)
+        #expect(frame?.x == 12)
+        #expect(frame?.height == 890)
+    }
+
+    @Test("recording key state without a sidecar records nothing")
+    func recordKeyStateWithoutSidecarIsNoop() {
+        let id = "frame-test-\(UUID().uuidString)"
+        PreviewSession.recordWindowKeyState(true, for: id)
+        #expect(PreviewSession.storedWindowFrame(for: id) == nil)
+    }
 }

--- a/previewsmcp/Tests/PreviewsJITLinkTests/CappedPersistentTests.swift
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/CappedPersistentTests.swift
@@ -224,6 +224,16 @@ struct CappedPersistentTests {
         try agent.addObject(path: probe.path)
         let bits = try agent.runOnMain(symbol: "preview_window_spec_probe")
         #expect(bits == 15, "bits=\(bits)")
+
+        // The visible path rasters before the window is first presented; the PNG must
+        // still contain the rendered content, not an empty backing store.
+        let rep = try #require(NSBitmapImageRep(data: Data(contentsOf: build.imagePath)))
+        let color = try #require(
+            rep.colorAt(x: rep.pixelsWide / 2, y: rep.pixelsHigh / 2)?
+                .usingColorSpace(.deviceRGB)
+        )
+        #expect(color.greenComponent > 0.5)
+        #expect(color.redComponent < 0.5)
     }
 
     @Test func bridgeRecordsWindowFrameOnMoveAndResize() async throws {

--- a/previewsmcp/Tests/PreviewsJITLinkTests/CappedPersistentTests.swift
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/CappedPersistentTests.swift
@@ -284,8 +284,14 @@ struct CappedPersistentTests {
         #expect(try agent.runOnMain(symbol: "preview_move_probe") == 0)
 
         let frame = try #require(PreviewSession.storedWindowFrame(for: session.id))
-        #expect(frame.width == 321)
-        #expect(frame.height == 654)
+        let content = await MainActor.run {
+            NSWindow.contentRect(
+                forFrameRect: NSRect(x: -8000, y: -7000, width: 321, height: 654),
+                styleMask: [.titled, .closable, .miniaturizable, .resizable]
+            )
+        }
+        #expect(frame.width == Double(content.width))
+        #expect(frame.height == Double(content.height))
         #expect(frame.x != -9000)
         #expect(frame.y != -9000)
     }

--- a/previewsmcp/Tests/PreviewsJITLinkTests/RespawnHandoffTests.swift
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/RespawnHandoffTests.swift
@@ -1,0 +1,99 @@
+import Darwin
+import Foundation
+import PreviewsCore
+import PreviewsJITLink
+import Testing
+
+struct RespawnHandoffTests {
+    private static func makeBuild(objectPath: URL, entrySymbol: String, dir: URL) -> JITRenderBuild {
+        JITRenderBuild(
+            objectPath: objectPath,
+            imagePath: dir.appendingPathComponent("unused.png"),
+            valuesPath: dir.appendingPathComponent("unused.json"),
+            entrySymbol: entrySymbol,
+            literals: []
+        )
+    }
+
+    private static func pidReportingSource(entrySymbol: String, pidPath: String) -> String {
+        """
+        import Foundation
+
+        @_cdecl("\(entrySymbol)")
+        public func \(entrySymbol)() -> Int32 {
+            let pid = String(ProcessInfo.processInfo.processIdentifier)
+            do {
+                try pid.write(toFile: "\(pidPath)", atomically: true, encoding: .utf8)
+                return 0
+            } catch {
+                return -1
+            }
+        }
+        """
+    }
+
+    private static func renderedPID(
+        _ reloader: JITStructuralReloader, compiler: Compiler, dir: URL
+    ) async throws -> (pid: Int32, build: JITRenderBuild) {
+        let pidPath = dir.appendingPathComponent("gen1.pid").path
+        let object = try await compiler.compileObject(
+            source: Self.pidReportingSource(entrySymbol: "handoff_gen1", pidPath: pidPath),
+            moduleName: "HandoffGen1Fixture"
+        )
+        let build = Self.makeBuild(objectPath: object, entrySymbol: "handoff_gen1", dir: dir)
+        try await reloader.render(build)
+        let text = try String(contentsOfFile: pidPath, encoding: .utf8)
+        let pid = try #require(Int32(text.trimmingCharacters(in: .whitespacesAndNewlines)))
+        #expect(kill(pid, 0) == 0)
+        return (pid, build)
+    }
+
+    @Test func respawnKillsOldAgentOnlyAfterNewAgentRenders() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("handoff-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let compiler = try await Compiler()
+        let reloader = JITStructuralReloader(generationCap: 1)
+        let (oldPID, _) = try await Self.renderedPID(reloader, compiler: compiler, dir: dir)
+
+        let probe = try await compiler.compileObject(
+            source: """
+            import Darwin
+
+            @_cdecl("handoff_gen2")
+            public func handoff_gen2() -> Int32 {
+                kill(\(oldPID), 0) == 0 ? 0 : -9
+            }
+            """,
+            moduleName: "HandoffGen2Fixture"
+        )
+        try await reloader.render(Self.makeBuild(objectPath: probe, entrySymbol: "handoff_gen2", dir: dir))
+        #expect(kill(oldPID, 0) != 0)
+    }
+
+    @Test func failedRespawnKeepsOldAgentAndItsRenderAlive() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("handoff-fail-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let compiler = try await Compiler()
+        let reloader = JITStructuralReloader(generationCap: 1)
+        let (oldPID, oldBuild) = try await Self.renderedPID(reloader, compiler: compiler, dir: dir)
+
+        let failing = try await compiler.compileObject(
+            source: """
+            @_cdecl("handoff_fail")
+            public func handoff_fail() -> Int32 { -7 }
+            """,
+            moduleName: "HandoffFailFixture"
+        )
+        await #expect(throws: (any Error).self) {
+            try await reloader.render(Self.makeBuild(objectPath: failing, entrySymbol: "handoff_fail", dir: dir))
+        }
+        #expect(kill(oldPID, 0) == 0)
+        try await reloader.render(oldBuild)
+    }
+}

--- a/previewsmcp/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
+++ b/previewsmcp/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import PreviewsCore
 @testable import PreviewsMacOS
@@ -185,6 +186,55 @@ struct PreviewHostJITReloadTests {
 
         host.closePreview(sessionID: "visible")
         #expect(host.agentWindowSpec(for: "visible") == nil)
+    }
+
+    @Test func restoreConvertsRecordedFrameToContentRectAndCarriesKey() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("p254r-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let sourceFile = dir.appendingPathComponent("ColorView.swift")
+        try """
+        import SwiftUI
+
+        #Preview {
+            Color.red.frame(width: 8, height: 8)
+        }
+        """.write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        let compiler = try await Compiler()
+        let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
+        let sidecar = PreviewSession.frameSidecarPath(for: session.id)
+        try? FileManager.default.removeItem(at: sidecar)
+        defer { try? FileManager.default.removeItem(at: sidecar) }
+
+        let host = PreviewHost(makeStructuralReloader: { RecordingReloader() })
+        try await host.jitStart(
+            sessionID: "s1", session: session,
+            title: "Preview: ColorView.swift",
+            size: NSSize(width: 320, height: 240), headless: false
+        )
+
+        let recorded: [String: Any] = [
+            "x": 100.0, "y": 200.0, "width": 400.0, "height": 632.0, "key": false,
+        ]
+        try JSONSerialization.data(withJSONObject: recorded).write(to: sidecar)
+
+        try await host.jitStructuralReload(sessionID: "s1", session: session)
+
+        let spec = try #require(host.agentWindowSpec(for: "s1"))
+        let content = NSWindow.contentRect(
+            forFrameRect: NSRect(x: 100, y: 200, width: 400, height: 632),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable]
+        )
+        #expect(spec.x == Double(content.origin.x))
+        #expect(spec.y == Double(content.origin.y))
+        #expect(spec.width == Double(content.width))
+        #expect(spec.height == Double(content.height))
+        #expect(content.height < 632)
+        #expect(!spec.activate)
+        #expect(PreviewSession.storedWindowFrame(for: session.id)?.isKey == false)
     }
 
     @Test func unchangedSourceFireDoesNotReload() async throws {

--- a/previewsmcp/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
+++ b/previewsmcp/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
@@ -187,7 +187,7 @@ struct PreviewHostJITReloadTests {
         #expect(host.agentWindowSpec(for: "visible") == nil)
     }
 
-    @Test func restoreBakesRecordedContentRectAndCarriesKey() async throws {
+    @Test func restoreBakesRecordedContentRect() async throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("p254r-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -227,8 +227,6 @@ struct PreviewHostJITReloadTests {
         #expect(spec.y == 200)
         #expect(spec.width == 400)
         #expect(spec.height == 600)
-        #expect(!spec.activate)
-        #expect(PreviewSession.storedWindowFrame(for: session.id)?.isKey == false)
     }
 
     @Test func unchangedSourceFireDoesNotReload() async throws {

--- a/previewsmcp/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
+++ b/previewsmcp/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
@@ -1,4 +1,3 @@
-import AppKit
 import Foundation
 import PreviewsCore
 @testable import PreviewsMacOS
@@ -188,7 +187,7 @@ struct PreviewHostJITReloadTests {
         #expect(host.agentWindowSpec(for: "visible") == nil)
     }
 
-    @Test func restoreConvertsRecordedFrameToContentRectAndCarriesKey() async throws {
+    @Test func restoreBakesRecordedContentRectAndCarriesKey() async throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("p254r-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -217,22 +216,17 @@ struct PreviewHostJITReloadTests {
         )
 
         let recorded: [String: Any] = [
-            "x": 100.0, "y": 200.0, "width": 400.0, "height": 632.0, "key": false,
+            "x": 100.0, "y": 200.0, "width": 400.0, "height": 600.0, "key": false,
         ]
         try JSONSerialization.data(withJSONObject: recorded).write(to: sidecar)
 
         try await host.jitStructuralReload(sessionID: "s1", session: session)
 
         let spec = try #require(host.agentWindowSpec(for: "s1"))
-        let content = NSWindow.contentRect(
-            forFrameRect: NSRect(x: 100, y: 200, width: 400, height: 632),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable]
-        )
-        #expect(spec.x == Double(content.origin.x))
-        #expect(spec.y == Double(content.origin.y))
-        #expect(spec.width == Double(content.width))
-        #expect(spec.height == Double(content.height))
-        #expect(content.height < 632)
+        #expect(spec.x == 100)
+        #expect(spec.y == 200)
+        #expect(spec.width == 400)
+        #expect(spec.height == 600)
         #expect(!spec.activate)
         #expect(PreviewSession.storedWindowFrame(for: session.id)?.isKey == false)
     }


### PR DESCRIPTION
Implements the core mechanism of the #254 native-window plan (docs/254-macos-native-window-plan.md, phase A3): a structural respawn is now a seamless handoff instead of a visible window swap.

## What changed

- **Kill-after-render ordering** (`JITStructuralReloader`): the fresh agent is fully stood up — spawned, linked, first render flushed to the WindowServer — before the old session is released (whose deinit kills the old agent and closes its window). A failure anywhere keeps the old agent and its window as the live session, and a failed render can no longer poison the literal fast path (`lastObjectPath` commits only after a successful render).
- **Frame carry**: the generated frame observer records the window's *content rect* (the space window creation bakes), so the daemon restore copies the sidecar verbatim — no style-mask duplication, no title-bar growth per respawn.
- **Focus carry, agent-owned**: the generated entry decides at render time whether the replacement window takes key, from the sidecar's live key record maintained by the outgoing agent's observers. A new generated `recordPreviewWindowState` entry runs after the outgoing agent is dead and reaped, making the survivor's record the sidecar's guaranteed last write. The daemon never reads or writes key state.
- **No flash on failure**: the new window is presented only after the raster succeeds, so a failing render never flashes a half-built window or disturbs focus.
- Preview windows drop their appear animation so the replacement lands with no visible pop.

## Verification

- New `RespawnHandoffTests`: a PID probe proves the old agent is alive during the new agent's first render and dead after; a failed respawn keeps the old agent serving renders.
- Sidecar, generator, and host tests updated for content-rect semantics and the runtime key decision; a pixel assertion covers raster-before-present.
- Live verification (CGWindowList poller at 60Hz over five rounds): zero samples without a preview window across every handoff; frames bit-identical including after a programmatic move; no focus steal when the preview was not key (Finder stayed frontmost); key carried when it was (NSWorkspace confirms the replacement agent frontmost).
- Gates: `/simplify` applied; workflow `/code-review` at high effort — 4 confirmed findings all fixed (stale-snapshot key bookkeeping, cap-path reassert stomp, lastObjectPath poisoning, failure flash) plus both plausible races eliminated by removing daemon sidecar writes entirely; hermetic lint green; full local suite 9/9 green (sims claimed/released per the interim #336 protocol).

## Not in this PR

- Input forwarding and the rest of the plan's phases beyond A1-A3 verification: macOS input is already native (the agent owns a real key window); no shell/raster machinery existed on main to delete (that was only on the abandoned `254-macos-native-window` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Upgrade note**: a sidecar written by a pre-PR agent recorded the window's *frame* rect; the new reader bakes it as a *content* rect, so the first respawn after upgrading grows the window by one title-bar height, once, then self-corrects on the survivor's first write.