### PR TITLE
#355: pin IOSPreviewE2ESupport.bootSimulator to dedicated previewsmcp-test-6

### DIFF
--- a/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
@@ -1052,19 +1052,25 @@ enum IOSPreviewE2ESupport {
         try run("/usr/bin/xcrun", ["simctl", "spawn", udid, program]).output
     }
 
-    /// The suite's dedicated `previewsmcp-test-6` device (#355), booted. Warm
-    /// reuse: `SimulatorTestDevices` keeps an existing well-shaped device, and
-    /// `simctl boot` on an already-booted one is a harmless error, so a booted
-    /// device from an earlier test is reused without a shutdown/boot cycle.
+    /// The suite's dedicated `previewsmcp-test-6` device (#355), resolved and
+    /// booted once per process. Warm reuse: `SimulatorTestDevices` keeps an
+    /// existing well-shaped device, and `simctl boot` on an already-booted one
+    /// is a harmless error (`run` does not throw on exit status), so a device
+    /// left booted by an earlier run is reused without a shutdown/boot cycle.
     /// Callers hold `SimulatorTestLock`, which `SimulatorTestDevices` requires.
+    private static let bootedDevice = Task { () throws -> String? in
+        guard let udid = await SimulatorTestDevices.udid(index: 6) else { return nil }
+        _ = try run("/usr/bin/xcrun", ["simctl", "boot", udid])
+        _ = try run("/usr/bin/xcrun", ["simctl", "bootstatus", udid, "-b"])
+        return udid
+    }
+
     static func bootSimulator() async throws -> String {
-        guard let udid = await SimulatorTestDevices.udid(index: 6) else {
+        guard let udid = try await bootedDevice.value else {
             throw SpikeError.message(
                 "no \(SimulatorTestDevices.name(index: 6)) simulator (missing iPhone 17 device type or iOS 26+ runtime)"
             )
         }
-        _ = try run("/usr/bin/xcrun", ["simctl", "boot", udid])
-        _ = try run("/usr/bin/xcrun", ["simctl", "bootstatus", udid, "-b"])
         // Even an already-"booted" device can have its display port down
         // (the #269 "device may not be booted or have no display" window),
         // so settle before returning it for render/capture.
@@ -1101,19 +1107,13 @@ enum IOSPreviewE2ESupport {
     }
 
     /// First available iPhone on a runtime older than iOS 26, or nil. Used to gate
-    /// and drive the #282 pre-iOS-26 scene-hosting repro.
-    static func availableUDIDBelowIOS26() -> String? {
-        iPhoneUDID(state: "available", whereMajor: { $0 < 26 })
-    }
-
-    /// First iPhone in the given simctl device `state` ("available" / "booted")
-    /// whose iOS major version satisfies `predicate`. Runtime keys look like
+    /// and drive the #282 pre-iOS-26 scene-hosting repro. Runtime keys look like
     /// `com.apple.CoreSimulator.SimRuntime.iOS-18-3`; the major is the
     /// `iOS-<major>-<minor>` segment.
-    private static func iPhoneUDID(state: String, whereMajor predicate: (Int) -> Bool) -> String? {
+    static func availableUDIDBelowIOS26() -> String? {
         guard
             let result = try? run(
-                "/usr/bin/xcrun", ["simctl", "list", "devices", state, "--json"]
+                "/usr/bin/xcrun", ["simctl", "list", "devices", "available", "--json"]
             ),
             let data = result.output.data(using: .utf8),
             let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -1122,7 +1122,7 @@ enum IOSPreviewE2ESupport {
             return nil
         }
         for (runtime, list) in devices {
-            guard let major = iOSMajorVersion(fromRuntimeKey: runtime), predicate(major) else {
+            guard let major = iOSMajorVersion(fromRuntimeKey: runtime), major < 26 else {
                 continue
             }
             guard let entries = list as? [[String: Any]] else { continue }

--- a/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
@@ -35,7 +35,7 @@ struct IOSPreviewE2ETests {
     func spawnInSessionRunsProgramAndReportsExit() async throws {
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
-        let udid = try IOSPreviewE2ESupport.bootSimulator()
+        let udid = try await IOSPreviewE2ESupport.bootSimulator()
         let exe = try IOSPreviewE2ESupport.compileExecutableForIOSSim(
             source: "int main(void) { return 0; }", name: "trivial_exit"
         )
@@ -67,7 +67,7 @@ struct IOSPreviewE2ETests {
     func inSessionSpawnGetsHostLoopbackNetworking() async throws {
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
-        let udid = try IOSPreviewE2ESupport.bootSimulator()
+        let udid = try await IOSPreviewE2ESupport.bootSimulator()
         let exe = try IOSPreviewE2ESupport.compileExecutableForIOSSim(
             source: """
             #include <sys/socket.h>
@@ -120,7 +120,7 @@ struct IOSPreviewE2ETests {
     func hostsRemoteSessionInRealHostApp() async throws {
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
-        let udid = try IOSPreviewE2ESupport.bootSimulator()
+        let udid = try await IOSPreviewE2ESupport.bootSimulator()
         let object = try IOSPreviewE2ESupport.compileForIOSSim("answer.c")
         let appPath = try await IOSAgentBuilder().ensureAgentApp()
         try IOSPreviewE2ESupport.installApp(udid: udid, appPath: appPath.path)
@@ -156,7 +156,7 @@ struct IOSPreviewE2ETests {
     func productionSessionEstablishesJITOverSecondSocket() async throws {
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
-        let udid = try IOSPreviewE2ESupport.bootSimulator()
+        let udid = try await IOSPreviewE2ESupport.bootSimulator()
         let object = try IOSPreviewE2ESupport.compileForIOSSim("answer.c")
 
         let tempDir = FileManager.default.temporaryDirectory
@@ -203,7 +203,7 @@ struct IOSPreviewE2ETests {
     func endToEndRendersOverJIT() async throws {
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
-        let udid = try IOSPreviewE2ESupport.bootSimulator()
+        let udid = try await IOSPreviewE2ESupport.bootSimulator()
 
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("previewsmcp-ios-jit-e2e-\(UUID().uuidString)")
@@ -255,7 +255,7 @@ struct IOSPreviewE2ETests {
     func agentReportsForegroundLifecycleState() async throws {
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
-        let udid = try IOSPreviewE2ESupport.bootSimulator()
+        let udid = try await IOSPreviewE2ESupport.bootSimulator()
 
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("previewsmcp-ios-jit-lifecycle-\(UUID().uuidString)")
@@ -305,7 +305,7 @@ struct IOSPreviewE2ETests {
     func relaunchReRendersCurrentPreview() async throws {
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
-        let udid = try IOSPreviewE2ESupport.bootSimulator()
+        let udid = try await IOSPreviewE2ESupport.bootSimulator()
 
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("previewsmcp-ios-jit-relaunch-\(UUID().uuidString)")
@@ -369,7 +369,7 @@ struct IOSPreviewE2ETests {
     func flashFreeRespawnGap() async throws {
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
-        let udid = try IOSPreviewE2ESupport.bootSimulator()
+        let udid = try await IOSPreviewE2ESupport.bootSimulator()
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("previewsmcp-gap-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -439,7 +439,7 @@ struct IOSPreviewE2ETests {
     func stopWaitsOutInFlightRespawn() async throws {
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
-        let udid = try IOSPreviewE2ESupport.bootSimulator()
+        let udid = try await IOSPreviewE2ESupport.bootSimulator()
 
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("previewsmcp-stop-race-\(UUID().uuidString)")
@@ -517,7 +517,7 @@ struct IOSPreviewE2ETests {
     func concurrentEditsSerialize() async throws {
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
-        let udid = try IOSPreviewE2ESupport.bootSimulator()
+        let udid = try await IOSPreviewE2ESupport.bootSimulator()
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("previewsmcp-ios-jit-serialize-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -575,7 +575,7 @@ struct IOSPreviewE2ETests {
     func literalEditReSeedsSameObjectWithoutRecompile() async throws {
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
-        let udid = try IOSPreviewE2ESupport.bootSimulator()
+        let udid = try await IOSPreviewE2ESupport.bootSimulator()
 
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("previewsmcp-ios-jit-literal-\(UUID().uuidString)")
@@ -650,7 +650,7 @@ struct IOSPreviewE2ETests {
     func endToEndRendersSetupWrappedOverJIT() async throws {
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
-        let udid = try IOSPreviewE2ESupport.bootSimulator()
+        let udid = try await IOSPreviewE2ESupport.bootSimulator()
 
         let hot = Self.packageRoot
             .appendingPathComponent("examples/spm/Sources/ToDo/Summary.swift")
@@ -1052,22 +1052,22 @@ enum IOSPreviewE2ESupport {
         try run("/usr/bin/xcrun", ["simctl", "spawn", udid, program]).output
     }
 
-    static func bootSimulator() throws -> String {
-        // Reuse a booted iOS 26+ device if present; otherwise boot a supported
-        // one. Live previews require iOS 26+ (#282), so a booted pre-26 device
-        // (e.g. one left from the repro test) must not be picked here.
-        if let booted = iPhoneUDID(state: "booted", whereMajor: { $0 >= 26 }) {
-            // Even an already-"booted" device can have its display port down
-            // (the #269 "device may not be booted or have no display" window),
-            // so settle before returning it for render/capture.
-            try waitForDisplayReady(udid: booted)
-            return booted
-        }
-        guard let udid = iPhoneUDID(state: "available", whereMajor: { $0 >= 26 }) else {
-            throw SpikeError.message("no available iOS 26+ iPhone simulator to boot")
+    /// The suite's dedicated `previewsmcp-test-6` device (#355), booted. Warm
+    /// reuse: `SimulatorTestDevices` keeps an existing well-shaped device, and
+    /// `simctl boot` on an already-booted one is a harmless error, so a booted
+    /// device from an earlier test is reused without a shutdown/boot cycle.
+    /// Callers hold `SimulatorTestLock`, which `SimulatorTestDevices` requires.
+    static func bootSimulator() async throws -> String {
+        guard let udid = await SimulatorTestDevices.udid(index: 6) else {
+            throw SpikeError.message(
+                "no \(SimulatorTestDevices.name(index: 6)) simulator (missing iPhone 17 device type or iOS 26+ runtime)"
+            )
         }
         _ = try run("/usr/bin/xcrun", ["simctl", "boot", udid])
         _ = try run("/usr/bin/xcrun", ["simctl", "bootstatus", udid, "-b"])
+        // Even an already-"booted" device can have its display port down
+        // (the #269 "device may not be booted or have no display" window),
+        // so settle before returning it for render/capture.
         try waitForDisplayReady(udid: udid)
         return udid
     }

--- a/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
@@ -1052,25 +1052,23 @@ enum IOSPreviewE2ESupport {
         try run("/usr/bin/xcrun", ["simctl", "spawn", udid, program]).output
     }
 
-    /// The suite's dedicated `previewsmcp-test-6` device (#355), resolved and
-    /// booted once per process. Warm reuse: `SimulatorTestDevices` keeps an
-    /// existing well-shaped device, and `simctl boot` on an already-booted one
-    /// is a harmless error (`run` does not throw on exit status), so a device
-    /// left booted by an earlier run is reused without a shutdown/boot cycle.
-    /// Callers hold `SimulatorTestLock`, which `SimulatorTestDevices` requires.
-    private static let bootedDevice = Task { () throws -> String? in
-        guard let udid = await SimulatorTestDevices.udid(index: 6) else { return nil }
-        _ = try run("/usr/bin/xcrun", ["simctl", "boot", udid])
-        _ = try run("/usr/bin/xcrun", ["simctl", "bootstatus", udid, "-b"])
-        return udid
-    }
-
+    /// The suite's dedicated `previewsmcp-test-6` device (#355), booted.
+    /// Resolve and boot run per call, not once per process: a transient
+    /// `simctl list` failure then costs one test instead of poisoning the
+    /// whole suite, and a device that shut down mid-suite is re-booted.
+    /// Warm reuse: `SimulatorTestDevices` keeps an existing well-shaped
+    /// device, and `simctl boot` on an already-booted one is a harmless
+    /// error (`run` does not throw on exit status), so a booted device is
+    /// reused without a shutdown/boot cycle. Callers hold
+    /// `SimulatorTestLock`, which `SimulatorTestDevices` requires.
     static func bootSimulator() async throws -> String {
-        guard let udid = try await bootedDevice.value else {
+        guard let udid = await SimulatorTestDevices.udid(index: 6) else {
             throw SpikeError.message(
                 "no \(SimulatorTestDevices.name(index: 6)) simulator (missing iPhone 17 device type or iOS 26+ runtime)"
             )
         }
+        _ = try run("/usr/bin/xcrun", ["simctl", "boot", udid])
+        _ = try run("/usr/bin/xcrun", ["simctl", "bootstatus", udid, "-b"])
         // Even an already-"booted" device can have its display port down
         // (the #269 "device may not be booted or have no display" window),
         // so settle before returning it for render/capture.

--- a/previewsmcp/Tests/TestSupport/SimulatorTestDevices.swift
+++ b/previewsmcp/Tests/TestSupport/SimulatorTestDevices.swift
@@ -28,6 +28,8 @@ import PreviewsCore
 /// - index 4: `SimulatorManagerTests.makeHIDClient` (PreviewsIOSTests target)
 /// - index 5: `SimulatorTestDevicesTests` (TestSupportTests target; resolves
 ///   only, never boots)
+/// - index 6: `IOSPreviewE2ESupport.bootSimulator()` (IOSPreviewE2ETests
+///   target; one warm-reused device for the whole `.serialized` suite)
 public enum SimulatorTestDevices {
     public static let deviceType = "com.apple.CoreSimulator.SimDeviceType.iPhone-17"
 


### PR DESCRIPTION
Part of #355 (the JITLink half; the VM warm-bake half is parked pending the merge-queue → GitHub-CI direction change).

## What

`IOSPreviewE2ESupport.bootSimulator()` was the last picker-style pool scan: it reused any booted iOS 26+ iPhone or booted the first available one, keeping the suite's device shape host-dependent and able to grab another suite's `previewsmcp-test-*` device. It now resolves the dedicated **index 6** via `SimulatorTestDevices` (assignment table updated); all 12 call sites gained `await`.

Design points:
- **Per-call resolve+boot, deliberately.** A memoized once-per-process variant was tried and reverted after review: it froze a transient `simctl list` nil into 11 red tests and removed the mid-suite re-boot self-heal. The ~11 redundant `boot`/`bootstatus` no-op spawns per suite run are immaterial against minutes-long tests.
- **Warm reuse preserved with less machinery**: `SimulatorTestDevices` keeps a well-shaped existing device, and `simctl boot` on a booted device is a harmless ignored error, so no shutdown/boot cycle.
- **Red-on-missing preserved**: the old pool-exhaustion path threw, so a missing device type/runtime stays a loud `SpikeError` here rather than the other suites' nil=skip (their old picker skipped; this suite's didn't).
- `SimulatorManager.bootDevice` reuse was considered and rejected: `sbDevice.boot()` throws on an already-booted device, which would break cross-run warm reuse.
- `iPhoneUDID(state:whereMajor:)` collapsed into `availableUDIDBelowIOS26()`, its one surviving caller (the #282 repro gate).

## Verification

- `IOSPreviewE2ETests` green end-to-end (creates `previewsmcp-test-6`, boots it, all 12 tests).
- /simplify + /code-review (high, workflow) run; findings addressed or skipped with reasons above.
- Full local suite: 11/11 targets green on the final tree (fresh IOSPreviewE2ETests run, 145.6s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
