### PR TITLE
#368: attribution instrumentation — tap-dropped vs capture-frozen from one specimen

### DIFF
--- a/previewsmcp/PreviewsIOS/FrameSource.swift
+++ b/previewsmcp/PreviewsIOS/FrameSource.swift
@@ -25,6 +25,16 @@ public final class EventDrivenFrameSource: FrameSource, @unchecked Sendable {
         streamer.latestFrame()
     }
 
+    /// How many frames the event-driven pipeline has accepted and how stale
+    /// the newest one is. Logged with each cached-frame snapshot so a frozen
+    /// specimen shows whether the display pipeline stalled (#368).
+    public func frameStats() -> (count: UInt64, ageSeconds: Double) {
+        var count: UInt64 = 0
+        var age: Double = 0
+        streamer.getFrameCount(&count, ageSeconds: &age)
+        return (count, age)
+    }
+
     /// Capture the live display surface on demand at `jpegQuality` (PNG when
     /// `jpegQuality >= 1.0`), reusing the streamer's wired pipeline. Unlike
     /// `nextFrame`, this re-encodes current content at the requested quality

--- a/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
+++ b/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
@@ -761,6 +761,10 @@ public actor IOSPreviewSession {
             // PNG/lossless request (quality >= 1.0) can't reuse the JPEG cache,
             // so it falls through to a fresh re-encode.
             if jpegQuality < 1.0, let cached = await source.nextFrame() {
+                let stats = source.frameStats()
+                Log.info(
+                    "iosSnap: cached frame #\(stats.count) age \(String(format: "%.1f", stats.ageSeconds))s"
+                )
                 return cached
             }
             // Ride over brief surface gaps (e.g. the agent respawn the OS forces

--- a/previewsmcp/PreviewsIOS/InputSink.swift
+++ b/previewsmcp/PreviewsIOS/InputSink.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PreviewsCore
 @preconcurrency import SimulatorBridge
 
 /// A destination for normalized (0..1) pointer input on a preview surface. The
@@ -19,10 +20,14 @@ public struct IndigoHIDInputSink: InputSink {
     }
 
     public func tap(x: Double, y: Double) {
-        _ = client.tapAt(x: x, y: y)
+        if !client.tapAt(x: x, y: y) {
+            Log.warn("hid: tap not dispatched (Indigo mouse function unavailable)")
+        }
     }
 
     public func drag(fromX: Double, fromY: Double, toX: Double, toY: Double, steps: Int) {
-        _ = client.dragFrom(x: fromX, fromY: fromY, toX: toX, toY: toY, steps: steps)
+        if !client.dragFrom(x: fromX, fromY: fromY, toX: toX, toY: toY, steps: steps) {
+            Log.warn("hid: drag not dispatched (Indigo mouse function unavailable)")
+        }
     }
 }

--- a/previewsmcp/PreviewsIOS/PreviewAppServer.swift
+++ b/previewsmcp/PreviewsIOS/PreviewAppServer.swift
@@ -184,20 +184,25 @@ public final class PreviewAppServer: @unchecked Sendable {
     }
 
     private func dispatch(_ body: Data) {
-        guard let command = try? JSONDecoder().decode(ControlCommand.self, from: body) else { return }
+        guard let command = try? JSONDecoder().decode(ControlCommand.self, from: body) else {
+            Log.warn("appserver: control body undecodable (\(body.count) bytes)")
+            return
+        }
         switch command.action {
         case "tap":
             if let x = command.x, let y = command.y {
+                Log.info("appserver: control tap(\(x), \(y))")
                 sink.tap(x: x, y: y)
             }
         case "drag":
             if let fromX = command.fromX, let fromY = command.fromY,
                let toX = command.toX, let toY = command.toY
             {
+                Log.info("appserver: control drag(\(fromX), \(fromY) -> \(toX), \(toY))")
                 sink.drag(fromX: fromX, fromY: fromY, toX: toX, toY: toY, steps: command.steps ?? 10)
             }
         default:
-            break
+            Log.warn("appserver: control unknown action '\(command.action)'")
         }
     }
 

