### PR TITLE
Probe-fd handoff: DaemonClient rides the probe connection instead of reconnecting

### DIFF
--- a/previewsmcp/PreviewsCLI/DaemonClient.swift
+++ b/previewsmcp/PreviewsCLI/DaemonClient.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MCP
 import PreviewsCore
+import System
 
 /// Client-side handle to the previewsmcp daemon.
 ///
@@ -54,14 +55,19 @@ enum DaemonClient {
         // (resolved authoritatively via `_NSGetExecutablePath`), so the
         // MCP `serverInfo.version` must equal our own compile-time
         // version — no handshake check needed on this branch.
-        let weJustSpawned = !DaemonProbe.canConnect()
+        //
+        // Either way the probe's connected socket is kept and handed to
+        // `openClient`, so the transport rides the probe connection
+        // instead of paying a second connect.
+        var probeSocket = DaemonProbe.connect()
+        let weJustSpawned = probeSocket == nil
         if weJustSpawned {
             let child = try spawnDaemon()
-            try await waitForSocket(timeout: startTimeout, child: child)
+            probeSocket = try await waitForSocket(timeout: startTimeout, child: child)
         }
 
         // If the daemon was already running but disappears between
-        // `canConnect()` and `openClient()`, a sibling CLI almost
+        // `DaemonProbe.connect()` and `openClient()`, a sibling CLI almost
         // certainly killed it for a version-mismatch respawn (issue
         // #142). The kill+respawn typically completes in <2s, so
         // wait for the socket to come back and retry the handshake
@@ -74,13 +80,13 @@ enum DaemonClient {
         let initResult: Initialize.Result
         do {
             (client, initResult) = try await openClient(
-                clientName: clientName, configure: configure
+                clientName: clientName, socket: probeSocket, configure: configure
             )
         } catch {
             guard !weJustSpawned else { throw error }
-            try await waitForSocket(timeout: startTimeout)
+            let socket = try await waitForSocket(timeout: startTimeout)
             (client, initResult) = try await openClient(
-                clientName: clientName, configure: configure
+                clientName: clientName, socket: socket, configure: configure
             )
         }
 
@@ -128,9 +134,12 @@ enum DaemonClient {
     /// daemon dead, a failed send) closes it after quiescence.
     static func openClient(
         clientName: String,
+        socket probeSocket: FileDescriptor? = nil,
         configure: ((any MCPClienting) async -> Void)?
     ) async throws -> (any MCPClienting, Initialize.Result) {
-        let socket = try DaemonSocket.connect(to: DaemonPaths.socket.path)
+        // A probe-handoff socket (already connected by `DaemonProbe.connect`
+        // or `waitForSocket`) is consumed here; otherwise connect fresh.
+        let socket = try probeSocket ?? DaemonSocket.connect(to: DaemonPaths.socket.path)
         let transport = FramedTransport(owningSocket: socket)
         let client = PreviewsMCPClient(
             name: clientName, version: PreviewsMCPCommand.version,
@@ -261,17 +270,22 @@ enum DaemonClient {
         return proc
     }
 
-    /// Poll the socket until it accepts connections or we give up.
+    /// Poll the socket until it accepts connections or we give up. The
+    /// winning poll's connected socket is returned (the caller owns it and
+    /// hands it to `openClient`), so readiness detection doubles as the
+    /// transport's connect.
     ///
     /// When `child` is the daemon process we just spawned, a startup crash
     /// is surfaced immediately as `daemonStartupFailed(exitCode:)` instead
     /// of waiting out the full timeout. The socket check runs first each
     /// iteration so a child that exited only because a sibling won the bind
     /// race still reads as success. See issue #99.
-    static func waitForSocket(timeout: TimeInterval, child: Process? = nil) async throws {
+    static func waitForSocket(
+        timeout: TimeInterval, child: Process? = nil
+    ) async throws -> FileDescriptor {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
-            if DaemonProbe.canConnect() { return }
+            if let socket = DaemonProbe.connect() { return socket }
             if let child, !child.isRunning {
                 throw DaemonClientError.daemonStartupFailed(exitCode: child.terminationStatus)
             }

--- a/previewsmcp/PreviewsCLI/DaemonProbe.swift
+++ b/previewsmcp/PreviewsCLI/DaemonProbe.swift
@@ -1,3 +1,5 @@
+import System
+
 /// Liveness check for the daemon: can we connect to its socket?
 ///
 /// This is the canonical "is the daemon running?" test. The kernel atomically
@@ -10,14 +12,20 @@
 /// - `ServeCommand --daemon` before unlinking a stale socket, to avoid
 ///   clobbering a running daemon whose PID file was deleted.
 /// - `StatusCommand` for its liveness report.
-/// - `DaemonClient` as the auto-start trigger.
+/// - `DaemonClient` as the auto-start trigger — via `connect()`, which keeps
+///   the probe's socket so the MCP transport reuses it instead of paying a
+///   second connect.
 enum DaemonProbe {
     /// A UDS `connect()` resolves immediately — it either succeeds or fails
-    /// with ENOENT/ECONNREFUSED — so no timeout machinery is needed.
+    /// with ENOENT/ECONNREFUSED — so no timeout machinery is needed. The
+    /// caller owns the returned socket; hand it to
+    /// `FramedTransport(owningSocket:)` or close it.
+    static func connect() -> FileDescriptor? {
+        try? DaemonSocket.connect(to: DaemonPaths.socket.path)
+    }
+
     static func canConnect() -> Bool {
-        guard let socket = try? DaemonSocket.connect(to: DaemonPaths.socket.path) else {
-            return false
-        }
+        guard let socket = connect() else { return false }
         try? socket.close()
         return true
     }

--- a/previewsmcp/PreviewsCLI/DaemonRestart.swift
+++ b/previewsmcp/PreviewsCLI/DaemonRestart.swift
@@ -76,10 +76,10 @@ extension DaemonClient {
             "prev=\(staleVersion),now=\(currentVersion),"
                 + "by=pid\(ProcessInfo.processInfo.processIdentifier)"
         let child = try spawnDaemon(restartReason: reason)
-        try await waitForSocket(timeout: startTimeout, child: child)
+        let socket = try await waitForSocket(timeout: startTimeout, child: child)
 
         let (client, initResult) = try await openClient(
-            clientName: clientName, configure: configure
+            clientName: clientName, socket: socket, configure: configure
         )
         if !versionsMatch(currentVersion, initResult.serverInfo.version) {
             await client.disconnect()

--- a/previewsmcp/Tests/PreviewsCLITests/WaitForSocketTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/WaitForSocketTests.swift
@@ -9,8 +9,8 @@ import Testing
 /// for the real daemon so the test is deterministic and fast.
 @Suite(.serialized)
 struct WaitForSocketTests {
-    /// Point `DaemonPaths` at an empty directory so `canConnect()` is false
-    /// (no `serve.sock`), run `body`, then restore the prior override.
+    /// Point `DaemonPaths` at an empty directory so `DaemonProbe.connect()`
+    /// returns nil (no `serve.sock`), run `body`, then restore the prior override.
     private func withEmptySocketDir(_ body: () async throws -> Void) async throws {
         let key = "PREVIEWSMCP_SOCKET_DIR"
         let previous = ProcessInfo.processInfo.environment[key]


### PR DESCRIPTION
Queue item from the 2026-07-10 handoff (no standing issue).

## What

`DaemonClient.connect` probed daemon liveness with a throwaway connect+close (`DaemonProbe.canConnect`) and then connected a second time for the MCP transport; the post-spawn and restart paths paid the same double connect through `waitForSocket`'s polling. Now:

- `DaemonProbe.connect()` returns the connected `FileDescriptor` (with `canConnect()` kept as connect+close for `StatusCommand`/`ServeCommand`, which only want a boolean).
- `waitForSocket` returns its winning poll's socket.
- `openClient` accepts an optional pre-connected socket and hands it straight to `FramedTransport(owningSocket:)`, which owns and closes it on every path (handshake failure included), so there is no orphan-fd window.
- All three production paths (already-running, post-spawn, restart respawn) ride the probe connection; `DaemonRestart`'s deliberate under-lock re-probe still connects fresh.

## Gates

- /simplify (2 agents): clean; two stale `canConnect()` comment mentions fixed.
- /code-review high (workflow): zero findings survived verification.
- Verified: PreviewsCLITests (incl. `WaitForSocketTests` contract), CLIIntegrationTests (daemon spawn/connect/restart paths), lint clean, full local suite 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)