### PR TITLE
Fix #348: fold test-side flock copies into TestFileLock with lock-path parity guard

### DIFF
--- a/previewsmcp/Tests/CLIIntegrationTests/DaemonTestLock.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/DaemonTestLock.swift
@@ -1,14 +1,10 @@
 import Foundation
 import os
+import PreviewsTestSupport
 
 /// Cross-suite serialization for daemon-touching integration tests.
-///
-/// Uses a blocking flock on a detached thread to avoid starving
-/// Swift's cooperative thread pool. The previous approach (non-
-/// blocking flock + Task.sleep polling) caused deadlocks on CI
-/// runners with small thread pools: N-1 polling tasks consumed all
-/// threads, preventing the lock-holding task's subprocess
-/// completion handlers from firing.
+/// Locking mechanics live in `TestFileLock` (TestSupport); this adds the
+/// per-run `serve.log` truncation and per-test marker.
 enum DaemonTestLock {
     /// Set true the first time any test acquires the lock in this process.
     /// Used to truncate `serve.log` exactly once per `swift test` run so
@@ -17,43 +13,8 @@ enum DaemonTestLock {
     /// the lock to prevent races with other suites running in parallel.
     private static let didTruncateLog = OSAllocatedUnfairLock<Bool>(initialState: false)
 
-    /// The daemon socket directory the test harness uses, resolved per run.
-    ///
-    /// Resolution chain (#283): explicit `PREVIEWSMCP_SOCKET_DIR` → a short dir
-    /// keyed by `$TEST_TMPDIR` → the system temp dir. Bazel sets `TEST_TMPDIR`
-    /// unique per test target and auto-cleans it, so keying the socket dir off
-    /// it gives per-target *and* per-run isolation with zero config: a stale
-    /// daemon left by a killed prior run can never own the next run's socket.
-    /// `CLIRunner` exports this value as `PREVIEWSMCP_SOCKET_DIR` into every
-    /// spawned daemon/CLI so production `DaemonPaths` picks it up unchanged
-    /// (production must NOT itself honor `TEST_TMPDIR`).
-    ///
-    /// We do NOT nest the socket under `$TEST_TMPDIR` itself: Bazel's
-    /// `$TEST_TMPDIR` lives deep under the execroot (~140 chars) and a Unix
-    /// domain socket path is capped at 104 bytes (`sun_path`) on macOS, so
-    /// `bind()` would silently fail. Instead we derive a short, stable
-    /// `/tmp/pmcp-<hash>` dir from the `$TEST_TMPDIR` string — unique per
-    /// target, stable within a run, and comfortably under the limit.
     static var effectiveSocketDir: String {
-        let env = ProcessInfo.processInfo.environment
-        if let override = env["PREVIEWSMCP_SOCKET_DIR"] {
-            return override
-        }
-        if let testTmp = env["TEST_TMPDIR"] {
-            return "/tmp/pmcp-\(shortHash(testTmp))"
-        }
-        return FileManager.default.temporaryDirectory.path
-    }
-
-    /// Deterministic short hex hash (FNV-1a, 64-bit) of `input`, for building a
-    /// short unique socket dir name that stays under the `sun_path` limit.
-    private static func shortHash(_ input: String) -> String {
-        var hash: UInt64 = 0xCBF2_9CE4_8422_2325
-        for byte in input.utf8 {
-            hash ^= UInt64(byte)
-            hash = hash &* 0x0000_0100_0000_01B3
-        }
-        return String(hash, radix: 16)
+        DaemonTestPaths.effectiveSocketDir
     }
 
     private static var daemonDirectory: URL {
@@ -62,10 +23,6 @@ enum DaemonTestLock {
 
     private static var serveLogPath: URL {
         daemonDirectory.appendingPathComponent("serve.log")
-    }
-
-    private static var lockPath: String {
-        (effectiveSocketDir as NSString).appendingPathComponent("previewsmcp-daemon-test.lock")
     }
 
     /// Run `body` while holding the cross-suite daemon lock.
@@ -78,64 +35,15 @@ enum DaemonTestLock {
         _ context: String = #function,
         body: @Sendable () async throws -> T
     ) async throws -> T {
-        // Acquire the lock on a non-cooperative thread so we don't
-        // block the Swift concurrency thread pool.
-        let path = lockPath
-        let fd = try await withCheckedThrowingContinuation {
-            (cont: CheckedContinuation<Int32, Error>) in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let dir = (path as NSString).deletingLastPathComponent
-                try? FileManager.default.createDirectory(
-                    atPath: dir, withIntermediateDirectories: true
-                )
-                let fd = open(path, O_CREAT | O_RDWR, 0o644)
-                guard fd >= 0 else {
-                    cont.resume(
-                        throwing: NSError(
-                            domain: NSPOSIXErrorDomain, code: Int(errno),
-                            userInfo: [
-                                NSLocalizedDescriptionKey:
-                                    "open(\(path)) failed",
-                            ]
-                        )
-                    )
-                    return
-                }
-                // Blocking flock — this thread sleeps in the kernel
-                // until the lock is available. Does NOT consume a
-                // cooperative thread.
-                if flock(fd, LOCK_EX) != 0 {
-                    close(fd)
-                    cont.resume(
-                        throwing: NSError(
-                            domain: NSPOSIXErrorDomain, code: Int(errno),
-                            userInfo: [
-                                NSLocalizedDescriptionKey:
-                                    "flock failed",
-                            ]
-                        )
-                    )
-                    return
-                }
-                cont.resume(returning: fd)
-            }
-        }
+        let lock = try await TestFileLock.acquire(DaemonTestPaths.daemonLockPath)
+        defer { lock.release() }
 
         // Inside the lock: prep serve.log so the diagnostic dump on
         // failure has clean, greppable context. Both ops are best-effort
         // — they must never fail the test.
         prepareServeLog(testContext: context)
 
-        let result: Swift.Result<T, Error>
-        do {
-            result = .success(try await body())
-        } catch {
-            result = .failure(error)
-        }
-
-        _ = flock(fd, LOCK_UN)
-        close(fd)
-        return try result.get()
+        return try await body()
     }
 
     /// Truncate `serve.log` on the first call in this process; always append

--- a/previewsmcp/Tests/MCPIntegrationTests/DaemonTestLock.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/DaemonTestLock.swift
@@ -1,106 +1,21 @@
 import Foundation
+import PreviewsTestSupport
 
 /// Cross-suite serialization for MCP integration tests.
-/// See CLIIntegrationTests/DaemonTestLock.swift for rationale.
+/// Locking mechanics live in `TestFileLock` (TestSupport).
 enum DaemonTestLock {
     @TaskLocal static var socketDir: String?
 
-    /// The daemon socket directory the test harness uses, resolved per run.
-    ///
-    /// Resolution chain (#283): explicit `PREVIEWSMCP_SOCKET_DIR` → a short dir
-    /// keyed by `$TEST_TMPDIR` → the system temp dir. Bazel sets `TEST_TMPDIR`
-    /// unique per test target and auto-cleans it, so keying the socket dir off
-    /// it gives per-target *and* per-run isolation with zero config: a stale
-    /// daemon left by a killed prior run can never own the next run's socket.
-    /// The harness exports this value as `PREVIEWSMCP_SOCKET_DIR` into every
-    /// spawned daemon so production `DaemonPaths` picks it up unchanged
-    /// (production must NOT itself honor `TEST_TMPDIR`).
-    ///
-    /// We do NOT nest the socket under `$TEST_TMPDIR` itself: Bazel's
-    /// `$TEST_TMPDIR` lives deep under the execroot (~140 chars) and a Unix
-    /// domain socket path is capped at 104 bytes (`sun_path`) on macOS, so
-    /// `bind()` would silently fail. Instead we derive a short, stable
-    /// `/tmp/pmcp-<hash>` dir from the `$TEST_TMPDIR` string — unique per
-    /// target, stable within a run, and comfortably under the limit.
     static var effectiveSocketDir: String {
-        let env = ProcessInfo.processInfo.environment
-        if let override = env["PREVIEWSMCP_SOCKET_DIR"] {
-            return override
-        }
-        if let testTmp = env["TEST_TMPDIR"] {
-            return "/tmp/pmcp-\(shortHash(testTmp))"
-        }
-        return FileManager.default.temporaryDirectory.path
+        DaemonTestPaths.effectiveSocketDir
     }
 
-    /// Deterministic short hex hash (FNV-1a, 64-bit) of `input`, for building a
-    /// short unique socket dir name that stays under the `sun_path` limit.
-    private static func shortHash(_ input: String) -> String {
-        var hash: UInt64 = 0xCBF2_9CE4_8422_2325
-        for byte in input.utf8 {
-            hash ^= UInt64(byte)
-            hash = hash &* 0x0000_0100_0000_01B3
-        }
-        return String(hash, radix: 16)
-    }
-
-    private static var lockPath: String {
-        (effectiveSocketDir as NSString).appendingPathComponent("previewsmcp-daemon-test.lock")
-    }
-
-    /// A held exclusive lock. Call `release()` to let the next waiter proceed;
-    /// pair it with `defer` at the acquisition site.
-    final class Guard: Sendable {
-        private let fd: Int32
-        fileprivate init(fd: Int32) {
-            self.fd = fd
-        }
-
-        func release() {
-            _ = flock(fd, LOCK_UN)
-            close(fd)
-        }
-    }
+    typealias Guard = TestFileLock.Guard
 
     /// Block until the cross-suite lock is held, then return a `Guard` the
     /// caller releases (via `defer`) when its critical section ends.
     static func acquire() async throws -> Guard {
-        let path = lockPath
-        let fd = try await withCheckedThrowingContinuation {
-            (cont: CheckedContinuation<Int32, Error>) in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let dir = (path as NSString).deletingLastPathComponent
-                try? FileManager.default.createDirectory(
-                    atPath: dir, withIntermediateDirectories: true
-                )
-                let fd = open(path, O_CREAT | O_RDWR, 0o644)
-                guard fd >= 0 else {
-                    cont.resume(
-                        throwing: NSError(
-                            domain: NSPOSIXErrorDomain, code: Int(errno),
-                            userInfo: [
-                                NSLocalizedDescriptionKey: "open(\(path)) failed",
-                            ]
-                        )
-                    )
-                    return
-                }
-                if flock(fd, LOCK_EX) != 0 {
-                    close(fd)
-                    cont.resume(
-                        throwing: NSError(
-                            domain: NSPOSIXErrorDomain, code: Int(errno),
-                            userInfo: [
-                                NSLocalizedDescriptionKey: "flock failed",
-                            ]
-                        )
-                    )
-                    return
-                }
-                cont.resume(returning: fd)
-            }
-        }
-        return Guard(fd: fd)
+        try await TestFileLock.acquire(DaemonTestPaths.daemonLockPath)
     }
 
     static func run<T: Sendable>(body: @Sendable () async throws -> T) async throws -> T {

--- a/previewsmcp/Tests/TestSupport/DaemonTestPaths.swift
+++ b/previewsmcp/Tests/TestSupport/DaemonTestPaths.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+public enum DaemonTestPaths {
+    /// The daemon socket directory the test harness uses, resolved per run.
+    ///
+    /// Resolution chain (#283): explicit `PREVIEWSMCP_SOCKET_DIR` → a short dir
+    /// keyed by `$TEST_TMPDIR` → the system temp dir. Bazel sets `TEST_TMPDIR`
+    /// unique per test target and auto-cleans it, so keying the socket dir off
+    /// it gives per-target *and* per-run isolation with zero config: a stale
+    /// daemon left by a killed prior run can never own the next run's socket.
+    /// The harness exports this value as `PREVIEWSMCP_SOCKET_DIR` into every
+    /// spawned daemon/CLI so production `DaemonPaths` picks it up unchanged
+    /// (production must NOT itself honor `TEST_TMPDIR`).
+    ///
+    /// We do NOT nest the socket under `$TEST_TMPDIR` itself: Bazel's
+    /// `$TEST_TMPDIR` lives deep under the execroot (~140 chars) and a Unix
+    /// domain socket path is capped at 104 bytes (`sun_path`) on macOS, so
+    /// `bind()` would silently fail. Instead we derive a short, stable
+    /// `/tmp/pmcp-<hash>` dir from the `$TEST_TMPDIR` string — unique per
+    /// target, stable within a run, and comfortably under the limit.
+    public static var effectiveSocketDir: String {
+        let env = ProcessInfo.processInfo.environment
+        if let override = env["PREVIEWSMCP_SOCKET_DIR"] {
+            return override
+        }
+        if let testTmp = env["TEST_TMPDIR"] {
+            return "/tmp/pmcp-\(shortHash(testTmp))"
+        }
+        return FileManager.default.temporaryDirectory.path
+    }
+
+    /// The per-run cross-suite daemon lock, shared by both integration
+    /// targets' `DaemonTestLock` facades — a single definition so the two
+    /// suites can never drift onto different lock files.
+    public static var daemonLockPath: String {
+        (effectiveSocketDir as NSString).appendingPathComponent("previewsmcp-daemon-test.lock")
+    }
+
+    /// Deterministic short hex hash (FNV-1a, 64-bit) of `input`, for building a
+    /// short unique socket dir name that stays under the `sun_path` limit.
+    private static func shortHash(_ input: String) -> String {
+        var hash: UInt64 = 0xCBF2_9CE4_8422_2325
+        for byte in input.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* 0x0000_0100_0000_01B3
+        }
+        return String(hash, radix: 16)
+    }
+}

--- a/previewsmcp/Tests/TestSupport/SimulatorTestLock.swift
+++ b/previewsmcp/Tests/TestSupport/SimulatorTestLock.swift
@@ -8,77 +8,24 @@ import Foundation
 /// suites concurrently share the host's single CoreSimulator service and
 /// degrade it for both. This lock closes that gap: a blocking flock on a
 /// fixed per-user path, so any workspace's sim-booting tests queue behind
-/// each other machine-wide.
+/// each other machine-wide. `tools/simlock` locks the same path for
+/// examples/ integration runs and ad-hoc shell workloads (#345); the two
+/// path literals must stay in lockstep (guarded by `LockPathParityTests`).
 ///
 /// Ordering: acquire this lock BEFORE `DaemonTestLock`. Sim-booting daemon
 /// tests hold both; daemon-only tests hold only `DaemonTestLock`, so no
 /// cycle is possible. Waiting for the lock counts against a test's
 /// `.timeLimit`, which is the intent — queueing behind another workspace's
 /// sim work is strictly better than racing it.
-///
-/// Uses a blocking flock on a detached thread (same rationale as
-/// `DaemonTestLock`): non-blocking polling from Swift concurrency starves
-/// small cooperative pools.
 public enum SimulatorTestLock {
-    private static let lockPath =
+    public static let lockPath =
         (NSHomeDirectory() as NSString).appendingPathComponent(".previewsmcp/sim.lock")
 
-    /// A held exclusive lock. Call `release()` to let the next waiter proceed;
-    /// pair it with `defer` at the acquisition site.
-    public final class Guard: Sendable {
-        private let fd: Int32
-        fileprivate init(fd: Int32) {
-            self.fd = fd
-        }
-
-        public func release() {
-            _ = flock(fd, LOCK_UN)
-            close(fd)
-        }
-    }
+    public typealias Guard = TestFileLock.Guard
 
     /// Block until the host-wide simulator lock is held, then return a `Guard`
     /// the caller releases (via `defer`) when its critical section ends.
-    ///
-    /// `O_CLOEXEC` is load-bearing: tests spawn children (daemons, `simctl`,
-    /// sim executables) while holding the lock, and an inherited dup of the
-    /// fd would keep the kernel flock held after this process exits — see
-    /// `DaemonRestart.acquireRestartLock` and issue #142.
     public static func acquire() async throws -> Guard {
-        let path = lockPath
-        let fd = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Int32, Error>) in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let dir = (path as NSString).deletingLastPathComponent
-                try? FileManager.default.createDirectory(
-                    atPath: dir, withIntermediateDirectories: true
-                )
-                let fd = open(path, O_CREAT | O_RDWR | O_CLOEXEC, 0o644)
-                guard fd >= 0 else {
-                    cont.resume(
-                        throwing: NSError(
-                            domain: NSPOSIXErrorDomain, code: Int(errno),
-                            userInfo: [
-                                NSLocalizedDescriptionKey: "open(\(path)) failed",
-                            ]
-                        )
-                    )
-                    return
-                }
-                if flock(fd, LOCK_EX) != 0 {
-                    close(fd)
-                    cont.resume(
-                        throwing: NSError(
-                            domain: NSPOSIXErrorDomain, code: Int(errno),
-                            userInfo: [
-                                NSLocalizedDescriptionKey: "flock failed",
-                            ]
-                        )
-                    )
-                    return
-                }
-                cont.resume(returning: fd)
-            }
-        }
-        return Guard(fd: fd)
+        try await TestFileLock.acquire(lockPath)
     }
 }