--- a/previewsmcp/SimulatorBridge/SimulatorBridge.m
+++ b/previewsmcp/SimulatorBridge/SimulatorBridge.m
@@ -562,7 +562,16 @@ static SBIndigoMouseFunc _loadMouseFunc(void) {
 // 0x32 = digitizer target. eventType 1 = down (begin and move), 2 = up. Must
 // run on `inputQueue` so concurrent gestures never interleave on the shared
 // client.
-- (void)_sendEventType:(int32_t)eventType x:(double)x y:(double)y {
+//
+// `deliveredLabel` (issue #368 attribution): when non-NULL, the SimulatorKit
+// send completion logs "<label> delivered". The completion fires only if the
+// underlying HID connection is alive, so a gesture whose dispatch was logged
+// but whose delivered line never appears pins a dead/stale HID client —
+// distinguishing dropped input from a frozen display in flake specimens.
+- (void)_sendEventType:(int32_t)eventType
+                     x:(double)x
+                     y:(double)y
+        deliveredLabel:(const char *)deliveredLabel {
   SBIndigoMouseFunc mouse = _loadMouseFunc();
   if (!mouse)
     return;
@@ -570,19 +579,28 @@ static SBIndigoMouseFunc _loadMouseFunc(void) {
   void *msg = mouse(&pt, NULL, 0x32, eventType, 1.0, 1.0, 0);
   if (!msg)
     return;
+  void (^completion)(void) = nil;
+  dispatch_queue_t completionQueue = NULL;
+  if (deliveredLabel) {
+    NSString *label = [NSString stringWithUTF8String:deliveredLabel];
+    completionQueue = self.inputQueue;
+    completion = ^{
+      NSLog(@"SimulatorBridge: hid %@ delivered", label);
+    };
+  }
   [(id<_SimDeviceLegacyHIDClient>)self.hidClient sendWithMessage:msg
                                                     freeWhenDone:YES
-                                                 completionQueue:NULL
-                                                      completion:nil];
+                                                 completionQueue:completionQueue
+                                                      completion:completion];
 }
 
 - (BOOL)tapAtX:(double)x y:(double)y {
   if (!_loadMouseFunc())
     return NO;
   dispatch_async(self.inputQueue, ^{
-    [self _sendEventType:1 x:x y:y];
+    [self _sendEventType:1 x:x y:y deliveredLabel:NULL];
     usleep(60000);
-    [self _sendEventType:2 x:x y:y];
+    [self _sendEventType:2 x:x y:y deliveredLabel:"tap up"];
   });
   return YES;
 }
@@ -596,16 +614,17 @@ static SBIndigoMouseFunc _loadMouseFunc(void) {
     return NO;
   NSInteger n = steps < 1 ? 10 : steps;
   dispatch_async(self.inputQueue, ^{
-    [self _sendEventType:1 x:fromX y:fromY];
+    [self _sendEventType:1 x:fromX y:fromY deliveredLabel:NULL];
     usleep(8000);
     for (NSInteger i = 1; i <= n; i++) {
       double t = (double)i / (double)n;
       [self _sendEventType:1
                          x:fromX + (toX - fromX) * t
-                         y:fromY + (toY - fromY) * t];
+                         y:fromY + (toY - fromY) * t
+            deliveredLabel:NULL];
       usleep(16000);
     }
-    [self _sendEventType:2 x:toX y:toY];
+    [self _sendEventType:2 x:toX y:toY deliveredLabel:"drag up"];
   });
   return YES;
 }
@@ -848,6 +867,8 @@ static const void *const kFBStreamerQueueKey = &kFBStreamerQueueKey;
   NSMutableDictionary<NSNumber *, NSUUID *> *_callbackUUIDs;
   NSMutableDictionary<NSNumber *, NSNumber *> *_lastSeeds;
   NSData *_latestFrame;
+  unsigned long long _frameCounter;
+  CFAbsoluteTime _lastFrameTime;
   BOOL _hasFrame;
   dispatch_source_t _healTimer;
   BOOL _stopRequested;
@@ -1054,6 +1075,8 @@ static const void *const kFBStreamerQueueKey = &kFBStreamerQueueKey;
 
   @synchronized(self) {
     _latestFrame = jpeg;
+    _frameCounter += 1;
+    _lastFrameTime = CFAbsoluteTimeGetCurrent();
   }
 
   // Frames are flowing: the heal timer's only job (re-wire while we have none)
@@ -1091,6 +1114,16 @@ static const void *const kFBStreamerQueueKey = &kFBStreamerQueueKey;
   }
 }
 
