### PR TITLE
Fix #358: JITRenderWindow activates flag presents visible windows without stealing focus

### DIFF
--- a/previewsmcp/PreviewsCore/BridgeGenerator.swift
+++ b/previewsmcp/PreviewsCore/BridgeGenerator.swift
@@ -7,7 +7,9 @@ import Foundation
 /// resize survives leaf edits. Nil means no spec at all — a borderless off-screen default size.
 /// Whether a new visible window takes key status is not baked: the generated entry decides at
 /// render time from the sidecar's live key record, so a focus change during the compile never
-/// steals or drops focus (#254).
+/// steals or drops focus (#254). `activates: false` opts a visible window out of that decision
+/// entirely — it is presented with `orderFrontRegardless()` and never takes key or activates
+/// the app, for callers that need a real on-screen window without stealing focus (#358).
 public struct JITRenderWindow: Sendable {
     public let x: Double
     public let y: Double
@@ -15,9 +17,11 @@ public struct JITRenderWindow: Sendable {
     public let height: Double
     public let title: String
     public let headless: Bool
+    public let activates: Bool
 
     public init(
-        x: Double, y: Double, width: Double, height: Double, title: String, headless: Bool = false
+        x: Double, y: Double, width: Double, height: Double, title: String,
+        headless: Bool = false, activates: Bool = true
     ) {
         self.x = x
         self.y = y
@@ -25,6 +29,7 @@ public struct JITRenderWindow: Sendable {
         self.height = height
         self.title = title
         self.headless = headless
+        self.activates = activates
     }
 }
 
@@ -239,23 +244,31 @@ public enum BridgeGenerator {
             // generation (the daemon keeps the old agent alive on failure). It takes key
             // and activates only when the sidecar's live record says the outgoing window
             // was key at this instant — decided at render time, not compile time, so a
-            // focus change during the compile never steals or drops focus. The trailing
-            // flush pushes the first frame to the WindowServer before the entry returns,
-            // because that return is the daemon's kill-the-old-agent signal.
+            // focus change during the compile never steals or drops focus. A spec with
+            // `activates: false` skips that decision and never takes key or activates
+            // the app (#358). The trailing flush pushes the first frame to the
+            // WindowServer before the entry returns, because that return is the
+            // daemon's kill-the-old-agent signal.
             preRasterPresent = """
             if !isNewWindow {
                                 window.orderFrontRegardless()
                             }
             """
+            let firstPresent =
+                window.activates
+                    ? """
+                    \(frameSidecarPath.map(runtimeKeyDecisionCode) ?? "let __takeKey = true")
+                                    if __takeKey {
+                                        window.makeKeyAndOrderFront(nil)
+                                        NSApplication.shared.activate(ignoringOtherApps: true)
+                                    } else {
+                                        window.orderFrontRegardless()
+                                    }
+                    """
+                    : "window.orderFrontRegardless()"
             postRasterPresent = """
             if isNewWindow {
-                                \(frameSidecarPath.map(runtimeKeyDecisionCode) ?? "let __takeKey = true")
-                                if __takeKey {
-                                    window.makeKeyAndOrderFront(nil)
-                                    NSApplication.shared.activate(ignoringOtherApps: true)
-                                } else {
-                                    window.orderFrontRegardless()
-                                }
+                                \(firstPresent)
                                 \(frameSidecarPath != nil ? frameObserverCode() : "")
                                 \(frameSidecarPath != nil ? "__previewsmcpWriteWindowState(window)" : "")
                                 window.displayIfNeeded()

--- a/previewsmcp/PreviewsMacOS/HostApp.swift
+++ b/previewsmcp/PreviewsMacOS/HostApp.swift
@@ -206,7 +206,7 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         else { return }
         agentWindowSpecs[sessionID] = JITRenderWindow(
             x: frame.x, y: frame.y, width: frame.width, height: frame.height,
-            title: spec.title, headless: false
+            title: spec.title, headless: false, activates: spec.activates
         )
     }
 

--- a/previewsmcp/Tests/PreviewsCoreTests/BridgeGeneratorRenderSizeTests.swift
+++ b/previewsmcp/Tests/PreviewsCoreTests/BridgeGeneratorRenderSizeTests.swift
@@ -60,7 +60,10 @@ struct BridgeGeneratorRenderSizeTests {
             frameSidecarPath: "/tmp/frame.json"
         )
         #expect(generated.source.contains(".titled"))
-        #expect(generated.source.contains("orderFrontRegardless"))
+        // Two presents: the window-reuse path and the new-window path. One means the
+        // new-window branch lost its present call and a fresh window never shows.
+        let presents = generated.source.components(separatedBy: "orderFrontRegardless").count - 1
+        #expect(presents == 2)
         #expect(!generated.source.contains("makeKeyAndOrderFront"))
         #expect(!generated.source.contains("activate(ignoringOtherApps"))
         #expect(generated.source.contains("didMoveNotification"))

--- a/previewsmcp/Tests/PreviewsCoreTests/BridgeGeneratorRenderSizeTests.swift
+++ b/previewsmcp/Tests/PreviewsCoreTests/BridgeGeneratorRenderSizeTests.swift
@@ -47,4 +47,23 @@ struct BridgeGeneratorRenderSizeTests {
         #expect(generated.source.contains(".titled"))
         #expect(generated.source.contains("makeKeyAndOrderFront"))
     }
+
+    @Test("non-activating visible window presents titled without taking key or activating")
+    func nonActivatingVisiblePresentsWithoutFocus() {
+        let generated = BridgeGenerator.generateCombinedSource(
+            originalSource: Self.source,
+            closureBody: "TestView()",
+            renderOutputPath: "/tmp/out.png",
+            renderWindow: JITRenderWindow(
+                x: 0, y: 0, width: 800, height: 1000, title: "t", activates: false
+            ),
+            frameSidecarPath: "/tmp/frame.json"
+        )
+        #expect(generated.source.contains(".titled"))
+        #expect(generated.source.contains("orderFrontRegardless"))
+        #expect(!generated.source.contains("makeKeyAndOrderFront"))
+        #expect(!generated.source.contains("activate(ignoringOtherApps"))
+        #expect(generated.source.contains("didMoveNotification"))
+        #expect(generated.source.contains("__previewsmcpWriteWindowState"))
+    }
 }

--- a/previewsmcp/Tests/PreviewsJITLinkTests/CappedPersistentTests.swift
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/CappedPersistentTests.swift
@@ -212,6 +212,7 @@ struct CappedPersistentTests {
                     if window.styleMask.contains(.titled) { bits |= 8 }
                     if !NSApplication.shared.isActive { bits |= 16 }
                     if !window.isKeyWindow { bits |= 32 }
+                    if window.isVisible { bits |= 64 }
                     return bits
                 }
             }
@@ -219,15 +220,30 @@ struct CappedPersistentTests {
             moduleName: "WindowSpecProbeFixture"
         )
 
+        // A second-generation build from the activating template keeps that codegen
+        // runtime-executed: rendering it against the existing window takes the
+        // window-reuse path, so nothing activates and the focus assertions below
+        // still hold (#358).
+        let activatingBuild = try await session.compileObjectForJIT(
+            window: JITRenderWindow(
+                x: -9000, y: -9000, width: 320, height: 240,
+                title: "Preview: ColorView.swift"
+            )
+        )
+
         let agent = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
         try agent.addObject(path: build.objectPath.path)
         #expect(try agent.runOnMain(symbol: build.entrySymbol) == 0)
         try agent.newGeneration()
+        try agent.addObject(path: activatingBuild.objectPath.path)
+        #expect(try agent.runOnMain(symbol: activatingBuild.entrySymbol) == 0)
+        try agent.newGeneration()
         try agent.addObject(path: probe.path)
-        // Bits 16/32 pin `activates: false` (#358): the agent app must never have
-        // been activated and its window must never have taken key.
+        // Bits 16/32/64 pin `activates: false` (#358): the window must be presented,
+        // but the agent app must never have been activated and the window must
+        // never have taken key.
         let bits = try agent.runOnMain(symbol: "preview_window_spec_probe")
-        #expect(bits == 63, "bits=\(bits)")
+        #expect(bits == 127, "bits=\(bits)")
 
         // The visible path rasters before the window is first presented; the PNG must
         // still contain the rendered content, not an empty backing store.

--- a/previewsmcp/Tests/PreviewsJITLinkTests/CappedPersistentTests.swift
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/CappedPersistentTests.swift
@@ -185,7 +185,7 @@ struct CappedPersistentTests {
         let build = try await session.compileObjectForJIT(
             window: JITRenderWindow(
                 x: -9000, y: -9000, width: 320, height: 240,
-                title: "Preview: ColorView.swift"
+                title: "Preview: ColorView.swift", activates: false
             )
         )
 
@@ -210,6 +210,8 @@ struct CappedPersistentTests {
                         bits |= 4
                     }
                     if window.styleMask.contains(.titled) { bits |= 8 }
+                    if !NSApplication.shared.isActive { bits |= 16 }
+                    if !window.isKeyWindow { bits |= 32 }
                     return bits
                 }
             }
@@ -222,8 +224,10 @@ struct CappedPersistentTests {
         #expect(try agent.runOnMain(symbol: build.entrySymbol) == 0)
         try agent.newGeneration()
         try agent.addObject(path: probe.path)
+        // Bits 16/32 pin `activates: false` (#358): the agent app must never have
+        // been activated and its window must never have taken key.
         let bits = try agent.runOnMain(symbol: "preview_window_spec_probe")
-        #expect(bits == 15, "bits=\(bits)")
+        #expect(bits == 63, "bits=\(bits)")
 
         // The visible path rasters before the window is first presented; the PNG must
         // still contain the rendered content, not an empty backing store.
@@ -257,7 +261,7 @@ struct CappedPersistentTests {
         let build = try await session.compileObjectForJIT(
             window: JITRenderWindow(
                 x: -9000, y: -9000, width: 320, height: 240,
-                title: "Preview: ColorView.swift"
+                title: "Preview: ColorView.swift", activates: false
             )
         )
 


### PR DESCRIPTION
Fixes #358.

## What

`JITRenderWindow` gains `activates` (default `true`, existing semantics unchanged). With `activates: false` the generated macOS render entry presents a new visible window via `orderFrontRegardless()` only — no `makeKeyAndOrderFront`, no `NSApplication.activate(ignoringOtherApps: true)` — while keeping the frame observers and sidecar state write. This is the issue's ranked fix (2): a first-class present-without-activate capability, not a test-mode kill switch.

Both `CappedPersistentTests` window-spec tests opt in, and the window-spec probe is tightened into the regression guard: bits 16/32 assert the agent app never activates and the window never takes key (`bits == 63`; the pre-fix behavior reports 15).

## Corrected audit (supersedes the issue's affected-suites list)

Verified from source, the only real in-repo focus stealers were the two `CappedPersistentTests` window tests:

- **MCPIntegrationTests/MacOSMCPTests** — never affected: the daemon defaults `headless ?? true` when the MCP arg is absent (PreviewStartHandler.swift:181), so those sessions never present a window.
- **PreviewsMacOSTests/PreviewHostJITReloadTests** — `headless: false` only bakes the spec; the suite drives a `RecordingReloader` fake that never executes the entry, so nothing presents.
- **RespawnHandoffTests / BridgeGeneratorFrameHandoverTests** — pid-probe entries and source-string assertions; no runtime windows, and no test in the repo asserts runtime key status.
- **CappedPersistentTests** — executes non-headless first renders in a live agent, where `__takeKey` falls back to `true` (no sidecar file exists on a session's first render). It cannot go headless: its probes assert the titled visible-window spec and the sidecar frame writer, which only exist on the non-headless path. Hence fix (1) from the issue is moot and this flag is the whole fix.

Respawn coherence: a never-activated window records `key: false` in the sidecar, so a later respawn through the normal key-decision path stays non-stealing.

The product question (should `previewsmcp run`'s first render activate at all?) remains deferred, as the issue notes; the CLI path is unchanged.

## Verification

- New string-pin test in `BridgeGeneratorRenderSizeTests` (`activates: false` keeps `.titled` + `orderFrontRegardless`, drops `makeKeyAndOrderFront`/`activate`, keeps observers + state write).
- `CappedPersistentTests` probe tightened to `bits == 63` (never active, never key).
- /simplify: clean (one noted skip: `headless`+`activates` as two bools admits one ignored combination; three-case enum judged a broader redesign against file convention).
- /code-review (high, workflow): 3 confirmed findings, all fixed in 5e02034 — activates now survives structural reload (restoreAgentWindowFrame), the activating template stays runtime-executed via a second-generation render against the existing window, and the presentation pins are strengthened (isVisible probe bit, present-count string assertion).
- Full local suite: 11/11 targets green on the final tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)