### PR TITLE
Fix #350: sample MJPEG streams over a raw socket — URLSession multipart is the flake

### DIFF
--- a/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
@@ -162,39 +162,31 @@ private func errorChainDump(_ error: Error) -> String {
     return lines.joined(separator: " | ")
 }
 
-/// Read a bounded sample of an MJPEG stream, asserting the multipart content
-/// type. URLSession unwraps multipart/x-mixed-replace and delivers the JPEG
-/// part bodies without the boundary.
+/// Read a bounded raw sample of the MJPEG response — status line, headers,
+/// and `limit` body bytes — over a plain socket, NOT URLSession.
 ///
-/// Uses a fresh single-use session, NOT `URLSession.shared`: these helpers
-/// abandon their response mid-body (the server is still streaming when the
-/// sample completes), and a shared session's connection pool can hand the
-/// dying connection to the next request against the same host:port — caught
-/// live as `NSURLErrorDomain Code=-1` on the follow-up `/stream.avcc` request
-/// ~50ms after a successful mjpeg sample (#320: daemon log showed the stream
-/// healthy, first frame sent, no server-side error). A fresh session has an
-/// empty pool, so nothing poisoned can be reused; `invalidateAndCancel()`
-/// tears the abandoned connection down with the session.
+/// URLSession is unusable for sampling multipart/x-mixed-replace: its
+/// multipart handling is timing-dependent, and once a full part sits
+/// buffered before the consumer starts iterating (loopback burst + a
+/// loaded machine), `AsyncBytes` either throws a bare NSURLError -1 or
+/// delivers no bytes at all while the task reports no error — reproduced
+/// deterministically outside the suite and root-caused as #350 (the ~1/9
+/// "NSURLError-1 after first frame sent" flake; the daemon side was never
+/// at fault). A raw read is timing-independent and asserts the actual
+/// wire framing the browser viewer consumes.
 private func readStreamSample(port: Int, limit: Int) async throws -> Data {
-    let session = URLSession(configuration: .ephemeral)
-    defer { session.invalidateAndCancel() }
-    var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/stream.mjpeg")!)
-    request.timeoutInterval = 15
-    let (bytes, response) = try await attributed("mjpeg-connect") {
-        try await session.bytes(for: request)
+    let raw = try await attributed("mjpeg-raw") {
+        try await RawHTTP.sample(
+            port: port, path: "/stream.mjpeg",
+            bodyLimit: limit, deadline: .seconds(10)
+        )
     }
-    let contentType = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Type") ?? ""
-    #expect(contentType.contains("multipart/x-mixed-replace"), "stream should be MJPEG multipart")
-
-    let buffer = OSAllocatedUnfairLock(initialState: Data())
-    try await boundedRead("mjpeg-body", bytes, deadline: .seconds(10)) { byte in
-        let count = buffer.withLock {
-            $0.append(byte)
-            return $0.count
-        }
-        return count < limit
-    }
-    return buffer.withLock { $0 }
+    #expect(
+        raw.head.contains("Content-Type: multipart/x-mixed-replace"),
+        "stream should be MJPEG multipart"
+    )
+    #expect(raw.body.range(of: Data("--frame\r\n".utf8)) != nil, "body should carry the part boundary")
+    return raw.body
 }
 
 /// Read the length-prefixed `/stream.avcc` envelope stream and collect the chunk
@@ -202,7 +194,9 @@ private func readStreamSample(port: Int, limit: Int) async throws -> Data {
 /// registered by then) to drive a screen change so an IDR is produced. Returns
 /// when every tag in `need` has been seen or `timeout` elapses.
 ///
-/// Fresh single-use session for the same reason as `readStreamSample`.
+/// Fresh single-use ephemeral session: this helper abandons its response
+/// mid-stream, and a shared session's connection pool can hand the dying
+/// connection to a later request against the same host:port (#320).
 private func readAVCCTags(
     port: Int, need: Set<UInt8>, timeout: Duration,
     onConnected: @escaping @Sendable () async -> Void

--- a/previewsmcp/Tests/PreviewsIOSTests/PreviewAppServerStreamTests.swift
+++ b/previewsmcp/Tests/PreviewsIOSTests/PreviewAppServerStreamTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PreviewsIOS
+import PreviewsTestSupport
 import Testing
 
 /// Verifies the PreviewAppServer MJPEG plumbing with a stub frame source. No
@@ -53,21 +54,16 @@ struct PreviewAppServerStreamTests {
     }
 }
 
-/// Read a bounded sample of an MJPEG stream, asserting the multipart content
-/// type. URLSession unwraps multipart/x-mixed-replace and delivers the JPEG
-/// part bodies without the boundary.
+/// Read a bounded raw sample of the MJPEG response, asserting the multipart
+/// content type and boundary on the wire. Raw socket, not URLSession — see
+/// RawHTTP.sample (#350).
 private func readStreamSample(port: Int, limit: Int) async throws -> Data {
-    var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/stream.mjpeg")!)
-    request.timeoutInterval = 15
-    let (bytes, response) = try await URLSession.shared.bytes(for: request)
-    let contentType = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Type") ?? ""
-    #expect(contentType.contains("multipart/x-mixed-replace"), "stream should be MJPEG multipart")
-
-    var buffer = Data()
-    let deadline = ContinuousClock.now + .seconds(10)
-    for try await byte in bytes {
-        buffer.append(byte)
-        if buffer.count >= limit || ContinuousClock.now >= deadline { break }
-    }
-    return buffer
+    let raw = try await RawHTTP.sample(
+        port: port, path: "/stream.mjpeg", bodyLimit: limit, deadline: .seconds(10)
+    )
+    #expect(
+        raw.head.contains("Content-Type: multipart/x-mixed-replace"),
+        "stream should be MJPEG multipart"
+    )
+    return raw.body
 }

