### PR TITLE
#340: remove two dead `import PreviewsCLI` from integration tests

### DIFF
--- a/previewsmcp/Tests/MCPIntegrationTests/DaemonLifecycleTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/DaemonLifecycleTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 import MCP
 import Network
-import PreviewsCLI
 import PreviewsTestSupport
 import Testing
 

--- a/previewsmcp/Tests/PreviewsCLITests/NetworkTransportHeartbeatTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/NetworkTransportHeartbeatTests.swift
@@ -2,7 +2,6 @@ import Foundation
 import MCP
 import Network
 import os
-import PreviewsCLI
 import PreviewsTestSupport
 import Testing
 


### PR DESCRIPTION
Removes the unused `import PreviewsCLI` from two integration-test files:
- `previewsmcp/Tests/PreviewsCLITests/NetworkTransportHeartbeatTests.swift`
- `previewsmcp/Tests/MCPIntegrationTests/DaemonLifecycleTests.swift`

Neither file references any `PreviewsCLI` symbol. Confirmed dead by building both test targets (`PreviewsCLITests`, `MCPIntegrationTests`) with the import removed — both compile clean. Lint green.

Pure deletion, no logic change (formal /simplify + /code-review are vacuous here; build + lint + the required CI gate are the verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)