### PR TITLE
Fix #345: tools/simlock host lock wrapper enrolls examples/ sim runs

### DIFF
--- a/.claude/skills/integration-test/SKILL.md
+++ b/.claude/skills/integration-test/SKILL.md
@@ -80,6 +80,22 @@ PreviewsMCP runs as two separate processes with independent state:
 
 8. **Report results.** For each example, report pass/fail per test step. Summarize at the end.
 
+## Host simulator lock (iOS steps)
+
+Simulator boots are serialized machine-wide (#336): `//previewsmcp` test targets take a blocking flock on `~/.previewsmcp/sim.lock`, and example runs must join the same queue (#345). Before the first step that starts an iOS simulator session, acquire the lock:
+
+```bash
+$(git rev-parse --show-toplevel)/tools/simlock hold
+```
+
+`hold` blocks until the lock is free — waiting behind another workspace's sim tests is expected; do not abort or time it out. On success it prints a token path. Each Bash call runs in a fresh shell, so remember the token in the conversation, not in an env var. After the last iOS session is stopped — including on failure or early abort — release it:
+
+```bash
+$(git rev-parse --show-toplevel)/tools/simlock release <token>
+```
+
+macOS-only sessions do not need the lock. If a previous run leaked a holder, `ls ~/.previewsmcp/sim.lock.hold-*` lists the token, and the number in the filename is the holder's PID. Check `ps -p <pid>` before touching it: if the process is gone, the lock is already free and `release` just removes the litter; if it is alive, it is an active holder (possibly another workspace's run) — only `release` it if you know it belongs to your own dead run, because releasing a live holder drops the lock mid-run.
+
 ## Project path guidance
 
 The example projects are nested inside the PreviewsMCP repo, which has its own `Package.swift`. Without an explicit `projectPath`, auto-detection walks up from the source file, finds the repo root SPM package first, and fails. **Always pass `projectPath` pointing to the example directory** (e.g., `examples/bazel/` or `examples/xcodeproj/`) when calling `preview_start` for Bazel or Xcode examples. The SPM example does not need this because its `Package.swift` is the closest one found.