--- a/previewsmcp/Tests/TestSupport/RawHTTPSample.swift
+++ b/previewsmcp/Tests/TestSupport/RawHTTPSample.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Bounded raw sampling of a streaming HTTP response over a plain blocking
+/// socket: status line, headers, and up to `bodyLimit` body bytes.
+///
+/// Exists because URLSession is unusable for sampling
+/// multipart/x-mixed-replace: its multipart handling is timing-dependent, and
+/// once a full part sits buffered before the consumer starts iterating
+/// (loopback burst + a loaded machine), `AsyncBytes` either throws a bare
+/// NSURLError -1 or delivers no bytes while the task reports no error —
+/// reproduced deterministically and root-caused as #350. A raw read is
+/// timing-independent and asserts the actual wire framing browser clients
+/// consume.
+public enum RawHTTP {
+    public struct SampleError: Error, LocalizedError {
+        public let message: String
+        public var errorDescription: String? {
+            message
+        }
+    }
+
+    /// Issue a GET and collect the response head plus up to `bodyLimit` body
+    /// bytes. `SO_RCVTIMEO` bounds each read and `deadline` bounds the whole
+    /// sample, so a stalled stream fails loudly instead of hanging. The socket
+    /// is closed on return; a streaming server sees a mid-stream disconnect,
+    /// which is an ordinary client departure.
+    public static func sample(
+        port: Int, path: String, bodyLimit: Int, deadline: Duration
+    ) async throws -> (head: String, body: Data) {
+        try await Task.detached {
+            let fd = socket(AF_INET, SOCK_STREAM, 0)
+            guard fd >= 0 else { throw SampleError(message: "socket() failed errno=\(errno)") }
+            defer { close(fd) }
+            var timeout = timeval(tv_sec: 2, tv_usec: 0)
+            setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+            var addr = sockaddr_in()
+            addr.sin_family = sa_family_t(AF_INET)
+            addr.sin_port = UInt16(port).bigEndian
+            addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+            let connected = withUnsafePointer(to: &addr) {
+                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    connect(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+                }
+            }
+            guard connected == 0 else {
+                throw SampleError(message: "connect(127.0.0.1:\(port)) failed errno=\(errno)")
+            }
+            let request = "GET \(path) HTTP/1.1\r\nHost: 127.0.0.1:\(port)\r\nConnection: close\r\n\r\n"
+            _ = request.withCString { write(fd, $0, strlen($0)) }
+
+            var received = Data()
+            let headTerminator = Data("\r\n\r\n".utf8)
+            var headEnd: Range<Data.Index>?
+            let clock = ContinuousClock.now
+            var chunk = [UInt8](repeating: 0, count: 16384)
+            while ContinuousClock.now - clock < deadline {
+                let n = read(fd, &chunk, chunk.count)
+                if n < 0, errno == EAGAIN || errno == EWOULDBLOCK { continue }
+                guard n > 0 else {
+                    throw SampleError(
+                        message: "stream closed early after \(received.count) bytes (read=\(n) errno=\(errno))"
+                    )
+                }
+                received.append(contentsOf: chunk[0 ..< n])
+                if headEnd == nil { headEnd = received.range(of: headTerminator) }
+                if let headEnd, received.count - headEnd.upperBound >= bodyLimit { break }
+            }
+            guard let headEnd else {
+                throw SampleError(message: "no response head within deadline (\(received.count) bytes)")
+            }
+            let head = String(decoding: received[..<headEnd.lowerBound], as: UTF8.self)
+            guard head.hasPrefix("HTTP/1.1 200") else {
+                throw SampleError(message: "unexpected status: \(head.prefix(40))")
+            }
+            return (head, received[headEnd.upperBound...])
+        }.value
+    }
+}


### PR DESCRIPTION
Closes #350.

## Root cause (full evidence chain on the issue)

URLSession's `AsyncBytes` cannot reliably consume `multipart/x-mixed-replace`, and its failure is timing-dependent: once a full part sits buffered before iteration starts (loopback burst + loaded machine), it throws a bare `NSURLErrorDomain -1` or delivers zero bytes while the task reports no error. Proven with a standalone repro speaking PreviewAppServer's exact framing: **4/6 fail in burst mode, 6/6 pass in streamed mode** — which is the historical ~1/9 rate, tonight's load-correlated spike, and every "daemon healthy, first frame sent" specimen ever collected. The daemon was never at fault.

## Fix

- `RawHTTP.sample` in TestSupport: bounded GET over a plain blocking socket (SO_RCVTIMEO per read + whole-sample deadline), returning the response head + body sample. Timing-independent by construction, and it asserts the actual on-wire framing (`--frame` boundary) that URLSession was hiding.
- Both MJPEG samplers use it: `IOSAppServerTests.readStreamSample` (the flaking one) and `PreviewAppServerStreamTests.readStreamSample` (the review gate caught this second URLSession copy carrying the same latent hazard).
- The avcc reader keeps URLSession: octet-stream has no multipart special-casing and was never implicated.

## Verification

- Repro: deterministic in both directions (posted to #350 with source).
- MCPIntegrationTests: 3/3 green locally under the same conditions that failed 2/5 earlier today, plus a 4th green in the full-suite gate.
- Full local suite 11/11 green, lint exit 0.
- Worktree audited clean after a stray session was found in it (coordinator-flagged; reflog/stash/diff all mine).

## Gates

/simplify + /code-review (2 combined source-verified agents): findings applied — shared helper extraction (killing the duplicated sampler + the `MCPTestError.custom` wart), stale doc cross-reference fix; socket craft verified clean (no busy-spin, no slice-index trap, byte-exact header match, loopback connect semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9tE6iZwyGJcX5Kx9LUnhm