--- a/previewsmcp/Tests/TestSupport/TestFileLock.swift
+++ b/previewsmcp/Tests/TestSupport/TestFileLock.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Blocking-flock primitive behind the test-side locks (`SimulatorTestLock`
+/// and both suites' `DaemonTestLock`).
+///
+/// Acquisition runs on a detached thread: a blocking flock on Swift
+/// concurrency's cooperative pool starves small pools, and the earlier
+/// non-blocking poll approach deadlocked CI runners whose N-1 polling tasks
+/// consumed every thread.
+///
+/// `O_CLOEXEC` is load-bearing: tests spawn children (daemons, `simctl`,
+/// sim executables) while holding a lock, and an inherited dup of the fd
+/// would keep the kernel flock held after a test process dies without
+/// unlocking — see `DaemonRestart.acquireRestartLock` and issue #142.
+public enum TestFileLock {
+    /// A held exclusive lock. Call `release()` to let the next waiter proceed;
+    /// pair it with `defer` at the acquisition site.
+    public final class Guard: Sendable {
+        private let fd: Int32
+        fileprivate init(fd: Int32) {
+            self.fd = fd
+        }
+
+        public func release() {
+            _ = flock(fd, LOCK_UN)
+            close(fd)
+        }
+    }
+
+    /// Block until the exclusive lock on `path` is held, then return a
+    /// `Guard` the caller releases when its critical section ends.
+    public static func acquire(_ path: String) async throws -> Guard {
+        let fd = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Int32, Error>) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let dir = (path as NSString).deletingLastPathComponent
+                try? FileManager.default.createDirectory(
+                    atPath: dir, withIntermediateDirectories: true
+                )
+                let fd = open(path, O_CREAT | O_RDWR | O_CLOEXEC, 0o644)
+                guard fd >= 0 else {
+                    cont.resume(
+                        throwing: NSError(
+                            domain: NSPOSIXErrorDomain, code: Int(errno),
+                            userInfo: [
+                                NSLocalizedDescriptionKey: "open(\(path)) failed",
+                            ]
+                        )
+                    )
+                    return
+                }
+                if flock(fd, LOCK_EX) != 0 {
+                    close(fd)
+                    cont.resume(
+                        throwing: NSError(
+                            domain: NSPOSIXErrorDomain, code: Int(errno),
+                            userInfo: [
+                                NSLocalizedDescriptionKey: "flock failed",
+                            ]
+                        )
+                    )
+                    return
+                }
+                cont.resume(returning: fd)
+            }
+        }
+        return Guard(fd: fd)
+    }
+}