+- (void)getFrameCount:(unsigned long long *)count
+           ageSeconds:(double *)ageSeconds {
+  @synchronized(self) {
+    *count = _frameCounter;
+    *ageSeconds = _frameCounter == 0
+                      ? INFINITY
+                      : CFAbsoluteTimeGetCurrent() - _lastFrameTime;
+  }
+}
+
 - (NSData *)captureFrameAtQuality:(double)jpegQuality {
   NSData * (^capture)(void) = ^NSData * {
     if (_stopped || _stopRequested)
@@ -1101,6 +1134,12 @@ static const void *const kFBStreamerQueueKey = &kFBStreamerQueueKey;
       return nil;
     if (IOSurfaceGetWidth(surface) == 0 || IOSurfaceGetHeight(surface) == 0)
       return nil;
+    // #368 attribution: a snapshot sequence whose surface ID and seed never
+    // move distinguishes "display content genuinely static" (dropped input)
+    // from "reading a detached surface" (seed frozen while the sim renders
+    // elsewhere, the #269 display-port class).
+    NSLog(@"SimulatorBridge: fb capture surface=%u seed=%u",
+          IOSurfaceGetID(surface), IOSurfaceGetSeed(surface));
     return _encodeSurface(surface, jpegQuality);
   };
 

--- a/previewsmcp/SimulatorBridge/include/SimulatorBridge.h
+++ b/previewsmcp/SimulatorBridge/include/SimulatorBridge.h
@@ -107,6 +107,14 @@ typedef NS_ENUM(NSInteger, SBDeviceState) {
 /// The most recently encoded frame, or nil before the first frame arrives.
 - (nullable NSData *)latestFrame;
 
+/// Read, atomically as a pair, the monotonic count of frames the
+/// event-driven capture path has accepted (i.e. surface seed changes it
+/// encoded) and the seconds since the newest one (INFINITY before the first
+/// frame). A counter that stops advancing while the screen should be
+/// changing pins a stalled display pipeline (issue #368 attribution).
+- (void)getFrameCount:(nonnull unsigned long long *)count
+           ageSeconds:(nonnull double *)ageSeconds;
+
 /// Encode the live display surface on demand at `jpegQuality` (PNG when
 /// `jpegQuality >= 1.0`), bypassing the cached stream frame. Reuses the wired
 /// display pipeline this streamer holds open, so it succeeds under the same


### PR DESCRIPTION
For #368 (does not close it — the issue stays open collecting specimens; this makes the next specimen decisive). No behavior changes, instrumentation only.

## What a specimen now shows

| Signal | Where it logs | What its absence/state pins |
|---|---|---|
| `appserver: control tap/drag(…)` + undecodable-body warns | daemon stderr (PreviewAppServer) | whether the control request reached the daemon |
| `SimulatorBridge: hid tap up/drag up delivered` | stderr of whichever process owns the SBHIDClient (daemon for /control, test process for direct-HID tests) | the SimulatorKit send completion only fires over a live HID connection — a logged dispatch with no delivered line pins a dead/stale client |
| `iosSnap: cached frame #N age Xs` | daemon stderr, once per preview_snapshot | frozen `#N` with growing age = display pipeline stalled; advancing `#N` = screen genuinely static |
| `SimulatorBridge: fb capture surface=I seed=S` | daemon stderr, cache-miss captures only | frozen seed on the same surface = detached-surface read (the #269 class) |

## Verified live

All signals observed in a local MCPIntegrationTests run (control receipt → delivered → frame stats). The instrumentation captured a bonus #350 specimen in the same run — first laptop reproduction, posted to that issue — showing the pipeline healthy (`frame #42 age 0.0s`) to the instant of the client-side NSURLError-1.

## Gates

- /simplify: 1 finding (frame count+age read was split across two locks) — applied as the single `getFrameCount:ageSeconds:` accessor.
- /code-review high (5 finder angles): 1 finding (completion block captured a raw `const char *`) — hardened to an `NSString` copy; angles B/C/cleanup/conventions clean.
- Lint exit 0. Full local suite 11/11 green, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9tE6iZwyGJcX5Kx9LUnhm