### PR TITLE
Fix #346: macOS preview_snapshot reads the live window on request

### DIFF
--- a/examples/spm/Sources/ToDo/LiveSnapshotProbe.swift
+++ b/examples/spm/Sources/ToDo/LiveSnapshotProbe.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// Integration test fixture for live-window snapshots (#346).
+///
+/// Fills the window with a solid color that flips from blue to red shortly
+/// after the view appears — a post-render state change with NO source edit and
+/// NO recompile. The render-time PNG captures the pre-flip blue; a live snapshot
+/// of the visible window must instead reflect the post-flip red. Used by
+/// `MacOSLiveSnapshotTests` to prove `preview_snapshot` reads the live window.
+struct LiveSnapshotProbe: View {
+    @State private var flipped = false
+
+    var body: some View {
+        (flipped ? Color(red: 1, green: 0, blue: 0) : Color(red: 0, green: 0, blue: 1))
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .onAppear {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                    flipped = true
+                }
+            }
+    }
+}
+
+#Preview {
+    LiveSnapshotProbe()
+}

--- a/previewsmcp/PreviewsCore/BridgeGenerator.swift
+++ b/previewsmcp/PreviewsCore/BridgeGenerator.swift
@@ -226,6 +226,7 @@ public enum BridgeGenerator {
         let preRasterPresent: String
         let postRasterPresent: String
         let stateWriter: String
+        let snapshotWriter: String
         if let window, !window.headless {
             let title = escapedForSwiftStringLiteral(window.title)
             createWindow = """
@@ -276,6 +277,7 @@ public enum BridgeGenerator {
                             }
             """
             stateWriter = frameSidecarPath.map(windowStateWriterCode) ?? ""
+            snapshotWriter = snapshotEntryCode(path: path)
         } else {
             // Headless spec or no spec: a borderless off-screen window used only to render at
             // the requested size, never shown or activated. Falls back to 400x600 with no spec.
@@ -293,9 +295,12 @@ public enum BridgeGenerator {
             """
             postRasterPresent = ""
             stateWriter = ""
+            snapshotWriter = ""
         }
         return """
+        \(rasterHelperCode())
         \(stateWriter)
+        \(snapshotWriter)
         @_cdecl("renderPreviewToFile")
         public func renderPreviewToFile() -> Int32 {
             MainActor.assumeIsolated {
@@ -316,35 +321,53 @@ public enum BridgeGenerator {
                 hosting.sizingOptions = []
                 window.contentView = hosting
                 \(preRasterPresent)
-                hosting.layoutSubtreeIfNeeded()
-                let bounds = hosting.bounds
-                guard bounds.width > 0, bounds.height > 0,
-                    let rep = NSBitmapImageRep(
-                        bitmapDataPlanes: nil,
-                        pixelsWide: Int(bounds.width.rounded()),
-                        pixelsHigh: Int(bounds.height.rounded()),
-                        bitsPerSample: 8,
-                        samplesPerPixel: 4,
-                        hasAlpha: true,
-                        isPlanar: false,
-                        colorSpaceName: .deviceRGB,
-                        bytesPerRow: 0,
-                        bitsPerPixel: 0
-                    )
-                else { return Int32(-1) }
-                rep.size = bounds.size
-                hosting.cacheDisplay(in: bounds, to: rep)
-                guard let data = rep.representation(using: .png, properties: [:]) else {
-                    return Int32(-2)
-                }
-                do {
-                    try data.write(to: URL(fileURLWithPath: "\(escapedForSwiftStringLiteral(path))"))
-                } catch {
-                    return Int32(-3)
-                }
+                let __rc = __previewsmcpRasterView(
+                    hosting, to: "\(escapedForSwiftStringLiteral(path))")
+                guard __rc == 0 else { return __rc }
                 \(postRasterPresent)
                 return 0
             }
+        }
+        """
+    }
+
+    /// Top-level helper (macOS render + live-snapshot entries) that rasters a view's current
+    /// content to a PNG at `path` via `cacheDisplay`, writing atomically so a failed write
+    /// leaves the previous image intact for a caller to fall back on. Emitting one helper keeps
+    /// the render-time PNG and the on-request live snapshot pixel-identical (#346): both go
+    /// through the same pixel format, color space, 1x point sizing, and PNG encoding. Status:
+    /// 0 ok, -2 zero bounds / bitmap alloc, -3 PNG encode, -4 write.
+    private static func rasterHelperCode() -> String {
+        """
+        @MainActor
+        func __previewsmcpRasterView(_ __view: NSView, to __path: String) -> Int32 {
+            __view.layoutSubtreeIfNeeded()
+            let __bounds = __view.bounds
+            guard __bounds.width > 0, __bounds.height > 0,
+                let __rep = NSBitmapImageRep(
+                    bitmapDataPlanes: nil,
+                    pixelsWide: Int(__bounds.width.rounded()),
+                    pixelsHigh: Int(__bounds.height.rounded()),
+                    bitsPerSample: 8,
+                    samplesPerPixel: 4,
+                    hasAlpha: true,
+                    isPlanar: false,
+                    colorSpaceName: .deviceRGB,
+                    bytesPerRow: 0,
+                    bitsPerPixel: 0
+                )
+            else { return Int32(-2) }
+            __rep.size = __bounds.size
+            __view.cacheDisplay(in: __bounds, to: __rep)
+            guard let __data = __rep.representation(using: .png, properties: [:]) else {
+                return Int32(-3)
+            }
+            do {
+                try __data.write(to: URL(fileURLWithPath: __path), options: .atomic)
+            } catch {
+                return Int32(-4)
+            }
+            return 0
         }
         """
     }
@@ -382,6 +405,32 @@ public enum BridgeGenerator {
                 else { return Int32(-1) }
                 __previewsmcpWriteWindowState(window)
                 return 0
+            }
+        }
+        """
+    }
+
+    /// Top-level entry (visible windows) that re-rasters the live preview window's current
+    /// content view to the baked image path — without rebuilding the view or touching window
+    /// placement. The daemon runs it over `runOnMain` when `preview_snapshot` targets a visible
+    /// session, so the returned image reflects post-render interaction (toggles, scrolls, typed
+    /// text) that the render-time PNG cannot contain (#346). `cacheDisplay` re-renders the view
+    /// hierarchy into a bitmap rather than screenshotting the display, so it works even when the
+    /// window is occluded or not key.
+    private static func snapshotEntryCode(path: String) -> String {
+        """
+        @_cdecl("snapshotPreviewWindow")
+        public func snapshotPreviewWindow() -> Int32 {
+            MainActor.assumeIsolated {
+                let identifier = NSUserInterfaceItemIdentifier("previewsmcp-preview")
+                guard
+                    let window = NSApplication.shared.windows.first(where: {
+                        $0.identifier == identifier
+                    }),
+                    let hosting = window.contentView
+                else { return Int32(-1) }
+                return __previewsmcpRasterView(
+                    hosting, to: "\(escapedForSwiftStringLiteral(path))")
             }
         }
         """

--- a/previewsmcp/PreviewsCore/StructuralReloader.swift
+++ b/previewsmcp/PreviewsCore/StructuralReloader.swift
@@ -16,4 +16,14 @@ public protocol StructuralReloader: Sendable {
     /// narrowing split). All are empty for the standalone path, where `objectPath` is
     /// self-contained.
     func render(_ build: JITRenderBuild) async throws
+
+    /// Re-raster the live agent window to its image path by running `entrySymbol`
+    /// (the generated `snapshotPreviewWindow`) on the live session's main thread, for a
+    /// visible session's on-request snapshot (#346). The default is a no-op so reloaders with
+    /// no live-window surface (and test stubs) need not implement it.
+    func snapshotLiveWindow(entrySymbol: String) async throws
+}
+
+public extension StructuralReloader {
+    func snapshotLiveWindow(entrySymbol _: String) async throws {}
 }

--- a/previewsmcp/PreviewsEngine/MacOSPreviewHandle.swift
+++ b/previewsmcp/PreviewsEngine/MacOSPreviewHandle.swift
@@ -67,6 +67,17 @@ public actor MacOSPreviewHandle: PreviewSessionHandle {
         let format: Snapshot.ImageFormat = quality >= 1.0 ? .png : .jpeg(quality: quality)
         let sessionID = id
         let colorScheme = await session.currentTraits.colorScheme
+        // Re-raster the live window to the session's image path first, so a visible session's
+        // snapshot reflects post-render interaction rather than the last render (#346). No-op
+        // for headless sessions — their render-time PNG is already the truth. Best-effort: a
+        // raster failure (e.g. a dead agent, or a transient zero-bounds/encode error) falls
+        // back to the last good on-disk PNG rather than failing the snapshot outright. The
+        // entry writes atomically, so a failed write leaves that fallback intact.
+        do {
+            try await host.refreshLiveSnapshot(sessionID: sessionID)
+        } catch {
+            Log.info("snap: live re-raster failed, serving last render: \(error)")
+        }
         return try await MainActor.run {
             guard let imagePath = host.agentSnapshotPath(for: sessionID) else {
                 throw SnapshotError.captureFailed

--- a/previewsmcp/PreviewsJITLink/JITStructuralReloader.swift
+++ b/previewsmcp/PreviewsJITLink/JITStructuralReloader.swift
@@ -82,6 +82,18 @@ public actor JITStructuralReloader: StructuralReloader {
         }
     }
 
+    /// Re-raster the live window to the current build's image path by running the generated
+    /// `snapshotPreviewWindow` entry on the live agent's main thread (#346). No live session
+    /// yet (no render has happened) means nothing to snapshot. A non-zero status is a real
+    /// raster failure and propagates, like the render entry.
+    public func snapshotLiveWindow(entrySymbol: String) async throws {
+        guard let session else { return }
+        let status = try session.runOnMain(symbol: entrySymbol)
+        guard status == 0 else {
+            throw JITReloadError.snapshotFailed(status: status)
+        }
+    }
+
     private func link(_ build: JITRenderBuild, into session: JITSession) throws {
         var mark = ContinuousClock.now
         for dylib in build.dylibPaths {
@@ -121,11 +133,14 @@ public actor JITStructuralReloader: StructuralReloader {
 
 public enum JITReloadError: Error, LocalizedError, CustomStringConvertible {
     case renderFailed(status: Int32)
+    case snapshotFailed(status: Int32)
 
     public var description: String {
         switch self {
         case let .renderFailed(status):
             "JIT render entry returned non-zero status \(status)"
+        case let .snapshotFailed(status):
+            "JIT live-snapshot entry returned non-zero status \(status)"
         }
     }
 

--- a/previewsmcp/PreviewsMacOS/HostApp.swift
+++ b/previewsmcp/PreviewsMacOS/HostApp.swift
@@ -276,6 +276,19 @@ public class PreviewHost: NSObject, NSApplicationDelegate {
         agentImagePaths[sessionID]
     }
 
+    /// Re-raster the live window to the session's image path before a snapshot, so
+    /// `preview_snapshot` reflects post-render interaction on a visible session (#346).
+    /// Only visible sessions run the generated `snapshotPreviewWindow` entry — headless ones
+    /// no-op, their render-time PNG is already the truth. No-op too without a reloader. Throws
+    /// a raster failure so the caller can decide whether to surface it or fall back to the last
+    /// good PNG (the handle falls back).
+    public func refreshLiveSnapshot(sessionID: String) async throws {
+        guard agentWindowSpecs[sessionID]?.headless == false,
+              let reloader = reloaders[sessionID]
+        else { return }
+        try await reloader.snapshotLiveWindow(entrySymbol: "snapshotPreviewWindow")
+    }
+
     /// Literal-only reload for an agent-backed session: rewrite the design-time values
     /// JSON and re-render the same object in the agent — no recompile. Returns the new
     /// image path, or nil if there is no reloader or no prior JIT build.

--- a/previewsmcp/Tests/MCPIntegrationTests/MacOSLiveSnapshotTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/MacOSLiveSnapshotTests.swift
@@ -1,0 +1,111 @@
+import AppKit
+import Foundation
+import MCP
+@testable import PreviewsCLI
+import Testing
+
+/// #346: `preview_snapshot` on a VISIBLE macOS window must reflect the live
+/// window's current state, not the PNG written at the last render. The
+/// `LiveSnapshotProbe` fixture flips blue→red ~0.4s after appearing with no
+/// source edit — a post-render state change the render-time PNG cannot contain.
+///
+/// The visible session must snapshot red (live). The headless session must
+/// stay blue (render-time PNG untouched — the gate the coordinator flagged).
+@Suite("MCP macOS live snapshot", .serialized)
+struct MacOSLiveSnapshotTests {
+    static let probePath: String =
+        MCPTestServer.spmExampleRoot.appendingPathComponent("Sources/ToDo/LiveSnapshotProbe.swift").path
+
+    /// Dominant color of the image's center pixel: `.red`, `.blue`, or `.other`.
+    enum CenterColor { case red, blue, other }
+
+    static func centerColor(of content: [Tool.Content]) throws -> CenterColor {
+        let (data, _) = try MCPTestServer.extractImageData(from: content)
+        guard let rep = NSBitmapImageRep(data: data),
+              let c = rep.colorAt(x: rep.pixelsWide / 2, y: rep.pixelsHigh / 2)?
+              .usingColorSpace(.deviceRGB)
+        else { return .other }
+        let r = c.redComponent, b = c.blueComponent
+        if r > b + 0.3 { return .red }
+        if b > r + 0.3 { return .blue }
+        return .other
+    }
+
+    @Test("visible window snapshot reflects live post-render state", .timeLimit(.minutes(20)))
+    func visibleSnapshotIsLive() async throws {
+        let lock = try await DaemonTestLock.acquire()
+        defer { lock.release() }
+
+        let server = try await MCPTestServer.start()
+        defer { server.stop() }
+
+        let (startContent, startError) = try await server.callTool(
+            name: "preview_start",
+            arguments: [
+                "filePath": .string(Self.probePath),
+                "projectPath": .string(MCPTestServer.spmExampleRoot.path),
+                "headless": .bool(false),
+            ]
+        )
+        #expect(startError != true, "preview_start (visible) should succeed")
+        let sessionID = try MCPTestServer.extractSessionID(from: startContent)
+        defer {
+            Task { _ = try? await server.callTool(
+                name: "preview_stop", arguments: ["sessionID": .string(sessionID)]
+            ) }
+        }
+
+        // The render-time PNG captured the pre-flip blue. Poll live snapshots
+        // until the flip (0.4s) lands and the live window reads red — generous
+        // cap so a slow agent delays the pass rather than failing it.
+        var last = CenterColor.other
+        for _ in 0 ..< 40 {
+            let (snap, snapError) = try await server.callTool(
+                name: "preview_snapshot",
+                arguments: ["sessionID": .string(sessionID), "quality": .double(1.0)]
+            )
+            #expect(snapError != true, "snapshot should succeed")
+            last = try Self.centerColor(of: snap)
+            if last == .red { break }
+            try await Task.sleep(for: .milliseconds(250))
+        }
+        #expect(last == .red, "visible snapshot must reflect the live red state, got \(last)")
+    }
+
+    @Test("headless snapshot keeps the render-time PNG (gate untouched)", .timeLimit(.minutes(20)))
+    func headlessSnapshotStaysRenderTime() async throws {
+        let lock = try await DaemonTestLock.acquire()
+        defer { lock.release() }
+
+        let server = try await MCPTestServer.start()
+        defer { server.stop() }
+
+        let (startContent, startError) = try await server.callTool(
+            name: "preview_start",
+            arguments: [
+                "filePath": .string(Self.probePath),
+                "projectPath": .string(MCPTestServer.spmExampleRoot.path),
+                "headless": .bool(true),
+            ]
+        )
+        #expect(startError != true, "preview_start (headless) should succeed")
+        let sessionID = try MCPTestServer.extractSessionID(from: startContent)
+        defer {
+            Task { _ = try? await server.callTool(
+                name: "preview_stop", arguments: ["sessionID": .string(sessionID)]
+            ) }
+        }
+
+        // Wait well past the fixture's 0.4s flip. A headless session never
+        // re-rasters live, so its snapshot stays the render-time blue no matter
+        // what the off-screen window's state advanced to.
+        try await Task.sleep(for: .seconds(2))
+        let (snap, snapError) = try await server.callTool(
+            name: "preview_snapshot",
+            arguments: ["sessionID": .string(sessionID), "quality": .double(1.0)]
+        )
+        #expect(snapError != true, "snapshot should succeed")
+        let color = try Self.centerColor(of: snap)
+        #expect(color == .blue, "headless snapshot must stay the render-time blue, got \(color)")
+    }
+}

--- a/previewsmcp/Tests/PreviewsCoreTests/BridgeGeneratorLiveSnapshotTests.swift
+++ b/previewsmcp/Tests/PreviewsCoreTests/BridgeGeneratorLiveSnapshotTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+@testable import PreviewsCore
+import Testing
+
+@Suite("BridgeGenerator live snapshot entry")
+struct BridgeGeneratorLiveSnapshotTests {
+    static let source = """
+    import SwiftUI
+
+    struct TestView: View {
+        var body: some View {
+            Text("Hello")
+        }
+    }
+
+    #Preview { TestView() }
+    """
+
+    @Test("visible render window emits a snapshotPreviewWindow entry baked with the image path")
+    func visibleEmitsSnapshotEntry() {
+        let generated = BridgeGenerator.generateCombinedSource(
+            originalSource: Self.source,
+            closureBody: "TestView()",
+            renderOutputPath: "/tmp/out.png",
+            renderWindow: JITRenderWindow(
+                x: 0, y: 0, width: 800, height: 1000, title: "t", headless: false
+            ),
+            frameSidecarPath: "/tmp/frame.json"
+        )
+        #expect(generated.source.contains("@_cdecl(\"snapshotPreviewWindow\")"))
+        #expect(generated.source.contains("/tmp/out.png"))
+    }
+
+    @Test("headless render window emits no snapshotPreviewWindow entry")
+    func headlessEmitsNoSnapshotEntry() {
+        let generated = BridgeGenerator.generateCombinedSource(
+            originalSource: Self.source,
+            closureBody: "TestView()",
+            renderOutputPath: "/tmp/out.png",
+            renderWindow: JITRenderWindow(
+                x: 0, y: 0, width: 800, height: 1000, title: "t", headless: true
+            ),
+            frameSidecarPath: "/tmp/frame.json"
+        )
+        #expect(!generated.source.contains("snapshotPreviewWindow"))
+    }
+
+    @Test("no render window emits no snapshotPreviewWindow entry")
+    func noWindowEmitsNoSnapshotEntry() {
+        let generated = BridgeGenerator.generateCombinedSource(
+            originalSource: Self.source,
+            closureBody: "TestView()",
+            renderOutputPath: "/tmp/out.png",
+            renderWindow: nil,
+            frameSidecarPath: nil
+        )
+        #expect(!generated.source.contains("snapshotPreviewWindow"))
+    }
+}


### PR DESCRIPTION
## Problem

`preview_snapshot` served the PNG written at the **last render**, so any post-render interaction on a **visible** macOS window (toggle, scroll, typed text) was invisible until the next re-render. Per the #254 plan, the agent should snapshot its own live window on request.

## Fix

- Generate an on-demand `snapshotPreviewWindow` `@_cdecl` (mirrors `recordPreviewWindowState`) that `cacheDisplay`-rasters the **live content view** to the session's image path — no view rebuild (which would discard the live state), no window-placement change.
- The daemon runs it over `runOnMain` (`PreviewHost.refreshLiveSnapshot` → `StructuralReloader.snapshotLiveWindow`) when `preview_snapshot` targets a **visible** session. Gated strictly on `!headless`; **headless sessions are unchanged** — their render-time PNG is already the truth.
- Render and snapshot now share one emitted `__previewsmcpRasterView` helper, so the render-time PNG and the live snapshot stay **pixel-identical** (same pixel format, color space, 1x sizing, PNG encode). The write is **atomic**, so a failed live raster leaves the last good PNG intact.
- The handle's live re-raster is **best-effort**: a raster failure logs and falls back to the last good PNG rather than failing the snapshot; a distinct `JITReloadError.snapshotFailed` gives the correct diagnostic.

## Verify (fail-first confirmed red, then green)

- `MacOSLiveSnapshotTests` (e2e): a windowed session's preview flips blue→red ~0.4s after appearing with **no source edit**. The visible session's snapshot reflects the live **red**; the headless twin stays the render-time **blue** (the gate). Both were confirmed to fail on the pre-fix code (visible returned blue).
- `BridgeGeneratorLiveSnapshotTests` (unit): the `snapshotPreviewWindow` entry is emitted iff `headless == false`.

## Scope / safety

- macOS-only. iOS is untouched: `compileObjectForJIT()` runs with no window (so no snapshot entry), and `IOSPreviewHandle` never calls `refreshLiveSnapshot`.
- Does not touch daemon socket/readiness/dispatch code.

## Gates (local)

- `/code-review` (high) + `/simplify` clean; findings applied (best-effort fallback, atomic write, shared raster helper, distinct error, dropped a derivable dict/DTO field).
- Green locally: PreviewsCore, PreviewsMacOS, PreviewsEngine, PreviewsCLI, PreviewsJITLink (macOS), and the macOS MCP integration suites (`MacOSMCPTests`, `MacOSLiveSnapshotTests`). `//tools/lint:check` clean. iOS-sim suites delegated to this PR's `bazel test //...` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)