### PR TITLE
#262: register the last three reloader tests via jitStart (kill the FSEvents +1)

### DIFF
--- a/previewsmcp/Tests/PreviewsEngineTests/MacOSPreviewHandleAgentSnapshotTests.swift
+++ b/previewsmcp/Tests/PreviewsEngineTests/MacOSPreviewHandleAgentSnapshotTests.swift
@@ -39,9 +39,12 @@ struct MacOSPreviewHandleAgentSnapshotTests {
         let compiler = try await Compiler()
         let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
         let host = PreviewHost(makeStructuralReloader: { RecordingReloader() })
-        host.watchFile(sessionID: "s1", session: session, filePath: sourceFile.path, compiler: compiler)
+        try await host.jitStart(
+            sessionID: "s1", session: session,
+            title: "s1", size: NSSize(width: 8, height: 8), headless: true
+        )
 
-        let imageURL = try await host.jitStructuralReload(sessionID: "s1", session: session)
+        let imageURL = try #require(host.agentSnapshotPath(for: "s1"))
         try Self.greenPNG().write(to: imageURL)
 
         let handle = MacOSPreviewHandle(id: "s1", session: session, host: host)

--- a/previewsmcp/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
+++ b/previewsmcp/Tests/PreviewsMacOSTests/PreviewHostJITReloadTests.swift
@@ -39,10 +39,11 @@ struct PreviewHostJITReloadTests {
 
         let reloader = RecordingReloader()
         let host = PreviewHost(makeStructuralReloader: { reloader })
-        host.watchFile(sessionID: "s1", session: session, filePath: sourceFile.path, compiler: compiler)
-
-        let imagePath = try await host.jitStructuralReload(sessionID: "s1", session: session)
-        #expect(host.agentSnapshotPath(for: "s1") == imagePath)
+        try await host.jitStart(
+            sessionID: "s1", session: session,
+            title: "s1", size: NSSize(width: 8, height: 8), headless: true
+        )
+        #expect(host.agentSnapshotPath(for: "s1") != nil)
         #expect(reloader.calls.count == 1)
         #expect(reloader.calls.first?.entrySymbol == "renderPreviewToFile")
     }
@@ -119,10 +120,13 @@ struct PreviewHostJITReloadTests {
 
         let compiler = try await Compiler()
         let session = PreviewSession(sourceFile: sourceFile, compiler: compiler)
-        let build = try await session.compileObjectForJIT()
 
         let host = PreviewHost(makeStructuralReloader: { RecordingReloader() })
-        host.watchFile(sessionID: "s1", session: session, filePath: sourceFile.path, compiler: compiler)
+        try await host.jitStart(
+            sessionID: "s1", session: session,
+            title: "s1", size: NSSize(width: 8, height: 8), headless: true
+        )
+        let build = try await session.compileObjectForJIT()
 
         let stringLiteral = try #require(
             build.literals.first { if case .string = $0.value { true } else { false } }


### PR DESCRIPTION
Fixes #262 (the residual; #276 already closed as its duplicate).

## What & why

Three macOS reloader tests still registered their session with `watchFile`, whose FSEvents `sinceNow` watcher replays the just-written fixture as a spurious structural reload — the deterministic-ish +1 render/call count. I reproduced it on current main: `structuralReloadRecordsAgentImage` failed 1/5 rapid reruns (`calls.count 2 vs 1`). This is the exact residual PR #298 fixed for the other two tests in these files.

A **production no-masking spike** (coordinator-gated) first confirmed the real daemon does **not** double-render on a genuine edit after `preview_start` (classify-before-reload + committed baseline; 0/1/0 across cold-start/genuine-edit/mtime-touch) — so the +1 is a test-setup artifact, not a masked product bug. Full spike table on #262.

## The conversion

`jitStart` registers the session and does exactly one structural render but installs **no** watcher, so the spurious fire can't occur:
- `structuralReloadRecordsAgentImage` / `snapshotReturnsAgentImage`: jitStart's single render replaces the test's explicit first `jitStructuralReload`; the rendered path now comes from `agentSnapshotPath(for:)` since jitStart returns Void.
- `literalReloadRewritesValuesAndRecordsImage`: the reference `build` is compiled **after** jitStart so it is the session's last build (what `applyLiteralValuesForJIT` patches) — jitStart's own compile would otherwise stale the pre-captured build and its per-UUID image path. All original assertions (`build.imagePath`, `build.valuesPath`, `"world"`) are preserved unchanged.

## Verification

- Both suites **12/12** across repeated `--nocache_test_results` runs (was ~1/5 failing).
- Full local suite 11/11 green, lint clean.
- Review gate (opus): no findings — confirmed the literal test is not vacuously green (still fails if persistence breaks) and the FSEvents watcher itself stays covered by the untouched `handleWatchedChange` tests.

Leaves #262's deeper note (production `watchFile` shares the `sinceNow` path — masked for unchanged content by #297/#300, spike-confirmed clean for real edits) recorded on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9tE6iZwyGJcX5Kx9LUnhm