### PR TITLE
#372: scheduled examples smoke workflow — the example renders that silently skip in CI

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,35 @@
+name: Examples
+
+# ci.yml's `bazel test //...` looks like it covers example renders via
+# SnapshotCommandTests, but only the spm example actually renders there:
+# the xcodeproj/xcworkspace/bazel example tests are tool-gated
+# (toolAvailable("mint"/"bazel")) and silently skip as "passed" under
+# bazel's sanitized test PATH — 0.03-0.14s "passes" in every CI log. This
+# workflow is the gated runner for that gap (#372), driving the bare CLI
+# with its default resource discovery (which the env-injecting tests also
+# never exercise). Scheduled + manual only, deliberately OUT of the
+# required path until its own track record justifies promotion. macOS
+# renders only; iOS example coverage is the follow-up noted on #372.
+
+on:
+  schedule:
+    # Tuesdays 14:00 UTC — staggered from ci.yml's Monday heartbeat.
+    - cron: '0 14 * * 2'
+  workflow_dispatch:
+
+concurrency:
+  group: examples-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  examples:
+    runs-on: [self-hosted, macOS, ARM64]
+    timeout-minutes: 60
+    env:
+      # Must match the .bazelrc --xcode_version pin.
+      DEVELOPER_DIR: /Applications/Xcode-26.2.0.app/Contents/Developer
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Render one preview per example project
+        run: bash scripts/examples-smoke.sh

--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,4 @@
 brew "bash"
 brew "bazelisk"
+brew "mint"
 brew "xcodes"

--- a/scripts/examples-smoke.sh
+++ b/scripts/examples-smoke.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Renders one preview from each example project through the built CLI and
+# asserts a valid PNG comes back — covering build-system detection, example
+# build, default runfiles resource discovery, and the macOS render path
+# end-to-end (#372). The equivalent SnapshotCommandTests silently skip for
+# every example but spm under bazel's sanitized PATH, so this script is the
+# only place the other three build systems render gated. iOS/simulator
+# example coverage is a follow-up; keeping this job sim-free lets it run
+# scheduled without contending for the simulator lane.
+set -euo pipefail
+
+root=$(git rev-parse --show-toplevel)
+out=$(mktemp -d)
+
+bazel build //previewsmcp/cli:previewsmcp
+bin="$root/bazel-bin/previewsmcp/cli/previewsmcp"
+
+"$bin" kill-daemon --timeout 5 >/dev/null 2>&1 || true
+trap '"$bin" kill-daemon --timeout 5 >/dev/null 2>&1 || true; rm -rf "$out"' EXIT
+
+fail=0
+for example in spm xcodeproj xcworkspace bazel; do
+  source_file="$root/examples/$example/Sources/ToDo/ToDoView.swift"
+  png="$out/$example.png"
+  echo "=== $example"
+  if [ -f "$root/examples/$example/project.yml" ]; then
+    if ! (cd "$root/examples/$example" && mint run xcodegen generate); then
+      echo "FAIL $example (xcodegen generate)"
+      fail=1
+      continue
+    fi
+  fi
+  if "$bin" snapshot "$source_file" --project "$root/examples/$example" \
+    --output "$png" \
+    && file "$png" | grep -q "PNG image data"; then
+    echo "OK $example ($(stat -f%z "$png") bytes)"
+  else
+    echo "FAIL $example"
+    fail=1
+  fi
+done
+
+exit "$fail"


### PR DESCRIPTION
For #372 (leaves it open for the iOS-examples follow-up; this ships the macOS half).

## Corrected premise (review-gate finding, verified from primary sources)

The issue said examples/ runs nowhere gated because of `.bazelignore`. Half right, wrong mechanism: SnapshotCommandTests *does* have per-example render tests, but only the **spm** one actually renders in CI — the xcodeproj/xcworkspace/bazel ones are tool-gated (`toolAvailable("mint"/"bazel")`) and **silently skip as "passed"** under bazel's sanitized test PATH. Every CI log shows them "passing" in 0.03–0.14s; a real render takes seconds to minutes. The mini also had no mint installed at all. So three of four build systems' example render paths were exercised nowhere, invisibly.

## What ships

- `scripts/examples-smoke.sh` — renders ToDoView from each example (spm, xcodeproj, xcworkspace, bazel) through the **bare** built CLI (default runfiles resource discovery — a path the env-injecting tests never exercise), running `mint run xcodegen generate` where the project is generated. Per-example FAIL accumulation (a generation failure fails that example and continues), tmpdir cleaned on exit.
- `.github/workflows/examples.yml` — mini runner, Tuesday cron (staggered from ci.yml's Monday heartbeat) + `workflow_dispatch`, own concurrency group, deliberately **not** in the required path until its record justifies promotion (protects the merge-gate trial from the heaviest suite class).
- `Brewfile` + mini provisioning: `mint` added and installed.

## Verification

- 4/4 examples render locally through the final script (xcodeproj/xcworkspace validated the generation step).
- Platform constraint: schedule/dispatch only fire from the default branch, so the first manual `gh workflow run Examples` after merge is the live check.

## Gates

Combined /code-review+/simplify agent: 3 findings, all applied — the false-premise correction (its headline claim was itself half-wrong; re-verified against the mini's own test logs and the skip-guard source), xcodegen failure aborting the whole script under `set -e`, tmpdir leak. Lint clean. No product/test code touched.

## Follow-up worth its own decision (not in this PR)

The silent-skip pattern — tool-gated `return` rendering as a 30ms "pass" — is the same inert-guard class #361 removed for `.disabled(if: CI)`. Options: make those guards loud (`Issue.record` / explicit skip), or drop the in-test tool-gating now that the smoke workflow owns example coverage. Flagging on #372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9tE6iZwyGJcX5Kx9LUnhm