--- a/tools/simlock
+++ b/tools/simlock
@@ -1,0 +1,113 @@
+#!/usr/bin/python3
+import fcntl
+import os
+import subprocess
+import sys
+import time
+
+LOCK_PATH = os.path.expanduser("~/.previewsmcp/sim.lock")
+
+
+def usage():
+    sys.stderr.write(
+        "usage: simlock run <command> [args...]\n"
+        "       simlock hold\n"
+        "       simlock release <token>\n"
+        "stale holder from a dead run: ls %s.hold-* then release that path\n"
+        % LOCK_PATH
+    )
+    sys.exit(2)
+
+
+def token_path(pid):
+    return "%s.hold-%d" % (LOCK_PATH, pid)
+
+
+def acquire():
+    os.makedirs(os.path.dirname(LOCK_PATH), exist_ok=True)
+    fd = os.open(LOCK_PATH, os.O_CREAT | os.O_RDWR | os.O_CLOEXEC, 0o644)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    return fd
+
+
+def cmd_run(argv):
+    if not argv:
+        usage()
+    acquire()
+    try:
+        returncode = subprocess.run(argv).returncode
+    except OSError as error:
+        sys.stderr.write("simlock: cannot run %s: %s\n" % (argv[0], error.strerror))
+        return 127
+    return 128 - returncode if returncode < 0 else returncode
+
+
+def cmd_hold():
+    os.makedirs(os.path.dirname(LOCK_PATH), exist_ok=True)
+    probe_fd = os.open(LOCK_PATH, os.O_CREAT | os.O_RDWR | os.O_CLOEXEC, 0o644)
+    try:
+        fcntl.flock(probe_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(probe_fd, fcntl.LOCK_UN)
+    except OSError:
+        sys.stderr.write("simlock: waiting for %s (held by another sim run)\n" % LOCK_PATH)
+    finally:
+        os.close(probe_fd)
+    read_end, write_end = os.pipe()
+    pid = os.fork()
+    if pid == 0:
+        os.close(read_end)
+        os.setsid()
+        devnull = os.open(os.devnull, os.O_RDWR)
+        os.dup2(devnull, 0)
+        os.dup2(devnull, 1)
+        os.dup2(devnull, 2)
+        acquire()
+        token = token_path(os.getpid())
+        open(token, "w").close()
+        os.write(write_end, b"1")
+        os.close(write_end)
+        while os.path.exists(token):
+            time.sleep(0.5)
+        os._exit(0)
+    os.close(write_end)
+    if os.read(read_end, 1) != b"1":
+        sys.stderr.write("simlock: holder died before acquiring the lock\n")
+        return 1
+    print(token_path(pid))
+    return 0
+
+
+def cmd_release(argv):
+    if len(argv) != 1:
+        usage()
+    token = os.path.abspath(argv[0])
+    prefix = os.path.basename(LOCK_PATH) + ".hold-"
+    name = os.path.basename(token)
+    if (
+        os.path.dirname(token) != os.path.dirname(LOCK_PATH)
+        or not name.startswith(prefix)
+        or not name[len(prefix):].isdigit()
+    ):
+        sys.stderr.write("simlock: not a hold token: %s\n" % argv[0])
+        return 2
+    try:
+        os.remove(token)
+    except FileNotFoundError:
+        sys.stderr.write("simlock: no such token (already released?): %s\n" % argv[0])
+    return 0
+
+
+def main():
+    if len(sys.argv) < 2:
+        usage()
+    command = sys.argv[1]
+    if command == "run":
+        sys.exit(cmd_run(sys.argv[2:]))
+    if command == "hold":
+        sys.exit(cmd_hold())
+    if command == "release":
+        sys.exit(cmd_release(sys.argv[2:]))
+    usage()
+
+
+main()


### PR DESCRIPTION
Closes #345.

#336 (PR #342) serializes `//previewsmcp` sim-booting test targets via a host flock on `~/.previewsmcp/sim.lock`, but examples/ integration runs and ad-hoc shell workloads boot sims through the production daemon and took no lock — the interim mailbox sim-claim ceremony covered them. This PR enrolls them mechanically and retires the ceremony.

## What

- **`tools/simlock`** — executable Python 3 script (shebang pinned to `/usr/bin/python3`, the CLT shim, present on any box that can build this repo). Same kernel contract as `SimulatorTestLock.swift`: `open(O_CREAT|O_RDWR|O_CLOEXEC, 0o644)` + blocking `flock(LOCK_EX)` on the same path, so both sides queue against each other. `O_CLOEXEC` is load-bearing (#142).
  - `run <cmd...>` — hold the lock for the command's duration, propagate its exit code (ad-hoc shell workloads).
  - `hold` / `release <token>` — for agent-driven runs whose iOS steps span many separate shell invocations and MCP calls: `hold` detaches a child that keeps the flock until the printed token file is removed; the pipe handshake guarantees `hold` returns only after the lock is actually held.
- **integration-test skill** — new "Host simulator lock (iOS steps)" section: hold before the first iOS simulator step, release after the last (macOS-only sessions exempt), plus leaked-holder recovery guidance.

## Verification

- 12-check external suite (scratchpad, commands in thread): blocks behind an external holder then proceeds; exit codes propagate (1, 7, 127 on missing command); a backgrounded child does not pin the lock after the wrapper exits (O_CLOEXEC); hold returns only post-acquisition and prints a waiting diagnostic while blocked; release frees within one poll tick, is idempotent, and refuses non-token paths.
- Cross-language interop: a Swift probe using `SimulatorTestLock.swift`'s exact `NSHomeDirectory()` path expression reports HELD while `simlock hold` is active; separately, the verification suite refused to run while the real bazel sim tests held the lock.
- Gates: /simplify (4 agents; dead PID write removed, token-path helper extracted, recovery hint moved into `usage()`) and /code-review high (workflow, 8 findings — 5 fixed: release path validation, missing-token warning, blocked-hold diagnostic, missing-command handling, pid-recycle recovery docs). Full bazel suite 8/9 + the known pre-existing #320 `NSURLError -1` flake in MCPIntegrationTests, which passed on re-run (9/9 effective). Lint green.

## Accepted residuals (flagged in review)

- A detached holder survives its owning session's death and holds the lock until manually released — no session-liveness signal exists by construction (same residual class as #336's per-test holding). Recovery is documented in the skill and in `usage()`.
- The lock path literal is duplicated across `SimulatorTestLock.swift` and `tools/simlock` (and can never be shared — Python vs Swift); a desync guard belongs in the planned four-copy flock consolidation follow-up.
- Holder polls its token at 0.5s — up to one tick of release latency, immaterial against sim boots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)