### PR TITLE
#344: rescue #254 native-window research + macOS input docs into git

### DIFF
--- a/docs/254-macos-native-window-plan.md
+++ b/docs/254-macos-native-window-plan.md
@@ -1,0 +1,224 @@
+# #254 macOS preview — native window with seamless respawn handoff
+
+## Summary
+
+The shipped #254 macOS path (shell-owns-agent) regressed the macOS
+experience: it is not a true macOS view. The agent renders off-screen, rasters
+its frame on the CPU (`cacheDisplay` → `CGImage` → IOSurface), and a separate
+shell process hosts that raster cross-process via `CALayerHost`; input is
+captured in the shell, shipped over a pipe, and replayed as synthesized
+`NSEvent`s. The result is a fixed-size screenshot in a window — it does not
+resize, scroll, or animate natively, input feels indirect, and it is not
+performant. A spike proved the root cause is unfixable in that topology: a
+`CAContext` carries **pixels, not views** — vending a live `NSHostingView`'s
+backing layer hosts nothing (the consumer shows empty), while a plain `CALayer`
+tree hosts fine. So any cross-process hosting is necessarily a raster.
+
+This plan reverses that decision for macOS. Unlike Xcode — whose canvas is
+embedded inside the Xcode app window and is therefore *forced* to host pixels
+cross-process — our preview is a standalone OS window dedicated to one preview.
+So the **agent can own that real window directly**: a real `NSWindow` with a
+real `NSHostingView`, native input, native resize and scrolling, GPU
+compositing, and no raster, no hosting, no input replay. The one hard problem is
+that the JIT metadata leak forces an agent respawn on every structural edit (on
+macOS as on iOS), and a respawn would close an agent-owned window. A second
+spike proved the fix: a **seamless handoff** — the daemon spawns the new agent,
+waits for its window to be up and rendered at the same frame, then kills the old
+agent. Because the new window covers the same rectangle before the old one dies,
+there is no visible gap. The wrong order (kill then spawn) shows the desktop;
+the right order is seamless.
+
+## Why the shipped approach is wrong (evidence)
+
+Spike artifacts and findings: [`research/254-native-window-spike/`](../research/254-native-window-spike/).
+
+- **Cross-process hosting is pixels, not views.** Vending an `NSHostingView`
+  backing layer over a `CAContext` (`ctx.layer = hosting.layer`) hosts nothing —
+  the consumer shows only its own fallback background — whether the producer
+  window is off-screen or on-screen. A pure `CALayer` tree (background colors,
+  render-server animation) hosts live and correctly. A view renders into its
+  window's backing surface, not into a free-standing, re-hostable layer.
+  Therefore the shipped path's raster is not an accident; *some* raster is
+  mandatory for any cross-process hosting.
+- **The raster we ship is slow and wrong-sized.** It is a CPU `cacheDisplay`,
+  produced only on render/input events (with a ~30 ms run-loop spin per input),
+  at the agent's fixed off-screen size. So it cannot reflow to the window
+  (content pins to a corner), and interaction is janky.
+- **The topology was copied from iOS, where it is forced and here it is not.**
+  On iOS only a foreground app can host a scene, so the agent cannot own a
+  visible window and a shell must. macOS has no such restriction: a process can
+  own a visible `NSWindow`. We paid the iOS tax without the iOS reason.
+
+## The macOS opportunity
+
+Xcode must embed its canvas inside the Xcode window, so it cross-process hosts
+the agent's pixels (its primary path is a `CAContext` layer fed by a rendered
+surface, with an IOSurface secondary). We are not constrained that way: our
+preview window is standalone and single-purpose. So we can let the agent own the
+real window and get a genuinely native view — the thing Xcode cannot do because
+its canvas is not a standalone window.
+
+## Target topology
+
+```
+  daemon (long-lived, MainActor): MCP + orchestration
+    │  compiles structural edits; coordinates respawn handoff; tracks the
+    │  session's window frame; serves preview_snapshot
+    │
+    │  (no shell process — deleted)
+    ▼
+  agent (respawns per structural edit): owns ONE real visible NSWindow
+    • NSHostingView renders the SwiftUI body into the real window
+    • receives native NSEvents directly (no capture/replay)
+    • resizes / scrolls / animates natively
+    • on request, snapshots its own live window
+    • on first render of a new generation, signals "ready" (window number + frame)
+```
+
+There is no persistent window-owner. Window continuity across respawn comes from
+**overlapping two agent windows at the same frame**, not from a shell that
+outlives the agent.
+
+## The four crossings, reconsidered
+
+1. **Display** — the agent owns a real on-screen `NSWindow` whose content view is
+   the `NSHostingView`. The window *is* the preview. No `CAContext`, no
+   `CALayerHost`, no IOSurface, no raster.
+2. **Respawn** — daemon-coordinated handoff (next section). The new agent opens
+   its window at the previous generation's current frame; frame and key-state are
+   preserved.
+3. **Input** — native. Real `NSEvent`s are delivered to the agent's real focused
+   window by AppKit. No capture, no serialization, no synthesis, no run-loop
+   spin, no re-raster.
+4. **Snapshot** — the agent reads its own live window (`cacheDisplay` of the
+   on-screen content view, or a window capture) on request and writes the PNG the
+   daemon already tracks. `preview_snapshot` serves that.
+
+## Respawn handoff protocol (the core new mechanism)
+
+On a structural edit (which forces a fresh agent because of the JIT leak):
+
+1. Daemon compiles the new object for generation N+1.
+2. Daemon reads generation N's **current** window frame (the user may have moved
+   or resized it) and whether it is key/frontmost.
+3. Daemon spawns the gen N+1 agent, passing that frame.
+4. Gen N+1 agent: create the `NSWindow` at the frame, install the
+   `NSHostingView` with the new content, `orderFront` (and `makeKey`/activate
+   only if gen N was key), render the first frame, then write a **ready signal**
+   (window number + frame) over the existing render/sidecar handshake.
+5. Daemon waits for the ready signal (with a timeout).
+6. Daemon kills gen N. Its window closes; gen N+1 already covers the same
+   rectangle in front, so there is no visible gap.
+7. Daemon records gen N+1 as current and updates the tracked frame.
+
+Ordering is the whole trick (proven by the spike): spawn-and-render **before**
+kill is seamless; kill-before-spawn shows the desktop. Within a generation (no
+structural edit — a literal edit or live interaction) the same agent and window
+persist, so there is no handoff and interaction stays fully in-place.
+
+### Edge cases
+
+- **New agent fails to start or render:** do not kill gen N. The old preview
+  stays on screen; surface the compile/run error. No gap, no data loss.
+- **User moved/resized the window:** step 2 captures the live frame just before
+  spawn, so placement persists across edits. This is what the old #195
+  frame-restore logic was for; it is repurposed here instead of deleted.
+- **Focus stealing:** activating the new window on every edit is disruptive.
+  Only `makeKey`/activate when gen N was key/frontmost; otherwise `orderFront`
+  at the same z-position. Preserve and carry the key-state across the handoff.
+- **Ready-signal timing:** signal only *after* the render entry completes (content
+  drawn), not when the window is merely created, or the overlap frame is blank.
+- **Multi-session:** each session is its own agent + window; the daemon tracks N
+  independent handoffs. Unchanged from today's per-session reloader model.
+- **Headless (CI/snapshot):** no visible window; the agent renders off-screen and
+  the daemon reads the snapshot. This path predates #254 and is unaffected.
+
+## What to keep, drop, and add
+
+**Drop** (the cross-process machinery):
+- `PreviewShell` process and target; `ProcessPreviewShellController`;
+  `PreviewShellController`/`NoopShellController` indirection.
+- `RemoteContext` raster vend (`previewsmcp_vend_image`) and the `CAContext` /
+  `CALayerHost` path.
+- Input pipe + replay: `PreviewInputEvent`, the `dispatchPreviewInput` generated
+  entry, `EventLineReader`, `PreviewHost.dispatchInput`,
+  `StructuralReloader.dispatchInput`.
+- IOSurface snapshot path and the `contextId` / `surfaceId` / `input` sidecars.
+
+**Keep / restore:**
+- Agent owns the visible `NSWindow` rendered by `NSHostingView` (pre-#254 shape).
+- JIT structural-reload + respawn machinery (`JITStructuralReloader`,
+  generation cap, per-session reloader).
+- Frame preservation across respawn (old #195 logic), repurposed for the
+  handoff.
+- Literal-only reload in place; snapshot-from-window.
+
+**Add:**
+- Daemon-side respawn-handoff coordinator (spawn-new → await-ready → kill-old).
+- Ready-signal handshake carrying window number + frame.
+- Live-frame capture of the outgoing generation before spawn.
+
+Net effect: this reverses the #254 display and input model for macOS and
+replaces the #195 "restore the frame after the flash" hack with an overlap that
+prevents the flash.
+
+## Performance
+
+A native window is GPU-composited live SwiftUI: native scrolling, resize, and
+animation, and native event handling. We delete the per-event CPU raster, the
+run-loop spin, the IOSurface copies, and the cross-process hosting overhead. The
+only respawn is on a structural edit, which already pays a recompile; the handoff
+hides even that. This should match or beat Xcode, which still pays for
+cross-process pixel hosting that we no longer do.
+
+## Phasing (each phase ships and verifies on its own)
+
+### Phase A1 — agent owns the visible window again
+Re-establish the on-screen `NSWindow` + `NSHostingView` render; remove the raster
+vend and the `CALayerHost` hosting. Snapshot reads the live window.
+- Verify: a visible native window appears; resizing the window reflows the
+  SwiftUI content; scrolling a `List` works; `preview_snapshot` returns the live
+  window; a manual run of the SPM `ToDoView` looks native and fills the window.
+
+### Phase A2 — native input
+Remove the capture/pipe/replay; real events reach the real window.
+- Verify: click a button and the action runs; type into a `TextField`; scroll a
+  list — all natively, no synthesized events, no re-raster.
+
+### Phase A3 — respawn handoff coordinator
+Implement spawn-new → await-ready → kill-old with frame and key-state preserved.
+- Verify: force a structural edit on a stateful preview; the window stays put
+  with no gap and no flicker (reproduce the spike's seamless transition end to
+  end), and a moved/resized window keeps its placement across the edit.
+
+### Phase A4 — cleanup + gates
+Delete `PreviewShell`, `RemoteContext`, the sidecars, and the input pipe; run
+`/simplify`, `/code-review`, and the full local suite.
+- Verify: no dead references; macOS suites green; lint clean.
+
+## Risks
+
+- **Focus stealing on respawn** — mitigated by carrying key/frontmost state and
+  only activating when warranted.
+- **Two windows briefly in Cmd-Tab / Dock during overlap** — brief and minor;
+  both are the agent executable.
+- **Ready-signal correctness** — a too-early signal yields a blank overlap frame;
+  signal after the first render completes.
+- **Visible mode needs a live WindowServer/GUI session** — same constraint as
+  today; headless rendering is unaffected.
+
+## Already derisked (do not re-litigate)
+
+- Cross-process `CAContext` hosting carries pixels, not views — an
+  `NSHostingView` layer cannot be hosted live (spike).
+- A native-window respawn handoff is seamless when the new window is up and
+  front before the old is killed; the reverse order shows a desktop gap (spike).
+- `NSRemoteView` / ViewBridge is a dead-end for a self-spawned agent (prior RE).
+
+## Source-of-truth inputs
+
+- Spike + findings: [`research/254-native-window-spike/`](../research/254-native-window-spike/).
+- Superseded plan (shell-owns-agent): [`254-macos-shell-owns-agent-plan.md`](254-macos-shell-owns-agent-plan.md).
+- Input forwarding research (still valid for iOS): the `previews-research`
+  branch `research/254-macos-input-*.md`.
+```

--- a/docs/254-macos-shell-owns-agent-plan.md
+++ b/docs/254-macos-shell-owns-agent-plan.md
@@ -1,0 +1,220 @@
+# #254 macOS shell-owns-agent — implementation plan
+
+## Summary
+
+Today on macOS each session spawns one `PreviewAgent` process that owns a real
+visible `NSWindow`, renders into it, and rasters a PNG via `cacheDisplay`. When
+the agent respawns (every structural edit past the generation cap, or on crash)
+its window vanishes and a fresh one is recreated. That causes a visible flicker
+and forced the #195 frame-restore hack (`restoreAgentWindowFrame`). #254 splits
+the visible window away from the respawning renderer: a long-lived **shell**
+owns one persistent window per session and hosts the agent's layer cross-process
+via `CAContext`/`CALayerHost`, while the **agent** becomes a pure renderer that
+respawns underneath without ever closing the window. The WindowServer holds the
+last frame across the respawn gap, so the window is never blank and #195 goes
+away. This mirrors the iOS shell-owns-agent topology already shipped.
+
+Splitting the window from the renderer means display and input become two
+independent cross-process crossings (iOS got both for free from FrontBoard scene
+hosting; macOS does not). Both are now derisked. Display is a proven
+`CALayerHost(contextID)` spike. Input is real `NSEvent` replay, confirmed by the
+`previews-research` runtime capture: the shell ships event fields, the agent
+synthesizes an `NSEvent` and dispatches it into its single window. Snapshots stop
+going through `cacheDisplay`-to-PNG and instead read a shared `IOSurface` the
+agent renders into, in-process in the shell, the same read path the iOS
+streaming side uses. This plan sequences that work in four phases, each
+independently shippable and verifiable, and flags the open decisions up front.
+
+## Source-of-truth inputs
+
+- Display + respawn derisk: memory `project_macos_agent_shell_derisk`; proven
+  spike at `/tmp/layerhost-spike/{producer.m,consumer.m}`.
+- Input forwarding research (committed on the `previews-research` branch):
+  `research/254-macos-input-plan.md` (implementation distillation) and
+  `research/254-macos-input-forwarding.md` (full findings + evidence).
+- iOS precedent: memory `project_ios_agent_lifecycle` (auto-respawn, race-free
+  stop, death-watch), `project_sim_streaming_architecture` (IOSurface read path).
+
+## Target topology and how it maps to current code
+
+Decided: a **separate per-session shell process** (matching iOS), not the
+daemon. The daemon stays thin — orchestration + MCP only — and spawns one shell
+per session; the shell owns the persistent window and hosts the respawning
+agent. See Open Decision #1 for the rationale.
+
+```
+  daemon (PreviewHost, long-lived, MainActor)
+    │  orchestration + MCP only; spawns one shell per session, tracks state
+    ▼
+  shell process (one per session, long-lived across agent respawns)
+    │  owns the persistent NSWindow; content layer = CALayerHost(contextID)
+    │  shows a fallback image until a contextID is bound
+    │  captures NSEvents over the window; ships fields upstream to the agent
+    │  reads the agent's IOSurface in-process for snapshots
+    ▼
+  agent (PreviewAgent, respawns on edits/crash)
+    • renders SwiftUI body into an offscreen NSWindow (window number is stable)
+    • vends a CAContext over its render layer → ships contextID to the shell
+    • renders each frame into a shared IOSurface (snapshots, later streaming)
+    • emits selectableRegions + control descriptions per frame (P2/P3)
+    • on an input message: synthesizes NSEvent → -[NSWindow sendEvent:]
+```
+
+Current code touchpoints:
+- `Sources/PreviewsCore/BridgeGenerator.swift` `renderToFileEntryPoint` (~L213-311):
+  the generated agent entry that today makes the `NSWindow` + `cacheDisplay`→PNG.
+  This is where the CAContext vend, the IOSurface render, and (P2/P3) the
+  region/control emission replace the PNG tail.
+- `Sources/PreviewsMacOS/HostApp.swift`: `jitStructuralReload` (L183),
+  `restoreAgentWindowFrame` the #195 hack (L192, to delete), `jitStart` (L207),
+  `agentSnapshotPath`/`agentImagePaths` the PNG snapshot source (L19, L261, to
+  become an IOSurface read), `reloader(for:)` (L235), `closePreview` (L155). The
+  daemon also gains: spawn/track one shell process per session, route the
+  contextID/surfaceID/input messages between shell and agent.
+- `Sources/PreviewsJITLink/JITStructuralReloader.swift`: `render` + respawn at
+  `generationCap` (L20, L78) — the respawn point where the shell must re-host
+  (rebind `CALayerHost.contextId`) instead of letting a window die.
+- `Sources/PreviewAgent/main.cpp` + `Sources/PreviewsJITLinkCxx`: the ORC EPC
+  transport (posix_spawn + socketpair). The upstream input message and the
+  downstream contextID/surfaceID handshake ride here or on a side channel.
+- New: a shell target (the per-session window-owner process), analogous to the
+  iOS `ios-host/shell`. It is the consumer half of the layerhost spike.
+
+## The four crossings
+
+1. **Display** — agent vends a `CAContext` (`+[CAContext remoteContextWithOptions:]`,
+   `.contextId` UInt32) over its root render layer; shell binds
+   `CALayerHost.contextId`. WindowServer composites cross-process and holds the
+   last frame when the agent dies. Re-host on respawn = rebind to the new
+   agent's contextID. Private QuartzCore SPI, acceptable for a dev tool (App
+   Store risk only if sandboxed). Proven in the spike.
+2. **Snapshot** — agent renders each frame into a shared `IOSurface` (handed to
+   the shell via mach port); shell reads pixels in-process via `IOSurfaceLock`
+   → `CIImage`/`CGImage` for `preview_snapshot`. Replaces `cacheDisplay`→PNG. A
+   `CALayerHost`'s pixels live server-side and cannot be read in-process, and
+   `CGWindowListCreateImage` is gone in macOS 15 — so the IOSurface is required,
+   not optional. NOT ScreenCaptureKit.
+3. **Live input** — real `NSEvent` replay. Shell ships `{type, locationInWindow
+   (window-local points, bottom-left origin), modifierFlags}` for pointer and
+   `{type, characters, charactersIgnoringModifiers, keyCode, isARepeat,
+   modifierFlags}` for keyboard. Agent synthesizes via `+[NSEvent
+   mouseEventWith…]` / `+[NSEvent keyEventWith…]` and calls `-[NSWindow
+   sendEvent:]` on its one stable window. Confirmed end-to-end in Xcode by the
+   research capture (Count 0→2, TextField "xyz").
+4. **Chrome + selection** (later phases) — both ride on the frame reply, no new
+   transport. Chrome: agent emits `[CanvasControlDescription]` + `controlStates`,
+   shell renders the controls and returns `CanvasControlEvent{controlIndex,
+   event, stateBox}`. Selection: agent emits `[SelectableRegion{path, rect,
+   accessibilityElement?}]`, shell hit-tests locally, no round-trip.
+
+## Phasing (each phase ships and verifies on its own)
+
+v1 = Phases 1+2 (decided). Phase 3 is a fast follow; Phase 4 is additive.
+
+### Phase 0 — preserve the spike
+- Move `/tmp/layerhost-spike` into the repo (e.g. `research/layerhost-spike/`)
+  so the proven display primitive is not lost.
+- Verify: spike builds and runs from its in-repo location.
+
+### Phase 1 — display split + respawn re-host (the spine; retires #195)
+The behavior-visible win: one persistent window that survives respawn with no
+flicker, no frame-restore hack.
+- New shell process: create one persistent `NSWindow` per session whose content
+  layer is a `CALayerHost`; bind `contextId` on first render; rebind on every
+  respawn; show a fallback image until first bind.
+- Agent: in `renderToFileEntryPoint`, in addition to the existing window, create
+  a `CAContext` over the hosting view's layer and report its `contextId` to the
+  shell. Keep the agent window offscreen (the shell owns the visible one).
+- Daemon: spawn + supervise the shell per session; relay the agent's contextID
+  to the shell; death-watch (reuse the iOS lifecycle pattern).
+- Reloader: at the `generationCap` respawn (`JITStructuralReloader`), hand the
+  new agent's contextID to the shell rather than tearing down a window.
+- Delete `restoreAgentWindowFrame` and the #195 sidecar plumbing — the window
+  no longer moves, so there is nothing to restore.
+- Verify: drive a structural edit that forces a respawn; the window stays open,
+  holds the last frame across the gap, then shows the new content. No flicker.
+  Manual run + the existing macOS reload tests (adjust for the new path).
+
+### Phase 2 — IOSurface snapshot read (replaces cacheDisplay→PNG)
+- Agent: render each frame into a shared `IOSurface` (CARenderer over an
+  IOSurface-backed `MTLTexture`, per the derisk producer note), hand the surface
+  to the shell via mach port.
+- Shell: replace the PNG snapshot source with an in-process `IOSurfaceLock` →
+  `CIImage` read; `preview_snapshot` serves that (daemon proxies to the shell,
+  or the shell writes the image the daemon already tracks). Reuse the iOS read
+  path (`SBCaptureFramebuffer` → `IOSurfaceLock` shape).
+- Verify: `preview_snapshot` returns a correct image for a live session and
+  after a respawn; double/triple-buffer so a repeated frame still refreshes
+  (`IOSurfaceGetSeed` to detect new frames). Existing snapshot tests, repointed.
+
+### Phase 3 — live input (NSEvent replay) [fast follow]
+- Transport: add one upstream input message carrying the wire fields above.
+- Shell: install an event monitor over the window; map the hit point into the
+  agent window's local space (points, bottom-left origin); ship the fields.
+  Pointer down/up/dragged/move + the key path first.
+- Agent: synthesize the `NSEvent` and `-[NSWindow sendEvent:]` into its one
+  window. PITFALL: never call `+[NSApplication sharedApplication]` (or otherwise
+  init AppKit) off the main thread in any setup/injected code — it corrupts the
+  event loop and kills the preview (cost the researcher ~6 VM runs). Validate
+  drag-heavy/hover controls early.
+- Verify: click a button in the shell window and the SwiftUI action runs
+  (state-driven update, no respawn); type into a TextField and characters land.
+  New integration test driving a counter + text field through the shell.
+
+### Phase 4 — selection then chrome (additive, ride on the frame)
+- Selection: agent emits `selectableRegions` next to the IOSurface frame; shell
+  hit-tests locally and surfaces the selected `path`. Geometry-only first; AX
+  element bytes deferred (residual unknown, not needed for v1).
+- Chrome: agent emits `controlDescriptions` + `controlStates`; shell renders
+  controls (start with `ToggleConfiguration` appearance/device) and returns
+  `CanvasControlEvent`s. The `Event` raw-value strings are the one unrecovered
+  detail (enum cases not exported); we define our own since we own both ends.
+- Verify: a click in selectable mode reports the right `path` without running
+  the action; a toggle flips appearance/device. Phase-scoped tests.
+
+## Open decisions
+
+1. **Shell owner: separate per-session shell process (DECIDED).** macOS daemons
+   *can* own `NSWindow`s (unlike iOS, where only a foreground app can host a
+   scene — the reason iOS is forced into 3 tiers). We still chose a separate
+   per-session shell process, because the daemon serves MCP for every session
+   and is the orchestrator: giving it N visible windows + per-session event
+   monitoring + cross-process layer hosting + IOSurface reads would load its
+   main run loop and erase the crash isolation between sessions (one AppKit
+   stall would block MCP for everyone). A separate shell keeps the daemon thin
+   and matches the iOS topology, so the lifecycle/death-watch code ports across.
+2. **v1 scope: Phases 1+2 (DECIDED).** Display + snapshot are coupled — once the
+   shell owns the window the agent window is offscreen, so the PNG path must
+   move to IOSurface in the same change. Phase 3 (live input) is a fast follow.
+3. **Wire types: our own compact codable vs re-encoding Apple's plist shapes.**
+   We control both ends. RECOMMENDATION: define our own minimal types for the
+   input/region/control fields; matching Apple's exact grammar buys nothing.
+4. **Where the contextID/surfaceID/input messages travel:** extend the ORC EPC
+   wrapper-function surface, or a small dedicated side socket between shell and
+   agent. RECOMMENDATION: reuse the existing socket/EPC path the reloader
+   already owns; avoid a second channel unless latency demands it.
+
+## Risks and pitfalls
+
+- Off-main AppKit init kills the preview (Phase 3) — see the pitfall above.
+- Drag-heavy / hover / nested tracking-loop controls (NSSlider drag) may not
+  complete from a synthesized `sendEvent:`; validate early, scope out if costly.
+- Setting `layer.contents`/contextID twice with the same value may not refresh;
+  double/triple-buffer the IOSurface and rebind deliberately on respawn.
+- `CAContext`/`CALayerHost` are private SPI; fine for a dev tool, but pin to OS
+  behavior we tested and keep the fallback image path (contextID is optional with
+  a fallback in Xcode's own `MacOSLayerHostedPreviewViewable`).
+- Display side still needs a live WindowServer/CA session; true headless on a
+  detached daemon is unconfirmed — verify in Phase 1.
+
+## Already derisked (do not re-litigate)
+
+- Cross-process `CALayerHost(contextId)` live hosting, last-frame hold on kill,
+  and respawn re-host all PROVEN on macOS 26.2 (the spike).
+- Live input is real `NSEvent` (pointer AND keyboard) into one stable window via
+  normal AppKit dispatch — confirmed at runtime, NOT the semantic
+  `RemoteEventPayload` protocol (that serves chrome/selection/diagnostics).
+- Chrome is shell-rendered from agent descriptions; selection is a shell-side
+  hit-test with no round-trip — both ride on the existing frame reply.
+- `NSRemoteView`/ViewBridge is a dead-end for a self-spawned agent.
+- ScreenCaptureKit is rejected for snapshots; IOSurface in-process read is the path.

--- a/research/254-macos-input-forwarding.md
+++ b/research/254-macos-input-forwarding.md
@@ -1,0 +1,551 @@
+# Research plan: macOS cross-process input forwarding for #254
+
+Status: research brief for the `previews-research` session. 2026-06-22.
+Owner of the implementation: #254 (port the iOS shell-owns-agent topology to macOS).
+This is NOT a handoff. It is a scoped research task with verification criteria.
+
+## Summary
+
+#254 splits the macOS preview into a long-lived **shell** window that hosts a
+short-lived **agent** process (the renderer that respawns on edits). On macOS,
+display and input are two independent cross-process crossings (iOS bundled both
+via FrontBoard scene hosting, which has no macOS equivalent). **Display is already
+derisked**: a proven `CAContext`/`CALayerHost(contextID)` spike hosts the agent's
+live layer in the shell window, holds the last frame when the agent dies, and
+re-hosts a respawned agent by rebinding the contextID. The agent will also render
+each frame into a shared IOSurface the daemon reads in-process for snapshots. The
+one remaining unknown is **input**: how does the shell get a click, drag, hover,
+keypress, or canvas-control toggle to act on the agent's view tree, when the shell
+window only hosts a server-side composited layer and owns no view objects?
+
+This plan does not assume the answer is "serialize NSEvents." Static RE of Xcode
+26.2's own preview frameworks shows Apple uses a **semantic event protocol**, not
+raw event replay: a dedicated `previewRemoteEvents` message stream carrying a
+`RemoteEventPayload`, a separate `canvasControlEvents` stream for canvas chrome
+(device toggles, Dynamic Type, etc.), and `SelectableRegion(path:rect:accessibilityElement:)`
+records that tell the canvas what is hittable and carry an accessibility blob. The
+research goal is to recover that protocol's actual encoding via runtime capture,
+decide whether we adopt Apple's semantic model or fall back to our own NSEvent
+serialize/replay, and hand #254 a concrete, verified input design.
+
+## What is already known (do not re-derive)
+
+- Source of truth: memory `project_macos_agent_shell_derisk` and the archived
+  handoff `2026-06-22-macos-agent-shell-254-derisk.md`.
+- Display + respawn primitive PROVEN: `/tmp/layerhost-spike/{producer.m,consumer.m}`
+  (build line in that handoff). `CAContext +remoteContextWithOptions:` -> `.contextId`,
+  consumer binds `CALayerHost.contextId`. WindowServer holds last frame on producer
+  kill. Re-host = rebind contextId.
+- Snapshot path SETTLED: agent renders into a shared IOSurface; daemon reads pixels
+  in-process via `IOSurfaceLock` -> `CIImage`/`CGImage`. NOT ScreenCaptureKit. Same
+  read path as the iOS streaming side (`SBCaptureFramebuffer` ->`IOSurfaceLock`).
+- `NSRemoteView`/ViewBridge is a DEAD-END for a self-spawned agent (private, gated
+  to the `.appex` NSExtension model, blocks host-side screenshotting). Do not pursue
+  unless static RE here surprises us.
+
+## Decisive static-RE evidence (Xcode 26.2, already gathered)
+
+Frameworks: `/Applications/Xcode-26.2.0.app/Contents/SharedFrameworks/Previews*.framework`.
+Method used: `nm -gU <binary> | swift demangle` + `strings`. Findings:
+
+- **`PreviewsMessagingHost.MessageStreamInstanceIdentifier`** enumerates the cross-process
+  message streams. The input-relevant ones:
+  - `previewRemoteEvents`  <- the live input/event channel (carries `RemoteEventPayload`).
+  - `canvasControlEvents`  <- canvas chrome controls (semantic, not raw input).
+  - `macOSSnapshots`       <- the snapshot channel (confirms our IOSurface plan).
+  - also: `registryRuntimeEvents`, `cFunctionStreamingOutput`, `nsPreviewSuppressedPresentations`.
+- **`RemoteEventPayload`** (in `PreviewsMessagingHost`): `PropertyListRepresentable`,
+  with a nested `DiagnosticsBehavior` enum. Its fields are NOT exposed as public
+  getters; only `init(propertyListValue:)` and `propertyListValue.getter`. So the
+  actual event encoding lives inside the property-list dict and is opaque to static
+  symbol dumps. **Recovering those dict keys is the central task of this research.**
+- **`CanvasControlEvent(event:controlIndex:state:)`** with `Event(rawValue: String)`,
+  and `CanvasControlDescription.ControlType.ToggleConfiguration(sfSymbolName:title:supportsInteractionEvents:)`.
+  So canvas chrome is a typed semantic event keyed by control index + a plist state
+  box, NOT a synthesized click on a button.
+- **`SelectableRegion(path: String, rect: CGRect, accessibilityElement: Data?)`**
+  carried on `RenderPayload`, `IOSurfacePayload`, `GeometryPayload`. `path` is a
+  view-tree path string; `accessibilityElement` is a serialized AX element. The
+  canvas hit-tests a click against these rects to resolve a semantic target. This
+  strongly implies selection/identification goes through AX + path, not pixel-space
+  event replay.
+- **Host-side viewables** (in `PreviewsDeveloperTools`) confirm the consumer shapes:
+  `MacOSLayerHostedPreviewViewable(contextID:UInt32?, ..., selectableRegionsInPixelSpace:, fallbackImage:)`
+  and `IOSurfacePreviewViewable(surfaceID:UInt32, ..., selectableRegionsInPixelSpace:)`.
+  Note `contextID` is optional with a `fallbackImage` — this is exactly the never-blank
+  story (show the still image until a contextID is bound).
+
+Negative evidence worth stating: a `strings` scan for `mouseDown/mouseUp/mouseDragged/keyDown/scrollWheel`
+on `PreviewsMessagingHost` found NONE. That is consistent with "no raw NSEvent
+names on the wire" but is not proof; the runtime capture below settles it.
+
+## Central hypothesis to confirm or refute
+
+**H:** Xcode forwards input as a small semantic protocol over `previewRemoteEvents`
+(a `RemoteEventPayload` plist) plus `canvasControlEvents`, and resolves clicks
+against `selectableRegions` (path + AX), rather than serializing/replaying raw
+`NSEvent`s into the agent's window. Live UI interaction (e.g. tapping a real
+SwiftUI `Button`, dragging an `NSSlider`) is therefore either (a) driven by the
+semantic payload into the preview runtime, or (b) NOT actually live in Xcode's
+canvas for arbitrary controls (Xcode's canvas is largely selection + chrome, with
+"live" interaction being a limited mode).
+
+Why the (a)/(b) distinction matters for #254: it sets our scope. If Xcode itself
+does not do general live interaction, we should not over-invest either; a semantic
+selection + canvas-control model may be the right product, with full live input as
+a later, explicitly-scoped add.
+
+## Subproblems and verification criteria
+
+### S1. Recover the `RemoteEventPayload` wire encoding (highest value)
+Capture the actual property-list dict Xcode sends on `previewRemoteEvents` during a
+real interaction with a macOS preview, and decode its keys (event kind, location,
+modifiers, target path, phase, etc.).
+
+- Method: in the research VM (see `project_vm_capture_baseline`), drive Xcode 26.2
+  with a trivial macOS preview, then either (i) dtrace/lldb on `XCPreviewAgent` and
+  the Xcode canvas process around `RemoteEventPayload.init(propertyListValue:)` /
+  `.propertyListValue.getter` and dump the plist, or (ii) interpose the transport
+  send/recv (the `Transport.activate(forReceivingEvents:)` async stream) and log
+  payloads. Prefer lldb breakpoints that print the `PropertyList` argument.
+- Verify: we have a labeled dump of >=4 distinct interactions (click, drag, key,
+  hover or scroll) showing the dict keys and value types for each. Done when we can
+  describe the event grammar well enough to re-encode it.
+
+### S2. Map `canvasControlEvents` and `CanvasControlDescription`
+Determine what canvas controls exist (the `controlIndex` space), their `Event`
+raw-value vocabulary, and how `ToggleConfiguration.supportsInteractionEvents` gates
+behavior.
+
+- Method: same VM; enumerate `CanvasControlEvent.Event(rawValue:)` candidates via
+  lldb on the getter, and observe which controls Xcode renders for a macOS preview.
+- Verify: a table of control types -> events -> state payloads. Done when we can say
+  whether our shell needs this channel for v1 (likely yes for device/appearance
+  toggles) or can defer it.
+
+### S3. Confirm the selection/hit-test path
+Determine whether a click in Xcode's canvas resolves via `selectableRegions`
+(path + `accessibilityElement`) to a selection, and whether that is separate from
+"live" interaction.
+
+- Method: VM; click inside vs outside a region, watch which stream fires
+  (`previewRemoteEvents` vs a selection channel) and whether the AX element is used.
+- Verify: a one-paragraph statement of "click -> selection" vs "click -> live event"
+  with evidence, plus how `selectableRegions` are produced agent-side (so #254's
+  agent can produce them too).
+
+### S4. Decide the #254 input mechanism (the actual deliverable)
+Given S1-S3, choose one and justify against the constraints (self-spawned agent, no
+Accessibility entitlement desired, no sandbox today, must survive respawn):
+
+- Option A — adopt Apple's semantic model: shell ships a `RemoteEventPayload`-like
+  plist over our existing ORC/socket transport; agent applies it to the preview
+  runtime; selection via our own `selectableRegions`. Pro: matches Xcode, robust to
+  layer hosting (no real window for events to land on). Con: must reimplement the
+  grammar and the agent-side application.
+- Option B — fall back to NSEvent serialize/replay: shell captures `NSEvent`s,
+  ships fields, agent synthesizes via `+[NSEvent mouseEventWithType:...]` +
+  `-[NSWindow sendEvent:]` on its own offscreen window. Pro: general, no protocol RE.
+  Con: hover/tracking-loop controls (NSSlider drag) are hard from injected
+  `sendEvent:`; coordinate spaces and `windowNumber` are process-local; the agent
+  window is offscreen so some AppKit paths may not engage.
+- Option C — hybrid: semantic for selection + canvas chrome (A), NSEvent replay only
+  for the narrow "live interaction" mode if we even ship it (B).
+- Verify: a recommendation with the failure modes of the rejected options named, and
+  a rough effort estimate for the chosen one. This is what #254's implementation plan
+  consumes.
+
+## Deliverable
+
+A short report appended to this file (or a sibling under `research/`) covering:
+S1 event grammar dump, S2 control table, S3 selection-vs-live verdict, and the S4
+recommendation. Plus: whether the `/tmp/layerhost-spike` display spike should be
+moved into the repo for reference.
+
+## Capture harness (implemented)
+
+A `capture-input-events` preset (`research/vm/Sources/previewsvm/SetupCommand.swift`)
+drives Xcode 26.2 in the `post-xcode-ready` VM over VNC. Run:
+
+```
+research/vm/.build/debug/previewsvm setup ~/.previews-research-vms/research.bundle \
+  --preset capture-input-events --transport vnc --retry 1 \
+  --restore-from post-xcode-ready --output-dir research/scripts/data/254-s0-capture
+```
+
+What it took to make the canvas render and the preview run in-VM (each was a
+real blocker, documented so we don't re-discover them):
+
+- **Display must be 1× to give the canvas room.** The VM display was 1920×1080
+  @220ppi → macOS HiDPI 2× → only ~640×360 usable points → the canvas pane
+  collapses to zero width and never shows a preview. Added
+  `VMConfiguration.DisplayResolution` with a `.roomy` mode (1280×720 @96ppi,
+  same RFB pixel size, 1× scaling, 4× the usable point area). Only this preset
+  uses `.roomy`; other presets keep `.standard` so their calibrated coords are
+  untouched. RFB framebuffer size is now read from the handshake
+  (`RFBClient.framebufferSize`) and used for OCR→click mapping instead of a
+  hardcoded 1280×720.
+- **Canvas open:** at 1× the canvas is open by default for a SwiftUI file. Do
+  NOT use Cmd+Option+Return — Xcode 26 rebound it to Coding Intelligence (a
+  modal that eats all later keystrokes; dismiss it via OCR-click "Remind Me
+  Later", Escape does not close it). The Editor-menu and Help-search paths are
+  flaky (OCR groups the whole menu bar into one block; Help→Down→Return hits a
+  Help topic).
+- **Preview activation:** the canvas being visible does NOT start the pipeline.
+  XCPreviewAgent only spawns after **Cmd+Option+P (Resume Preview)**. With that,
+  `pgrep XCPreviewAgent` → AGENT_UP and the preview renders.
+- **OCR button-click disambiguation:** once the preview renders, the rendered
+  "Increment" sits in the canvas (high framebuffer x, ~1039/1280) while the
+  source `Button("Increment")` is center-left; OCR resolves to the rendered one.
+  Before the preview renders, OCR matches the source instead — so a successful
+  rendered-button click is itself a signal the pipeline is live.
+
+## S0 result — macOS canvas IS live (hypothesis branch (a), confirmed)
+
+Fixture: a `#Preview` of a `@State var count` view with `Text("Count: \(count)")`
+and `Button("Increment") { count += 1 }`. The harness OCR-clicked the rendered
+button twice. The canvas readout went **Count: 0 → Count: 2** (screenshots in
+`research/scripts/data/254-s0-capture/attempt-1/`: `09-05-count-before` … `11-07-after-click-2`).
+
+So Xcode's macOS preview canvas executes real live interaction: a click on the
+rendered control runs the SwiftUI action and the `@State`-driven view updates in
+place (no agent respawn needed for state-only changes). This settles the (a)/(b)
+question from the hypothesis: live interaction is genuine, not selection-only.
+
+Implication for #254: a live input path is in scope (it is a real Xcode feature,
+not an illusion), so S1 (recovering the `previewRemoteEvents` / `RemoteEventPayload`
+wire encoding) is worth doing in full, and Option A (semantic protocol) or C
+(hybrid) — not just selection + chrome — should be on the table for S4.
+
+## S1 progress — runtime capture path (dtrace ruled out)
+
+- The agent reliably spawns (Cmd+Option+P) and clicks land on the rendered
+  button, so events DO flow on a real interaction.
+- **dtrace pid provider cannot attach to XCPreviewAgent**: `dtrace: failed to
+  grab pid <n>: (ipc/?) unknown subsystem error`, even with SIP off + AMFI off.
+  This confirms the W3 note that the pid provider is gated by a signed-binary
+  check separate from SIP. So dtrace is OUT for the agent; the in-agent
+  interposer (LC_LOAD_DYLIB binary patch, proven by W3) is the only runtime
+  path that runs inside the agent's address space.
+- The payload is Swift-encoded: `RemoteEventPayload.init(propertyListValue:)`
+  (mangled `_$s21PreviewsMessagingHost18RemoteEventPayloadO17propertyListValueAC0a10FoundationC008PropertyH0V_tKcfC`)
+  on the receiver, `RemoteEventPayload.propertyListValue.getter` on the sender.
+  `PreviewsMessagingHost`/`PreviewsFoundationHost` import NO CFPropertyList/xpc
+  serialization symbols, so there is no easy C chokepoint; the dict lives behind
+  `PropertyList.serializableDictionary : [String:Any]` and a `PropertyListArchiver`
+  type. Capturing the exact keys needs in-agent Swift hooking (an arm64 prologue
+  detour on the init symbol that then reads `serializableDictionary` and writes a
+  plist) or tapping `LazyPropertyList`'s backing bytes — a real engineering task,
+  not a one-liner.
+
+## S1 — receiver is PreviewsMessagingOS (NOT …Host); Option C de-risked
+
+Important correction to the static-RE section above: those symbols
+(`PreviewsMessagingHost.*`) are the **sender/Xcode** side. The **agent**
+(XCPreviewAgent, the receiver) loads the **OS** variants from
+`/System/Library/PrivateFrameworks/`: `PreviewsMessagingOS`,
+`PreviewsFoundationOS`, plus `PreviewsInjection`, `XOJITExecutor`,
+`PreviewsServices`, `PreviewsOSSupport(UI)`. The types mirror the Host side
+1:1 — `PreviewsMessagingOS` exports `RemoteEventPayload.init(propertyListValue:)`,
+`RemoteEventRequestPayload`, `CanvasControlEvent` (+ `.Event` rawValue enum),
+`SelectableRegion`, `RenderPayload`/`IOSurfacePayload`/`GeometryPayload`
+(all carrying `[SelectableRegion]`), `HostedPreviewReply`/`StaticPreviewReply`
+(carrying `controlDescriptions` + `controlStates`). Dump the OS-side exports
+with `dyld_info -exports <path>` (reads the shared cache; the on-disk file does
+not exist). The receiver-decode symbol is
+`$s19PreviewsMessagingOS18RemoteEventPayloadO17propertyListValueAC0a10FoundationC008PropertyH0V_tKcfC`.
+
+Option C de-risk (PASSED): the W3 LC_LOAD_DYLIB patch injects a probe dylib
+into XCPreviewAgent (confirmed `LOADED pid=… exe=…/XCPreviewAgent`), and from
+in-process `dlsym(RTLD_DEFAULT, …)` resolves all four OS-side init symbols to
+non-null addresses (`resolved=4/4`, e.g. RemoteEventPayload.init at 0x27f7…).
+So an in-agent arm64 prologue detour on `RemoteEventPayload.init(propertyListValue:)`
+is feasible. Next: detour that symbol, and in the hook read the incoming
+`PreviewsFoundationOS.PropertyList` via its `serializableDictionary : [String:Any]`
+getter, bridge to NSDictionary, and write a plist per event → the exact wire
+grammar (S1 deliverable). Probe + injection live in the `capture-input-events`
+preset; evidence in `research/scripts/data/254-s1-probe/`.
+
+## S1 detour — mechanism PROVEN, target symbol not on the click path
+
+The in-agent arm64 inline detour works. Evidence (one run):
+`LOADED pid=… → RESOLVED target=0x… → INSTALLED rc=0` on
+`RemoteEventPayload.init(propertyListValue:)`, plus an **arc4random canary**
+(same detour, called by us) that fired `CANARY arc4random hook fired #1`. So
+`vm_protect(VM_PROT_COPY)` text patching of the dyld shared cache + the
+relocated-prologue trampoline + the register-preserving asm stub all function
+on Apple Silicon with SIP+AMFI off.
+
+But clicking the rendered button (clicks confirmed landing at fb (1039,409),
+same agent pid that installed the hook) produced **no HOOK** on
+`RemoteEventPayload.init`. Since the mechanism is proven, the conclusion is that
+the live click is NOT decoded through that exported symbol in the agent — most
+likely `init(propertyListValue:)` is **inlined** into the PreviewsMessagingOS
+stream-decode path (the exported symbol survives for the protocol witness /
+external callers, but the runtime decode uses an inlined copy), or the pointer
+event decodes via a different entry than `RemoteEventPayload`.
+
+Next options (inlining-proof, in rough order): (1) detour the **protocol-witness**
+`PropertyListRepresentable.init(propertyListValue:)` for RemoteEventPayload
+(called indirectly via the witness table, so not inlined) — quick, reuses the
+detour infra; (2) detour the **stream-receive** boundary in PreviewsMessagingOS
+(the OS-side `AsyncMessageStream`-equivalent that delivers a `LazyPropertyList`
+per message) and dump every message, filtering for the event one; (3) byte-tap
+the transport receive (C ABI, inlining- and patch-proof) and decode offline.
+Also worth a parallel check: confirm whether the agent instead receives a
+synthesized real event (NSEvent/CGEvent) for in-preview interaction, with the
+semantic `previewRemoteEvents`/RemoteEventPayload path reserved for the sender.
+
+## S1 — four semantic payload inits are silent on a click (hypothesis pivot)
+
+Multi-slot detour run (mechanism re-confirmed: arc4random canary fired). All
+four exported `init(propertyListValue:)` decoders installed rc=0 in the agent:
+`RemoteEventPayload` (0x279825394), `RemoteEventRequestPayload` (0x279824350),
+`CanvasControlEvent` (0x279782ae8), `SelectableRegion` (0x2797b2208). Clicking
+the rendered button produced **HOOK on none of them** (only the canary).
+
+So the live in-preview pointer interaction is NOT decoded through the semantic
+PreviewsMessagingOS plist types in the agent. This pivots the working answer:
+the semantic `previewRemoteEvents` / `RemoteEventPayload` protocol (proven on
+the Host/sender side) is likely NOT the channel for ordinary pointer events
+into a live preview. Leading hypothesis now: the click is delivered to the
+agent's hosted view as a **synthesized real event** (AppKit/SwiftUI event
+path), with the semantic protocol reserved for specific remote events / canvas
+chrome. (Less likely but possible: all four inits are inlined and an unexported
+decode runs — but four independent types inlining together is unlikely.)
+
+Next discriminators (cheap → robust): (1) hook ObjC `-[NSApplication sendEvent:]`
+/ `-[NSView mouseDown:]` / hit-test in the agent (ObjC swizzle, no arm64
+detour) — if these fire on a canvas click, real-event delivery is confirmed;
+(2) byte-tap the agent's IPC receive (mach_msg / xpc / read, C ABI,
+type-and-inlining-proof) and dump what arrives on a click, decode offline.
+This refines the S4 recommendation either way: if macOS forwards real events,
+#254's live-input path is NSEvent-replay-shaped (Option B), not a semantic
+plist (Option A) — the opposite of what the static Host-side RE suggested.
+
+## S1 BLOCKER — agent re-sign breaks the live preview (prior hook results void)
+
+A swizzle-only run (zero arm64 text patching, just clean ObjC
+method_setImplementation on sendEvent:) STILL showed the canvas "Cannot
+preview" error and the click OCR fell back to the source line (no rendered
+button). So the detour was never the culprit. The common factor across all
+injected runs is the agent prep: `mach-o-add-dylib` (LC_LOAD_DYLIB) + ad-hoc
+`codesign --force --sign - --entitlements <get-task-allow-only>`. Re-signing
+with ONLY get-task-allow strips the agent's real entitlements (and changes its
+cdhash), which breaks the preview pipeline — XCPreviewAgent can no longer
+render. The S0 runs worked because they never injected.
+
+Consequence: ALL the "silent hook" S1 results above (4 semantic inits silent,
+sendEvent: silent) are FALSE NEGATIVES — the preview was dead, so no input
+events ever flowed. They prove nothing about the click path.
+
+Unblock (next): inject WITHOUT breaking the preview. Re-sign preserving the
+agent's FULL original entitlements plus get-task-allow — extract them first via
+`codesign -d --entitlements - --xml <agent>` or `ldid -e` (the CMS-blob caveat
+in the W3 notes can be worked around with the xml form), merge get-task-allow,
+re-sign with the complete set. Or test a no-re-sign path: with AMFI off, a
+binary whose signature was invalidated by the LC_LOAD_DYLIB edit may still
+execute AND keep its entitlements honored — verify empirically. Verification:
+after injection, the canvas renders the counter and a click increments it
+(same check S0 used) AND the dylib's hooks fire. Only then are hook results
+trustworthy. (W3's JIT capture used the same get-task-allow-only re-sign and
+"worked" because it traced compile/respawn on edits, not live interactive
+rendering, so it never needed a fully-live preview.)
+
+## S1 RESOLVED — live pointer input is a REAL NSEvent, not the semantic protocol
+
+The earlier "agent re-sign breaks the preview" conclusion was wrong. The real
+cause was a bug in my own probe: `install_objc_probes` called
+`+[NSApplication sharedApplication]` from the background installer thread, which
+initialized NSApplication off the main thread ("GetMainEventLoop returned a
+bogus value; Carbon Thread Manager imprinted on the main thread") and corrupted
+the agent's event loop, killing the preview. The agent re-sign (ad-hoc,
+get-task-allow) is FINE. Removing that one call fixed everything.
+
+With the probe fixed (class-level swizzle only, no instantiation), the injected
+agent renders a LIVE preview and a click increments the counter (Count 0 → 2),
+AND the swizzled event hooks fire per click:
+
+```
+NSAppSendEvent type=1   (leftMouseDown)   NSWinSendEvent type=1
+NSAppSendEvent type=2   (leftMouseUp)      NSWinSendEvent type=2
+```
+
+So the verdict: **Xcode forwards an in-preview pointer interaction to the agent
+as a real `NSEvent`** (leftMouseDown=1 / leftMouseUp=2), delivered through the
+agent's normal AppKit dispatch (`-[NSApplication sendEvent:]` →
+`-[NSWindow sendEvent:]`). It is NOT carried by the semantic
+`RemoteEventPayload` / `previewRemoteEvents` plist protocol — all four OS-side
+payload decoders stayed silent on a click (now a trustworthy result, since the
+preview was live this time). This **refutes hypothesis H for pointer input**.
+The static-RE semantic protocol (Host side) and `SelectableRegion`/AX records
+are real but serve other roles (canvas chrome via `canvasControlEvents`,
+selection, keyboard/diagnostics) — not the live pointer path.
+
+Method that settled it: `capture-input-events` preset →
+`research/scripts/data/254-s1/event-detour.c` injected into XCPreviewAgent via
+LC_LOAD_DYLIB. The arm64 prologue-detour mechanism is proven (arc4random
+canary) but unused for the verdict; the ObjC `sendEvent:` swizzle is what
+caught the real events. Evidence: `research/scripts/data/254-s1-fixed/`.
+
+## S4 recommendation for #254 (the deliverable)
+
+Adopt **Option B — NSEvent serialize/replay — for live pointer input**, because
+that is exactly what Xcode itself does: the shell captures `NSEvent`s over the
+hosted layer and ships their fields to the agent, which synthesizes an
+`NSEvent` (`+[NSEvent mouseEventWith…]`) and delivers it to its hosted view via
+`-[NSWindow sendEvent:]` / the responder chain. We confirmed the agent's view
+processes real events end to end (state updates, no respawn). Pair this with a
+**hybrid (Option C)** for the non-pointer surfaces the semantic protocol does
+own: canvas chrome (device/appearance toggles) maps to `CanvasControlEvent`
+over a control channel, and selection/identification uses our own
+`selectableRegions` (path + AX) — but those are secondary to shipping live
+pointer input.
+
+Rejected — Option A (semantic `RemoteEventPayload` plist for pointer input):
+refuted by the runtime capture; the agent does not decode pointer clicks that
+way. Pursuing it would reimplement a protocol Xcode does not use for this path.
+
+## S1 refinement RESOLVED — coordinate space + window + keyboard path
+
+A follow-up probe extended the `sendEvent:` swizzle to log
+`-[NSEvent locationInWindow]` (CGPoint, returned in d0/d1 via plain
+`objc_msgSend` on arm64, NOT `_stret`) and `-[NSEvent windowNumber]`, and added
+a `TextField` + `.type("xyz")` step to exercise the keyboard path. Result
+(`research/scripts/data/254-s1-loc/`, preview confirmed live: Count → 2 and the
+field shows `xyz`):
+
+```
+type=1/2 (mouse down/up)  loc=160.9,151.0  win=50   ← Increment button clicks
+type=5/8/9 (move/enter/exit) loc=90.9,95.0 win=50   ← over the TextField
+type=10/11 (keyDown/keyUp) loc=0.0,332.0  win=50    ← the xyz typing
+```
+
+Three settled facts for #254's Option-B implementation:
+
+1. **One stable real `NSWindow` (number 50) receives every event** — pointer and
+   keyboard alike. The agent owns a single real window; synthesize events into it.
+2. **Pointer events carry real window-local coordinates** (`locationInWindow`,
+   AppKit bottom-left origin, in points): clicks land at sane positions inside
+   the preview content bounds. So #254 maps shell-side hit coordinates into this
+   window's local space and builds the `NSEvent` with that `locationInWindow`.
+3. **Keyboard also flows as real `NSEvent`s** — `keyDown`/`keyUp` (type 10/11)
+   dispatch through both `-[NSApplication sendEvent:]` and `-[NSWindow
+   sendEvent:]`, same path as pointer. This generalizes the S1 verdict: *all*
+   live input is real NSEvents, so Option B covers keyboard too (build with
+   `+[NSEvent keyEventWith…]`). Key events' `locationInWindow` is not meaningful
+   (mouse-position artifact); use `characters`/`keyCode`, not location.
+
+This closes the coordinate contract. Both `sendEvent:` entry points fire for
+every event, confirming full normal AppKit dispatch into the agent's window.
+
+## S2 RESOLVED — canvas chrome is a separate semantic control channel
+
+Verdict: canvas chrome (device/appearance/variants/timeline controls) is NOT an
+NSEvent path. It is a fully separate semantic channel where **the agent
+describes the controls and the shell (Xcode) renders them**, structurally
+distinct from the S1 live-pointer path. This is settled by static RE of the
+`PreviewsMessagingOS` exports (`research/scripts/data/254-s2-chrome/`,
+`dyld_info -exports` + `swift demangle`):
+
+- Both render replies carry the chrome: `HostedPreviewReply` and
+  `StaticPreviewReply` each expose `controlDescriptions: [CanvasControlDescription]`
+  + `controlStates: [PlistValueBox]`, and `ShellUpdatePayload` carries
+  `controlStates: [PlistValueBox]?`. So the agent ships, per render, the set of
+  controls to draw plus their current state.
+- The shell draws those controls (they are never views in the agent's window)
+  and, on interaction, sends back a `CanvasControlEvent`. Because the agent
+  renders no chrome, a chrome interaction *cannot* arrive as an NSEvent into the
+  agent — which is why this channel is needed in addition to Option B.
+
+Control table (the `controlIndex` space + event/state vocabulary):
+
+- `CanvasControlEvent` (shell → agent): `controlIndex: Int` (which control),
+  `event: CanvasControlEvent.Event`, `stateBox: PlistValueBox` (the new state).
+  `Event` is a `RawRepresentable` **String** enum (`init(rawValue: String)`,
+  `rawValue: String`; conforms Equatable/Hashable). The generic ctor is
+  `init<A: PropertyListRepresentable & Equatable>(event:controlIndex:state:)`.
+  The exact `Event` raw-value strings are NOT exported (enum cases live in
+  metadata, not named symbols) — the one residual unknown, and the brief already
+  flagged it as lldb-only, which the agent's task-port gate blocks.
+- `CanvasControlDescription` (agent → shell, one per control): `controlType:
+  ControlType`, `modifiers: Modifiers`, `thumbnailGeometry: ThumbnailGeometry?`,
+  plus a static `.disabled`. `ControlType` is an enum of three configs:
+  - `ToggleConfiguration(sfSymbolName: String, title: String,
+    supportsInteractionEvents: Bool)` — device/appearance toggles. The
+    `supportsInteractionEvents` flag is the brief's gate: it marks whether the
+    control emits `CanvasControlEvent`s (interactive) vs. is display-only.
+  - `GridConfiguration(sections: [Section(title, items: [Item(title)])])` —
+    pickers (device/variant grids).
+  - `TimelineConfiguration(stops: [TimelineStop(id, name, sfSymbolName?)],
+    allowShuffle: Bool)` — the animation/timeline scrubber.
+
+Runtime note (why the silence test was moot): the run added an appearance-toggle
+probe, but the only text-addressable canvas control in this Xcode 26 layout is
+the destination picker ("Automatic – My Mac" → My Mac / Mac Catalyst / More) —
+the appearance/variants controls are icon buttons OCR cannot target. So the
+attempted toggle was a no-op (canvas stayed light, Count unchanged;
+`07c`/`07d`). It did not matter: the reply-carries-`controlDescriptions` design
+proves the chrome is shell-rendered, so an NSEvent-silence observation would
+have been redundant. Evidence + the full demangled export dump:
+`research/scripts/data/254-s2-chrome/`.
+
+Implication for #254 (confirms S4's hybrid): v1 needs this channel for any
+device/appearance chrome. The agent emits `CanvasControlDescription`s in its
+render reply; the shell renders them and returns `CanvasControlEvent`s. This is
+orthogonal to the Option-B NSEvent path (live in-preview pointer/keyboard).
+
+## S3 RESOLVED — selection is a shell-side hit-test, separate from live input
+
+Verdict: a canvas selection is resolved by the shell hit-testing the click
+against agent-produced regions, with NO round-trip to the agent. It is separate
+from the S1 live-pointer path, and the two are chosen by canvas mode (live/play
+forwards the NSEvent per S1; selectable/inspect consumes the click for a local
+region hit-test). Settled by static RE (the `SelectableRegion` shape, already in
+the S2 dump `research/scripts/data/254-s2-chrome/control-exports.txt`) plus the
+S1 runtime result.
+
+How `selectableRegions` are produced agent-side (the brief's open question):
+
+- `SelectableRegion(path: String, rect: __C.CGRect, accessibilityElement:
+  Foundation.Data?)`, plus `scaledBy(Double)` (zoom/HiDPI) and a `propertyListValue`
+  codec. So each region is a hit `rect` (canvas coords), a `path` string (the
+  view identity used for selection), and an optional archived AX element blob.
+- The agent ships an array of these alongside every frame: `RenderPayload`,
+  `IOSurfacePayload`, and the geometry-only `GeometryPayload` all expose
+  `selectableRegions: [SelectableRegion]`. So selection data rides with the
+  render reply, not a separate query.
+- There is NO `hitTest`/`selectAt` request symbol from shell back to the agent
+  (searched the exports). The shell owns the hit-test: it has `rect` + `path` +
+  AX locally, so it resolves selection and drives the inspector without the
+  agent. This is why selection is independent of (and cheaper than) the live
+  event path.
+
+Implication for #254: if our shell wants Xcode-style selection, the agent must
+emit `selectableRegions` next to its IOSurface frame (one `{rect, path, AX?}`
+per selectable view), and the shell hit-tests locally. #254 already plans an
+IOSurface display path (`project_macos_agent_shell_derisk`), so this slots in as
+an extra field on that frame payload. It is optional for a v1 that only needs
+live interaction; it is required for click-to-select/inspect.
+
+Not runtime-demoed (and why it is unnecessary): a clean demo would switch the
+canvas to selectable mode and show a click highlighting the view without
+incrementing the counter. The mode toggle is an icon button OCR cannot target
+(same blocker as S2's chrome controls). But the type shapes are decisive: the
+agent ships full hit-test data to the shell and there is no select-request back,
+so selection is shell-side by construction. Residual unknown: the exact bytes of
+the `accessibilityElement` archive (an `NSAccessibility`-element encoding) — not
+needed for #254 unless we mirror Xcode's AX-driven selection.
+
+## Constraints and gotchas (carry forward)
+
+- Use the research VM for Xcode RE/dtrace; restore post-xcode-ready snapshot
+  (`project_vm_capture_baseline`). Do RE after `AGENT_UP` + fd-redirect.
+- These Xcode types confirm the PROTOCOL; we reimplement, never link against them.
+- Prefer in-process / no-permission primitives. `CGEventPostToPid` is unreliable for
+  off-screen/non-frontmost targets and needs Accessibility + non-sandboxed — treat as
+  last resort, not a baseline.
+- Two sims are often booted by parallel agents; the streaming agent uses sim
+  92BCBA8E. Not relevant to macOS RE but avoid stepping on its VM/sim.
+- Coordinate with the `previews-research` mailbox agent; this overlaps the
+  `project_sim_streaming_architecture` IOSurface work.

--- a/research/254-macos-input-plan.md
+++ b/research/254-macos-input-plan.md
@@ -1,0 +1,216 @@
+# #254 macOS input forwarding — implementation plan
+
+## Summary
+
+Xcode's live macOS preview moves input over **two separate channels**, and
+#254 should mirror that split. Live in-preview interaction (pointer and
+keyboard) reaches the preview agent as ordinary `NSEvent`s delivered into one
+real `NSWindow`. Everything around the preview is not an NSEvent at all: canvas
+chrome (device and appearance toggles) is a semantic `CanvasControlEvent`
+channel, and click-to-select is a shell-side hit-test against regions the agent
+publishes with each frame. The recovery work behind this plan is recorded in
+[`254-macos-input-forwarding.md`](254-macos-input-forwarding.md); this document
+is the implementation-facing distillation.
+
+The contract for #254 is therefore simple to state. The agent renders into a
+real (offscreen) `NSWindow` and publishes, with every frame, the pixels plus two
+small side-tables: the chrome controls to draw and the selectable regions to hit
+test. The shell draws the chrome, hit-tests selection locally, and sends back
+only two kinds of upstream message: synthesized `NSEvent`s for live interaction,
+and `CanvasControlEvent`s for chrome. A v1 that only needs live interaction is
+just the NSEvent path. Chrome and selection are additive and can land later.
+
+## What was verified (and how)
+
+All findings come from runtime capture and static RE inside the research VM
+(Xcode 26.2, SIP and AMFI off, `post-xcode-ready` snapshot), using the
+`capture-input-events` preset. The agent cannot be attached by dtrace or lldb
+(task-port gate plus a `previewsd` heartbeat that SIGKILLs on a paused
+breakpoint), so the runtime evidence comes from an in-agent dylib injected by
+binary-patching `XCPreviewAgent` (`LC_LOAD_DYLIB` + ad-hoc re-sign), which
+swizzles `-[NSApplication sendEvent:]` and `-[NSWindow sendEvent:]`. The static
+evidence comes from `dyld_info -exports` over the OS-side frameworks plus
+`swift demangle`.
+
+| Area | Verdict | Evidence |
+| --- | --- | --- |
+| Live pointer | Real `NSEvent` (`leftMouseDown`/`Up`) into one window, runs the action (Count 0→2) | `research/scripts/data/254-s1-fixed/`, `254-s1-loc/` |
+| Live keyboard | Real `NSEvent` (`keyDown`/`keyUp`), same window, same dispatch | `254-s1-loc/s1-detour.log` |
+| Coordinate space | Window-local points, AppKit bottom-left origin, one stable `NSWindow` | `254-s1-loc/` |
+| Canvas chrome | Separate semantic `CanvasControlEvent` channel, shell-rendered | `254-s2-chrome/control-exports.txt` |
+| Selection | Shell-side hit-test against agent-published `SelectableRegion`s, no round-trip | `254-s2-chrome/control-exports.txt` |
+
+## Architecture: two channels
+
+```
+        ┌─────────────────────────── agent (XCPreviewAgent analog) ───────────────────────────┐
+        │  renders SwiftUI body into a real (offscreen) NSWindow                               │
+        │  emits a render reply per frame: { IOSurface frame, [CanvasControlDescription],      │
+        │                                    [SelectableRegion] }                              │
+        └───────────────▲───────────────────────────────────────────────┬─────────────────────┘
+                        │ upstream                                        │ downstream (render reply)
+   live input:  NSEvent fields ──────► agent synthesizes +[NSEvent …]    │
+   chrome:      CanvasControlEvent ───► agent applies control state       │
+   selection:   (nothing)                                                 ▼
+        ┌────────────────────────────────────── shell ────────────────────────────────────────┐
+        │  displays the frame (CALayerHost / IOSurface), draws the chrome controls,            │
+        │  routes a user gesture by canvas mode:                                               │
+        │    live mode      → serialize the NSEvent fields, send upstream                      │
+        │    selectable mode→ hit-test the point against [SelectableRegion] locally (no send)  │
+        │    chrome control → send a CanvasControlEvent upstream                               │
+        └──────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+Mode is a shell-side decision. Xcode's canvas has a live/play mode and a
+selectable/inspect mode; the shell chooses whether a click is forwarded as an
+event or consumed for a hit-test. The agent does not decide.
+
+## The data-flow contract
+
+### 1. Live input — `NSEvent` replay (the v1 core)
+
+What Xcode does, confirmed at runtime: the shell forwards the user's pointer and
+keyboard interaction and the agent receives a real `NSEvent` through normal
+AppKit dispatch (`-[NSApplication sendEvent:]` then `-[NSWindow sendEvent:]`).
+Both pointer and keyboard travel this way, into one stable `NSWindow`.
+
+Agent side:
+- Own one real `NSWindow` (offscreen is fine; it already exists for rendering).
+- On an incoming input message, synthesize the event and deliver it:
+  - pointer: `+[NSEvent mouseEventWithType:location:modifierFlags:…
+    windowNumber:…]` then `-[NSWindow sendEvent:]`.
+  - keyboard: `+[NSEvent keyEventWithType:location:modifierFlags:…
+    characters:charactersIgnoringModifiers:isARepeat:keyCode:]` then
+    `-[NSWindow sendEvent:]`.
+
+Shell side:
+- Capture the gesture, map the hit point into the agent window's local
+  coordinate space (points, bottom-left origin), and ship the fields below.
+
+Wire fields (minimal):
+- `type` (NSEventType), `locationInWindow` (CGPoint, window-local points),
+  `modifierFlags`.
+- keyboard adds `characters`, `charactersIgnoringModifiers`, `keyCode`,
+  `isARepeat`. For keyboard, `locationInWindow` is not meaningful (it is a
+  mouse-position artifact); drive off `keyCode`/`characters`.
+
+Coordinate contract (settled): the agent expects window-local points in AppKit
+bottom-left origin, into its single hosted window. The shell maps from its
+display surface coordinates into that window's space before building the event.
+
+Pitfalls:
+- Tracking-loop controls (a slider drag, hover) are awkward from a synthesized
+  `sendEvent:` because some AppKit paths assume a live mouse. Start with
+  down/up/dragged/move and a real key path; revisit drag-heavy controls if they
+  misbehave.
+- Do not initialize AppKit from a background thread in any injected/setup code.
+  Calling `+[NSApplication sharedApplication]` off the main thread corrupts the
+  agent event loop and kills the preview. This cost ~6 VM runs to find.
+
+### 2. Canvas chrome — `CanvasControlEvent`
+
+The chrome controls (device, appearance, variants, timeline) are not views in
+the agent's window. The agent **describes** them and the shell **draws** them,
+so a chrome interaction can never arrive at the agent as an `NSEvent`. This is
+why the channel exists.
+
+Downstream, per render reply (agent → shell): `[CanvasControlDescription]` +
+`[controlStates]`. Carried on `HostedPreviewReply` and `StaticPreviewReply`
+(`controlDescriptions: [CanvasControlDescription]`, `controlStates:
+[PlistValueBox]`); incremental state on `ShellUpdatePayload.controlStates`.
+
+`CanvasControlDescription`:
+- `controlType: ControlType`, `modifiers: Modifiers`, `thumbnailGeometry:
+  ThumbnailGeometry?`, plus a static `.disabled`.
+- `ControlType` is one of:
+  - `ToggleConfiguration(sfSymbolName: String, title: String,
+    supportsInteractionEvents: Bool)` — device/appearance toggles.
+    `supportsInteractionEvents` gates whether the control emits events
+    (interactive) or is display-only.
+  - `GridConfiguration(sections: [Section(title, items: [Item(title)])])` —
+    device/variant pickers.
+  - `TimelineConfiguration(stops: [TimelineStop(id, name, sfSymbolName?)],
+    allowShuffle: Bool)` — animation scrubber.
+
+Upstream, on interaction (shell → agent): `CanvasControlEvent`:
+- `controlIndex: Int` (which control, indexing the description list),
+- `event: Event` (a `RawRepresentable` String enum),
+- `stateBox: PlistValueBox` (the new state).
+- generic ctor: `init<A: PropertyListRepresentable & Equatable>(event:,
+  controlIndex:, state:)`.
+
+Residual unknown: the `Event` raw-value strings. The enum cases are not exported
+symbols (they live in metadata), and the only way to enumerate them is lldb on
+the getter, which the agent's task-port gate blocks. Not needed for v1; recover
+later by other means if we ship rich chrome.
+
+### 3. Selection — shell-side hit-test (no round-trip)
+
+A selection is resolved by the shell hit-testing the click against regions the
+agent publishes with each frame. There is no `hitTest`/`selectAt` request back
+to the agent (searched the exports), so selection costs nothing upstream.
+
+Per render reply (agent → shell): `selectableRegions: [SelectableRegion]`,
+carried on `RenderPayload`, `IOSurfacePayload`, and the geometry-only
+`GeometryPayload`.
+
+`SelectableRegion`:
+- `path: String` — the view identity used for selection,
+- `rect: CGRect` — the hit area in canvas coordinates,
+- `accessibilityElement: Data?` — an archived AX element (optional),
+- `scaledBy(Double)` — scale the region for zoom/HiDPI.
+
+Agent side: emit one `{rect, path, AX?}` per selectable view alongside the
+frame. Shell side: on a click in selectable mode, hit-test the point against the
+`rect`s, take the `path` as the selection identity, and drive the inspector.
+
+Residual unknown: the exact bytes of the `accessibilityElement` archive
+(`NSAccessibility` element encoding). Only needed if we mirror Xcode's AX-driven
+selection; geometry-only selection works without it.
+
+## How this rides on the planned display path
+
+#254's display work already plans a shared `IOSurface` (for snapshots and
+selection) and a `CAContext`/`CALayerHost` live-hosting path (see the
+shell-owns-agent derisk). The two input side-tables attach directly to that:
+
+- The frame payload is exactly the place chrome and selection live in Xcode.
+  `IOSurfacePayload` already carries `selectableRegions`, so #254's frame
+  message gains a `selectableRegions` field and (when we add chrome) a
+  `controlDescriptions` + `controlStates` field.
+- No new transport is required for chrome or selection. They are fields on the
+  reply that already carries the frame. Only live input needs an upstream
+  message, and that is small (the `NSEvent` fields above).
+
+## Suggested phasing
+
+- **Phase 1 — live input (Option B).** Upstream `NSEvent` fields, agent
+  synthesizes and dispatches into its window. Ship pointer down/up/drag/move and
+  the key path. This alone gives a live, clickable, typable preview.
+- **Phase 2 — selection.** Agent emits `selectableRegions` on the frame; shell
+  hit-tests locally and reports the selected `path`. Geometry-only first; add AX
+  later if needed.
+- **Phase 3 — chrome.** Agent emits `controlDescriptions`/`controlStates`; shell
+  renders the controls and returns `CanvasControlEvent`s. Start with
+  `ToggleConfiguration` (appearance/device) since it is the common case.
+
+## Open decisions for #254
+
+- Whether v1 ships only Phase 1, or also Phase 2 selection. Selection is cheap
+  (no upstream traffic) but needs the agent to compute regions.
+- Whether to define our own compact wire types or to re-encode Apple's plist
+  shapes 1:1. We control both ends, so a compact `Codable`/plist of the fields
+  above is enough. Matching Apple's exact grammar buys nothing here.
+- Drag-heavy and hover controls under synthesized `sendEvent:` are the main
+  technical risk to validate early in Phase 1.
+
+## References
+
+- Findings + method: [`254-macos-input-forwarding.md`](254-macos-input-forwarding.md).
+- Evidence: `research/scripts/data/254-s1-fixed/`, `254-s1-loc/`,
+  `254-s2-chrome/` (the demangled control + region exports are in
+  `254-s2-chrome/control-exports.txt`).
+- Capture harness: the `capture-input-events` preset in
+  `research/vm/Sources/previewsvm/SetupCommand.swift`.
+- Injected probe: `research/scripts/data/254-s1/event-detour.c` (arm64
+  prologue-detour + `sendEvent:` swizzle).

--- a/research/254-native-window-spike/FINDINGS.md
+++ b/research/254-native-window-spike/FINDINGS.md
@@ -1,0 +1,59 @@
+# #254 native-window spike — findings
+
+Two spikes that drove the macOS rethink in
+[`docs/254-macos-native-window-plan.md`](../../docs/254-macos-native-window-plan.md).
+Both are macOS GUI programs; run them in a logged-in Aqua session. Build with
+`./build.sh`.
+
+## Spike 1 — can a CAContext host a live SwiftUI view? (No.)
+
+Question: the shipped #254 path rasters the agent frame and hosts the raster.
+Could we instead host the agent's *live* `NSHostingView` layer over a `CAContext`
+(like our `layerhost-spike` proved for a plain `CALayer`), and get a native,
+self-updating preview?
+
+Run:
+
+```
+./producer_live ./ctxid            # off-screen NSHostingView, vends ctx.layer = hosting.layer
+ONSCREEN=1 ./producer_live ./ctxid # same, but on-screen window
+./consumer ./ctxid                 # hosts the contextId via CALayerHost
+```
+
+Result: **the consumer is empty** (shows only its own fallback background),
+off-screen *and* on-screen. By contrast `../layerhost-spike/producer` (a plain
+`CALayer` tree) hosts live and correctly.
+
+Conclusion: a `CAContext` carries **pixels, not views**. An `NSView` renders into
+its window's backing surface, not into a free-standing, re-hostable layer. So any
+cross-process hosting is necessarily a raster — there is no "host the live view"
+shortcut. This is why the shipped raster path is not a fixable mistake but an
+inherent property of the topology, and why macOS should drop cross-process
+hosting and let the agent own the real window.
+
+## Spike 2 — is a native-window respawn handoff seamless? (Yes, if ordered.)
+
+Question: if the agent owns the real window, the JIT-leak-forced respawn on each
+structural edit would close it. Can we hand off to a new agent with no visible
+gap?
+
+`agent_native` owns a real native SwiftUI window at a given frame:
+`agent_native <label> <r> <g> <b> <x> <y> <w> <h>`.
+
+Good order (spawn new at the same frame, order it front, render, THEN kill old):
+
+```
+./agent_native "OLD v1" 0.85 0.2 0.2  400 300 460 340   # gen 1, red
+# ... read its frame with ./wbounds agent_native ...
+./agent_native "NEW v2" 0.2 0.75 0.3  400 300 460 340   # gen 2, green, same frame, front
+kill <old pid>                                           # only after gen 2 is up + rendered
+```
+
+Result: **seamless** — the region shows red → green → green with no gap and no
+movement (`h_t0`/`h_t1`/`h_t2` in the plan). The reverse order (kill old, then
+spawn new) shows the **desktop** in the gap (`bad_gap`). Ordering is the whole
+trick: the new window must cover the same rectangle before the old one dies.
+
+Conclusion: Option A (agent owns the real window) is viable. The daemon must
+spawn the new agent, wait for a "first frame rendered" signal at the same frame,
+then kill the old agent. See the plan's handoff protocol.

--- a/research/254-native-window-spike/agent_native.swift
+++ b/research/254-native-window-spike/agent_native.swift
@@ -1,0 +1,40 @@
+// Respawn-handoff spike "agent": owns a REAL native SwiftUI window at a given
+// frame (Option A). Each generation is a separate process; the daemon places
+// the new one at the same frame and orders it in before killing the old, so the
+// preview never drops. args: label r g b x y w h
+import AppKit
+import SwiftUI
+
+let a = CommandLine.arguments
+let label = a[1]
+let (r, g, b) = (Double(a[2])!, Double(a[3])!, Double(a[4])!)
+let (x, y, w, h) = (Double(a[5])!, Double(a[6])!, Double(a[7])!, Double(a[8])!)
+
+struct GenView: View {
+    let label: String
+    let color: Color
+    var body: some View {
+        color.overlay(
+            Text(label)
+                .font(.system(size: 64, weight: .bold))
+                .foregroundColor(.white)
+        )
+    }
+}
+
+let app = NSApplication.shared
+app.setActivationPolicy(.regular)
+
+let hosting = NSHostingView(rootView: GenView(label: label, color: Color(red: r, green: g, blue: b)))
+let win = NSWindow(
+    contentRect: NSRect(x: x, y: y, width: w, height: h),
+    styleMask: [.titled, .closable, .resizable], backing: .buffered, defer: false
+)
+win.title = "Preview"
+win.isReleasedWhenClosed = false
+win.contentView = hosting
+win.setFrameOrigin(NSPoint(x: x, y: y))
+win.makeKeyAndOrderFront(nil)
+app.activate(ignoringOtherApps: true)
+FileHandle.standardError.write("agent \(label) windowNumber=\(win.windowNumber) pid=\(getpid())\n".data(using: .utf8)!)
+app.run()

--- a/research/254-native-window-spike/build.sh
+++ b/research/254-native-window-spike/build.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Build the #254 native-window spikes (see FINDINGS.md).
+#   producer_live  -- vends an NSHostingView's layer over a CAContext (does NOT host)
+#   consumer       -- hosts a CAContext via CALayerHost (reused from layerhost-spike)
+#   agent_native   -- owns a real native window; used for the respawn-handoff test
+#   wbounds        -- prints an on-screen window's bounds, for screencapture -R
+set -eu
+cd "$(dirname "$0")"
+swiftc -O producer_live.swift -o producer_live -framework AppKit
+swiftc -O agent_native.swift -o agent_native -framework AppKit
+swiftc -O wbounds.swift -o wbounds
+clang -fobjc-arc -framework AppKit -framework QuartzCore -framework CoreGraphics -o consumer consumer.m
+echo "built: producer_live agent_native wbounds consumer"

--- a/research/254-native-window-spike/consumer.m
+++ b/research/254-native-window-spike/consumer.m
@@ -1,0 +1,76 @@
+// Consumer half of the #254 macOS cross-process layer-hosting spike.
+// Stands in for the preview SHELL: it owns a persistent NSWindow and hosts the
+// producer's (agent's) layer cross-process via CALayerHost, rebinding the
+// context id whenever the producer is (re)launched. The window never closes
+// across a producer kill/respawn; the WindowServer holds the last frame in the
+// gap. Private QuartzCore SPI (CALayerHost) declared inline; resolved at
+// runtime.
+//
+// Build: see build.sh. Run: ./consumer ./ctxid  (windowNumber printed to
+// stderr)
+
+#import <AppKit/AppKit.h>
+#import <QuartzCore/QuartzCore.h>
+
+@interface CALayerHost : CALayer
+@property uint32_t contextId;
+@end
+
+int main(int argc, const char *argv[]) {
+  @autoreleasepool {
+    if (argc < 2) {
+      fprintf(stderr, "usage: %s <ctxid-file>\n", argv[0]);
+      return 1;
+    }
+    [NSApplication sharedApplication];
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+
+    NSWindow *win = [[NSWindow alloc]
+        initWithContentRect:NSMakeRect(100, 100, 400, 300)
+                  styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable
+                    backing:NSBackingStoreBuffered
+                      defer:NO];
+    win.title = @"layerhost consumer";
+    win.releasedWhenClosed = NO;
+
+    NSView *content = win.contentView;
+    content.wantsLayer = YES;
+    content.layer.backgroundColor = NSColor.systemGreenColor.CGColor;
+
+    CALayerHost *host = [CALayerHost layer];
+    host.frame = content.bounds;
+    host.autoresizingMask = kCALayerWidthSizable | kCALayerHeightSizable;
+    [content.layer addSublayer:host];
+
+    [win makeKeyAndOrderFront:nil];
+    [NSApp activateIgnoringOtherApps:YES];
+    fprintf(stderr, "consumer windowNumber=%ld\n", (long)win.windowNumber);
+
+    NSString *path = [NSString stringWithUTF8String:argv[1]];
+    __block uint32_t current = 0;
+    [NSTimer
+        scheduledTimerWithTimeInterval:0.25
+                               repeats:YES
+                                 block:^(NSTimer *t) {
+                                   NSString *s = [NSString
+                                       stringWithContentsOfFile:path
+                                                       encoding:
+                                                           NSUTF8StringEncoding
+                                                          error:nil];
+                                   uint32_t cid =
+                                       s ? (uint32_t)strtoul(s.UTF8String, NULL,
+                                                             10)
+                                         : 0;
+                                   if (cid != 0 && cid != current) {
+                                     current = cid;
+                                     host.contextId = cid;
+                                     fprintf(stderr,
+                                             "consumer bound contextId=%u\n",
+                                             cid);
+                                   }
+                                 }];
+
+    [NSApp run];
+  }
+  return 0;
+}

--- a/research/254-native-window-spike/producer_live.swift
+++ b/research/254-native-window-spike/producer_live.swift
@@ -1,0 +1,69 @@
+// Live-layer spike producer: mirrors the preview AGENT exactly.
+// A SwiftUI NSHostingView in an OFF-SCREEN, ordered-front borderless window
+// (same as the agent's render window), whose @State changes on a timer to
+// simulate input-driven updates. We vend the hosting view's REAL backing layer
+// over a CAContext (ctx.layer = hosting.layer) -- NOT a raster. If the consumer
+// shows the number incrementing / color flipping after binding the contextId
+// once, then an off-screen agent view vends a continuously-live layer
+// cross-process, which is the unknown blocking the rework.
+//
+// CAContext is private QuartzCore SPI, reached via the ObjC runtime (KVC).
+
+import AppKit
+import SwiftUI
+
+struct PulseView: View {
+    @State private var on = false
+    @State private var count = 0
+    let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+    var body: some View {
+        (on ? Color.green : Color.red)
+            .overlay(
+                Text("\(count)")
+                    .font(.system(size: 96, weight: .bold))
+                    .foregroundColor(.white)
+            )
+            .frame(width: 400, height: 300)
+            .onReceive(timer) { _ in
+                on.toggle()
+                count += 1
+            }
+    }
+}
+
+let app = NSApplication.shared
+app.setActivationPolicy(.accessory)
+
+let hosting = NSHostingView(rootView: PulseView())
+hosting.wantsLayer = true
+hosting.frame = NSRect(x: 0, y: 0, width: 400, height: 300)
+
+let win = NSWindow(
+    contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+    styleMask: [.borderless], backing: .buffered, defer: false
+)
+let onscreen = ProcessInfo.processInfo.environment["ONSCREEN"] != nil
+win.setFrameOrigin(onscreen ? NSPoint(x: 60, y: 60) : NSPoint(x: -10000, y: -10000))
+win.contentView = hosting
+win.orderFrontRegardless()
+hosting.layoutSubtreeIfNeeded()
+
+guard let caContextClass = NSClassFromString("CAContext") as? NSObject.Type else {
+    fatalError("CAContext class not found")
+}
+let ctx = caContextClass
+    .perform(NSSelectorFromString("remoteContextWithOptions:"), with: [String: Any]())!
+    .takeUnretainedValue() as! NSObject
+// Retain across the run loop.
+let retained = Unmanaged.passRetained(ctx)
+_ = retained
+
+guard let layer = hosting.layer else { fatalError("hosting has no layer") }
+ctx.setValue(layer, forKey: "layer")
+let cid = ctx.value(forKey: "contextId") as! UInt32
+
+let path = CommandLine.arguments[1]
+try? "\(cid)".write(toFile: path, atomically: true, encoding: .utf8)
+FileHandle.standardError.write("producer contextId=\(cid)\n".data(using: .utf8)!)
+
+app.run()

--- a/research/254-native-window-spike/wbounds.swift
+++ b/research/254-native-window-spike/wbounds.swift
@@ -1,0 +1,11 @@
+// Print "X Y W H" (top-left screen coords, points) of the first on-screen window
+// whose owner executable matches arg 1. Used to derive a fixed screencapture -R
+// region for the handoff spike.
+import AppKit
+let want = CommandLine.arguments[1]
+let list = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]] ?? []
+for win in list where (win[kCGWindowOwnerName as String] as? String ?? "") == want {
+    let b = win[kCGWindowBounds as String] as! [String: Any]
+    print("\(Int(b["X"] as! Double)) \(Int(b["Y"] as! Double)) \(Int(b["Width"] as! Double)) \(Int(b["Height"] as! Double))")
+    break
+}

--- a/research/README.md
+++ b/research/README.md
@@ -1,0 +1,20 @@
+# research/
+
+Non-shipping reference material: exploratory spikes and research briefs that
+back product decisions. Nothing here is built by Bazel or `Package.swift`, and
+`research/` is excluded from the lint sweep (`tools/lint/lint.sh`), same bucket
+as `examples/`. Compiled spike binaries are never committed — build them from
+source with each spike's `build.sh` in a logged-in GUI session.
+
+## #254 macOS native-window preview
+
+The design that reverses the shipped shell-owns-agent macOS path to
+agent-owns-a-real-`NSWindow` with a seamless respawn handoff. Plan doc:
+[`docs/254-macos-native-window-plan.md`](../docs/254-macos-native-window-plan.md).
+
+| Path | What it is |
+|---|---|
+| [`layerhost-spike/`](layerhost-spike/) | Two-process proof of the cross-process display primitive: `CAContext` → `CALayerHost` hosts a live layer, holds the last frame when the producer dies, and re-hosts on respawn. Shows a `CAContext` carries pixels, not views. |
+| [`254-native-window-spike/`](254-native-window-spike/) | Two spikes behind the rethink: (1) a `CAContext` cannot host a live `NSHostingView` (so any cross-process hosting is a raster), and (2) the ordered respawn handoff is gapless — spawn+render the new window before killing the old. See `FINDINGS.md`. |
+| [`254-macos-input-plan.md`](254-macos-input-plan.md) | Implementation plan for macOS input: native `NSEvent`s into one real window for live interaction, separate semantic channels for chrome/selection. |
+| [`254-macos-input-forwarding.md`](254-macos-input-forwarding.md) | Research brief on cross-process input forwarding for the (now reversed) shell-owns-agent topology. |

--- a/research/layerhost-spike/.gitignore
+++ b/research/layerhost-spike/.gitignore
@@ -1,0 +1,5 @@
+producer
+consumer
+ctxid
+*.log
+*.png

--- a/research/layerhost-spike/README.md
+++ b/research/layerhost-spike/README.md
@@ -1,0 +1,44 @@
+# #254 layer-hosting spike
+
+A two-process proof of the macOS cross-process display primitive behind #254.
+The **producer** stands in for the preview agent; the **consumer** stands in for
+the shell. Reconstructed from `project_macos_agent_shell_derisk` after the
+original `/tmp` copy was lost (it was never committed).
+
+## What it proves
+
+1. **Cross-process layer hosting works** for a self-spawned process pair on
+   macOS, with no `.appex`/NSExtension: the consumer's `NSWindow` shows the
+   producer's live, animating layer by binding `CALayerHost.contextId` to the
+   producer's `CAContext.contextId`. No `NSRemoteView`/ViewBridge.
+2. **The WindowServer holds the last frame when the producer dies** — the
+   consumer window keeps showing the frozen content instead of going blank. This
+   is the never-blank-across-respawn behavior for free.
+3. **Re-host on respawn** — relaunch the producer (new `contextId`); the consumer
+   polls the id file and rebinds `CALayerHost.contextId`, so the same window
+   shows the new producer's content and never closes.
+
+## Mechanism
+
+- `+[CAContext remoteContextWithOptions:]` → `CAContext` with a settable `.layer`
+  and a read-only `.contextId` (UInt32). Private QuartzCore SPI.
+- `CALayerHost` (CALayer subclass) with a settable `contextId`. Set it to the
+  producer's `contextId` to host that layer.
+- The public wrapper `CARemoteLayerServer`/`Client` is reportedly broken on
+  modern macOS, so this uses the private `CAContext`/`CALayerHost` directly —
+  the same path Xcode uses (`MacOSLayerHostedPreviewViewable(contextID:)`).
+
+## Build & run
+
+```
+./build.sh
+./producer ./ctxid &        # writes its contextId to ./ctxid, animates
+./consumer ./ctxid &        # opens a window, binds the contextId, prints windowNumber
+# capture the consumer window (windowNumber is on the consumer's stderr):
+screencapture -l<WINDOW_NUMBER> out-window.png
+kill %1                     # kill the producer -> consumer holds the last frame
+./producer ./ctxid &        # respawn -> consumer rebinds, window never closed
+```
+
+Needs a live WindowServer/CA session (a logged-in GUI session), not a detached
+daemon. Snapshots in the product use an IOSurface read, not `screencapture`.

--- a/research/layerhost-spike/build.sh
+++ b/research/layerhost-spike/build.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Build the #254 macOS layer-hosting spike (producer + consumer).
+set -eu
+cd "$(dirname "$0")"
+CFLAGS="-fobjc-arc -framework AppKit -framework QuartzCore -framework CoreGraphics"
+clang $CFLAGS -o producer producer.m
+clang $CFLAGS -o consumer consumer.m
+echo "built: producer consumer"

--- a/research/layerhost-spike/consumer.m
+++ b/research/layerhost-spike/consumer.m
@@ -1,0 +1,76 @@
+// Consumer half of the #254 macOS cross-process layer-hosting spike.
+// Stands in for the preview SHELL: it owns a persistent NSWindow and hosts the
+// producer's (agent's) layer cross-process via CALayerHost, rebinding the
+// context id whenever the producer is (re)launched. The window never closes
+// across a producer kill/respawn; the WindowServer holds the last frame in the
+// gap. Private QuartzCore SPI (CALayerHost) declared inline; resolved at
+// runtime.
+//
+// Build: see build.sh. Run: ./consumer ./ctxid  (windowNumber printed to
+// stderr)
+
+#import <AppKit/AppKit.h>
+#import <QuartzCore/QuartzCore.h>
+
+@interface CALayerHost : CALayer
+@property uint32_t contextId;
+@end
+
+int main(int argc, const char *argv[]) {
+  @autoreleasepool {
+    if (argc < 2) {
+      fprintf(stderr, "usage: %s <ctxid-file>\n", argv[0]);
+      return 1;
+    }
+    [NSApplication sharedApplication];
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+
+    NSWindow *win = [[NSWindow alloc]
+        initWithContentRect:NSMakeRect(100, 100, 400, 300)
+                  styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable
+                    backing:NSBackingStoreBuffered
+                      defer:NO];
+    win.title = @"layerhost consumer";
+    win.releasedWhenClosed = NO;
+
+    NSView *content = win.contentView;
+    content.wantsLayer = YES;
+    content.layer.backgroundColor = NSColor.systemGreenColor.CGColor;
+
+    CALayerHost *host = [CALayerHost layer];
+    host.frame = content.bounds;
+    host.autoresizingMask = kCALayerWidthSizable | kCALayerHeightSizable;
+    [content.layer addSublayer:host];
+
+    [win makeKeyAndOrderFront:nil];
+    [NSApp activateIgnoringOtherApps:YES];
+    fprintf(stderr, "consumer windowNumber=%ld\n", (long)win.windowNumber);
+
+    NSString *path = [NSString stringWithUTF8String:argv[1]];
+    __block uint32_t current = 0;
+    [NSTimer
+        scheduledTimerWithTimeInterval:0.25
+                               repeats:YES
+                                 block:^(NSTimer *t) {
+                                   NSString *s = [NSString
+                                       stringWithContentsOfFile:path
+                                                       encoding:
+                                                           NSUTF8StringEncoding
+                                                          error:nil];
+                                   uint32_t cid =
+                                       s ? (uint32_t)strtoul(s.UTF8String, NULL,
+                                                             10)
+                                         : 0;
+                                   if (cid != 0 && cid != current) {
+                                     current = cid;
+                                     host.contextId = cid;
+                                     fprintf(stderr,
+                                             "consumer bound contextId=%u\n",
+                                             cid);
+                                   }
+                                 }];
+
+    [NSApp run];
+  }
+  return 0;
+}

--- a/research/layerhost-spike/producer.m
+++ b/research/layerhost-spike/producer.m
@@ -1,0 +1,58 @@
+// Producer half of the #254 macOS cross-process layer-hosting spike.
+// Stands in for the preview AGENT: it owns a render layer (red background with
+// a spinning blue box), vends it over a CAContext, and writes the context id to
+// a file so the consumer (the shell) can host it via CALayerHost. Private
+// QuartzCore SPI (CAContext) declared inline; resolved at runtime from
+// QuartzCore.
+//
+// Build: see build.sh. Run: ./producer ./ctxid
+
+#import <AppKit/AppKit.h>
+#import <QuartzCore/QuartzCore.h>
+
+@interface CAContext : NSObject
++ (CAContext *)remoteContextWithOptions:(NSDictionary *)options;
+@property(readonly) uint32_t contextId;
+@property(strong) CALayer *layer;
+@end
+
+int main(int argc, const char *argv[]) {
+  @autoreleasepool {
+    if (argc < 2) {
+      fprintf(stderr, "usage: %s <ctxid-file>\n", argv[0]);
+      return 1;
+    }
+    [NSApplication sharedApplication];
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+
+    CALayer *root = [CALayer layer];
+    root.frame = CGRectMake(0, 0, 400, 300);
+    root.backgroundColor = NSColor.systemRedColor.CGColor;
+
+    CALayer *box = [CALayer layer];
+    box.frame = CGRectMake(150, 100, 100, 100);
+    box.backgroundColor = NSColor.systemBlueColor.CGColor;
+    [root addSublayer:box];
+
+    CABasicAnimation *spin =
+        [CABasicAnimation animationWithKeyPath:@"transform.rotation.z"];
+    spin.fromValue = @0;
+    spin.toValue = @(2 * M_PI);
+    spin.duration = 2.0;
+    spin.repeatCount = HUGE_VALF;
+    [box addAnimation:spin forKey:@"spin"];
+
+    CAContext *ctx = [CAContext remoteContextWithOptions:@{}];
+    ctx.layer = root;
+
+    FILE *f = fopen(argv[1], "w");
+    if (f) {
+      fprintf(f, "%u", ctx.contextId);
+      fclose(f);
+    }
+    fprintf(stderr, "producer contextId=%u\n", ctx.contextId);
+
+    [NSApp run];
+  }
+  return 0;
+}

--- a/tools/lint/lint.sh
+++ b/tools/lint/lint.sh
@@ -21,8 +21,8 @@ mode="${1:-check}"
 cd "$BUILD_WORKSPACE_DIRECTORY"
 fail=0
 
-# Generated sources and example projects are never linted.
-_exclude='(^examples/|/IOSAgentAppSource\.swift$|/IOSAppIconData\.swift$)'
+# Generated sources, example projects, and research spikes are never linted.
+_exclude='(^examples/|^research/|/IOSAgentAppSource\.swift$|/IOSAppIconData\.swift$)'
 
 _candidates() {
   if [[ "$mode" == staged ]]; then


### PR DESCRIPTION
Lands the local-only #254 macOS research into git so the abandoned worktrees/branch that held it can be safely discarded. Supersedes withdrawn PR #332 (same rescue set + two macOS-input docs + a fresh index).

## What lands
- `docs/254-macos-native-window-plan.md` — the settled design: the agent owns a real native `NSWindow` (real `NSHostingView`, native input/resize/scroll), with a daemon-coordinated seamless respawn handoff. Reverses the shipped shell-owns-agent macOS path.
- `docs/254-macos-shell-owns-agent-plan.md` — the superseded shell-owns-agent plan, kept as the record the native-window plan reverses (was local-only on the abandoned branch).
- `research/254-native-window-spike/` — spikes proving a `CAContext` hosts pixels, not views (so any cross-process hosting is a raster), and the ordered respawn handoff is gapless. Sources only.
- `research/layerhost-spike/` — cross-process `CAContext`→`CALayerHost` proof (holds last frame on producer death, re-hosts on respawn). Sources + README; compiled binaries dropped and gitignored.
- `research/254-macos-input-{plan,forwarding}.md` — macOS input research (native `NSEvent`s into one window + separate semantic channels for chrome/selection).
- `research/README.md` — fresh index of what lands here (the previews-research README was JIT-spike-specific with broken links).
- `tools/lint/lint.sh` — exclude `research/` from the lint sweep, same never-linted bucket as `examples/` (verbatim match to #332's ERE change).

## No product code
Docs + non-shipping throwaway spikes + a 2-line lint exclude. No Bazel/Package.swift graph changes.

## Verification
- `bazel run //tools/lint:check` green (exit 0); zero `research/` files reach any linter — the new `^research/` exclude covers them.
- `/simplify` (4 agents) — 0 findings.
- `/code-review` (high, workflow) — 0 findings survived verification.
- No compiled binaries staged (verified `git diff --cached` clean of `consumer`/`producer`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)