### PR TITLE
#362: right-size test timeouts from CI wall clocks + fix all first-party compiler warnings

### DIFF
--- a/previewsmcp/PreviewsCLI/FDReadiness.swift
+++ b/previewsmcp/PreviewsCLI/FDReadiness.swift
@@ -31,7 +31,7 @@ enum FDReadiness {
 
     private static let reattemptInterval: DispatchTimeInterval = .seconds(1)
 
-    private static func wait(on source: some DispatchSourceProtocol) async {
+    private static func wait(on source: some DispatchSourceProtocol & SendableMetatype) async {
         nonisolated(unsafe) let source = source
         await withTaskCancellationHandler {
             await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in

--- a/previewsmcp/PreviewsCLI/PreviewsMCPApp.swift
+++ b/previewsmcp/PreviewsCLI/PreviewsMCPApp.swift
@@ -12,7 +12,7 @@ enum CLIPlatform: String, ExpressibleByArgument, CaseIterable {
 
 /// Let `--build-system` parse straight into the core enum so ArgumentParser
 /// validates the value and lists the choices in `--help`.
-extension BuildSystemKind: ExpressibleByArgument {}
+extension BuildSystemKind: @retroactive ExpressibleByArgument {}
 
 /// Wall-clock instant the process began. Captured at app entry (the first
 /// line of `PreviewsMCPApp.main`) so the `preview_build_info` MCP tool can

--- a/previewsmcp/PreviewsCLI/PreviewsMCPClient.swift
+++ b/previewsmcp/PreviewsCLI/PreviewsMCPClient.swift
@@ -106,7 +106,7 @@ actor PreviewsMCPClient: MCPClienting, LivenessPinging {
                     do {
                         try await transport.send(frame)
                     } catch {
-                        await self.fail(id: id, with: error)
+                        self.fail(id: id, with: error)
                     }
                 }
             }

--- a/previewsmcp/PreviewsIOS/AVCCVideoStream.swift
+++ b/previewsmcp/PreviewsIOS/AVCCVideoStream.swift
@@ -59,7 +59,7 @@ enum AVCCEnvelope {
 public final class AVCCVideoStream: @unchecked Sendable {
     private let encoder: H264Encoder
     private let queue = DispatchQueue(label: "com.previewsmcp.avcc")
-    private var subscribers: [ObjectIdentifier: (Data) -> Void] = [:]
+    private var subscribers: [ObjectIdentifier: @Sendable (Data) -> Void] = [:]
     private var cachedDescription: Data?
     private var pendingKeyframe = false
     /// Mirrors `!subscribers.isEmpty` for a lock-cheap fast path in `feed`, so an
@@ -96,7 +96,7 @@ public final class AVCCVideoStream: @unchecked Sendable {
     /// Register a subscriber. Replays the cached decoder description and arms a
     /// forced keyframe so the new client decodes promptly. `send` is invoked on
     /// this type's queue with each enveloped chunk.
-    func addSubscriber(_ id: ObjectIdentifier, send: @escaping (Data) -> Void) {
+    func addSubscriber(_ id: ObjectIdentifier, send: @escaping @Sendable (Data) -> Void) {
         queue.async {
             if let desc = self.cachedDescription { send(desc) }
             self.pendingKeyframe = true

--- a/previewsmcp/SimulatorBridge/SimulatorBridge.m
+++ b/previewsmcp/SimulatorBridge/SimulatorBridge.m
@@ -27,6 +27,7 @@
 - (NSString *)stateString;
 - (id)runtime;
 - (id)deviceType;
+- (id)io;
 - (BOOL)isAvailable;
 - (BOOL)bootWithOptions:(NSDictionary *)options error:(NSError **)error;
 - (BOOL)shutdownWithError:(NSError **)error;

--- a/previewsmcp/Tests/PreviewsCLITests/BUILD.bazel
+++ b/previewsmcp/Tests/PreviewsCLITests/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_swift//swift:swift.bzl", "swift_test")
 
 swift_test(
     name = "PreviewsCLITests",
+    size = "small",
     srcs = glob(
         ["**/*.swift"],
         # Locates list_tools_snapshot.json via #filePath, which resolves

--- a/previewsmcp/Tests/PreviewsEngineTests/BUILD.bazel
+++ b/previewsmcp/Tests/PreviewsEngineTests/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_swift//swift:swift.bzl", "swift_test")
 
 swift_test(
     name = "PreviewsEngineTests",
+    size = "small",
     srcs = glob(["**/*.swift"]),
     copts = [
         "-swift-version",

--- a/previewsmcp/Tests/PreviewsIOSTests/BUILD.bazel
+++ b/previewsmcp/Tests/PreviewsIOSTests/BUILD.bazel
@@ -2,7 +2,7 @@ load("@rules_swift//swift:swift.bzl", "swift_test")
 
 swift_test(
     name = "PreviewsIOSTests",
-    timeout = "eternal",
+    timeout = "long",
     srcs = glob(["**/*.swift"]),
     copts = [
         "-swift-version",

--- a/previewsmcp/Tests/PreviewsIOSTests/H264EncoderTests.swift
+++ b/previewsmcp/Tests/PreviewsIOSTests/H264EncoderTests.swift
@@ -1,5 +1,6 @@
 import CoreVideo
 import Foundation
+import os
 @testable import PreviewsIOS
 import Testing
 
@@ -51,13 +52,12 @@ struct H264EncoderTests {
         let encoder = H264Encoder(fps: 30, bitrate: 2_000_000)
 
         let result: H264Encoder.Encoded? = await withCheckedContinuation { cont in
-            let lock = NSLock()
-            var resumed = false
-            func finish(_ encoded: H264Encoder.Encoded?) {
-                lock.lock()
-                let first = !resumed
-                resumed = true
-                lock.unlock()
+            let resumed = OSAllocatedUnfairLock(initialState: false)
+            @Sendable func finish(_ encoded: H264Encoder.Encoded?) {
+                let first = resumed.withLock { alreadyResumed in
+                    defer { alreadyResumed = true }
+                    return !alreadyResumed
+                }
                 if first { cont.resume(returning: encoded) }
             }
 

--- a/previewsmcp/Tests/PreviewsMacOSTests/BUILD.bazel
+++ b/previewsmcp/Tests/PreviewsMacOSTests/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_swift//swift:swift.bzl", "swift_test")
 
 swift_test(
     name = "PreviewsMacOSTests",
+    size = "small",
     srcs = glob(["**/*.swift"]),
     copts = [
         "-swift-version",

--- a/previewsmcp/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
+++ b/previewsmcp/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
@@ -88,7 +88,7 @@ struct PreviewHostJITReloadTests {
         #expect(made.count == 2)
         #expect(made.first?.calls.count == 2)
 
-        weak var first = made.first
+        weak let first = made.first
         made.removeFirst()
         host.closePreview(sessionID: "a")
         #expect(first == nil)

--- a/previewsmcp/Tests/TestSupportTests/BUILD.bazel
+++ b/previewsmcp/Tests/TestSupportTests/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_swift//swift:swift.bzl", "swift_test")
 
 swift_test(
     name = "TestSupportTests",
+    size = "small",
     srcs = glob(
         ["*.swift"],
         exclude = ["SimulatorTestDevicesTests.swift"],


### PR DESCRIPTION
Closes #362.

## Commit 1 — size/timeout right-sizing (from 6 mini CI runs of wall-clock data)

Two classes of target, sized differently on purpose:

- **Honest caps where the test process has no long watchdogs**: unit suites (`TestSupportTests`, `PreviewsCLITests`, `PreviewsEngineTests`, `PreviewsMacOSTests`) run 0.2–15s worst-ever → `size = "small"` (60s, ≥4x margin over the worst wedged-machine sample). `PreviewsIOSTests` runs 128s healthy with only seconds-scale inner timeouts → `eternal` → `long` (900s, 7x margin). `PreviewsJITLinkTests` keeps `long`: 300s over its 189s wedged sample is too thin while #353 is an open watch.
- **`eternal` stays where it is a backstop over layered in-test watchdogs, and is now documented as such rather than trial panic**: `MCPIntegrationTests` (1200s per-test `.timeLimit` over 600s `preview_start` bounds), `CLIIntegrationTests` (600s `.timeLimit`s over CLIRunner's 300s run timeouts), `IOSPreviewE2ETests` (483s on the only healthy sample — 900 would be under 2x). The bazel cap must sit above the in-test watchdogs so they die first and dump daemon/CLI stderr; a SIGKILL at 900s would land mid-test with no diagnostics. `SimulatorTestDevicesTests` similarly stays at the 300s default matching its `.timeLimit(.minutes(5))` cold device-creation budget.

## Commit 2 — every first-party compiler warning from the CI trial builds

- `PreviewsMCPApp`: `@retroactive ExpressibleByArgument` on `BuildSystemKind` (CLI owns the pairing; PreviewsCore must not depend on ArgumentParser).
- `PreviewsMCPClient`: send-failure `Task` inherits actor isolation → no `await` on sync `fail()`.
- `FDReadiness`: `SendableMetatype` constraint for the source metatype captured by the Sendable cancel closures.
- `AVCCVideoStream`: subscriber sinks are `@Sendable` (invoked from the encoder queue; sole caller captures only the Sendable `NWConnection`).
- `SimulatorBridge`: declare `-io` in the `_SimDevice` SPI protocol so `@selector(io)` compiles clean like the file's other SPI calls (simplify-gate finding: deeper than the initial `NSSelectorFromString` swap).
- `H264EncoderTests`: `@Sendable` `finish` with the once-latch in an `OSAllocatedUnfairLock`.
- `PreviewHostJITReloadTests`: `weak let`.

External-dep warnings (swift-argument-parser, async-algorithms, SymbolKit) stay: they only re-emit when those cached actions rebuild, so they are near-zero noise on the mini.

## Gates

- `/simplify` (4 agents): 1 finding (SimulatorBridge selector altitude) — applied.
- `/code-review` high (8 finders + source verification): 6 candidates → 4 confirmed, all applied (SimulatorTestDevicesTests small revert, MCP/CLI eternal restore, JITLink long restore); 2 refuted (PreviewsIOSTests `long` and the `small` unit suites have ≥4x worst-case margins).
- Full local suite: running, result posted below before un-drafting.
- Lint: clean (exit 0; remaining SwiftLint length/complexity warnings are pre-existing style debt, out of scope per issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9tE6iZwyGJcX5Kx9LUnhm