### PR TITLE
Audit and shrink AGENTS.md (#341)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,92 +1,69 @@
 # AGENTS.md
 
-Project instructions for any AI coding agent (Claude Code, Codex, Cursor, Aider, …) working in this repo.
+Project instructions for any AI coding agent (Claude Code, Codex, Cursor, Aider, …) working in this repo. User-facing usage — install, CLI subcommands, `--json`, traits, variants, setup plugin, touch injection — lives in [README.md](README.md). This file is the build/test/merge workflow and the architecture an agent needs to change code safely.
 
 ## Project
 
-PreviewsMCP — standalone SwiftUI preview renderer with MCP server for AI-driven UI development. Renders `#Preview` blocks outside Xcode on both macOS and iOS simulator, with hot-reload, touch interaction, and accessibility tree inspection.
+PreviewsMCP renders SwiftUI `#Preview` blocks outside Xcode on both macOS and the iOS simulator, with hot-reload, touch interaction, and accessibility-tree inspection, driven from a CLI and an MCP server.
 
-## Setup
+## Build, test, lint
 
-Bazel (via [bazelisk](https://github.com/bazelbuild/bazelisk)) is the build for development, tests, and CI. SwiftPM is kept for external consumers of the library products (see [Consuming via SwiftPM](#consuming-via-swiftpm)).
+Bazel (via [bazelisk](https://github.com/bazelbuild/bazelisk)) is the **one** build for development, tests, CI, and lint. Do not validate a change with `swift build` / `swift test` (see the Package.swift note below).
 
 ```bash
-brew bundle                              # Install tools (bazelisk; lint tools are hermetic via //tools/lint)
-git config core.hooksPath .githooks      # Activate pre-commit formatting hook
-bazel build //...                        # Build all targets (first build builds LLVM, ~3-4 min)
+brew bundle                                          # bazelisk; lint tools are hermetic via //tools/lint
+git config core.hooksPath .githooks                  # activate pre-commit formatting hook
+bazel build //...                                    # first build compiles Swift-fork LLVM from source (~3-4 min), then pinned
+bazel test //previewsmcp/Tests/...                   # all test suites
+bazel test //previewsmcp/Tests/PreviewsJITLinkTests  # one suite
+bazel run //previewsmcp/cli:previewsmcp -- --version # run the CLI
+bazel run //tools/lint:format                        # auto-fix formatting (SwiftFormat, clang-format, buildifier)
+bazel run //tools/lint:check                         # verify everything; the merge gate runs this
+bazel run //tools/lint:staged                        # verify only staged files (what the pre-commit hook runs)
 ```
 
 Or run `/bootstrap` in Claude Code.
 
-## Build & Test
+The first build compiles the Swift-fork LLVM from source via `rules_foreign_cc` (pinned, reused after). The iOS JIT resources (`server.o`, `liborc_rt_iossim.a`, the LLVM TargetProcess libs) and the `PreviewAgent` executor build and wire through runfiles automatically — no helper scripts.
 
-```bash
-bazel build //...                                  # Build all targets
-bazel test //previewsmcp/Tests/...                 # Run all test suites
-bazel test //previewsmcp/Tests/PreviewsJITLinkTests  # Run a specific suite
-bazel run //previewsmcp/cli:previewsmcp -- --version  # Run the CLI
-```
+Lint runs through hermetic, Bazel-pinned tools under `//tools/lint`, so only `bazelisk` is needed and a local commit can never disagree with the gate on tool versions: SwiftFormat (`.swiftformat`, owns formatting), SwiftLint (`.swiftlint.yml`, non-strict, semantic rules only — cyclomatic complexity, function length, nesting), clang-format (`.clang-format`), and buildifier for Starlark. SwiftFormat's `hoistTry`, `hoistAwait`, and `preferKeyPath` are disabled because they produced invalid or compiler-crashing Swift — re-verify the full build, not just lint, before re-enabling them.
 
-The first `bazel build` compiles the Swift-fork LLVM from source via `rules_foreign_cc` (~3-4 min); it is pinned, so later builds reuse it. The iOS JIT resources (`server.o`, `liborc_rt_iossim.a`, the LLVM TargetProcess libs) and the `PreviewAgent` executor are built and wired through runfiles automatically — Bazel builds LLVM hermetically, so no helper scripts are needed.
-
-Daemon-touching test suites use `DaemonTestLock` (flock) for cross-target serialization — `@Suite(.serialized)` only orders within a suite, not across test targets. The integration suites are tagged `local` (unsandboxed, like `swift test`) and `exclusive`.
-
-### Consuming via SwiftPM
-
-`Package.swift` stays the published manifest so other Swift projects can depend on the library products (notably `PreviewsSetupKit`). It also feeds the Bazel build: `rules_swift_package_manager` reads it to sync external dependencies. SwiftPM still builds and tests the package directly (`swift build` / `swift test`), with the same coverage, as a fallback and for consumers.
-
-## Formatting & Linting
-
-Lint and format run through hermetic, Bazel-pinned tools under `//tools/lint`, so no host installs are needed (only `bazelisk`) and a local commit can never disagree with the merge gate on tool versions. The tools are [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) (config: `.swiftformat`), [SwiftLint](https://github.com/realm/SwiftLint) (config: `.swiftlint.yml`), [clang-format](https://clang.llvm.org/docs/ClangFormat.html) (config: `.clang-format`), and [buildifier](https://github.com/bazelbuild/buildtools) for Starlark.
-
-```bash
-bazel run //tools/lint:format   # auto-fix formatting (SwiftFormat, clang-format, buildifier)
-bazel run //tools/lint:check    # verify everything; the merge-queue gate runs this
-bazel run //tools/lint:staged   # verify only git-staged files (what the pre-commit hook runs)
-```
-
-SwiftFormat owns formatting; SwiftLint runs non-strict and catches semantic issues (cyclomatic complexity, function length, nesting depth) with the overlapping formatting rules disabled. SwiftFormat's `hoistTry`, `hoistAwait`, and `preferKeyPath` rules are disabled in `.swiftformat` because they produced invalid or compiler-crashing Swift; re-verify the full build, not just lint, before re-enabling them.
+**Package.swift is not a build path.** It publishes exactly one library, `PreviewsSetupKit`, for external SwiftPM consumers, and feeds the Bazel build (`rules_swift_package_manager` reads it to sync external dependencies). It does **not** contain the CLI, engine, or test targets, so `swift build` / `swift test` compile a near-empty package and pass without exercising any code you changed — a false positive. Build and test only via the Bazel commands above.
 
 ## Architecture
 
 ```
-previewsmcp/             # Umbrella for all first-party Bazel-built code (one dir per module)
+previewsmcp/             # umbrella for all first-party Bazel-built code (one dir per module)
 ├── SimulatorBridge/     # ObjC — runtime-loads CoreSimulator.framework (no build-time linking)
-├── PreviewsCore/        # Platform-agnostic: parser, compiler, bridge gen, differ, file watcher
+├── PreviewsCore/        # platform-agnostic: parser, compiler, bridge gen, differ, file watcher
 ├── PreviewsMacOS/       # macOS host: NSApplication + NSWindow + Snapshot (runs inside the daemon)
 ├── PreviewsIOS/         # iOS simulator: SimulatorManager, IOSAgentBuilder, IOSPreviewSession
-├── PreviewsEngine/      # Cross-platform engine wiring PreviewsCore + iOS/macOS hosts
+├── PreviewsEngine/      # cross-platform engine wiring PreviewsCore + iOS/macOS hosts
 ├── PreviewsJITLink/     # Swift JIT-link layer (+ PreviewsJITLinkCxx C++ shim)
-├── PreviewsCLI/         # CLI (ArgumentParser) + daemon + MCP server (swift-sdk) — library target
+├── PreviewsCLI/         # CLI (ArgumentParser) + daemon + MCP server (swift-sdk) — a library
 ├── PreviewAgent/        # C++ in-process JIT executor binary
-├── cli/                 # Thin executable shim (Bazel target //previewsmcp/cli:previewsmcp)
-├── ios-host/            # iOS agent/shell/executor app source embedded at session start
-└── Tests/               # All unit + integration test suites
+├── cli/                 # thin executable shim → //previewsmcp/cli:previewsmcp
+├── ios-host/            # iOS agent/shell/executor app source, embedded at session start
+└── Tests/               # all unit + integration test suites
 
-Sources/
-└── PreviewsSetupKit/    # Setup plugin protocol (PreviewSetup) — the only SwiftPM-exposed library
+Sources/PreviewsSetupKit/  # the only SwiftPM-exposed library (the PreviewSetup plugin protocol)
 ```
 
-`PreviewsCLI` is a library, not an `executableTarget`, so the test targets in `previewsmcp/Tests/PreviewsCLITests/` and `previewsmcp/Tests/MCPIntegrationTests/` can `@testable import PreviewsCLI` under both `swift test` and Xcode-driven SPM builds (Xcode's dependency scanner refuses to expose an executable target's swiftmodule to dependent tests, which broke `xcodebuild build-for-testing` before PR #184). `previewsmcp/cli/` is a three-line shim that imports `PreviewsCLI` and calls `PreviewsMCPApp.main()` — the only purpose of that target is to be the executable product. Match the `previewsmcp` directory/target naming if `PreviewsCLI` is sliced further (see `prompts/modularization.md` on the `previews-research` branch).
-
-- **PreviewsCore** has no platform-specific dependencies (no AppKit, no CoreSimulator)
-- **SimulatorBridge** is ObjC because it uses `objc_lookUpClass` / protocol casts for private API access
-- **PreviewsIOS** depends on SimulatorBridge; touch injection runs in-app via Hammer approach (IOHIDEvent + BKSHIDEventSetDigitizerInfo)
-- **iOS agent-app source lives in `previewsmcp/ios-host/agent/`** (`AgentApp.swift`, `Info.plist`, `AppIcon.png`), with the shell app alongside it in `previewsmcp/ios-host/shell/`. The `embed_host_app_source` rule (driven by `bazel/embed.bzl`, wired in `bazel/embed/BUILD.bazel`) reads those files and emits `IOSAgentAppSource.generated.swift` exposing them as `IOSAgentAppSource.code` / `.infoPlist` / `IOSAppIconData.bytes` (base64-encoded). `IOSAgentBuilder` writes the source out at session start and compiles it with swiftc targeting arm64-apple-ios-simulator. Byte-equivalence with the previous stringified blob is pinned by `IOSAgentBuilderHashTests`.
+- **PreviewsCore** has no platform-specific dependencies (no AppKit, no CoreSimulator).
+- **SimulatorBridge** is ObjC because it uses `objc_lookUpClass` / protocol casts for private-API access; **PreviewsIOS** depends on it, and touch injection runs in-app via the Hammer approach (IOHIDEvent + `BKSHIDEventSetDigitizerInfo`).
+- **PreviewsCLI is a `swift_library`, not an executable**, so the test targets can `@testable import PreviewsCLI`; `previewsmcp/cli/` is a three-line shim that calls `PreviewsMCPApp.main()` and exists only to be the executable product. Match the `previewsmcp` directory/target naming if `PreviewsCLI` is sliced further.
+- **iOS agent-app source is real Swift** in `previewsmcp/ios-host/agent/` (`AgentApp.swift`, `Info.plist`, `AppIcon.png`), with the shell app alongside in `previewsmcp/ios-host/shell/`. The `embed_host_app_source` rule (`bazel/embed.bzl`, wired in `bazel/embed/BUILD.bazel`) reads those files and emits `IOSHostAppSource.generated.swift`, which defines the `IOSAgentAppSource` enum exposing them as base64 constants. `IOSAgentBuilder` writes the source out at session start and compiles it with swiftc targeting arm64-apple-ios-simulator. Byte-equivalence is pinned by `IOSAgentBuilderHashTests`.
 
 ### Daemon model
 
-All CLI subcommands except `serve` are **daemon clients** — they connect to a background daemon process over a Unix domain socket at `~/.previewsmcp/serve.sock`. The daemon auto-starts on first CLI invocation (ADB-style) and persists across commands.
+All CLI subcommands except `serve` are **daemon clients** — they connect to a background daemon over a Unix domain socket at `~/.previewsmcp/serve.sock`. The daemon auto-starts on first CLI invocation (ADB-style) and persists across commands. CLI convention: read-oriented commands write data/JSON to **stdout** and progress/logs to **stderr**; imperative commands write confirmations to stderr only, keeping stdout clean for piping.
 
 Key files:
-- `DaemonClient.swift` — auto-start + connect via `withDaemonClient(name:body:)`. Registers a stderr log-forwarder for `LogMessageNotification` before the MCP handshake.
+- `DaemonClient.swift` — auto-start + connect via `withDaemonClient(name:body:)`; registers a stderr log-forwarder for `LogMessageNotification` before the MCP handshake.
 - `DaemonListener.swift` — POSIX UDS accept loop (`DaemonSocket`), per-connection `PreviewsMCPServer` over `FramedTransport`.
 - `DaemonLifecycle.swift` — PID file, `setsid()` detachment, signal handlers.
-- `DaemonProbe.swift` — socket liveness check (connect + immediate close).
 - `SessionResolver.swift` — resolves `--session <uuid>` / `--file <path>` / sole-running-session targeting.
 - `DaemonProtocol.swift` — shared `Codable` DTOs for `structuredContent` payloads on tool responses.
-- `MCPContentHelpers.swift` — `Value.decode(_:)`, the `DaemonToolCalling` seam, `emitJSON(...)`.
-- `SessionTargetingOptions.swift` — shared `@OptionGroup` for `--session` / `--file`.
 
 `PreviewsMCPApp.swift` routes commands: only `serve` runs `NSApplication`; everything else uses `dispatchMain()` + async `Task`.
 
@@ -97,175 +74,59 @@ Key files:
 - **Stdio** (default) — spawned by MCP clients via `.mcp.json` (Claude Code, Cursor). Self-contained: own `PreviewHost`, `IOSSessionManager`, `ConfigCache`. Resident for the lifetime of the MCP host process.
 - **UDS daemon** (`--daemon`) — auto-spawned by every CLI subcommand at `~/.previewsmcp/serve.sock`. Persists across CLI invocations.
 
-A session created via MCP tools lives in the stdio process and is **not** visible to `previewsmcp list` / `snapshot --session-id …` (which talk to the daemon). And vice versa.
+A session created via MCP tools lives in the stdio process and is **not** visible to `previewsmcp list` / `snapshot --session-id …` (which talk to the daemon), and vice versa.
 
-When validating code changes, both halves can go stale — `swift build` overwrites the binary, but resident processes keep running the old code:
+When validating code changes, both halves can go stale — `bazel build` overwrites the binary, but resident processes keep running the old code:
 
-- Refresh stdio: `/exit` and relaunch Claude Code (or call `preview_build_info` to detect staleness — `stale: true` means the on-disk binary has been rebuilt since the running process started).
-- Refresh daemon: `previewsmcp kill-daemon` (auto-respawns on next CLI invocation; #142's version-mismatch handshake also restarts it transparently).
+- Refresh stdio: `/exit` and relaunch Claude Code (or call `preview_build_info` — `stale: true` means the on-disk binary was rebuilt since the running process started).
+- Refresh daemon: `previewsmcp kill-daemon` (auto-respawns on the next CLI invocation; #142's version-mismatch handshake also restarts it transparently).
 
-The stdio server has no equivalent of #142's handshake — there's no peer to handshake with — so the staleness must be detected client-side.
+The stdio server has no equivalent of #142's handshake — there's no peer to handshake with — so staleness must be detected client-side.
 
-**Worktrees (#154):** open Claude Code from inside the worktree directory, not via `/resume` from the main repo. `/resume` preserves the original project root, so the stdio MCP server keeps pointing at the main repo's `.build/...` binary regardless of where you re-launched. Fresh launches in each worktree resolve the relative `.mcp.json` command path correctly. The integration-test skill's Step 2 catches the mismatch automatically if you forget.
+**Worktrees (#154):** open Claude Code from inside the worktree directory, not via `/resume` from the main repo. `/resume` preserves the original project root, so the stdio MCP server keeps pointing at the main repo's `bazel-bin/...` binary regardless of where you re-launched. Fresh launches in each worktree resolve the relative `.mcp.json` command path correctly. The integration-test skill's Step 2 catches the mismatch automatically if you forget.
 
-### CLI subcommands
+## Key conventions
 
-| Command | Purpose | Daemon? |
-|---------|---------|---------|
-| `run` | Start a live preview session (attached or `--detach`) | client |
-| `snapshot` | Screenshot a preview (reuses existing session or ephemeral) | client |
-| `variants` | Multi-trait screenshot sweep | client |
-| `list` | Enumerate `#Preview` blocks in a file | local |
-| `configure` | Change traits on a live session | client |
-| `switch` | Switch active `#Preview` block | client |
-| `elements` | Dump iOS accessibility tree as JSON | client |
-| `touch` | Inject tap or swipe on iOS simulator | client |
-| `simulators` | List available iOS simulator devices | client |
-| `stop` | Close one or all sessions (`--all`) | client |
-| `status` | Check daemon liveness | local |
-| `kill-daemon` | Stop the daemon process | local |
-| `serve` | Start the daemon (usually auto-started) | IS the daemon |
+- Swift 6.0 strict concurrency — actors for shared state, `Sendable` structs for cross-isolation data.
+- Private framework access: runtime-load via `Bundle(path:).loadAndReturnError()` + `objc_lookUpClass()`, never build-time link.
+- Old dylibs/views are retained (never `dlclose`) to prevent `EXC_BAD_ACCESS`.
+- `.tag()` integer literals are excluded from `ThunkGenerator` to avoid Int/CGFloat overload ambiguity.
+- All custom `Error` types conform to `LocalizedError` with `errorDescription` (not just `CustomStringConvertible`) so the MCP server reports useful messages.
 
-### Structured output (`--json`)
+## MCP server
 
-Seven read-oriented commands support `--json` for scripts and agent consumption: `run --detach`, `snapshot`, `variants`, `list`, `status`, `simulators`, `elements`. When `--json` is set, stdout gets one JSON document; progress/log messages still go to stderr. Imperative commands (`stop`, `touch`, `configure`, `switch`) do not get `--json`.
+Binary: `scripts/previewsmcp serve` (builds `//previewsmcp/cli:previewsmcp` via bazelisk, then execs it).
+Config: `.mcp.json` at the repo root — Claude Code auto-spawns the stdio server from it at session start, which is what the `mcp__previewsmcp__*` tools and the `integration-test` skill reach.
 
-The daemon also populates `CallTool.Result.structuredContent` alongside text content blocks on 7 MCP tool handlers. CLI commands decode `structuredContent` via `Value.decode(T.self)` using the DTOs from `DaemonProtocol.swift` — no regex parsing of prose.
+Tools: `preview_list`, `preview_start`, `preview_configure`, `preview_switch`, `preview_variants`, `preview_snapshot`, `preview_elements`, `preview_touch`, `preview_stop`, `simulator_list`, `session_list`, `preview_build_info`. Handlers that return non-trivial data emit a `structuredContent` payload (Codable DTOs from `DaemonProtocol.swift`) alongside the text content blocks, so agents can skip parsing prose.
 
-### Output streams
+## Git & merge workflow
 
-CLI commands follow a stdout-for-data, stderr-for-side-effects convention:
+`main` is branch-protected — every change goes through a PR. Create a feature branch before committing; use a worktree when working in parallel with other agents to avoid conflicts.
 
-- **Read-oriented** commands (`list`, `status`, `simulators`, `elements`, `snapshot`, `variants`, `run --detach`) write their primary output (data, JSON, session ID) to **stdout**. Progress and log messages go to stderr.
-- **Imperative** commands (`configure`, `switch`, `touch`, `stop`) write confirmation messages to **stderr** only, keeping stdout clean for piping.
-- Daemon log forwarding (`LogMessageNotification` → stderr) applies to all daemon-client commands.
+CI (self-hosted Mac mini runner: `bazel run //tools/lint:check` + `bazel test //...`, ~9 min warm) is a **non-required, corroborating signal** — `required_status_checks` is not on the `main` ruleset, so nothing gates a merge automatically. Local verification is the gate, and you run all of it.
 
-## Key Conventions
+Merge checklist — a green CI check is corroborating, not a substitute:
 
-- Swift 6.0 strict concurrency — actors for shared state, Sendable structs for cross-isolation data
-- Private framework access: runtime-load via `Bundle(path:).loadAndReturnError()` + `objc_lookUpClass()`, never build-time link
-- iOS agent app source is real Swift in `previewsmcp/ios-host/agent/AgentApp.swift` (lintable, formatable, compile-checked); the `embed_host_app_source` rule embeds it as a base64 constant for runtime compilation with swiftc targeting arm64-apple-ios-simulator
-- Old dylibs/views are retained (never dlclose) to prevent EXC_BAD_ACCESS
-- `.tag()` integer literals are excluded from ThunkGenerator to avoid Int/CGFloat overload ambiguity
-- All custom Error types must conform to `LocalizedError` with `errorDescription` (not just `CustomStringConvertible`) so MCP server reports useful messages
+1. `/simplify` then `/code-review` on each chunk of your diff.
+2. `bazel run //tools/lint:check` clean.
+3. Full local suite: `bazel test //previewsmcp/Tests/...` (all unit suites) plus the `integration-test` skill for the example end-to-end coverage. No CI shortcut. (`swift test` is not a fallback — see the Package.swift note.)
+4. Classify each failure as yours-vs-preexisting; a preexisting failure on `main` is not a blocker, but say so explicitly.
+5. Stage explicit paths (`git add <path> …`) — never `git add -A`.
+6. Un-draft the PR, then squash-merge your own PR.
 
-## MCP Server
+## Test architecture
 
-Binary: `scripts/previewsmcp serve` (builds `//previewsmcp/cli:previewsmcp` via bazelisk, then execs it)
-Config: `/.mcp.json` (in parent directory)
-
-Tools: `preview_list`, `preview_start`, `preview_configure`, `preview_switch`, `preview_variants`, `preview_snapshot`, `preview_elements`, `preview_touch`, `preview_stop`, `simulator_list`, `session_list`, `preview_build_info`
-
-All tool handlers that return non-trivial data emit a `structuredContent` payload (Codable DTOs from `DaemonProtocol.swift`) alongside the human-readable text content blocks. Agents that consume `structuredContent` can skip parsing prose.
-
-## Trait Injection
-
-`preview_configure` and `preview_start` accept these trait parameters to render previews under different SwiftUI traits:
-
-| Trait | Values | SwiftUI modifier |
-|-------|--------|-----------------|
-| `colorScheme` | `"light"`, `"dark"` | `.preferredColorScheme()` |
-| `dynamicTypeSize` | `"xSmall"` through `"accessibility5"` | `.dynamicTypeSize()` |
-| `locale` | BCP 47 identifier (e.g., `"en"`, `"ar"`, `"ja-JP"`) | `.environment(\.locale, ...)` |
-| `layoutDirection` | `"leftToRight"`, `"rightToLeft"` | `.environment(\.layoutDirection, ...)` |
-| `legibilityWeight` | `"regular"`, `"bold"` | `.environment(\.legibilityWeight, ...)` |
-
-Traits are injected as view modifiers in the generated bridge code. Changing traits triggers a full recompile (@State is lost). Traits persist across hot-reload cycles and preview switches. Pass an empty string `""` to clear a previously set trait.
-
-`locale` is not validated against a fixed list — any non-empty string is accepted. `layoutDirection` and `legibilityWeight` are validated against their respective enum values.
-
-## Multi-Preview Support
-
-Files with multiple `#Preview` blocks are fully supported. `preview_list` shows all previews with closure body snippets. `preview_start` accepts a `previewIndex` parameter (default 0) and returns the full list of available previews. `preview_switch` changes which preview is rendered in a running session without tearing down the session — traits persist across switches, @State is reset. If a switch fails (e.g., invalid index), the session rolls back to the previous preview.
-
-**macOS limitation:** `dynamicTypeSize` has no visible effect on macOS. macOS does not have a system-level Dynamic Type feature, and `NSHostingView` does not scale fonts in response to the `.dynamicTypeSize()` modifier. Use iOS simulator previews to test dynamic type sizes. `colorScheme` works on both platforms.
-
-## Variant Capture
-
-`preview_variants` captures screenshots under multiple trait configurations in a single MCP call. Pass preset names (`"light"`, `"dark"`, `"xSmall"` through `"accessibility5"`, `"rtl"`, `"ltr"`, `"boldText"`) or JSON object strings for custom combinations (e.g., `{"colorScheme":"dark","locale":"ar","layoutDirection":"rightToLeft","label":"dark-arabic"}`). The session's original traits are restored after all variants are captured. Each variant triggers a recompile.
-
-## Project Config
-
-A `.previewsmcp.json` file at the project root sets defaults for all CLI commands and MCP tool calls. All fields are optional.
-
-```json
-{
-  "platform": "ios",
-  "device": "iPhone 16 Pro",
-  "traits": {
-    "colorScheme": "dark",
-    "dynamicTypeSize": "large",
-    "locale": "en"
-  },
-  "quality": 0.9,
-  "setup": {
-    "moduleName": "MyAppPreviewSetup",
-    "typeName": "AppPreviewSetup"
-  }
-}
-```
-
-**Precedence:** explicit MCP/CLI parameter > config file > built-in default. The config file is auto-discovered by walking up from the source file directory. CLI commands accept `--config <path>` to override auto-discovery.
-
-The `device` field accepts either a device name (e.g., `"iPhone 16 Pro"`) or a UDID.
-
-## Setup Plugin
-
-`PreviewsSetupKit` is a zero-dependency SwiftUI-only library that ships the `PreviewSetup` protocol. It replaces micro apps / dev apps by providing the same mock dependency setup and theme wrapping without maintaining a separate app target.
-
-**Two methods, two lifecycles:**
-
-| Method | When | Survives hot-reload? | Use case |
-|--------|------|---------------------|----------|
-| `setUp()` | Once per session, before first preview | Yes | Firebase init, auth, fonts, DI container |
-| `wrap(_:)` | Every dylib load | N/A | Theme providers, environment values |
-
-`setUp()` is `async throws` and runs completely outside the hot-reload path. If it throws, the preview renders without setup and the error is reported as a warning. Trait modifiers from `preview_configure` are applied outside the wrap, so explicit overrides always take precedence.
-
-The setup target is declared in `.previewsmcp.json` via `setup.moduleName`, `setup.typeName`, and `setup.packagePath` (relative to config file). PreviewsMCP builds the setup package independently via `SetupBuilder` — the user's app target has no dependency on PreviewsMCP. Standalone mode (no build system) ignores the setup config with a warning.
-
-## iOS Touch Injection
-
-Uses Hammer approach (in-app, headless, no mouse movement):
-1. IOKit: `IOHIDEventCreateDigitizerFingerEvent` (transducerType=3)
-2. BackBoardServices: `BKSHIDEventSetDigitizerInfo` with `UIWindow._contextId`
-3. UIKit: `UIApplication._enqueueHIDEvent:`
-
-All loaded via dlopen/dlsym inside the iOS host app. Does NOT use IndigoHID/SimulatorKit (those create pointer events, not touch events on Xcode 26.2).
-
-## Git Workflow
-
-The `main` branch has branch protections — all changes must go through a pull request. Always create a feature branch before committing. Use worktrees when working in parallel with other agents to avoid conflicts.
-
-### Verifying a PR before merge
-
-CI runs on a self-hosted Mac mini runner (`bazel test //...` + `bazel run //tools/lint:check`, ~9 min warm) but is a **non-required signal** while it builds a track record — the `required_status_checks` rule is not yet on the `main` ruleset, so nothing gates a merge automatically. Verification is local and mandatory: a PR does **not** merge until **all unit tests pass** and **the example integration tests pass via the `integration-test` skill**. Run the suites with `bazel test //previewsmcp/Tests/...`, then run the `integration-test` skill for the example end-to-end coverage. (`swift test` still works as a fallback; pass `--filter PreviewsJITLinkTests --no-parallel` for the JIT tests there.) A green CI check is corroborating, not sufficient.
-
-## Test Notes
-
-### Test architecture
-
-- **DaemonTestLock** serializes daemon-touching tests across suites via `flock`. Uses blocking `flock(LOCK_EX)` on `DispatchQueue.global` — NOT non-blocking polling with `Task.sleep`, which starves Swift's cooperative thread pool on CI runners with small pools (~3-4 threads) and causes deadlocks. The lock file, `serve.log`, and the daemon socket all live under `DaemonTestLock.effectiveSocketDir` so concurrent jobs get separate state.
-- **Per-run daemon socket dir (#283).** `DaemonTestLock.effectiveSocketDir` resolves `PREVIEWSMCP_SOCKET_DIR` → a short `/tmp/pmcp-<hash>` keyed off `$TEST_TMPDIR` → system temp. Bazel sets `TEST_TMPDIR` unique per test target, so the hash makes the socket dir unique per target with NO hand-allocated `PREVIEWSMCP_SOCKET_DIR` literal. We hash to `/tmp/pmcp-<hash>` instead of nesting under `$TEST_TMPDIR` because a Unix-domain socket path is capped at 104 bytes (`sun_path`) on macOS and `$TEST_TMPDIR` is already ~140 chars deep — `bind()` would silently fail. The harness (`MCPTestServer.start`, `CLIRunner`, `DaemonLifecycleTests`, `RunCommandTests`, `VersionHandshakeTests`, `LogsCommandTests`) EXPORTS this value as `PREVIEWSMCP_SOCKET_DIR` into EVERY spawned daemon/CLI so production `DaemonPaths` picks it up — any test that spawns the binary directly must do the same or it will resolve a different socket than its probes. Production `DaemonPaths` must NOT honor `TEST_TMPDIR` — the `$TEST_TMPDIR` rung lives only in the test-side resolver. The `/tmp/pmcp-<hash>` dir is not auto-deleted, but it is stale-safe: `cleanSlate()` + the daemon's connect-probe single-instance guard reclaim any leftover.
-- **`@Suite(.serialized)`** only orders tests within a single suite. It does NOT serialize across suites or test targets. DaemonTestLock exists to fill that gap.
-- **`MCPTestServer.withTimeout`** races `body` against a detached `Thread` (pthread) timer, NOT a `Task.sleep`-based one. When the MCP SDK's transport loop busy-spins on a wedged server (see issue #135), the cooperative pool is starved and `Task.sleep`-based timers never fire — the prior `withThrowingTaskGroup` implementation silently timed out at Swift Testing's `.timeLimit` with no diagnostic. The pthread resumes a shared `CheckedContinuation` directly, which is a synchronous primitive with no pool dependency. On timeout the pthread also calls `process.terminate()` on the server subprocess so the daemon-side state doesn't persist into the next test. Note: the body `Task` may leak if its pending MCP continuation never drains (SDK transport EOF does not resume `pendingRequests`; only `disconnect()` does) — acceptable cost for an already-failing test; the process exits shortly after.
-- All daemon-touching tests share one daemon at `~/.previewsmcp/serve.sock` (or `PREVIEWSMCP_SOCKET_DIR` if set). Each suite calls `cleanSlate()` at the start to kill any leftover daemon; the daemon auto-starts on the first CLI command and persists within the suite.
-
-### CI-specific concerns
-
-- **CI is one `bazel` job** on the self-hosted Mac mini runner: `bazel run //tools/lint:check` then `bazel test //...`. There is no cross-job daemon contention — target isolation comes from the per-target socket dirs below.
-- **Bazel daemon-touching test targets need NO `PREVIEWSMCP_SOCKET_DIR`** in their `swift_test` `env` — the harness derives a per-run, per-target socket dir from `$TEST_TMPDIR` (`DaemonTestLock.effectiveSocketDir`) and exports it into spawned daemons (#283). New daemon-touching targets get isolation automatically; do not add a hand-allocated literal. (An explicit `PREVIEWSMCP_SOCKET_DIR` still wins if a specific path is ever required.)
-- **The daemon requires a window server** (`NSApplication.shared` + `NSHostingView` for rendering). The runner is a LaunchAgent in the mini's auto-login GUI session, which provides one — the daemon must not be spawned in a context that loses display access (e.g., certain `launchd` contexts). If tests hang with zero output, check whether `CGMainDisplayID()` returns 0.
-- **Daemon startup is slow on CI** (~5-10s vs ~500ms locally). The `DaemonClient.connect(startTimeout:)` default is 30s to accommodate this.
-- **Bidirectional MCP-ping liveness** — both sides of the daemon channel run the shared missed-pong loop in `PingLiveness.swift`: the client pings every 5s and disconnects after 6 missed pongs (~30s wedged-daemon bound; policy and rationale on `DaemonClient.openClient`), the daemon pings every 60s and disconnects after 3 (dead-client backstop; see `DaemonListener`). ANY inbound frame counts as life. A client-side disconnect drains pending requests, so the body's `callTool` awaits throw a transport error rather than hanging forever. There is NO unsolicited server traffic on an idle connection: the pre-stage-6 2s `logger: "heartbeat"` notification and the `StallTimer` actor are retired, and `registerStderrLogForwarder` filters the heartbeat logger only for stale pre-stage-6 daemons in the version-skew window. Do NOT emit unsolicited `ProgressNotification`s — without a `progressToken` they are out-of-spec; use `server.log(level:,logger:,data:)`.
-- **MCPTestServer watchdog** — every active `MCPTestServer` spawns a detached `Thread` (real pthread) that wakes every 60s and writes the elapsed time plus the tail of the server's stderr to the test process's own stderr via `fputs`. Silent on the happy path (tests < 60s never emit), but when Swift Testing's `.timeLimit` kills a hanging MCP test the CI log contains a minute-by-minute trail of what the server subprocess was actually doing. The first implementation used `DispatchSource.makeTimerSource(qos: .utility)` — that produced no output in a real CI hang because libdispatch's utility-QoS workers were starved by whatever was burning cores. A raw pthread sidesteps QoS scheduling and Swift concurrency entirely; `Thread.sleep` blocks in the kernel rather than suspending a cooperative task. Don't replace it with `Task.sleep` or a GCD-based variant: the whole point is to survive cooperative-pool and libdispatch-QoS starvation.
+- **DaemonTestLock** serializes daemon-touching tests across suites via blocking `flock(LOCK_EX)` on `DispatchQueue.global` — NOT non-blocking polling with `Task.sleep`, which starves Swift's cooperative pool on runners with small pools (~3-4 threads) and deadlocks. `@Suite(.serialized)` only orders tests within one suite, not across suites or test targets — DaemonTestLock fills that gap. The lock file, `serve.log`, and the socket all live under `DaemonTestLock.effectiveSocketDir`.
+- **Per-run daemon socket dir (#283).** `DaemonTestLock.effectiveSocketDir` resolves `PREVIEWSMCP_SOCKET_DIR` → a short `/tmp/pmcp-<hash>` keyed off `$TEST_TMPDIR` → system temp. Bazel sets `TEST_TMPDIR` unique per test target, so the hash makes the socket dir unique per target with no hand-allocated literal. We hash to `/tmp/pmcp-<hash>` instead of nesting under `$TEST_TMPDIR` because a UDS path is capped at 104 bytes (`sun_path`) on macOS and `$TEST_TMPDIR` is already ~140 chars deep — `bind()` would silently fail. The harness (`MCPTestServer.start`, `CLIRunner`, `DaemonLifecycleTests`, `RunCommandTests`, `VersionHandshakeTests`, `LogsCommandTests`) exports this value as `PREVIEWSMCP_SOCKET_DIR` into every spawned daemon/CLI so production `DaemonPaths` picks it up — any test that spawns the binary directly must do the same or it resolves a different socket than its probes. Production `DaemonPaths` must NOT honor `TEST_TMPDIR`; that rung lives only in the test-side resolver. New daemon-touching targets get isolation automatically — do NOT add a hand-allocated `PREVIEWSMCP_SOCKET_DIR` literal (an explicit one still wins if a specific path is ever required). The dir is not auto-deleted but is stale-safe: `cleanSlate()` + the daemon's connect-probe single-instance guard reclaim leftovers.
+- **Bidirectional MCP-ping liveness.** Both sides of the daemon channel run the shared missed-pong loop in `PingLiveness.swift`: the client pings every 5s and disconnects after 6 missed pongs (~30s wedged-daemon bound; see `DaemonClient.openClient`), the daemon pings every 60s and disconnects after 3 (dead-client backstop; see `DaemonListener`). ANY inbound frame counts as life. A client-side disconnect drains pending requests, so the body's `callTool` awaits throw a transport error rather than hanging forever. There is NO unsolicited server traffic on an idle connection. Do NOT emit unsolicited `ProgressNotification`s — without a `progressToken` they are out-of-spec; use `server.log(level:,logger:,data:)`.
+- **`MCPTestServer.withTimeout` and its watchdog both run on detached real pthreads, never `Task.sleep`/`DispatchSource`/GCD.** When the MCP SDK's transport loop busy-spins on a wedged server (#135), the cooperative pool and libdispatch-QoS workers are starved and those timers never fire; a raw pthread with `Thread.sleep` blocks in the kernel and survives. `withTimeout` races `body` against the pthread, which resumes a shared `CheckedContinuation` (a synchronous primitive) and calls `process.terminate()` on the server subprocess so daemon-side state doesn't leak into the next test. The always-on watchdog wakes every 60s and `fputs`-writes elapsed time + the server's stderr tail to the test process's stderr — silent under 60s, but a minute-by-minute trail when `.timeLimit` kills a hang.
+- **The daemon needs a window server** (`NSApplication.shared` + `NSHostingView` to render). If daemon-touching tests hang with zero output, check whether `CGMainDisplayID()` returns 0 — the daemon lost display access.
 
 ### iOS simulator tests
 
-- **`SimulatorManager.bootDevice` blocks until the device is actually booted.** `SBDevice.boot()` alone returns as soon as boot *starts*; `bootDevice` wraps it and then awaits `xcrun simctl bootstatus <udid> -b` (Apple's "block until SpringBoard is up" primitive). Callers can stop sleep-then-hoping. Default timeout is 180s — typical CI boot is 5-15s but P95 on busy GHA runners has been observed at 60-90s.
-- **Display attach is async vs. bootstatus.** The display subsystem wires ports AFTER SpringBoard is up. On CI this race typically closes within 2-8s. `SimulatorManager.screenshotData` retries direct `SBCaptureFramebuffer` capture up to 5× with 2s backoff before falling back to `xcrun simctl io <udid> screenshot` (which has its own 60s timeout — it can hang indefinitely if the display never attaches).
-- **Each sim-booting test resolves its own dedicated device via `SimulatorTestDevices` (#337).** Each test passes a distinct index and gets a harness-owned simulator named `previewsmcp-test-<index>`, created on demand as an iPhone 17 on the newest installed iOS 26+ runtime (idempotent; wrong-shape or duplicate devices with that name are deleted and recreated). This replaced the retired `IOSSimulatorPicker`, which indexed the shared `simctl` pool sorted by runtime and UDID — the index→model mapping was arbitrary per machine and reshuffled when an Xcode update changed the default device set. Resolve while holding `SimulatorTestLock` (creation mutates the shared device set); add a new index for any new iOS test that boots a device and record it in the `SimulatorTestDevices` doc comment.
-- **iPhones only, not iPads.** The dedicated devices are pinned to iPhone 17. M-chip iPads (Air/Pro with M2+) on GHA runners have been observed exceeding 60s bootstatus — iPhones are reliable in the <15s window.
-- **`AsyncProcessTimeout` carries pre-kill `capturedStdout` / `capturedStderr`.** When `runAsync(timeout:)` fires, the subprocess is SIGTERM'd and its pipes drained before the error is thrown, so CI logs show *which* stage the subprocess stalled at (e.g., `Waiting on <SpringBoard>`) rather than just "it hung."
-- **CoreSimulator daemon state can still flake** after rapid boot/shutdown cycles — retry logic is built into `IOSPreviewSession.start()` for transient boot failures.
-- The `bootAndShutdown` and `endToEnd` tests always clean up (shutdown device) even on failure.
+- **`SimulatorManager.bootDevice` blocks until the device is actually booted.** `SBDevice.boot()` returns as soon as boot *starts*; `bootDevice` then awaits `xcrun simctl bootstatus <udid> -b` (block until SpringBoard is up). Default timeout 180s.
+- **Display attach is async vs. bootstatus** — the display subsystem wires ports after SpringBoard is up. `SimulatorManager.screenshotData` retries direct `SBCaptureFramebuffer` capture up to 5× with 2s backoff before falling back to `xcrun simctl io <udid> screenshot`.
+- **Each sim-booting test resolves its own dedicated device via `SimulatorTestDevices` (#337).** Each test passes a distinct index and gets a harness-owned simulator `previewsmcp-test-<index>`, created on demand as an iPhone 17 on the newest installed iOS 26+ runtime (idempotent). Resolve while holding `SimulatorTestLock` (creation mutates the shared device set); add a new index for any new device-booting test and record it in the `SimulatorTestDevices` doc comment.
+- **iPhones only, not iPads.** M-chip iPads have been observed exceeding 60s bootstatus; iPhones are reliable in the <15s window.
+- **`AsyncProcessTimeout` drains the subprocess's pipes before throwing** (`runAsync(timeout:)` SIGTERMs then captures stdout/stderr), so logs show which stage stalled. CoreSimulator daemon state can still flake after rapid boot/shutdown cycles — `IOSPreviewSession.start()` retries transient boot failures.


### PR DESCRIPTION
Closes #341.

Shrinks AGENTS.md from ~6.9k to ~4.0k estimated tokens (42% cut, `wc -c / 4`), weighting the remaining content toward the build/test/merge workflow and test craft, and dropping the ~half that duplicated README (install, CLI usage, `--json`, traits, variants, multi-preview, setup plugin, touch injection → now a pointer to README.md).

## Four stale claims fixed
- **SwiftPM coverage.** Post-#246 `Package.swift` publishes only `PreviewsSetupKit`, so `swift build` / `swift test` compile a near-empty package and pass without exercising changed code — a false positive. Replaced the "same coverage / `swift test` fallback" advice, and swept the stray `swift build` (daemon-staleness) and `.build/...` (worktree) mentions, with the real Bazel build+test+lint reality.
- **.mcp.json location.** Was "parent directory"; it is at the **repo root**. Fixed, and noted it is what Claude Code auto-spawns the stdio server from (what `mcp__previewsmcp__*` and the integration-test skill reach).
- **"CI-specific concerns" section.** Moved the three load-bearing bullets under **Test architecture** (per-target socket dir #283, bidirectional MCP-ping liveness, MCPTestServer pthread watchdog) and deleted the CI-runner-specific bullets. Kept the window-server / `CGMainDisplayID()==0` hang hint as a real debugging lever.
- **Merge gate** (previously described twice, neither complete) consolidated into one checklist: `/simplify` + `/code-review` per chunk → `lint:check` → full local suite (no CI) → classify failures ours-vs-preexisting → stage explicit paths → un-draft → squash-merge.

## Scope / verification
- Docs-only diff (markdown), no runtime surface — unit/integration suites N/A.
- `bazel run //tools/lint:check` clean (exit 0; remaining warnings are pre-existing in untouched source files).
- No comment-policy section added — that is sequenced under #365, after this lands.
- `.mcp.json` retained (keep/remove is being arbitrated separately); this PR only fixes its documented location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)