### PR TITLE
Fix #352: shell-first launch with activate_suspended agent — no breadcrumb, no flash

### DIFF
--- a/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
+++ b/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
@@ -248,8 +248,22 @@ public actor IOSPreviewSession {
                     udid: deviceUDID, bundleID: Self.agentBundleID
                 )
 
-                stage("attempt \(attempt): launching agent app")
-                launchedPid = try await simulatorManager.launchApp(
+                // Shell first, agent second (#352). The shell's foreground
+                // transition then originates from SpringBoard, not from the
+                // agent, so the status bar never shows a "< Agent" back-
+                // breadcrumb. The shell retries the agent-UDS connect until
+                // the agent binds it, so launching it before the agent is
+                // safe. The agent launches with activate_suspended and never
+                // takes the foreground at all — which also removes the
+                // transient agent-active flash on every launch.
+                stage("attempt \(attempt): launching shell app")
+                _ = try await simulatorManager.launchApp(
+                    udid: deviceUDID,
+                    bundleID: Self.shellBundleID,
+                    arguments: ["--agent-sock", agentSockPath]
+                )
+                stage("attempt \(attempt): launching agent app (background)")
+                launchedPid = try await simulatorManager.launchAppInBackground(
                     udid: deviceUDID,
                     bundleID: Self.agentBundleID,
                     arguments: launchArgs
@@ -275,21 +289,13 @@ public actor IOSPreviewSession {
 
         // 6. Accept connection from agent app (up to 10 seconds). This also
         // confirms the agent's didFinishLaunchingWithOptions has run, so its
-        // handshake socket is bound before the shell connects to it below.
+        // handshake socket is bound; the already-running shell's UDS retry
+        // loop connects to it, reads the agent's audit token, and routes the
+        // cross-process hosted scene back to the agent. The shell is
+        // long-lived and survives agent respawns (no relaunch flash).
         stage("launched pid=\(pid); awaiting socket connection")
         await progress?.report(.connectingToApp, message: "Waiting for agent app connection...")
         try await channel.awaitConnect(timeout: .seconds(10))
-
-        // 6b. Launch the foreground shell that hosts the agent's scene. The
-        // shell reads the agent's audit token off the now-bound handshake socket
-        // and routes a cross-process scene back to the agent. The shell is
-        // long-lived and survives agent respawns (no relaunch flash).
-        stage("launching shell app")
-        _ = try await simulatorManager.launchApp(
-            udid: deviceUDID,
-            bundleID: Self.shellBundleID,
-            arguments: ["--agent-sock", agentSockPath]
-        )
 
         // 8. Accept the executor's EPC connection and stand up the remote session
         // over it. The host connects --port and --jit-port independently, so this
@@ -623,7 +629,10 @@ public actor IOSPreviewSession {
         let port = try await channel.bindAndListen()
         let jitPort = try bindJITListener()
 
-        let pid = try await simulatorManager.launchApp(
+        // Background launch (#352): the long-lived shell stays foreground and
+        // the new agent never takes the screen, so the respawn is invisible
+        // (no transient agent-active flash, no "< Agent" breadcrumb).
+        let pid = try await simulatorManager.launchAppInBackground(
             udid: deviceUDID,
             bundleID: Self.agentBundleID,
             arguments: Self.agentLaunchArgs(port: port, jitPort: jitPort, agentSockPath: agentSockPath)

--- a/previewsmcp/PreviewsIOS/SimulatorManager.swift
+++ b/previewsmcp/PreviewsIOS/SimulatorManager.swift
@@ -256,6 +256,73 @@ public actor SimulatorManager: SimulatorLister {
         }
     }
 
+    /// Run a blocking SB private-API call on a GCD thread, racing a
+    /// wall-clock deadline. Exactly one resume wins. If the deadline does,
+    /// the blocked thread is abandoned (the call cannot be cancelled — it
+    /// eventually unblocks or leaks with the process) and `onTimeout` is
+    /// returned.
+    private static func runBlockingWithDeadline<T: Sendable>(
+        timeout: TimeInterval,
+        onTimeout: T,
+        _ body: @escaping @Sendable () -> T
+    ) async -> T {
+        await withCheckedContinuation { (cont: CheckedContinuation<T, Never>) in
+            let resumed = OSAllocatedUnfairLock(initialState: false)
+            let queue = DispatchQueue.global(qos: .userInitiated)
+            let finish: @Sendable (T) -> Void = { value in
+                let first = resumed.withLock { done -> Bool in
+                    guard !done else { return false }
+                    done = true
+                    return true
+                }
+                if first { cont.resume(returning: value) }
+            }
+            queue.async { finish(body()) }
+            queue.asyncAfter(deadline: .now() + timeout) { finish(onTimeout) }
+        }
+    }
+
+    /// Launch an app WITHOUT activating it, via CoreSimulator's
+    /// `activate_suspended` launch option: the process runs its launch
+    /// sequence but FrontBoard never brings it to the foreground (#352).
+    ///
+    /// `simctl launch` has no equivalent flag, so this one launch path uses
+    /// the SBDevice private API that `launchApp` retired on PR #141 (it can
+    /// hang unboundably on an intermediate-booted device). The call runs
+    /// under `runBlockingWithDeadline` with a 60s bound: on timeout this
+    /// throws and callers recover the device through their reboot-retry
+    /// loop, same as a hung `simctl launch`.
+    public func launchAppInBackground(
+        udid: String, bundleID: String, arguments: [String]
+    ) async throws -> Int {
+        try ensureLoaded()
+        let sbDevice = try findSBDevice(udid: udid)
+        let result: Result<Int, SimulatorError> = await Self.runBlockingWithDeadline(
+            timeout: 60,
+            onTimeout: .failure(
+                .launchFailed("background launch of \(bundleID) hung (exceeded 60s)")
+            )
+        ) {
+            var error: NSError?
+            let pid = sbDevice.launchApp(
+                withBundleID: bundleID,
+                arguments: arguments,
+                environment: nil,
+                suspended: true,
+                error: &error
+            )
+            guard pid > 0 else {
+                return .failure(
+                    .launchFailed(
+                        error?.localizedDescription ?? "background launch failed for \(bundleID)"
+                    )
+                )
+            }
+            return .success(pid)
+        }
+        return try result.get()
+    }
+
     /// Best-effort terminate of `bundleID` on `udid` via `simctl terminate`.
     ///
     /// Defensive cleanup before re-launching the host: a prior test or
@@ -450,12 +517,9 @@ public actor SimulatorManager: SimulatorLister {
     /// `SBCaptureFramebuffer` is a synchronous private-API C function that
     /// on PR #141 CI has been observed to block indefinitely inside the
     /// kernel when the simulator's display subsystem is in a bad state.
-    /// Swift `Task` cancellation can't preempt a synchronous C call, so
-    /// we dispatch the call onto a background thread and race it against
-    /// a semaphore-based deadline. If the deadline wins, we abandon the
-    /// blocked thread (it will eventually unblock or leak with the
-    /// process) and report `.timedOut` so the caller can retry or fall
-    /// back to the simctl path.
+    /// Swift `Task` cancellation can't preempt a synchronous C call, so it
+    /// runs under `runBlockingWithDeadline`; a deadline win reports
+    /// `.timedOut` so the caller can retry or fall back to the simctl path.
     private enum FramebufferCaptureResult {
         case success(Data)
         case failure(NSError?)
@@ -467,35 +531,12 @@ public actor SimulatorManager: SimulatorLister {
         jpegQuality: Double,
         timeout: TimeInterval
     ) async -> FramebufferCaptureResult {
-        await withCheckedContinuation { (cont: CheckedContinuation<FramebufferCaptureResult, Never>) in
-            let resumed = OSAllocatedUnfairLock<Bool>(initialState: false)
-            let queue = DispatchQueue.global(qos: .userInitiated)
-
-            queue.async {
-                var err: NSError?
-                let data = SBCaptureFramebuffer(sbDevice, jpegQuality, &err)
-                let didResume = resumed.withLock { done -> Bool in
-                    guard !done else { return false }
-                    done = true
-                    return true
-                }
-                guard didResume else { return }
-                if let data {
-                    cont.resume(returning: .success(data as Data))
-                } else {
-                    cont.resume(returning: .failure(err))
-                }
+        await Self.runBlockingWithDeadline(timeout: timeout, onTimeout: .timedOut) {
+            var err: NSError?
+            guard let data = SBCaptureFramebuffer(sbDevice, jpegQuality, &err) else {
+                return .failure(err)
             }
-
-            queue.asyncAfter(deadline: .now() + timeout) {
-                let didResume = resumed.withLock { done -> Bool in
-                    guard !done else { return false }
-                    done = true
-                    return true
-                }
-                guard didResume else { return }
-                cont.resume(returning: .timedOut)
-            }
+            return .success(data as Data)
         }
     }
 

--- a/previewsmcp/SimulatorBridge/SimulatorBridge.m
+++ b/previewsmcp/SimulatorBridge/SimulatorBridge.m
@@ -280,6 +280,7 @@ static Class _loadSimulatorKitHIDClass(NSError **error) {
 - (NSInteger)launchAppWithBundleID:(NSString *)bundleID
                          arguments:(NSArray<NSString *> *)args
                        environment:(NSDictionary<NSString *, NSString *> *)env
+                         suspended:(BOOL)suspended
                              error:(NSError **)error {
   @try {
     NSMutableDictionary *options = [NSMutableDictionary dictionary];
@@ -287,6 +288,8 @@ static Class _loadSimulatorKitHIDClass(NSError **error) {
       options[@"arguments"] = args;
     if (env)
       options[@"environment"] = env;
+    if (suspended)
+      options[@"activate_suspended"] = @YES;
 
     int pid = [(id<_SimDevice>)_simDevice launchApplicationWithID:bundleID
                                                           options:options

--- a/previewsmcp/SimulatorBridge/include/SimulatorBridge.h
+++ b/previewsmcp/SimulatorBridge/include/SimulatorBridge.h
@@ -31,10 +31,14 @@ typedef NS_ENUM(NSInteger, SBDeviceState) {
                error:(NSError *_Nullable *_Nullable)error;
 
 /// Launch an app. Returns the PID on success, or -1 on failure.
+/// `suspended` maps to CoreSimulator's `activate_suspended` launch option:
+/// the app process launches and runs its launch sequence but is never
+/// activated (brought to the foreground) by FrontBoard.
 - (NSInteger)launchAppWithBundleID:(NSString *)bundleID
                          arguments:(nullable NSArray<NSString *> *)args
                        environment:
                            (nullable NSDictionary<NSString *, NSString *> *)env
+                         suspended:(BOOL)suspended
                              error:(NSError *_Nullable *_Nullable)error;
 
 /// Spawn a process inside the device's boot session ("in-session"), the way

--- a/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
@@ -248,9 +248,9 @@ struct IOSPreviewE2ETests {
     /// reports its `applicationState` over the JSON channel; `IOSPreviewSession`
     /// exposes the latest as `agentApplicationState`. After `start()` the daemon
     /// must observe a valid breadcrumb, proving the flash detector is wired end
-    /// to end. The exact state is environment-dependent (a headless simctl launch
-    /// reports `background`, not `active`); later shell-hosted stages assert the
-    /// agent stays non-`active` across respawn, where the value is meaningful.
+    /// to end. Since #352 the agent launches with `activate_suspended` and must
+    /// never be `active` — the shell owns the foreground from the first frame,
+    /// so no launch flash and no "< Agent" status-bar breadcrumb.
     @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
     func agentReportsForegroundLifecycleState() async throws {
         let simLock = try await SimulatorTestLock.acquire()
@@ -292,7 +292,7 @@ struct IOSPreviewE2ETests {
             if state != nil { break }
             try await Task.sleep(for: .milliseconds(200))
         }
-        #expect(["active", "inactive", "background"].contains(state))
+        #expect(["inactive", "background"].contains(state))
         await session.stop()
     }
 

--- a/previewsmcp/Tests/TestSupport/SimulatorTestDevices.swift
+++ b/previewsmcp/Tests/TestSupport/SimulatorTestDevices.swift
@@ -84,11 +84,8 @@ public enum SimulatorTestDevices {
     /// by simctl's implicit default; creation walks the list so a runtime
     /// that rejects the pinned device type falls back to the next.
     private static func supportedRuntimes() async throws -> [String] {
-        let output = try await simctl(["list", "runtimes", "--json"])
-        guard output.exitCode == 0,
-              let data = output.stdout.data(using: .utf8),
-              let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let runtimes = json["runtimes"] as? [[String: Any]]
+        guard let runtimes = try await simctlJSON(["list", "runtimes"])?["runtimes"]
+            as? [[String: Any]]
         else { return [] }
 
         return
@@ -119,11 +116,8 @@ public enum SimulatorTestDevices {
     /// itself failed — distinct from "no such device", so a listing hiccup
     /// never triggers a duplicate create.
     private static func list(name: String) async throws -> [Device]? {
-        let output = try await simctl(["list", "devices", "--json"])
-        guard output.exitCode == 0,
-              let data = output.stdout.data(using: .utf8),
-              let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let devicesByRuntime = json["devices"] as? [String: [[String: Any]]]
+        guard let devicesByRuntime = try await simctlJSON(["list", "devices"])?["devices"]
+            as? [String: [[String: Any]]]
         else { return nil }
 
         var devices: [Device] = []
@@ -141,6 +135,16 @@ public enum SimulatorTestDevices {
             }
         }
         return devices.sorted { $0.udid < $1.udid }
+    }
+
+    /// Run a `--json` simctl listing and decode its top-level dictionary,
+    /// or nil when the invocation or decode failed.
+    private static func simctlJSON(_ arguments: [String]) async throws -> [String: Any]? {
+        let output = try await simctl(arguments + ["--json"])
+        guard output.exitCode == 0,
+              let data = output.stdout.data(using: .utf8)
+        else { return nil }
+        return try JSONSerialization.jsonObject(with: data) as? [String: Any]
     }
 
     /// A 60s timeout bounds a truly hung simctl (observed on PR #141 CI);

--- a/previewsmcp/Tests/TestSupportTests/SimulatorTestDevicesTests.swift
+++ b/previewsmcp/Tests/TestSupportTests/SimulatorTestDevicesTests.swift
@@ -32,9 +32,9 @@ struct SimulatorTestDevicesTests {
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         let devicesByRuntime = json?["devices"] as? [String: [[String: Any]]] ?? [:]
         let entries = devicesByRuntime.values.joined()
-            .filter { $0["udid"] as? String == first }
+            .filter { $0["name"] as? String == SimulatorTestDevices.name(index: 5) }
         #expect(entries.count == 1)
-        #expect(entries.first?["name"] as? String == SimulatorTestDevices.name(index: 5))
+        #expect(entries.first?["udid"] as? String == first)
         #expect(
             entries.first?["deviceTypeIdentifier"] as? String == SimulatorTestDevices.deviceType
         )


### PR DESCRIPTION
Fixes #352.

## What

- `IOSPreviewSession.start` now launches the **shell first** — its foreground transition originates from SpringBoard, so the status bar never shows the "< Agent" back-breadcrumb. The shell's existing UDS retry loop (indefinite, 100ms cadence) waits for the agent to bind the handshake socket, so the ordering is safe.
- The agent launches through a new SBDevice bridge path with CoreSimulator's `activate_suspended` launch option (found by RE of the CoreSimulator binary; it sits in the `arguments`/`environment`/`wait_for_debugger`/`standalone` option-key cluster). The agent runs its full launch sequence (sockets bind, JIT executor connects) but FrontBoard never activates it — on initial launch **and respawn**, which also removes the transient agent-active flash that `AgentForegroundRedirect` had to tolerate.
- `simctl launch` has no equivalent flag, so this single path returns to the private API `launchApp` retired on PR #141 — bounded by a new shared `runBlockingWithDeadline` helper (60s; orphaned thread on timeout; callers recover via the existing reboot-retry loop). `captureFramebufferWithTimeout` now uses the same helper instead of its own copy of the once-resume race.
- The stage-0 lifecycle e2e is tightened from "any valid state" to **never `active`** — the durable regression guard for the no-flash/no-breadcrumb property.
- Riders from review on the #337 harness: the idempotency test now filters by device *name* (the UDID filter was a tautology that couldn't catch duplicate-name regressions), and the two simctl `--json` parse blocks folded into one `simctlJSON` helper.

## Verification

- Full local suite 11/11 green on the new launch order (re-running on the final amended revision).
- Daemon log shows the new stage order: `launching shell app` → `launching agent app (background)` → connect in 135ms → render → `start complete` (~3s).
- `agentReportsForegroundLifecycleState` (tightened) green: the agent never reports `active`.
- `relaunchReRendersCurrentPreview` green: respawn path works with the background launch.
- Mid-session simulator screenshots show a clean status bar (no breadcrumb) with the preview rendering.

## Gates

- /simplify (2 agents): extracted `runBlockingWithDeadline` (was a third copy of the bounded-blocking race); affirmed the separate method over a `suspended:` param on `launchApp` (different risk profiles: bounded subprocess vs orphaning private API) and leaving `AgentForegroundRedirect` untouched (any `AgentApp.swift` edit forces an `IOSAgentBuilderHashTests` re-pin — fold the now-vestigial transient-active tolerance into the next agent edit that pays it).
- /code-review high (workflow): 6 findings → fixed pid-0-as-success guard, the UDID-filter test tautology, and the JSON-parse duplication. Skipped: hypothetical `activate_suspended` semantics change on future runtimes (empirically green on the pinned iOS 26 runtimes; fails loudly at `awaitConnect` if it ever changes — and the tightened e2e is the canary) and the suggestion to re-soften the lifecycle assertion (the narrowing IS the regression guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)