### PR TITLE
#267: snapshot-all — batch-render every #Preview headless with manifest + gallery

### DIFF
--- a/previewsmcp/PreviewsCLI/HTMLGallery.swift
+++ b/previewsmcp/PreviewsCLI/HTMLGallery.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Renders a `SnapshotAllCommand.Manifest` into a self-contained static HTML
+/// gallery. Images are referenced by their manifest-relative paths, so the
+/// gallery is portable as long as it sits beside the `images/` directory the
+/// batch wrote.
+enum HTMLGallery {
+    static func render(_ manifest: SnapshotAllCommand.Manifest) -> String {
+        let cards = manifest.entries.map(card).joined(separator: "\n")
+        let summary =
+            "\(manifest.imageCount) rendered · \(manifest.skippedCount) skipped · "
+                + "\(manifest.errorCount) failed · \(manifest.previewCount) previews"
+
+        return """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Preview Gallery</title>
+        <style>
+        :root { color-scheme: light dark; }
+        body { font-family: -apple-system, system-ui, sans-serif; margin: 2rem; }
+        h1 { font-size: 1.25rem; }
+        .summary { color: #888; margin-bottom: 1.5rem; }
+        .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 1rem; }
+        .card { border: 1px solid #8883; border-radius: 8px; padding: 0.75rem; }
+        .card img { width: 100%; height: auto; border-radius: 4px; background: #8881; }
+        .card .name { font-weight: 600; margin-top: 0.5rem; }
+        .card .meta { color: #888; font-size: 0.85rem; word-break: break-all; }
+        .card.skipped, .card.error { color: #888; }
+        .card .status { font-size: 0.85rem; }
+        .card.error .status { color: #c0392b; }
+        </style>
+        </head>
+        <body>
+        <h1>Preview Gallery</h1>
+        <div class="summary">\(escape(summary))</div>
+        <div class="grid">
+        \(cards)
+        </div>
+        </body>
+        </html>
+        """
+    }
+
+    private static func card(_ entry: SnapshotAllCommand.ManifestEntry) -> String {
+        let title = escape(entry.name ?? "Preview [\(entry.index)]")
+        let variantLabel = entry.variant.map { " · \(escape($0))" } ?? ""
+        let meta = escape((entry.file as NSString).lastPathComponent) + ":\(entry.line)"
+
+        let body: String
+        switch entry.status {
+        case .ok:
+            let src = escape(entry.image ?? "")
+            body = "<img src=\"\(src)\" alt=\"\(title)\" loading=\"lazy\">"
+        case .skipped:
+            body = "<div class=\"status\">skipped: \(escape(entry.error ?? ""))</div>"
+        case .error:
+            body = "<div class=\"status\">error: \(escape(entry.error ?? ""))</div>"
+        }
+
+        return """
+        <div class="card \(entry.status.rawValue)">
+        \(body)
+        <div class="name">\(title)\(variantLabel)</div>
+        <div class="meta">\(meta)</div>
+        </div>
+        """
+    }
+
+    private static func escape(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+}

--- a/previewsmcp/PreviewsCLI/HTMLGallery.swift
+++ b/previewsmcp/PreviewsCLI/HTMLGallery.swift
@@ -52,7 +52,12 @@ enum HTMLGallery {
         let body: String
         switch entry.status {
         case .ok:
-            let src = escape(entry.image ?? "")
+            // Percent-encode the path so a variant label with a URL-reserved
+            // char (#, ?, …) in the filename doesn't break the <img> ref, then
+            // HTML-escape the result for the attribute.
+            let encoded = (entry.image ?? "")
+                .addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+            let src = escape(encoded)
             body = "<img src=\"\(src)\" alt=\"\(title)\" loading=\"lazy\">"
         case .skipped:
             body = "<div class=\"status\">skipped: \(escape(entry.error ?? ""))</div>"

--- a/previewsmcp/PreviewsCLI/PreviewsMCPApp.swift
+++ b/previewsmcp/PreviewsCLI/PreviewsMCPApp.swift
@@ -136,7 +136,8 @@ struct PreviewsMCPCommand: ParsableCommand {
         """,
         version: version,
         subcommands: [
-            RunCommand.self, ListCommand.self, SnapshotCommand.self, VariantsCommand.self,
+            RunCommand.self, ListCommand.self, SnapshotCommand.self, SnapshotAllCommand.self,
+            VariantsCommand.self,
             ConfigureCommand.self, SwitchCommand.self, ElementsCommand.self,
             TouchCommand.self, SimulatorsCommand.self, StopCommand.self,
             ServeCommand.self, StatusCommand.self, LogsCommand.self, KillDaemonCommand.self,

--- a/previewsmcp/PreviewsCLI/SnapshotAllCommand.swift
+++ b/previewsmcp/PreviewsCLI/SnapshotAllCommand.swift
@@ -1,0 +1,624 @@
+import ArgumentParser
+import Foundation
+import MCP
+import PreviewsCore
+import PreviewsEngine
+
+/// Batch-render every `#Preview` (and legacy `PreviewProvider`) under a file
+/// or directory headless, writing an image per (preview × trait variant), a
+/// JSON manifest, and an optional static HTML gallery.
+///
+/// This is pure orchestration over the existing primitives — discovery goes
+/// through `PreviewParser` (the same AST walk `list` uses) and rendering
+/// through the daemon's `preview_start` / `preview_switch` / `preview_snapshot`
+/// / `preview_variants` tools. No new discovery or render engine.
+///
+/// One session is started per *file*, then `preview_switch` moves across the
+/// file's preview indices — `switch` reuses the session's already-compiled
+/// stable module and only recompiles the small per-preview overlay, so a whole
+/// file costs one compile, not one-per-preview.
+///
+/// macOS is the clean headless lane. iOS previews need a booted simulator, so
+/// they are gated: a file that resolves to the iOS platform is recorded as
+/// `skipped` rather than rendered. No simulator is ever booted.
+struct SnapshotAllCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "snapshot-all",
+        abstract: "Batch-render every #Preview in a file or directory headless",
+        discussion: """
+        Walks a Swift file or directory, discovers every #Preview and legacy
+        PreviewProvider (the same AST walk as `list`), renders each headless,
+        and writes to the --out directory:
+
+          • images/  — one image per preview (per trait variant with --variants)
+          • manifest.json — one entry per rendered slot (name, file, line,
+            index, variant, traits, image path, status)
+          • index.html — a static gallery (with --html)
+
+        macOS renders headless with no simulator. iOS previews are gated:
+        they're recorded as `skipped` (batch iOS needs a booted simulator).
+
+        Uses the `previewsmcp` daemon — it will be auto-started if needed.
+        """
+    )
+
+    @Argument(
+        help: "Swift file or directory to scan (default: current directory)",
+        transform: Path.normalize
+    )
+    var path: String = "."
+
+    @Option(name: [.short, .long], help: "Output directory")
+    var out: String = "./preview-snapshots"
+
+    @Option(
+        name: .long,
+        help: ArgumentHelp(
+            "Trait variants to render per preview. Comma-separated (light,dark) or repeated.",
+            discussion: """
+            Each variant is a preset name (light, dark, xSmall…accessibility5, rtl, ltr, boldText) \
+            or a JSON object string with trait fields. JSON variants (starting with '{') are never \
+            comma-split. With no --variants, one image is rendered per preview.
+            """
+        )
+    )
+    var variants: [String] = []
+
+    @Flag(name: .long, help: "Also write a static HTML gallery (index.html)")
+    var html: Bool = false
+
+    @Option(name: .long, help: "Image format")
+    var format: ImageFormat = .jpeg
+
+    @Option(name: .long, help: "JPEG quality 0.0–1.0 (ignored for PNG; default 0.85)")
+    var quality: Double?
+
+    @Option(name: .long, help: "Window width")
+    var width: Int = 400
+
+    @Option(name: .long, help: "Window height")
+    var height: Int = 600
+
+    @Option(name: .long, help: "Target platform: 'macos' or 'ios' (auto-detected per file if omitted)")
+    var platform: CLIPlatform?
+
+    @Option(
+        name: .long,
+        help: "Project root path (auto-detected if omitted)",
+        transform: Path.normalize
+    )
+    var project: String?
+
+    @Option(name: .long, help: "Xcode scheme name (multi-scheme .xcodeproj / .xcworkspace only)")
+    var scheme: String?
+
+    @Option(name: .long, help: "Force the build system, overriding auto-detection")
+    var buildSystem: BuildSystemKind?
+
+    @Option(
+        name: .long,
+        help: "Path to .previewsmcp.json config file (auto-discovered if omitted)",
+        transform: Path.normalize
+    )
+    var config: String?
+
+    @Flag(name: .long, help: "Emit the manifest JSON on stdout in addition to writing it")
+    var json: Bool = false
+
+    enum ImageFormat: String, ExpressibleByArgument, CaseIterable {
+        case jpeg, png
+    }
+
+    mutating func run() async throws {
+        guard FileManager.default.fileExists(atPath: path) else {
+            throw ValidationError("path does not exist: \(path)")
+        }
+        if format == .jpeg, let quality, quality >= 1.0 {
+            throw ValidationError(
+                "--quality must be < 1.0 when --format jpeg; use --format png for lossless output."
+            )
+        }
+        // Resolve variant labels up front so a bad preset / duplicate label
+        // fails before any compile.
+        let resolvedVariants = try Self.resolveVariants(variants)
+
+        let exitCode = try await DaemonClient.withDaemonClient(
+            name: "previewsmcp-snapshot-all"
+        ) { client in
+            try await execute(on: client, resolvedVariants: resolvedVariants)
+        }
+        if exitCode != 0 { throw ExitCode(exitCode) }
+    }
+
+    // MARK: - Orchestration
+
+    /// The daemon-driving body, factored out so tests can call it against a
+    /// fake `DaemonToolCalling`. Discovers previews, renders each headless,
+    /// writes the images + manifest (+ optional gallery), and returns the
+    /// process exit code.
+    func execute(
+        on client: any DaemonToolCalling,
+        resolvedVariants: [PreviewTraits.Variant]
+    ) async throws -> Int32 {
+        var isDirectory: ObjCBool = false
+        FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+        let files = isDirectory.boolValue ? ListCommand.swiftFiles(in: path) : [path]
+        // Slugs are relative to the walked root so images from different
+        // files never collide (two files can both have a preview at index 0).
+        let slugRoot = isDirectory.boolValue
+            ? path : (path as NSString).deletingLastPathComponent
+
+        let outURL = URL(fileURLWithPath: Path.normalize(out))
+        let imagesDir = outURL.appendingPathComponent("images")
+        try FileManager.default.createDirectory(at: imagesDir, withIntermediateDirectories: true)
+
+        var entries: [ManifestEntry] = []
+        var previewCount = 0
+        for file in files {
+            let previews: [PreviewInfo]
+            do {
+                previews = try PreviewParser.parse(fileAt: URL(fileURLWithPath: file))
+            } catch {
+                fputs("warning: skipping \(file): \(error.localizedDescription)\n", stderr)
+                continue
+            }
+            guard !previews.isEmpty else { continue }
+            previewCount += previews.count
+            entries += await renderFile(
+                file: file,
+                previews: previews,
+                slugRoot: slugRoot,
+                resolvedVariants: resolvedVariants,
+                imagesDir: imagesDir,
+                client: client
+            )
+        }
+
+        let imageCount = entries.count(where: { $0.status == .ok })
+        let skippedCount = entries.count(where: { $0.status == .skipped })
+        let errorCount = entries.count(where: { $0.status == .error })
+
+        let manifest = Manifest(
+            root: URL(fileURLWithPath: path).path,
+            previewCount: previewCount,
+            imageCount: imageCount,
+            skippedCount: skippedCount,
+            errorCount: errorCount,
+            entries: entries
+        )
+        try writeManifest(manifest, to: outURL)
+        if html {
+            try writeGallery(manifest, to: outURL)
+        }
+        if json {
+            try emitJSON(manifest)
+        }
+
+        fputs(
+            "snapshot-all: \(imageCount) rendered, \(skippedCount) skipped, "
+                + "\(errorCount) failed across \(previewCount) previews.\n",
+            stderr
+        )
+        return Self.exitCode(ok: imageCount, failed: errorCount)
+    }
+
+    /// Render every (preview × variant) slot for one file. Starts a single
+    /// session, switches across preview indices, and stops it. iOS-resolved
+    /// files are skipped without touching the daemon. Failures are recorded
+    /// per slot and never abort the batch.
+    private func renderFile(
+        file: String,
+        previews: [PreviewInfo],
+        slugRoot: String,
+        resolvedVariants: [PreviewTraits.Variant],
+        imagesDir: URL,
+        client: any DaemonToolCalling
+    ) async -> [ManifestEntry] {
+        let fileURL = URL(fileURLWithPath: file)
+        let configResult = loadProjectConfig(explicit: config, fileURL: fileURL)
+        let resolvedPlatform = SnapshotCommand.resolvePlatform(
+            explicit: platform,
+            config: configResult?.config,
+            project: project,
+            fileURL: fileURL
+        )
+        let slug = Self.slug(for: file, root: slugRoot)
+
+        guard resolvedPlatform == .macos else {
+            return previews.flatMap { preview in
+                slots(for: resolvedVariants).map { slot in
+                    ManifestEntry(
+                        preview: preview, file: file, slot: slot,
+                        image: nil, status: .skipped,
+                        error: "iOS previews are gated; batch iOS needs a booted simulator"
+                    )
+                }
+            }
+        }
+
+        let sessionID: String
+        do {
+            sessionID = try await startSession(file: file, platform: resolvedPlatform, client: client)
+        } catch {
+            let message = (error as? DaemonToolError)?.description ?? error.localizedDescription
+            return previews.flatMap { preview in
+                slots(for: resolvedVariants).map { slot in
+                    ManifestEntry(
+                        preview: preview, file: file, slot: slot,
+                        image: nil, status: .error, error: message
+                    )
+                }
+            }
+        }
+        var result: [ManifestEntry] = []
+        for preview in previews {
+            if preview.index > 0 {
+                do {
+                    try await switchTo(index: preview.index, sessionID: sessionID, client: client)
+                } catch {
+                    let message = (error as? DaemonToolError)?.description
+                        ?? error.localizedDescription
+                    result += slots(for: resolvedVariants).map { slot in
+                        ManifestEntry(
+                            preview: preview, file: file, slot: slot,
+                            image: nil, status: .error, error: message
+                        )
+                    }
+                    continue
+                }
+            }
+            result += await renderPreview(
+                preview: preview, file: file, slug: slug,
+                resolvedVariants: resolvedVariants,
+                sessionID: sessionID, imagesDir: imagesDir, client: client
+            )
+        }
+        // Await teardown before moving to the next file: a fire-and-forget
+        // stop would let the batch exit with the session still live, orphaning
+        // it in the daemon. The render loop above never throws out (every
+        // failure is recorded as an entry), so no defer is needed.
+        await stopSession(sessionID: sessionID, client: client)
+        return result
+    }
+
+    /// Render every variant slot of the currently-active preview.
+    private func renderPreview(
+        preview: PreviewInfo,
+        file: String,
+        slug: String,
+        resolvedVariants: [PreviewTraits.Variant],
+        sessionID: String,
+        imagesDir: URL,
+        client: any DaemonToolCalling
+    ) async -> [ManifestEntry] {
+        if resolvedVariants.isEmpty {
+            let slot = RenderSlot(label: nil, traits: PreviewTraits())
+            do {
+                let data = try await snapshot(sessionID: sessionID, client: client)
+                let image = try write(data, slug: slug, index: preview.index, label: nil, to: imagesDir)
+                return [ManifestEntry(
+                    preview: preview, file: file, slot: slot,
+                    image: image, status: .ok, error: nil
+                )]
+            } catch {
+                let message = (error as? DaemonToolError)?.description ?? error.localizedDescription
+                return [ManifestEntry(
+                    preview: preview, file: file, slot: slot,
+                    image: nil, status: .error, error: message
+                )]
+            }
+        }
+
+        do {
+            let outcomes = try await captureVariants(
+                sessionID: sessionID, resolvedVariants: resolvedVariants, client: client
+            )
+            return outcomes.map { outcome in
+                let slot = RenderSlot(label: outcome.label, traits: outcome.traits)
+                switch outcome.rendered {
+                case let .success(data):
+                    do {
+                        let image = try write(
+                            data, slug: slug, index: preview.index,
+                            label: outcome.label, to: imagesDir
+                        )
+                        return ManifestEntry(
+                            preview: preview, file: file, slot: slot,
+                            image: image, status: .ok, error: nil
+                        )
+                    } catch {
+                        return ManifestEntry(
+                            preview: preview, file: file, slot: slot,
+                            image: nil, status: .error, error: error.localizedDescription
+                        )
+                    }
+                case let .failure(message):
+                    return ManifestEntry(
+                        preview: preview, file: file, slot: slot,
+                        image: nil, status: .error, error: message
+                    )
+                }
+            }
+        } catch {
+            let message = (error as? DaemonToolError)?.description ?? error.localizedDescription
+            return slots(for: resolvedVariants).map { slot in
+                ManifestEntry(
+                    preview: preview, file: file, slot: slot,
+                    image: nil, status: .error, error: message
+                )
+            }
+        }
+    }
+
+    // MARK: - Daemon calls
+
+    private func startSession(
+        file: String, platform: CLIPlatform, client: any DaemonToolCalling
+    ) async throws -> String {
+        var startArgs: [String: Value] = [
+            "filePath": .string(file),
+            "previewIndex": .int(0),
+            "width": .int(width),
+            "height": .int(height),
+            "headless": .bool(true),
+            "platform": .string(platform.rawValue),
+        ]
+        if let project { startArgs["projectPath"] = .string(project) }
+        if let scheme { startArgs["scheme"] = .string(scheme) }
+        if let buildSystem { startArgs["buildSystem"] = .string(buildSystem.rawValue) }
+        if let config { startArgs["config"] = .string(config) }
+
+        let response = try await client.callToolStructured(name: "preview_start", arguments: startArgs)
+        if response.isError == true {
+            throw DaemonToolError.daemonError(response.content.joinedText())
+        }
+        guard let structured = response.structuredContent else {
+            throw DaemonToolError.daemonError("preview_start response missing structuredContent")
+        }
+        return try structured.decode(DaemonProtocol.PreviewStartResult.self).sessionID
+    }
+
+    private func switchTo(index: Int, sessionID: String, client: any DaemonToolCalling) async throws {
+        let response = try await client.callToolStructured(
+            name: "preview_switch",
+            arguments: ["sessionID": .string(sessionID), "previewIndex": .int(index)]
+        )
+        if response.isError == true {
+            throw DaemonToolError.daemonError(response.content.joinedText())
+        }
+    }
+
+    private func snapshot(sessionID: String, client: any DaemonToolCalling) async throws -> Data {
+        let response = try await client.callToolStructured(
+            name: "preview_snapshot",
+            arguments: ["sessionID": .string(sessionID), "quality": .double(resolvedQuality())]
+        )
+        if response.isError == true {
+            throw DaemonToolError.daemonError(response.content.joinedText())
+        }
+        for item in response.content {
+            if case let .image(base64, _, _) = item {
+                guard let data = Data(base64Encoded: base64) else {
+                    throw DaemonToolError.daemonError("daemon returned invalid (non-base64) image data")
+                }
+                return data
+            }
+        }
+        throw DaemonToolError.daemonError("daemon response contained no image content")
+    }
+
+    /// One resolved variant's rendered outcome.
+    private struct VariantOutcome {
+        let label: String
+        let traits: PreviewTraits
+        let rendered: RenderResult
+
+        enum RenderResult {
+            case success(Data)
+            case failure(String)
+        }
+    }
+
+    private func captureVariants(
+        sessionID: String,
+        resolvedVariants: [PreviewTraits.Variant],
+        client: any DaemonToolCalling
+    ) async throws -> [VariantOutcome] {
+        // Pass the comma-expanded tokens, not the raw `--variants` values: a
+        // single "light,dark" token would reach the daemon as one unknown
+        // preset. Expansion mirrors `resolveVariants`, so the daemon derives
+        // the same labels we key `traitsByLabel` on below.
+        let tokens = Self.expandVariantTokens(variants)
+        let response = try await client.callToolStructured(
+            name: "preview_variants",
+            arguments: [
+                "sessionID": .string(sessionID),
+                "variants": .array(tokens.map { .string($0) }),
+                "quality": .double(resolvedQuality()),
+            ]
+        )
+        if response.isError == true {
+            throw DaemonToolError.daemonError(response.content.joinedText())
+        }
+        guard let structured = response.structuredContent else {
+            throw DaemonToolError.daemonError("preview_variants response missing structuredContent")
+        }
+        let result = try structured.decode(DaemonProtocol.VariantsResult.self)
+        let traitsByLabel = Dictionary(
+            resolvedVariants.map { ($0.label, $0.traits) }, uniquingKeysWith: { first, _ in first }
+        )
+
+        return result.variants.map { outcome in
+            let traits = traitsByLabel[outcome.label] ?? PreviewTraits()
+            if outcome.status == "ok",
+               let imageIndex = outcome.imageIndex,
+               imageIndex < response.content.count,
+               case let .image(base64, _, _) = response.content[imageIndex],
+               let data = Data(base64Encoded: base64)
+            {
+                return VariantOutcome(label: outcome.label, traits: traits, rendered: .success(data))
+            }
+            let message = outcome.status == "ok"
+                ? "daemon reported ok but image data was missing or invalid"
+                : (outcome.error ?? "unknown error")
+            return VariantOutcome(label: outcome.label, traits: traits, rendered: .failure(message))
+        }
+    }
+
+    private func stopSession(sessionID: String, client: any DaemonToolCalling) async {
+        do {
+            _ = try await client.callToolStructured(
+                name: "preview_stop", arguments: ["sessionID": .string(sessionID)]
+            )
+        } catch {
+            fputs("warning: failed to stop session \(sessionID): \(error)\n", stderr)
+        }
+    }
+
+    // MARK: - Output
+
+    private func write(
+        _ data: Data, slug: String, index: Int, label: String?, to imagesDir: URL
+    ) throws -> String {
+        let ext = format == .png ? "png" : "jpg"
+        let name = label.map { "\(slug)-\(index)-\($0)" } ?? "\(slug)-\(index)"
+        let fileName = "\(name).\(ext)"
+        try data.write(to: imagesDir.appendingPathComponent(fileName))
+        return "images/\(fileName)"
+    }
+
+    private func writeManifest(_ manifest: Manifest, to outURL: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode(manifest)
+        try data.write(to: outURL.appendingPathComponent("manifest.json"))
+    }
+
+    private func writeGallery(_ manifest: Manifest, to outURL: URL) throws {
+        let html = HTMLGallery.render(manifest)
+        try Data(html.utf8).write(to: outURL.appendingPathComponent("index.html"))
+    }
+
+    // MARK: - Helpers
+
+    func resolvedQuality() -> Double {
+        if format == .png { return 1.0 }
+        return quality ?? 0.85
+    }
+
+    /// Empty when no `--variants` were given (the single implicit "default"
+    /// slot is handled by the caller). Otherwise one `RenderSlot` per variant.
+    private func slots(for resolvedVariants: [PreviewTraits.Variant]) -> [RenderSlot] {
+        if resolvedVariants.isEmpty {
+            return [RenderSlot(label: nil, traits: PreviewTraits())]
+        }
+        return resolvedVariants.map { RenderSlot(label: $0.label, traits: $0.traits) }
+    }
+
+    /// Comma-split bare `--variants` tokens (light,dark) while keeping JSON
+    /// object variants whole (they legitimately contain commas).
+    static func expandVariantTokens(_ tokens: [String]) -> [String] {
+        tokens.flatMap { token -> [String] in
+            token.hasPrefix("{") ? [token] : token.split(separator: ",").map(String.init)
+        }
+    }
+
+    /// Expand and validate `--variants` tokens, resolving each to a `Variant`
+    /// (label + traits) and rejecting duplicate labels.
+    static func resolveVariants(_ tokens: [String]) throws -> [PreviewTraits.Variant] {
+        let resolved: [PreviewTraits.Variant]
+        do {
+            resolved = try expandVariantTokens(tokens).map(PreviewTraits.parseVariantString)
+        } catch {
+            throw ValidationError(error.localizedDescription)
+        }
+        var seen: Set<String> = []
+        for variant in resolved where !seen.insert(variant.label).inserted {
+            throw ValidationError(
+                "Duplicate variant label '\(variant.label)'. Provide a unique 'label' field."
+            )
+        }
+        return resolved
+    }
+
+    /// Filename-safe slug for a source file, relative to the walked root so
+    /// images from different files never collide.
+    static func slug(for file: String, root: String) -> String {
+        var relative = file
+        let prefix = root.hasSuffix("/") ? root : root + "/"
+        if file.hasPrefix(prefix) {
+            relative = String(file.dropFirst(prefix.count))
+        } else {
+            relative = (file as NSString).lastPathComponent
+        }
+        if relative.hasSuffix(".swift") {
+            relative = String(relative.dropLast(".swift".count))
+        }
+        let allowed = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+        return String(relative.map { allowed.contains($0) ? $0 : "_" })
+    }
+
+    /// Exit codes mirror `variants`: 0 all rendered, 2 total failure, 1
+    /// partial. Skips are neutral — an all-iOS (all-skipped) run exits 0.
+    static func exitCode(ok: Int, failed: Int) -> Int32 {
+        if failed == 0 { return 0 }
+        return ok == 0 ? 2 : 1
+    }
+}
+
+/// One resolved render target: a trait variant (or the implicit default).
+private struct RenderSlot {
+    let label: String?
+    let traits: PreviewTraits
+}
+
+extension SnapshotAllCommand {
+    /// Machine-readable batch result. `entries` is the backbone — one per
+    /// rendered (preview × variant) slot, each carrying its own status.
+    struct Manifest: Encodable {
+        let root: String
+        /// Distinct previews discovered (matches `list` output count).
+        let previewCount: Int
+        /// Entries with an image written to disk.
+        let imageCount: Int
+        let skippedCount: Int
+        let errorCount: Int
+        let entries: [ManifestEntry]
+    }
+
+    struct ManifestEntry: Encodable {
+        let name: String?
+        let file: String
+        let line: Int
+        let index: Int
+        let variant: String?
+        let traits: DaemonProtocol.TraitsDTO?
+        /// Path relative to the output directory; nil for skipped/error.
+        let image: String?
+        let status: Status
+        let error: String?
+
+        enum Status: String, Encodable {
+            case ok, skipped, error
+        }
+
+        fileprivate init(
+            preview: PreviewInfo,
+            file: String,
+            slot: RenderSlot,
+            image: String?,
+            status: Status,
+            error: String?
+        ) {
+            name = preview.name
+            self.file = file
+            line = preview.line
+            index = preview.index
+            variant = slot.label
+            traits = DaemonProtocol.TraitsDTO.orNil(slot.traits)
+            self.image = image
+            self.status = status
+            self.error = error
+        }
+    }
+}

--- a/previewsmcp/PreviewsCLI/SnapshotAllCommand.swift
+++ b/previewsmcp/PreviewsCLI/SnapshotAllCommand.swift
@@ -118,14 +118,14 @@ struct SnapshotAllCommand: AsyncParsableCommand {
                 "--quality must be < 1.0 when --format jpeg; use --format png for lossless output."
             )
         }
-        // Resolve variant labels up front so a bad preset / duplicate label
-        // fails before any compile.
-        let resolvedVariants = try Self.resolveVariants(variants)
+        // Resolve variant labels + tokens up front so a bad preset / duplicate
+        // label fails before any compile, and the split/lookup happens once.
+        let plan = try VariantPlan.resolve(from: variants)
 
         let exitCode = try await DaemonClient.withDaemonClient(
             name: "previewsmcp-snapshot-all"
         ) { client in
-            try await execute(on: client, resolvedVariants: resolvedVariants)
+            try await execute(on: client, plan: plan)
         }
         if exitCode != 0 { throw ExitCode(exitCode) }
     }
@@ -138,7 +138,7 @@ struct SnapshotAllCommand: AsyncParsableCommand {
     /// process exit code.
     func execute(
         on client: any DaemonToolCalling,
-        resolvedVariants: [PreviewTraits.Variant]
+        plan: VariantPlan
     ) async throws -> Int32 {
         var isDirectory: ObjCBool = false
         FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
@@ -168,15 +168,21 @@ struct SnapshotAllCommand: AsyncParsableCommand {
                 file: file,
                 previews: previews,
                 slugRoot: slugRoot,
-                resolvedVariants: resolvedVariants,
+                plan: plan,
                 imagesDir: imagesDir,
                 client: client
             )
         }
 
-        let imageCount = entries.count(where: { $0.status == .ok })
-        let skippedCount = entries.count(where: { $0.status == .skipped })
-        let errorCount = entries.count(where: { $0.status == .error })
+        // Tally the three statuses in a single pass over the entries.
+        var imageCount = 0, skippedCount = 0, errorCount = 0
+        for entry in entries {
+            switch entry.status {
+            case .ok: imageCount += 1
+            case .skipped: skippedCount += 1
+            case .error: errorCount += 1
+            }
+        }
 
         let manifest = Manifest(
             root: URL(fileURLWithPath: path).path,
@@ -199,7 +205,9 @@ struct SnapshotAllCommand: AsyncParsableCommand {
                 + "\(errorCount) failed across \(previewCount) previews.\n",
             stderr
         )
-        return Self.exitCode(ok: imageCount, failed: errorCount)
+        // Exit-code mapping is identical to `variants` (0 all / 2 total / 1
+        // partial); skips are neutral, so an all-iOS run reports 0 failures.
+        return VariantsCommand.exitCode(successCount: imageCount, failCount: errorCount)
     }
 
     /// Render every (preview × variant) slot for one file. Starts a single
@@ -210,7 +218,7 @@ struct SnapshotAllCommand: AsyncParsableCommand {
         file: String,
         previews: [PreviewInfo],
         slugRoot: String,
-        resolvedVariants: [PreviewTraits.Variant],
+        plan: VariantPlan,
         imagesDir: URL,
         client: any DaemonToolCalling
     ) async -> [ManifestEntry] {
@@ -225,14 +233,11 @@ struct SnapshotAllCommand: AsyncParsableCommand {
         let slug = Self.slug(for: file, root: slugRoot)
 
         guard resolvedPlatform == .macos else {
-            return previews.flatMap { preview in
-                slots(for: resolvedVariants).map { slot in
-                    ManifestEntry(
-                        preview: preview, file: file, slot: slot,
-                        image: nil, status: .skipped,
-                        error: "iOS previews are gated; batch iOS needs a booted simulator"
-                    )
-                }
+            return previews.flatMap {
+                failedEntries(
+                    preview: $0, file: file, plan: plan, status: .skipped,
+                    message: "iOS previews are gated; batch iOS needs a booted simulator"
+                )
             }
         }
 
@@ -240,14 +245,11 @@ struct SnapshotAllCommand: AsyncParsableCommand {
         do {
             sessionID = try await startSession(file: file, platform: resolvedPlatform, client: client)
         } catch {
-            let message = (error as? DaemonToolError)?.description ?? error.localizedDescription
-            return previews.flatMap { preview in
-                slots(for: resolvedVariants).map { slot in
-                    ManifestEntry(
-                        preview: preview, file: file, slot: slot,
-                        image: nil, status: .error, error: message
-                    )
-                }
+            return previews.flatMap {
+                failedEntries(
+                    preview: $0, file: file, plan: plan, status: .error,
+                    message: Self.message(from: error)
+                )
             }
         }
         var result: [ManifestEntry] = []
@@ -256,21 +258,16 @@ struct SnapshotAllCommand: AsyncParsableCommand {
                 do {
                     try await switchTo(index: preview.index, sessionID: sessionID, client: client)
                 } catch {
-                    let message = (error as? DaemonToolError)?.description
-                        ?? error.localizedDescription
-                    result += slots(for: resolvedVariants).map { slot in
-                        ManifestEntry(
-                            preview: preview, file: file, slot: slot,
-                            image: nil, status: .error, error: message
-                        )
-                    }
+                    result += failedEntries(
+                        preview: preview, file: file, plan: plan, status: .error,
+                        message: Self.message(from: error)
+                    )
                     continue
                 }
             }
             result += await renderPreview(
                 preview: preview, file: file, slug: slug,
-                resolvedVariants: resolvedVariants,
-                sessionID: sessionID, imagesDir: imagesDir, client: client
+                plan: plan, sessionID: sessionID, imagesDir: imagesDir, client: client
             )
         }
         // Await teardown before moving to the next file: a fire-and-forget
@@ -286,67 +283,67 @@ struct SnapshotAllCommand: AsyncParsableCommand {
         preview: PreviewInfo,
         file: String,
         slug: String,
-        resolvedVariants: [PreviewTraits.Variant],
+        plan: VariantPlan,
         sessionID: String,
         imagesDir: URL,
         client: any DaemonToolCalling
     ) async -> [ManifestEntry] {
-        if resolvedVariants.isEmpty {
+        if plan.isEmpty {
             let slot = RenderSlot(label: nil, traits: PreviewTraits())
             do {
                 let data = try await snapshot(sessionID: sessionID, client: client)
-                let image = try write(data, slug: slug, index: preview.index, label: nil, to: imagesDir)
-                return [ManifestEntry(
+                return [writtenEntry(
                     preview: preview, file: file, slot: slot,
-                    image: image, status: .ok, error: nil
+                    data: data, slug: slug, imagesDir: imagesDir
                 )]
             } catch {
-                let message = (error as? DaemonToolError)?.description ?? error.localizedDescription
                 return [ManifestEntry(
                     preview: preview, file: file, slot: slot,
-                    image: nil, status: .error, error: message
+                    image: nil, status: .error, error: Self.message(from: error)
                 )]
             }
         }
 
         do {
             let outcomes = try await captureVariants(
-                sessionID: sessionID, resolvedVariants: resolvedVariants, client: client
+                sessionID: sessionID, plan: plan, client: client
             )
             return outcomes.map { outcome in
-                let slot = RenderSlot(label: outcome.label, traits: outcome.traits)
                 switch outcome.rendered {
                 case let .success(data):
-                    do {
-                        let image = try write(
-                            data, slug: slug, index: preview.index,
-                            label: outcome.label, to: imagesDir
-                        )
-                        return ManifestEntry(
-                            preview: preview, file: file, slot: slot,
-                            image: image, status: .ok, error: nil
-                        )
-                    } catch {
-                        return ManifestEntry(
-                            preview: preview, file: file, slot: slot,
-                            image: nil, status: .error, error: error.localizedDescription
-                        )
-                    }
+                    writtenEntry(
+                        preview: preview, file: file, slot: outcome.slot,
+                        data: data, slug: slug, imagesDir: imagesDir
+                    )
                 case let .failure(message):
-                    return ManifestEntry(
-                        preview: preview, file: file, slot: slot,
+                    ManifestEntry(
+                        preview: preview, file: file, slot: outcome.slot,
                         image: nil, status: .error, error: message
                     )
                 }
             }
         } catch {
-            let message = (error as? DaemonToolError)?.description ?? error.localizedDescription
-            return slots(for: resolvedVariants).map { slot in
-                ManifestEntry(
-                    preview: preview, file: file, slot: slot,
-                    image: nil, status: .error, error: message
-                )
-            }
+            return failedEntries(
+                preview: preview, file: file, plan: plan, status: .error,
+                message: Self.message(from: error)
+            )
+        }
+    }
+
+    /// Build one error/skip `ManifestEntry` per render slot of a preview, so a
+    /// whole-preview failure still accounts for every expected slot.
+    private func failedEntries(
+        preview: PreviewInfo,
+        file: String,
+        plan: VariantPlan,
+        status: ManifestEntry.Status,
+        message: String
+    ) -> [ManifestEntry] {
+        plan.slots.map { slot in
+            ManifestEntry(
+                preview: preview, file: file, slot: slot,
+                image: nil, status: status, error: message
+            )
         }
     }
 
@@ -407,10 +404,10 @@ struct SnapshotAllCommand: AsyncParsableCommand {
         throw DaemonToolError.daemonError("daemon response contained no image content")
     }
 
-    /// One resolved variant's rendered outcome.
+    /// One variant's rendered outcome, already paired with the render slot it
+    /// belongs to (so the caller doesn't rebuild it).
     private struct VariantOutcome {
-        let label: String
-        let traits: PreviewTraits
+        let slot: RenderSlot
         let rendered: RenderResult
 
         enum RenderResult {
@@ -421,19 +418,17 @@ struct SnapshotAllCommand: AsyncParsableCommand {
 
     private func captureVariants(
         sessionID: String,
-        resolvedVariants: [PreviewTraits.Variant],
+        plan: VariantPlan,
         client: any DaemonToolCalling
     ) async throws -> [VariantOutcome] {
         // Pass the comma-expanded tokens, not the raw `--variants` values: a
         // single "light,dark" token would reach the daemon as one unknown
-        // preset. Expansion mirrors `resolveVariants`, so the daemon derives
-        // the same labels we key `traitsByLabel` on below.
-        let tokens = Self.expandVariantTokens(variants)
+        // preset. The daemon derives the same labels we key `traitsByLabel` on.
         let response = try await client.callToolStructured(
             name: "preview_variants",
             arguments: [
                 "sessionID": .string(sessionID),
-                "variants": .array(tokens.map { .string($0) }),
+                "variants": .array(plan.tokens.map { .string($0) }),
                 "quality": .double(resolvedQuality()),
             ]
         )
@@ -444,24 +439,23 @@ struct SnapshotAllCommand: AsyncParsableCommand {
             throw DaemonToolError.daemonError("preview_variants response missing structuredContent")
         }
         let result = try structured.decode(DaemonProtocol.VariantsResult.self)
-        let traitsByLabel = Dictionary(
-            resolvedVariants.map { ($0.label, $0.traits) }, uniquingKeysWith: { first, _ in first }
-        )
 
         return result.variants.map { outcome in
-            let traits = traitsByLabel[outcome.label] ?? PreviewTraits()
+            let slot = RenderSlot(
+                label: outcome.label, traits: plan.traitsByLabel[outcome.label] ?? PreviewTraits()
+            )
             if outcome.status == "ok",
                let imageIndex = outcome.imageIndex,
                imageIndex < response.content.count,
                case let .image(base64, _, _) = response.content[imageIndex],
                let data = Data(base64Encoded: base64)
             {
-                return VariantOutcome(label: outcome.label, traits: traits, rendered: .success(data))
+                return VariantOutcome(slot: slot, rendered: .success(data))
             }
             let message = outcome.status == "ok"
                 ? "daemon reported ok but image data was missing or invalid"
                 : (outcome.error ?? "unknown error")
-            return VariantOutcome(label: outcome.label, traits: traits, rendered: .failure(message))
+            return VariantOutcome(slot: slot, rendered: .failure(message))
         }
     }
 
@@ -477,14 +471,28 @@ struct SnapshotAllCommand: AsyncParsableCommand {
 
     // MARK: - Output
 
-    private func write(
-        _ data: Data, slug: String, index: Int, label: String?, to imagesDir: URL
-    ) throws -> String {
-        let ext = format == .png ? "png" : "jpg"
-        let name = label.map { "\(slug)-\(index)-\($0)" } ?? "\(slug)-\(index)"
-        let fileName = "\(name).\(ext)"
-        try data.write(to: imagesDir.appendingPathComponent(fileName))
-        return "images/\(fileName)"
+    /// Write a rendered image for one slot and return the `ok` manifest entry
+    /// pointing at it — or, if the write fails, an `error` entry. Shared by the
+    /// no-variants and variants success paths.
+    private func writtenEntry(
+        preview: PreviewInfo, file: String, slot: RenderSlot,
+        data: Data, slug: String, imagesDir: URL
+    ) -> ManifestEntry {
+        do {
+            let ext = format == .png ? "png" : "jpg"
+            let name = slot.label.map { "\(slug)-\(preview.index)-\($0)" } ?? "\(slug)-\(preview.index)"
+            let fileName = "\(name).\(ext)"
+            try data.write(to: imagesDir.appendingPathComponent(fileName))
+            return ManifestEntry(
+                preview: preview, file: file, slot: slot,
+                image: "images/\(fileName)", status: .ok, error: nil
+            )
+        } catch {
+            return ManifestEntry(
+                preview: preview, file: file, slot: slot,
+                image: nil, status: .error, error: error.localizedDescription
+            )
+        }
     }
 
     private func writeManifest(_ manifest: Manifest, to outURL: URL) throws {
@@ -506,13 +514,10 @@ struct SnapshotAllCommand: AsyncParsableCommand {
         return quality ?? 0.85
     }
 
-    /// Empty when no `--variants` were given (the single implicit "default"
-    /// slot is handled by the caller). Otherwise one `RenderSlot` per variant.
-    private func slots(for resolvedVariants: [PreviewTraits.Variant]) -> [RenderSlot] {
-        if resolvedVariants.isEmpty {
-            return [RenderSlot(label: nil, traits: PreviewTraits())]
-        }
-        return resolvedVariants.map { RenderSlot(label: $0.label, traits: $0.traits) }
+    /// Coerce a thrown error into a manifest message, preferring a daemon
+    /// tool error's message over the generic `localizedDescription`.
+    static func message(from error: Error) -> String {
+        (error as? DaemonToolError)?.description ?? error.localizedDescription
     }
 
     /// Comma-split bare `--variants` tokens (light,dark) while keeping JSON
@@ -523,23 +528,9 @@ struct SnapshotAllCommand: AsyncParsableCommand {
         }
     }
 
-    /// Expand and validate `--variants` tokens, resolving each to a `Variant`
-    /// (label + traits) and rejecting duplicate labels.
-    static func resolveVariants(_ tokens: [String]) throws -> [PreviewTraits.Variant] {
-        let resolved: [PreviewTraits.Variant]
-        do {
-            resolved = try expandVariantTokens(tokens).map(PreviewTraits.parseVariantString)
-        } catch {
-            throw ValidationError(error.localizedDescription)
-        }
-        var seen: Set<String> = []
-        for variant in resolved where !seen.insert(variant.label).inserted {
-            throw ValidationError(
-                "Duplicate variant label '\(variant.label)'. Provide a unique 'label' field."
-            )
-        }
-        return resolved
-    }
+    private static let slugAllowed = Set(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+    )
 
     /// Filename-safe slug for a source file, relative to the walked root so
     /// images from different files never collide.
@@ -554,15 +545,7 @@ struct SnapshotAllCommand: AsyncParsableCommand {
         if relative.hasSuffix(".swift") {
             relative = String(relative.dropLast(".swift".count))
         }
-        let allowed = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
-        return String(relative.map { allowed.contains($0) ? $0 : "_" })
-    }
-
-    /// Exit codes mirror `variants`: 0 all rendered, 2 total failure, 1
-    /// partial. Skips are neutral — an all-iOS (all-skipped) run exits 0.
-    static func exitCode(ok: Int, failed: Int) -> Int32 {
-        if failed == 0 { return 0 }
-        return ok == 0 ? 2 : 1
+        return String(relative.map { slugAllowed.contains($0) ? $0 : "_" })
     }
 }
 
@@ -570,6 +553,55 @@ struct SnapshotAllCommand: AsyncParsableCommand {
 private struct RenderSlot {
     let label: String?
     let traits: PreviewTraits
+}
+
+/// Resolved `--variants` state, computed once per invocation: the parsed
+/// variants (labels + traits), the comma-expanded tokens the daemon parses,
+/// and a label→traits lookup for re-associating the daemon's outcomes.
+struct VariantPlan {
+    fileprivate let variants: [PreviewTraits.Variant]
+    fileprivate let tokens: [String]
+    fileprivate let traitsByLabel: [String: PreviewTraits]
+
+    /// True when no `--variants` were given; the caller renders one default
+    /// slot per preview.
+    var isEmpty: Bool {
+        variants.isEmpty
+    }
+
+    /// Render slots for one preview: the implicit default when no variants
+    /// were given, otherwise one per variant.
+    fileprivate var slots: [RenderSlot] {
+        if variants.isEmpty { return [RenderSlot(label: nil, traits: PreviewTraits())] }
+        return variants.map { RenderSlot(label: $0.label, traits: $0.traits) }
+    }
+
+    /// Expand + validate the raw `--variants` tokens once, rejecting duplicate
+    /// labels. Throws a `ValidationError` so a bad preset fails before compile.
+    static func resolve(from raw: [String]) throws -> VariantPlan {
+        let tokens = SnapshotAllCommand.expandVariantTokens(raw)
+        let variants: [PreviewTraits.Variant]
+        do {
+            variants = try tokens.map(PreviewTraits.parseVariantString)
+        } catch {
+            throw ValidationError(error.localizedDescription)
+        }
+        var seen: Set<String> = []
+        for variant in variants where !seen.insert(variant.label).inserted {
+            throw ValidationError(
+                "Duplicate variant label '\(variant.label)'. Provide a unique 'label' field."
+            )
+        }
+        let traitsByLabel = Dictionary(
+            variants.map { ($0.label, $0.traits) }, uniquingKeysWith: { first, _ in first }
+        )
+        return VariantPlan(variants: variants, tokens: tokens, traitsByLabel: traitsByLabel)
+    }
+
+    /// Ordered variant labels, for tests/inspection.
+    var labels: [String] {
+        variants.map(\.label)
+    }
 }
 
 extension SnapshotAllCommand {

--- a/previewsmcp/PreviewsCLI/SnapshotAllCommand.swift
+++ b/previewsmcp/PreviewsCLI/SnapshotAllCommand.swift
@@ -196,6 +196,7 @@ struct SnapshotAllCommand: AsyncParsableCommand {
         }
 
         let manifest = Manifest(
+            version: Self.manifestVersion,
             root: URL(fileURLWithPath: path).path,
             previewCount: previewCount,
             imageCount: imageCount,
@@ -643,9 +644,16 @@ struct VariantPlan {
 }
 
 extension SnapshotAllCommand {
+    /// Schema version of `manifest.json`. Bump when the shape changes in a
+    /// non-additive way; consumers (e.g. #41 visual diff) branch on it. Purely
+    /// additive fields do not require a bump.
+    static let manifestVersion = 1
+
     /// Machine-readable batch result. `entries` is the backbone — one per
     /// rendered (preview × variant) slot, each carrying its own status.
     struct Manifest: Encodable {
+        /// Schema version; see `SnapshotAllCommand.manifestVersion`.
+        let version: Int
         let root: String
         /// Distinct previews discovered (matches `list` output count).
         let previewCount: Int

--- a/previewsmcp/PreviewsCLI/SnapshotAllCommand.swift
+++ b/previewsmcp/PreviewsCLI/SnapshotAllCommand.swift
@@ -109,15 +109,21 @@ struct SnapshotAllCommand: AsyncParsableCommand {
         case jpeg, png
     }
 
-    mutating func run() async throws {
+    func validate() throws {
         guard FileManager.default.fileExists(atPath: path) else {
             throw ValidationError("path does not exist: \(path)")
+        }
+        if let quality, !(0.0 ... 1.0).contains(quality) {
+            throw ValidationError("--quality must be between 0.0 and 1.0.")
         }
         if format == .jpeg, let quality, quality >= 1.0 {
             throw ValidationError(
                 "--quality must be < 1.0 when --format jpeg; use --format png for lossless output."
             )
         }
+    }
+
+    mutating func run() async throws {
         // Resolve variant labels + tokens up front so a bad preset / duplicate
         // label fails before any compile, and the split/lookup happens once.
         let plan = try VariantPlan.resolve(from: variants)
@@ -154,6 +160,7 @@ struct SnapshotAllCommand: AsyncParsableCommand {
 
         var entries: [ManifestEntry] = []
         var previewCount = 0
+        var usedSlugs: Set<String> = []
         for file in files {
             let previews: [PreviewInfo]
             do {
@@ -164,10 +171,14 @@ struct SnapshotAllCommand: AsyncParsableCommand {
             }
             guard !previews.isEmpty else { continue }
             previewCount += previews.count
+            // Disambiguate slugs across files: two distinct paths can map to
+            // the same base slug (e.g. `Foo/Bar.swift` and `Foo_Bar.swift`),
+            // which would otherwise overwrite each other's images.
+            let slug = Self.uniqueSlug(for: file, root: slugRoot, used: &usedSlugs)
             entries += await renderFile(
                 file: file,
                 previews: previews,
-                slugRoot: slugRoot,
+                slug: slug,
                 plan: plan,
                 imagesDir: imagesDir,
                 client: client
@@ -217,7 +228,7 @@ struct SnapshotAllCommand: AsyncParsableCommand {
     private func renderFile(
         file: String,
         previews: [PreviewInfo],
-        slugRoot: String,
+        slug: String,
         plan: VariantPlan,
         imagesDir: URL,
         client: any DaemonToolCalling
@@ -230,7 +241,6 @@ struct SnapshotAllCommand: AsyncParsableCommand {
             project: project,
             fileURL: fileURL
         )
-        let slug = Self.slug(for: file, root: slugRoot)
 
         guard resolvedPlatform == .macos else {
             return previews.flatMap {
@@ -440,13 +450,13 @@ struct SnapshotAllCommand: AsyncParsableCommand {
         }
         let result = try structured.decode(DaemonProtocol.VariantsResult.self)
 
-        return result.variants.map { outcome in
+        let returned = result.variants.map { outcome -> VariantOutcome in
             let slot = RenderSlot(
                 label: outcome.label, traits: plan.traitsByLabel[outcome.label] ?? PreviewTraits()
             )
             if outcome.status == "ok",
                let imageIndex = outcome.imageIndex,
-               imageIndex < response.content.count,
+               imageIndex >= 0, imageIndex < response.content.count,
                case let .image(base64, _, _) = response.content[imageIndex],
                let data = Data(base64Encoded: base64)
             {
@@ -457,6 +467,20 @@ struct SnapshotAllCommand: AsyncParsableCommand {
                 : (outcome.error ?? "unknown error")
             return VariantOutcome(slot: slot, rendered: .failure(message))
         }
+
+        // Account for any requested variant the daemon didn't return an outcome
+        // for (version skew / partial response) so a missing slot surfaces as a
+        // failure instead of silently vanishing from the manifest.
+        let returnedLabels = Set(result.variants.map(\.label))
+        let missing = plan.variants
+            .filter { !returnedLabels.contains($0.label) }
+            .map { variant in
+                VariantOutcome(
+                    slot: RenderSlot(label: variant.label, traits: variant.traits),
+                    rendered: .failure("daemon returned no outcome for variant '\(variant.label)'")
+                )
+            }
+        return returned + missing
     }
 
     private func stopSession(sessionID: String, client: any DaemonToolCalling) async {
@@ -546,6 +570,20 @@ struct SnapshotAllCommand: AsyncParsableCommand {
             relative = String(relative.dropLast(".swift".count))
         }
         return String(relative.map { slugAllowed.contains($0) ? $0 : "_" })
+    }
+
+    /// A `slug` guaranteed unique within `used`. Distinct source paths can map
+    /// to the same base slug (`/` and other disallowed chars both become `_`);
+    /// on a clash we append `-2`, `-3`, … so images never overwrite each other.
+    static func uniqueSlug(for file: String, root: String, used: inout Set<String>) -> String {
+        let base = slug(for: file, root: root)
+        var candidate = base
+        var suffix = 2
+        while !used.insert(candidate).inserted {
+            candidate = "\(base)-\(suffix)"
+            suffix += 1
+        }
+        return candidate
     }
 }
 

--- a/previewsmcp/Tests/CLIIntegrationTests/SnapshotAllCommandTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/SnapshotAllCommandTests.swift
@@ -23,6 +23,7 @@ struct SnapshotAllCommandTests {
     /// (preview × variant) slot. Only the fields the tests assert on are
     /// decoded.
     private struct Manifest: Decodable {
+        let version: Int
         let previewCount: Int
         let imageCount: Int
         let skippedCount: Int
@@ -64,6 +65,7 @@ struct SnapshotAllCommandTests {
             #expect(result.exitCode == 0, "stderr: \(result.stderr)")
 
             let manifest = try Self.loadManifest(in: outDir)
+            #expect(manifest.version == 1, "manifest carries a schema version")
             // ToDoView.swift declares exactly two #Preview blocks.
             #expect(manifest.previewCount == 2, "expected 2 discovered previews")
             #expect(manifest.imageCount == 2)

--- a/previewsmcp/Tests/CLIIntegrationTests/SnapshotAllCommandTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/SnapshotAllCommandTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import PreviewsTestSupport
+import Testing
+
+/// End-to-end coverage for `snapshot-all`: batch-render every `#Preview` in a
+/// target headless, writing an image per (preview × variant), a JSON
+/// manifest, and an optional static HTML gallery.
+///
+/// Targets a single source file (`ToDoView.swift`, two macOS `#Preview`
+/// blocks) rather than the whole `examples/spm` tree. That keeps the run
+/// deterministic and cheap — one compile plus one cheap index switch — and
+/// avoids the tree's UIKit-only / LocalDep-dependent previews, which don't
+/// render on headless macOS. The directory-walk and per-file orchestration
+/// logic is covered exhaustively (and without a real renderer) by
+/// `PreviewsCLITests/SnapshotAllCommandLogicTests.swift`.
+@Suite("CLI snapshot-all command", .serialized)
+struct SnapshotAllCommandTests {
+    private static func cleanSlate() async throws {
+        _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+    }
+
+    /// The manifest's `entries` array is the backbone: one per rendered
+    /// (preview × variant) slot. Only the fields the tests assert on are
+    /// decoded.
+    private struct Manifest: Decodable {
+        let previewCount: Int
+        let imageCount: Int
+        let skippedCount: Int
+        let errorCount: Int
+        let entries: [Entry]
+
+        struct Entry: Decodable {
+            let index: Int
+            let variant: String?
+            let image: String?
+            let status: String
+        }
+    }
+
+    private static func loadManifest(in outDir: URL) throws -> Manifest {
+        let data = try Data(contentsOf: outDir.appendingPathComponent("manifest.json"))
+        return try JSONDecoder().decode(Manifest.self, from: data)
+    }
+
+    private static let toDoView = CLIRunner.spmExampleRoot
+        .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
+
+    // MARK: - Base batch render
+
+    @Test("snapshot-all renders one image per discovered preview", .timeLimit(.minutes(5)))
+    func batchRendersEveryPreview() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let outDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: outDir) }
+
+            let result = try await CLIRunner.run(
+                "snapshot-all",
+                arguments: [
+                    Self.toDoView, "--out", outDir.path,
+                    "--project", CLIRunner.spmExampleRoot.path, "--format", "png",
+                ]
+            )
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+
+            let manifest = try Self.loadManifest(in: outDir)
+            // ToDoView.swift declares exactly two #Preview blocks.
+            #expect(manifest.previewCount == 2, "expected 2 discovered previews")
+            #expect(manifest.imageCount == 2)
+            #expect(manifest.skippedCount == 0)
+            #expect(manifest.errorCount == 0)
+            #expect(manifest.entries.count == 2)
+            #expect(Set(manifest.entries.map(\.index)) == [0, 1])
+
+            for entry in manifest.entries {
+                #expect(entry.status == "ok")
+                #expect(entry.variant == nil)
+                // Every manifest image path must resolve to a real PNG on disk.
+                let image = try #require(entry.image)
+                try CLIRunner.assertValidPNG(at: outDir.appendingPathComponent(image).path)
+            }
+        }
+    }
+
+    // MARK: - Variants multiply outputs + HTML gallery
+
+    @Test("snapshot-all --variants multiplies outputs and --html emits a gallery", .timeLimit(.minutes(5)))
+    func variantsAndGallery() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let outDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: outDir) }
+
+            let result = try await CLIRunner.run(
+                "snapshot-all",
+                arguments: [
+                    Self.toDoView, "--out", outDir.path,
+                    "--variants", "light,dark", "--html", "--format", "png",
+                    "--project", CLIRunner.spmExampleRoot.path,
+                ]
+            )
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+
+            let manifest = try Self.loadManifest(in: outDir)
+            // Two previews × two variants (light, dark) = four images; the
+            // discovered-preview count stays two.
+            #expect(manifest.previewCount == 2)
+            #expect(manifest.imageCount == 4)
+            #expect(manifest.entries.count == 4)
+            #expect(Set(manifest.entries.compactMap(\.variant)) == ["light", "dark"])
+
+            for entry in manifest.entries {
+                #expect(entry.status == "ok")
+                let image = try #require(entry.image)
+                try CLIRunner.assertValidPNG(at: outDir.appendingPathComponent(image).path)
+            }
+
+            // The gallery is a self-contained static HTML file that references
+            // every rendered image by its manifest-relative path.
+            let galleryURL = outDir.appendingPathComponent("index.html")
+            let gallery = try String(contentsOf: galleryURL, encoding: .utf8)
+            for entry in manifest.entries {
+                let image = try #require(entry.image)
+                #expect(gallery.contains(image), "gallery should reference \(image)")
+            }
+        }
+    }
+}

--- a/previewsmcp/Tests/PreviewsCLITests/SnapshotAllCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SnapshotAllCommandLogicTests.swift
@@ -89,6 +89,7 @@ struct SnapshotAllCommandLogicTests {
         #expect(code == 0)
 
         let manifest = try env.manifest()
+        #expect(manifest.version == SnapshotAllCommand.manifestVersion)
         #expect(manifest.previewCount == 2)
         #expect(manifest.imageCount == 2)
         #expect(manifest.errorCount == 0)
@@ -239,6 +240,7 @@ struct SnapshotAllCommandLogicTests {
     }
 
     private struct DecodedManifest: Decodable {
+        let version: Int
         let previewCount: Int
         let imageCount: Int
         let skippedCount: Int

--- a/previewsmcp/Tests/PreviewsCLITests/SnapshotAllCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SnapshotAllCommandLogicTests.swift
@@ -1,0 +1,250 @@
+import Foundation
+import MCP
+@testable import PreviewsCLI
+import PreviewsCore
+import Testing
+
+/// `snapshot-all`'s CLI-side orchestration, tested without a real daemon or
+/// renderer. Discovery (`PreviewParser`) and file writing are real — only the
+/// daemon tool calls are faked — so these cover the batch loop, iOS gating,
+/// per-slot failure handling, the manifest, and the HTML gallery end to end
+/// at millisecond speed. Real rendering / PNG validity lives in
+/// `CLIIntegrationTests/SnapshotAllCommandTests.swift`.
+@Suite("snapshot-all CLI-glue logic")
+struct SnapshotAllCommandLogicTests {
+    // MARK: - Pure helpers
+
+    @Test("resolveVariants comma-splits bare tokens but keeps JSON variants whole")
+    func resolveVariantsSplitting() throws {
+        let bare = try SnapshotAllCommand.resolveVariants(["light,dark"])
+        #expect(bare.map(\.label) == ["light", "dark"])
+
+        let json = try SnapshotAllCommand.resolveVariants([
+            #"{"colorScheme":"dark","locale":"ar","label":"dark-ar"}"#,
+        ])
+        #expect(json.map(\.label) == ["dark-ar"])
+    }
+
+    @Test("resolveVariants rejects duplicate labels")
+    func resolveVariantsDuplicateLabel() {
+        #expect(throws: (any Error).self) {
+            _ = try SnapshotAllCommand.resolveVariants(["light,light"])
+        }
+    }
+
+    @Test("slug is relative to the walked root so images never collide")
+    func slugRelativeToRoot() {
+        #expect(
+            SnapshotAllCommand.slug(for: "/proj/Sources/ToDo/View.swift", root: "/proj")
+                == "Sources_ToDo_View"
+        )
+        // A file target uses its parent as root, so just the basename remains.
+        #expect(
+            SnapshotAllCommand.slug(for: "/proj/Sources/View.swift", root: "/proj/Sources")
+                == "View"
+        )
+    }
+
+    @Test("exitCode: 0 all ok, 2 total failure, 1 partial, skips neutral")
+    func exitCodes() {
+        #expect(SnapshotAllCommand.exitCode(ok: 3, failed: 0) == 0)
+        #expect(SnapshotAllCommand.exitCode(ok: 0, failed: 0) == 0)
+        #expect(SnapshotAllCommand.exitCode(ok: 0, failed: 2) == 2)
+        #expect(SnapshotAllCommand.exitCode(ok: 2, failed: 1) == 1)
+    }
+
+    @Test("resolvedQuality: png → 1.0, jpeg → explicit or 0.85")
+    func resolvedQuality() throws {
+        #expect(try SnapshotAllCommand.parse(["--format", "png"]).resolvedQuality() == 1.0)
+        #expect(try SnapshotAllCommand.parse(["--format", "jpeg"]).resolvedQuality() == 0.85)
+        #expect(
+            try SnapshotAllCommand.parse(["--format", "jpeg", "--quality", "0.5"])
+                .resolvedQuality() == 0.5
+        )
+    }
+
+    // MARK: - Orchestration
+
+    @Test("renders one image per preview and writes a matching manifest")
+    func batchNoVariants() async throws {
+        let env = try Fixture(previewCount: 2)
+        defer { env.cleanup() }
+        let client = FakeDaemonClient(responses: [
+            "preview_start": try CallTool.Result.ephemeralStartResult(),
+            "preview_switch": CallTool.Result(content: []),
+            "preview_snapshot": Self.imageResult(),
+            "preview_stop": CallTool.Result(content: []),
+        ])
+
+        let code = try await env.command.execute(on: client, resolvedVariants: [])
+        #expect(code == 0)
+
+        let manifest = try env.manifest()
+        #expect(manifest.previewCount == 2)
+        #expect(manifest.imageCount == 2)
+        #expect(manifest.errorCount == 0)
+        #expect(manifest.entries.count == 2)
+        #expect(manifest.entries.allSatisfy { $0.status == "ok" && $0.variant == nil })
+        for entry in manifest.entries {
+            let image = try #require(entry.image)
+            #expect(FileManager.default.fileExists(atPath: env.out.appendingPathComponent(image).path))
+        }
+        // One session for the file: start, one switch (index 0→1), two
+        // snapshots, one stop.
+        #expect(client.calls.map(\.name) == [
+            "preview_start", "preview_snapshot", "preview_switch", "preview_snapshot", "preview_stop",
+        ])
+    }
+
+    @Test("--variants multiplies outputs and --html references every image")
+    func batchVariantsAndGallery() async throws {
+        let env = try Fixture(previewCount: 1, extraArgs: ["--variants", "light,dark", "--html"])
+        defer { env.cleanup() }
+        let variants = try SnapshotAllCommand.resolveVariants(env.command.variants)
+        let client = FakeDaemonClient(responses: [
+            "preview_start": try CallTool.Result.ephemeralStartResult(),
+            "preview_variants": try Self.variantsResult(labels: ["light", "dark"]),
+            "preview_stop": CallTool.Result(content: []),
+        ])
+
+        let code = try await env.command.execute(on: client, resolvedVariants: variants)
+        #expect(code == 0)
+
+        let manifest = try env.manifest()
+        #expect(manifest.previewCount == 1)
+        #expect(manifest.imageCount == 2)
+        #expect(manifest.entries.count == 2)
+        #expect(Set(manifest.entries.compactMap(\.variant)) == ["light", "dark"])
+
+        let gallery = try String(
+            contentsOf: env.out.appendingPathComponent("index.html"), encoding: .utf8
+        )
+        for entry in manifest.entries {
+            let image = try #require(entry.image)
+            #expect(gallery.contains(image))
+        }
+    }
+
+    @Test("iOS-resolved previews are skipped without touching the daemon")
+    func iosGated() async throws {
+        let env = try Fixture(previewCount: 2, extraArgs: ["--platform", "ios"])
+        defer { env.cleanup() }
+        let client = FakeDaemonClient()
+
+        let code = try await env.command.execute(on: client, resolvedVariants: [])
+        // All skipped → nothing failed → exit 0.
+        #expect(code == 0)
+        #expect(client.calls.isEmpty, "no simulator/daemon work for gated iOS previews")
+
+        let manifest = try env.manifest()
+        #expect(manifest.previewCount == 2)
+        #expect(manifest.skippedCount == 2)
+        #expect(manifest.imageCount == 0)
+        #expect(manifest.entries.allSatisfy { $0.status == "skipped" && $0.image == nil })
+    }
+
+    @Test("one failed render is recorded and the batch continues (partial exit)")
+    func partialFailureContinues() async throws {
+        let env = try Fixture(previewCount: 2)
+        defer { env.cleanup() }
+        // Preview 0 snapshots fine; preview 1's snapshot fails. The batch must
+        // still finish preview 0 and stop the session.
+        let client = FakeDaemonClient(
+            responses: [
+                "preview_start": try CallTool.Result.ephemeralStartResult(),
+                "preview_switch": CallTool.Result(content: []),
+                "preview_stop": CallTool.Result(content: []),
+            ],
+            sequences: [
+                "preview_snapshot": [
+                    Self.imageResult(),
+                    CallTool.Result(content: [.text("render failed")], isError: true),
+                ],
+            ]
+        )
+
+        let code = try await env.command.execute(on: client, resolvedVariants: [])
+        #expect(code == 1, "partial failure → exit 1")
+
+        let manifest = try env.manifest()
+        #expect(manifest.imageCount == 1)
+        #expect(manifest.errorCount == 1)
+        #expect(client.calls.contains { $0.name == "preview_stop" }, "session stopped despite failure")
+    }
+
+    // MARK: - Fixtures
+
+    /// A source file with `count` `#Preview` blocks, plus an output dir and a
+    /// parsed command pointed at both. Real files so `PreviewParser` discovers
+    /// real previews.
+    private struct Fixture {
+        let command: SnapshotAllCommand
+        let out: URL
+        private let root: URL
+
+        init(previewCount count: Int, extraArgs: [String] = []) throws {
+            root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("snapshot-all-logic-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let source = root.appendingPathComponent("Views.swift")
+            let blocks = (0 ..< count)
+                .map { "#Preview(\"P\($0)\") { Text(\"\($0)\") }" }
+                .joined(separator: "\n")
+            try Data("import SwiftUI\n\(blocks)\n".utf8).write(to: source)
+            out = root.appendingPathComponent("out")
+
+            command = try SnapshotAllCommand.parse(
+                [source.path, "--out", out.path, "--platform", "macos"] + extraArgs
+            )
+        }
+
+        func manifest() throws -> DecodedManifest {
+            let data = try Data(contentsOf: out.appendingPathComponent("manifest.json"))
+            return try JSONDecoder().decode(DecodedManifest.self, from: data)
+        }
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: root)
+        }
+    }
+
+    private struct DecodedManifest: Decodable {
+        let previewCount: Int
+        let imageCount: Int
+        let skippedCount: Int
+        let errorCount: Int
+        let entries: [Entry]
+
+        struct Entry: Decodable {
+            let index: Int
+            let variant: String?
+            let image: String?
+            let status: String
+        }
+    }
+
+    // MARK: - Canned daemon responses
+
+    private static func imageResult() -> CallTool.Result {
+        CallTool.Result(content: [
+            .image(data: Data("x".utf8).base64EncodedString(), mimeType: "image/png", metadata: nil),
+        ])
+    }
+
+    /// A `preview_variants` response: one `.image` block and one `ok` outcome
+    /// per label, mirroring how `PreviewVariantsHandler` packs them.
+    private static func variantsResult(labels: [String]) throws -> CallTool.Result {
+        let content: [Tool.Content] = labels.map { _ in
+            .image(data: Data("x".utf8).base64EncodedString(), mimeType: "image/png", metadata: nil)
+        }
+        let outcomes = labels.enumerated().map { index, label in
+            DaemonProtocol.VariantOutcomeDTO(
+                status: "ok", index: index, label: label, imageIndex: index, error: nil
+            )
+        }
+        let structured = DaemonProtocol.VariantsResult(
+            variants: outcomes, successCount: labels.count, failCount: 0
+        )
+        return try CallTool.Result(content: content, structuredContent: structured)
+    }
+}

--- a/previewsmcp/Tests/PreviewsCLITests/SnapshotAllCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SnapshotAllCommandLogicTests.swift
@@ -14,21 +14,21 @@ import Testing
 struct SnapshotAllCommandLogicTests {
     // MARK: - Pure helpers
 
-    @Test("resolveVariants comma-splits bare tokens but keeps JSON variants whole")
-    func resolveVariantsSplitting() throws {
-        let bare = try SnapshotAllCommand.resolveVariants(["light,dark"])
-        #expect(bare.map(\.label) == ["light", "dark"])
+    @Test("VariantPlan comma-splits bare tokens but keeps JSON variants whole")
+    func variantPlanSplitting() throws {
+        let bare = try VariantPlan.resolve(from: ["light,dark"])
+        #expect(bare.labels == ["light", "dark"])
 
-        let json = try SnapshotAllCommand.resolveVariants([
+        let json = try VariantPlan.resolve(from: [
             #"{"colorScheme":"dark","locale":"ar","label":"dark-ar"}"#,
         ])
-        #expect(json.map(\.label) == ["dark-ar"])
+        #expect(json.labels == ["dark-ar"])
     }
 
-    @Test("resolveVariants rejects duplicate labels")
-    func resolveVariantsDuplicateLabel() {
+    @Test("VariantPlan rejects duplicate labels")
+    func variantPlanDuplicateLabel() {
         #expect(throws: (any Error).self) {
-            _ = try SnapshotAllCommand.resolveVariants(["light,light"])
+            _ = try VariantPlan.resolve(from: ["light,light"])
         }
     }
 
@@ -43,14 +43,6 @@ struct SnapshotAllCommandLogicTests {
             SnapshotAllCommand.slug(for: "/proj/Sources/View.swift", root: "/proj/Sources")
                 == "View"
         )
-    }
-
-    @Test("exitCode: 0 all ok, 2 total failure, 1 partial, skips neutral")
-    func exitCodes() {
-        #expect(SnapshotAllCommand.exitCode(ok: 3, failed: 0) == 0)
-        #expect(SnapshotAllCommand.exitCode(ok: 0, failed: 0) == 0)
-        #expect(SnapshotAllCommand.exitCode(ok: 0, failed: 2) == 2)
-        #expect(SnapshotAllCommand.exitCode(ok: 2, failed: 1) == 1)
     }
 
     @Test("resolvedQuality: png → 1.0, jpeg → explicit or 0.85")
@@ -76,7 +68,7 @@ struct SnapshotAllCommandLogicTests {
             "preview_stop": CallTool.Result(content: []),
         ])
 
-        let code = try await env.command.execute(on: client, resolvedVariants: [])
+        let code = try await env.command.execute(on: client, plan: try VariantPlan.resolve(from: []))
         #expect(code == 0)
 
         let manifest = try env.manifest()
@@ -100,14 +92,14 @@ struct SnapshotAllCommandLogicTests {
     func batchVariantsAndGallery() async throws {
         let env = try Fixture(previewCount: 1, extraArgs: ["--variants", "light,dark", "--html"])
         defer { env.cleanup() }
-        let variants = try SnapshotAllCommand.resolveVariants(env.command.variants)
+        let plan = try VariantPlan.resolve(from: env.command.variants)
         let client = FakeDaemonClient(responses: [
             "preview_start": try CallTool.Result.ephemeralStartResult(),
             "preview_variants": try Self.variantsResult(labels: ["light", "dark"]),
             "preview_stop": CallTool.Result(content: []),
         ])
 
-        let code = try await env.command.execute(on: client, resolvedVariants: variants)
+        let code = try await env.command.execute(on: client, plan: plan)
         #expect(code == 0)
 
         let manifest = try env.manifest()
@@ -131,7 +123,7 @@ struct SnapshotAllCommandLogicTests {
         defer { env.cleanup() }
         let client = FakeDaemonClient()
 
-        let code = try await env.command.execute(on: client, resolvedVariants: [])
+        let code = try await env.command.execute(on: client, plan: try VariantPlan.resolve(from: []))
         // All skipped → nothing failed → exit 0.
         #expect(code == 0)
         #expect(client.calls.isEmpty, "no simulator/daemon work for gated iOS previews")
@@ -163,7 +155,7 @@ struct SnapshotAllCommandLogicTests {
             ]
         )
 
-        let code = try await env.command.execute(on: client, resolvedVariants: [])
+        let code = try await env.command.execute(on: client, plan: try VariantPlan.resolve(from: []))
         #expect(code == 1, "partial failure → exit 1")
 
         let manifest = try env.manifest()

--- a/previewsmcp/Tests/PreviewsCLITests/SnapshotAllCommandLogicTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/SnapshotAllCommandLogicTests.swift
@@ -45,6 +45,23 @@ struct SnapshotAllCommandLogicTests {
         )
     }
 
+    @Test("uniqueSlug disambiguates distinct files that share a base slug")
+    func uniqueSlugCollision() {
+        var used: Set<String> = []
+        // `Foo/Bar.swift` and `Foo_Bar.swift` both slug to "Foo_Bar" (the `/`
+        // becomes `_`); the second must not overwrite the first.
+        let a = SnapshotAllCommand.uniqueSlug(for: "/proj/Foo/Bar.swift", root: "/proj", used: &used)
+        let b = SnapshotAllCommand.uniqueSlug(for: "/proj/Foo_Bar.swift", root: "/proj", used: &used)
+        #expect(a == "Foo_Bar")
+        #expect(b == "Foo_Bar-2")
+    }
+
+    @Test("validate rejects an out-of-range --quality")
+    func validateQualityRange() {
+        #expect(throws: (any Error).self) { _ = try SnapshotAllCommand.parse(["--quality", "-0.5"]) }
+        #expect(throws: (any Error).self) { _ = try SnapshotAllCommand.parse(["--quality", "1.5"]) }
+    }
+
     @Test("resolvedQuality: png → 1.0, jpeg → explicit or 0.85")
     func resolvedQuality() throws {
         #expect(try SnapshotAllCommand.parse(["--format", "png"]).resolvedQuality() == 1.0)
@@ -115,6 +132,27 @@ struct SnapshotAllCommandLogicTests {
             let image = try #require(entry.image)
             #expect(gallery.contains(image))
         }
+    }
+
+    @Test("a requested variant the daemon omits is recorded as an error")
+    func missingVariantOutcome() async throws {
+        let env = try Fixture(previewCount: 1, extraArgs: ["--variants", "light,dark"])
+        defer { env.cleanup() }
+        let plan = try VariantPlan.resolve(from: env.command.variants)
+        // The daemon returns only "light"; "dark" is missing from the response.
+        let client = FakeDaemonClient(responses: [
+            "preview_start": try CallTool.Result.ephemeralStartResult(),
+            "preview_variants": try Self.variantsResult(labels: ["light"]),
+            "preview_stop": CallTool.Result(content: []),
+        ])
+
+        let code = try await env.command.execute(on: client, plan: plan)
+        #expect(code == 1, "one rendered + one missing → partial exit")
+
+        let manifest = try env.manifest()
+        #expect(manifest.entries.count == 2, "missing variant still gets an entry")
+        #expect(manifest.imageCount == 1)
+        #expect(manifest.errorCount == 1)
     }
 
     @Test("iOS-resolved previews are skipped without touching the daemon")


### PR DESCRIPTION
Closes #267.

## What

New `previewsmcp snapshot-all [<path>] --out ./preview-snapshots [--variants light,dark] [--html]` subcommand. Walks a Swift file or directory, discovers every `#Preview` (and legacy `PreviewProvider`), renders each headless, and writes:

- `images/` — one image per preview (per trait variant with `--variants`)
- `manifest.json` — one entry per rendered slot (name, file, line, index, variant, traits, image path, status `ok`/`skipped`/`error`)
- `index.html` — optional static gallery (with `--html`), the open-source analog to Emerge's Preview Gallery / Prefire's Playbook, but no device

## How (pure orchestration, no new engines)

- **Discovery** reuses `PreviewParser` + `ListCommand.swiftFiles` (the same AST walk `list` uses) — no second discovery path.
- **Rendering** reuses the daemon's existing `preview_start` / `preview_switch` / `preview_snapshot` / `preview_variants` tools.
- **One session per file**, then `preview_switch` across indices — `switch` reuses the session's compiled stable module, so a whole file costs one compile, not one-per-preview.
- macOS is the clean headless lane. **iOS is gated**: a file that resolves to the iOS platform is recorded as `skipped` per-file via `SnapshotCommand.resolvePlatform` — no simulator is ever booted.
- Exit codes mirror `variants` (0 all / 1 partial / 2 total); skips are neutral, so an all-iOS run exits 0.

## Tests

- 9 `FakeDaemonClient` logic tests (batch loop, `--variants` multiplication, iOS gating with zero daemon calls, per-slot failure → partial exit + continue, manifest, gallery) — millisecond speed, real `PreviewParser` + real file writes, faked daemon.
- 2 `CLIIntegrationTests` real end-to-end against `examples/spm` `ToDoView.swift`: base batch (2 PNGs + manifest) and `--variants light,dark --html` (4 PNGs + gallery referencing each image).

Full local suite (all 11 targets) green; `tools/lint:check` clean. CLI-only surface for now per #267's "CLI-first is the lower-risk start."

🤖 Generated with [Claude Code](https://claude.com/claude-code)