### PR TITLE
#350: attribute appServerEndToEnd stream failures at every exit face

### DIFF
--- a/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
@@ -188,7 +188,7 @@ private func readStreamSample(port: Int, limit: Int) async throws -> Data {
     #expect(contentType.contains("multipart/x-mixed-replace"), "stream should be MJPEG multipart")
 
     let buffer = OSAllocatedUnfairLock(initialState: Data())
-    try await attributed("mjpeg-body") {
+    do {
         try await boundedRead(bytes, deadline: .seconds(10)) { byte in
             let count = buffer.withLock {
                 $0.append(byte)
@@ -196,6 +196,15 @@ private func readStreamSample(port: Int, limit: Int) async throws -> Data {
             }
             return count < limit
         }
+    } catch {
+        let consumed = buffer.withLock { $0.count }
+        print(
+            "APPSERVER-ATTR site=mjpeg-body consumed=\(consumed)"
+                + " wireBytes=\(bytes.task.countOfBytesReceived)"
+                + " taskError=\(bytes.task.error.map(errorChainDump) ?? "nil")"
+                + " thrown: \(errorChainDump(error))"
+        )
+        throw error
     }
     return buffer.withLock { $0 }
 }

--- a/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
@@ -188,23 +188,12 @@ private func readStreamSample(port: Int, limit: Int) async throws -> Data {
     #expect(contentType.contains("multipart/x-mixed-replace"), "stream should be MJPEG multipart")
 
     let buffer = OSAllocatedUnfairLock(initialState: Data())
-    do {
-        try await boundedRead(bytes, deadline: .seconds(10)) { byte in
-            let count = buffer.withLock {
-                $0.append(byte)
-                return $0.count
-            }
-            return count < limit
+    try await boundedRead("mjpeg-body", bytes, deadline: .seconds(10)) { byte in
+        let count = buffer.withLock {
+            $0.append(byte)
+            return $0.count
         }
-    } catch {
-        let consumed = buffer.withLock { $0.count }
-        print(
-            "APPSERVER-ATTR site=mjpeg-body consumed=\(consumed)"
-                + " wireBytes=\(bytes.task.countOfBytesReceived)"
-                + " taskError=\(bytes.task.error.map(errorChainDump) ?? "nil")"
-                + " thrown: \(errorChainDump(error))"
-        )
-        throw error
+        return count < limit
     }
     return buffer.withLock { $0 }
 }
@@ -236,28 +225,26 @@ private func readAVCCTags(
         var connected = false
     }
     let state = OSAllocatedUnfairLock(initialState: Parse())
-    try await attributed("avcc-body") {
-        try await boundedRead(bytes, deadline: timeout) { byte in
-            let fireConnect = state.withLock { parse -> Bool in
-                if parse.connected { return false }
-                parse.connected = true
-                return true
+    try await boundedRead("avcc-body", bytes, deadline: timeout) { byte in
+        let fireConnect = state.withLock { parse -> Bool in
+            if parse.connected { return false }
+            parse.connected = true
+            return true
+        }
+        if fireConnect {
+            await onConnected()
+        }
+        return state.withLock { parse in
+            parse.buffer.append(byte)
+            while parse.buffer.count - parse.offset >= 4 {
+                let length =
+                    Int(parse.buffer[parse.offset]) << 24 | Int(parse.buffer[parse.offset + 1]) << 16
+                        | Int(parse.buffer[parse.offset + 2]) << 8 | Int(parse.buffer[parse.offset + 3])
+                guard parse.buffer.count - parse.offset >= 4 + length else { break }
+                parse.seen.insert(parse.buffer[parse.offset + 4])
+                parse.offset += 4 + length
             }
-            if fireConnect {
-                await onConnected()
-            }
-            return state.withLock { parse in
-                parse.buffer.append(byte)
-                while parse.buffer.count - parse.offset >= 4 {
-                    let length =
-                        Int(parse.buffer[parse.offset]) << 24 | Int(parse.buffer[parse.offset + 1]) << 16
-                            | Int(parse.buffer[parse.offset + 2]) << 8 | Int(parse.buffer[parse.offset + 3])
-                    guard parse.buffer.count - parse.offset >= 4 + length else { break }
-                    parse.seen.insert(parse.buffer[parse.offset + 4])
-                    parse.offset += 4 + length
-                }
-                return !need.isSubset(of: parse.seen)
-            }
+            return !need.isSubset(of: parse.seen)
         }
     }
     return state.withLock { $0.seen }
@@ -283,7 +270,14 @@ private func readAVCCTags(
 /// suspended task and its dead connection for the remaining test-process
 /// lifetime, which is bounded and harmless. The caller's assertions on
 /// whatever partial data arrived produce the attributable failure.
+///
+/// Every abnormal exit (deadline in any of its three faces, or a genuine
+/// stream error) prints an `APPSERVER-ATTR site=… exit=…` line with the
+/// task's wire-level byte count and task error, so a #350 specimen is
+/// attributed no matter which face it wears; the healthy limit-met exit
+/// stays quiet.
 private func boundedRead(
+    _ site: String,
     _ bytes: URLSession.AsyncBytes,
     deadline: Duration,
     consume: @escaping @Sendable (UInt8) async -> Bool
@@ -293,13 +287,17 @@ private func boundedRead(
             guard await consume(byte) else { break }
         }
     }
-    let resumed = OSAllocatedUnfairLock(initialState: false)
-    func claimResume() -> Bool {
-        resumed.withLock { done in
-            if done { return false }
-            done = true
+    let resolvedBy = OSAllocatedUnfairLock<String?>(initialState: nil)
+    func claimResume(_ who: String) -> Bool {
+        resolvedBy.withLock { claimed in
+            if claimed != nil { return false }
+            claimed = who
             return true
         }
+    }
+    func taskDump() -> String {
+        "wireBytes=\(bytes.task.countOfBytesReceived)"
+            + " taskError=\(bytes.task.error.map(errorChainDump) ?? "nil")"
     }
     do {
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
@@ -311,19 +309,30 @@ private func boundedRead(
                 } catch {
                     result = .failure(error)
                 }
-                if claimResume() { cont.resume(with: result) }
+                if claimResume("reader") { cont.resume(with: result) }
             }
             Task {
                 try? await Task.sleep(for: deadline)
                 bytes.task.cancel()
                 reader.cancel()
                 try? await Task.sleep(for: .seconds(2))
-                if claimResume() { cont.resume(returning: ()) }
+                if claimResume("deadline") { cont.resume(returning: ()) }
             }
+        }
+        if resolvedBy.withLock({ $0 }) == "deadline" {
+            print("APPSERVER-ATTR site=\(site) exit=deadline-abandoned \(taskDump())")
         }
     } catch is CancellationError {
         // Deadline: the caller inspects what arrived.
+        print("APPSERVER-ATTR site=\(site) exit=deadline-cancellation \(taskDump())")
     } catch let error as URLError where error.code == .cancelled {
         // Same, surfaced through URLSession instead.
+        print("APPSERVER-ATTR site=\(site) exit=deadline-urlcancelled \(taskDump())")
+    } catch {
+        print(
+            "APPSERVER-ATTR site=\(site) exit=threw \(taskDump())"
+                + " thrown: \(errorChainDump(error))"
+        )
+        throw error
     }
 }

--- a/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
@@ -79,7 +79,9 @@ struct IOSAppServerTests {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = Data(#"{"action":"drag","fromX":0.5,"fromY":0.7,"toX":0.5,"toY":0.3,"steps":12}"#.utf8)
-        let (_, response) = try await URLSession.shared.data(for: request)
+        let (_, response) = try await attributed("control-post") {
+            try await URLSession.shared.data(for: request)
+        }
         #expect((response as? HTTPURLResponse)?.statusCode == 200, "control POST should return 200")
         _ = try await server.awaitSnapshotChange(
             sessionID: sessionID, baseline: beforeDrag, timeout: .seconds(10)
@@ -102,7 +104,9 @@ struct IOSAppServerTests {
             drag.httpBody = Data(
                 #"{"action":"drag","fromX":0.5,"fromY":0.3,"toX":0.5,"toY":0.7,"steps":12}"#.utf8
             )
-            _ = try? await URLSession.shared.data(for: drag)
+            _ = try? await attributed("avcc-keyframe-drag") {
+                try await URLSession.shared.data(for: drag)
+            }
         }
         #expect(tags.contains(0x01), "avcc stream should carry an avcC description")
         #expect(tags.contains(0x02), "avcc stream should carry an H.264 keyframe")
@@ -119,6 +123,44 @@ struct IOSAppServerTests {
             name: "preview_stop", arguments: ["sessionID": .string(sessionID)]
         )
     }
+}
+
+/// Attribution for the #350 residual: `NSURLErrorDomain Code=-1 "(null)"` is
+/// opaque at the top level, and the daemon side already logs healthy (#334),
+/// so the failing layer must be pinned from the client. On error this prints
+/// which await site threw plus the full `NSUnderlyingError`/CFStream cascade
+/// (`_kCFStreamErrorDomainKey`/`CodeKey` carry the POSIX-level cause, e.g.
+/// ECONNRESET vs ECONNREFUSED), then rethrows unchanged.
+private func attributed<T>(
+    _ site: String, _ body: () async throws -> T
+) async rethrows -> T {
+    do {
+        return try await body()
+    } catch {
+        print("APPSERVER-ATTR site=\(site) \(errorChainDump(error))")
+        throw error
+    }
+}
+
+private func errorChainDump(_ error: Error) -> String {
+    var lines = [String]()
+    var current: NSError? = error as NSError
+    var depth = 0
+    while let nsError = current, depth < 6 {
+        var line = "[\(depth)] domain=\(nsError.domain) code=\(nsError.code)"
+        for key in ["_kCFStreamErrorDomainKey", "_kCFStreamErrorCodeKey"] {
+            if let value = nsError.userInfo[key] {
+                line += " \(key)=\(value)"
+            }
+        }
+        if let url = nsError.userInfo[NSURLErrorFailingURLStringErrorKey] {
+            line += " url=\(url)"
+        }
+        lines.append(line)
+        current = nsError.userInfo[NSUnderlyingErrorKey] as? NSError
+        depth += 1
+    }
+    return lines.joined(separator: " | ")
 }
 
 /// Read a bounded sample of an MJPEG stream, asserting the multipart content
@@ -139,17 +181,21 @@ private func readStreamSample(port: Int, limit: Int) async throws -> Data {
     defer { session.invalidateAndCancel() }
     var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/stream.mjpeg")!)
     request.timeoutInterval = 15
-    let (bytes, response) = try await session.bytes(for: request)
+    let (bytes, response) = try await attributed("mjpeg-connect") {
+        try await session.bytes(for: request)
+    }
     let contentType = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Type") ?? ""
     #expect(contentType.contains("multipart/x-mixed-replace"), "stream should be MJPEG multipart")
 
     let buffer = OSAllocatedUnfairLock(initialState: Data())
-    try await boundedRead(bytes, deadline: .seconds(10)) { byte in
-        let count = buffer.withLock {
-            $0.append(byte)
-            return $0.count
+    try await attributed("mjpeg-body") {
+        try await boundedRead(bytes, deadline: .seconds(10)) { byte in
+            let count = buffer.withLock {
+                $0.append(byte)
+                return $0.count
+            }
+            return count < limit
         }
-        return count < limit
     }
     return buffer.withLock { $0 }
 }
@@ -168,7 +214,9 @@ private func readAVCCTags(
     defer { session.invalidateAndCancel() }
     var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/stream.avcc")!)
     request.timeoutInterval = 25
-    let (bytes, response) = try await session.bytes(for: request)
+    let (bytes, response) = try await attributed("avcc-connect") {
+        try await session.bytes(for: request)
+    }
     let contentType = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Type") ?? ""
     #expect(contentType.contains("application/octet-stream"), "avcc stream should be octet-stream")
 
@@ -179,26 +227,28 @@ private func readAVCCTags(
         var connected = false
     }
     let state = OSAllocatedUnfairLock(initialState: Parse())
-    try await boundedRead(bytes, deadline: timeout) { byte in
-        let fireConnect = state.withLock { parse -> Bool in
-            if parse.connected { return false }
-            parse.connected = true
-            return true
-        }
-        if fireConnect {
-            await onConnected()
-        }
-        return state.withLock { parse in
-            parse.buffer.append(byte)
-            while parse.buffer.count - parse.offset >= 4 {
-                let length =
-                    Int(parse.buffer[parse.offset]) << 24 | Int(parse.buffer[parse.offset + 1]) << 16
-                        | Int(parse.buffer[parse.offset + 2]) << 8 | Int(parse.buffer[parse.offset + 3])
-                guard parse.buffer.count - parse.offset >= 4 + length else { break }
-                parse.seen.insert(parse.buffer[parse.offset + 4])
-                parse.offset += 4 + length
+    try await attributed("avcc-body") {
+        try await boundedRead(bytes, deadline: timeout) { byte in
+            let fireConnect = state.withLock { parse -> Bool in
+                if parse.connected { return false }
+                parse.connected = true
+                return true
             }
-            return !need.isSubset(of: parse.seen)
+            if fireConnect {
+                await onConnected()
+            }
+            return state.withLock { parse in
+                parse.buffer.append(byte)
+                while parse.buffer.count - parse.offset >= 4 {
+                    let length =
+                        Int(parse.buffer[parse.offset]) << 24 | Int(parse.buffer[parse.offset + 1]) << 16
+                            | Int(parse.buffer[parse.offset + 2]) << 8 | Int(parse.buffer[parse.offset + 3])
+                    guard parse.buffer.count - parse.offset >= 4 + length else { break }
+                    parse.seen.insert(parse.buffer[parse.offset + 4])
+                    parse.offset += 4 + length
+                }
+                return !need.isSubset(of: parse.seen)
+            }
         }
     }
     return state.withLock { $0.seen }


### PR DESCRIPTION
Instrumentation for #350 (does NOT close it — the issue stays open to collect specimens).

## What

Test-only changes in `IOSAppServerTests.swift`:

- `attributed(site:)` — print-and-rethrow wrapper on the 4 connect/POST await sites (`control-post`, `mjpeg-connect`, `avcc-connect`, `avcc-keyframe-drag`), printing the full `NSUnderlyingError`/CFStream error cascade that the top-level `-1 "(null)"` hides.
- `boundedRead` gains a site label and self-attributes **every abnormal exit** — the genuine throw, both cancellation faces, and the deadline-abandoned normal return (detected by labeling which task claimed the resume) — with wire-level `countOfBytesReceived` and the task-level error. The healthy limit-met exit stays quiet. This closes the gap the /simplify altitude reviewer caught: the silent-hang face previously produced no attribution at all.

## What the instrumentation already established (documented on #350)

The first isolated run caught a live specimen: throw site is the mjpeg body read ~50ms after connect, during first-frame delivery, with a completely bare error chain (no CFStream cause — not a wire-level reset). The full daemon timeline falsified an initial deadline-starvation hypothesis (corrected on the issue); an 8-run isolated campaign after that was 8/8 green (~1/9 baseline). This PR arms routine runs to self-attribute the next natural occurrence across all failure faces.

## Verification

- Filtered `appServerEndToEnd` run green with the final code (20.7s), quiet on the healthy path; the earlier live specimen plus a forced error exercised the print path.
- Full bazel suite 10/10; lint green.
- Gates: /simplify (3 agents, 4 angles — boundary-attribution finding applied, print-scaffolding consolidation subsumed by it); /code-review high (workflow): 2 candidates, both refuted, zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)