--- a/previewsmcp/Tests/TestSupportTests/BUILD.bazel
+++ b/previewsmcp/Tests/TestSupportTests/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_swift//swift:swift.bzl", "swift_test")
+
+swift_test(
+    name = "TestSupportTests",
+    srcs = glob(["*.swift"]),
+    copts = [
+        "-swift-version",
+        "6",
+    ],
+    data = ["//tools:simlock"],
+    visibility = ["//visibility:public"],
+    deps = ["//previewsmcp/Tests/TestSupport"],
+)

--- a/previewsmcp/Tests/TestSupportTests/LockPathParityTests.swift
+++ b/previewsmcp/Tests/TestSupportTests/LockPathParityTests.swift
@@ -1,0 +1,18 @@
+import Foundation
+import PreviewsTestSupport
+import Testing
+
+struct LockPathParityTests {
+    @Test func simlockScriptLocksTheSamePathAsSimulatorTestLock() throws {
+        let srcdir = try #require(ProcessInfo.processInfo.environment["TEST_SRCDIR"])
+        let script = try String(
+            contentsOfFile: "\(srcdir)/_main/tools/simlock", encoding: .utf8
+        )
+        let match = try #require(
+            script.firstMatch(of: /LOCK_PATH = os\.path\.expanduser\("~\/(.+)"\)/)
+        )
+        let scriptPath =
+            (NSHomeDirectory() as NSString).appendingPathComponent(String(match.1))
+        #expect(scriptPath == SimulatorTestLock.lockPath)
+    }
+}

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["simlock"])


### PR DESCRIPTION
Closes #348.

Folds the three test-side copies of the open+flock dance into one TestSupport primitive, and guards the one contract that can never be code-shared.

## What

- **`TestSupport/TestFileLock.swift`** — the blocking-flock primitive (detached thread against cooperative-pool starvation, `O_CLOEXEC` per #142, `Guard.release()`), line-for-line from the prior copies.
- **`TestSupport/DaemonTestPaths.swift`** — the byte-identical `effectiveSocketDir`/`shortHash` pair that was duplicated across both DaemonTestLocks (#283 resolution chain), plus `daemonLockPath` so the two integration suites can never drift onto different lock files.
- **Facades kept, ~35 call sites untouched**: CLI `DaemonTestLock` keeps serve.log truncation + per-test marker; MCP `DaemonTestLock` keeps `@TaskLocal socketDir` + `acquire()`/`run()`; `SimulatorTestLock` keeps the fixed host path.
- **`TestSupportTests/LockPathParityTests`** — new lightweight target asserting `SimulatorTestLock.lockPath` matches the literal in `tools/simlock` (read via runfiles data dep; `tools/BUILD.bazel` exports it). Falsified: mutating the Python literal makes it FAIL, reverting makes it PASS.
- **Production untouched**: `DaemonRestart.acquireRestartLock` deliberately stays (per #348 scope).

## Behavior deltas (intended)

- The two DaemonTestLock fds now carry `O_CLOEXEC` (previously absent — benign only while their lock paths are per-run; now aligned with the sim lock).
- CLI `DaemonTestLock.run` releases via `defer` instead of explicit unlock-after-Result (same semantics, matches the MCP copy).

## Verification

- Full bazel suite 10/10 on the final code (both integration suites re-ran on the consolidated locks; 6 re-executed, 4 cached).
- Parity guard falsification: literal mutated → FAILED, reverted → PASSED.
- Gates: /simplify (4 agents; applied the `daemonLockPath` hoist both reuse and simplification converged on; skipped typealias inline and facade-wrapper removal with reasons — call sites need them). /code-review high (workflow): 3 candidates, all refuted, zero findings. Lint green (one sortImports fix after the amend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)