### PR TITLE
Retire the last URLSession streaming reader: /stream.avcc over a raw socket

### DIFF
--- a/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
@@ -195,142 +195,41 @@ private func readStreamSample(port: Int, limit: Int) async throws -> Data {
 }
 
 /// Read the length-prefixed `/stream.avcc` envelope stream and collect the chunk
-/// tags seen. `onConnected` runs once the first byte arrives (the subscriber is
-/// registered by then) to drive a screen change so an IDR is produced. Returns
-/// when every tag in `need` has been seen or `timeout` elapses.
-///
-/// Fresh single-use ephemeral session: this helper abandons its response
-/// mid-stream, and a shared session's connection pool can hand the dying
-/// connection to a later request against the same host:port (#320).
+/// tags seen. `onConnected` runs once the first body bytes arrive (the
+/// subscriber is registered by then) to drive a screen change so an IDR is
+/// produced. Returns when every tag in `need` has been seen or `timeout`
+/// elapses. Raw socket, not URLSession — see RawHTTP.stream (#350).
 private func readAVCCTags(
     port: Int, need: Set<UInt8>, timeout: Duration,
     onConnected: @escaping @Sendable () async -> Void
 ) async throws -> Set<UInt8> {
-    let session = URLSession(configuration: .ephemeral)
-    defer { session.invalidateAndCancel() }
-    var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/stream.avcc")!)
-    request.timeoutInterval = 25
-    let (bytes, response) = try await attributed("avcc-connect") {
-        try await session.bytes(for: request)
-    }
-    let contentType = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Type") ?? ""
-    #expect(contentType.contains("application/octet-stream"), "avcc stream should be octet-stream")
-
     struct Parse {
         var buffer = [UInt8]()
         var offset = 0
         var seen = Set<UInt8>()
-        var connected = false
     }
     let state = OSAllocatedUnfairLock(initialState: Parse())
-    try await boundedRead("avcc-body", bytes, deadline: timeout) { byte in
-        let fireConnect = state.withLock { parse -> Bool in
-            if parse.connected { return false }
-            parse.connected = true
-            return true
-        }
-        if fireConnect {
-            await onConnected()
-        }
-        return state.withLock { parse in
-            parse.buffer.append(byte)
-            while parse.buffer.count - parse.offset >= 4 {
-                let length =
-                    Int(parse.buffer[parse.offset]) << 24 | Int(parse.buffer[parse.offset + 1]) << 16
-                        | Int(parse.buffer[parse.offset + 2]) << 8 | Int(parse.buffer[parse.offset + 3])
-                guard parse.buffer.count - parse.offset >= 4 + length else { break }
-                parse.seen.insert(parse.buffer[parse.offset + 4])
-                parse.offset += 4 + length
-            }
-            return !need.isSubset(of: parse.seen)
-        }
-    }
-    return state.withLock { $0.seen }
-}
-
-/// Feed `bytes` to `consume` until it returns false or `deadline` elapses,
-/// then return; rethrows genuine stream errors. The deadline must bound the
-/// await itself, not just the loop body: when the app server drops the
-/// connection without URLSession surfacing it (observed: server-side drop
-/// right after headers → zero body bytes → socket gone, iterator never
-/// resumes), an in-body deadline check is unreachable and the test hangs
-/// holding DaemonTestLock until its `.timeLimit` — queued suites then blow
-/// their own limits as collateral.
-///
-/// The outer await must never structurally depend on the reader resuming.
-/// Two weaker designs were disproven by thread-sampling recurred wedges:
-/// cooperative `Task.cancel()` does not resume an iterator parked inside
-/// `AsyncBytes.Iterator.next()`, and even `bytes.task.cancel()` leaves the
-/// continuation unresumed when the transfer is already dead underneath
-/// (`reloadBufferAndNext()` parked with no completion left to deliver). So
-/// the deadline path races the reader via a once-guarded continuation and,
-/// after a short grace for the cancels to land, abandons it — leaking one
-/// suspended task and its dead connection for the remaining test-process
-/// lifetime, which is bounded and harmless. The caller's assertions on
-/// whatever partial data arrived produce the attributable failure.
-///
-/// Every abnormal exit (deadline in any of its three faces, or a genuine
-/// stream error) prints an `APPSERVER-ATTR site=… exit=…` line with the
-/// task's wire-level byte count and task error, so a #350 specimen is
-/// attributed no matter which face it wears; the healthy limit-met exit
-/// stays quiet.
-private func boundedRead(
-    _ site: String,
-    _ bytes: URLSession.AsyncBytes,
-    deadline: Duration,
-    consume: @escaping @Sendable (UInt8) async -> Bool
-) async throws {
-    let reader = Task {
-        for try await byte in bytes {
-            guard await consume(byte) else { break }
-        }
-    }
-    let resolvedBy = OSAllocatedUnfairLock<String?>(initialState: nil)
-    func claimResume(_ who: String) -> Bool {
-        resolvedBy.withLock { claimed in
-            if claimed != nil { return false }
-            claimed = who
-            return true
-        }
-    }
-    func taskDump() -> String {
-        "wireBytes=\(bytes.task.countOfBytesReceived)"
-            + " taskError=\(bytes.task.error.map(errorChainDump) ?? "nil")"
-    }
-    do {
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            Task {
-                let result: Result<Void, Error>
-                do {
-                    try await reader.value
-                    result = .success(())
-                } catch {
-                    result = .failure(error)
+    let head = try await attributed("avcc-raw") {
+        try await RawHTTP.stream(
+            port: port, path: "/stream.avcc", deadline: timeout, onConnected: onConnected
+        ) { chunk in
+            state.withLock { parse in
+                parse.buffer.append(contentsOf: chunk)
+                while parse.buffer.count - parse.offset >= 4 {
+                    let length =
+                        Int(parse.buffer[parse.offset]) << 24 | Int(parse.buffer[parse.offset + 1]) << 16
+                            | Int(parse.buffer[parse.offset + 2]) << 8 | Int(parse.buffer[parse.offset + 3])
+                    guard parse.buffer.count - parse.offset >= 4 + length else { break }
+                    parse.seen.insert(parse.buffer[parse.offset + 4])
+                    parse.offset += 4 + length
                 }
-                if claimResume("reader") { cont.resume(with: result) }
-            }
-            Task {
-                try? await Task.sleep(for: deadline)
-                bytes.task.cancel()
-                reader.cancel()
-                try? await Task.sleep(for: .seconds(2))
-                if claimResume("deadline") { cont.resume(returning: ()) }
+                return !need.isSubset(of: parse.seen)
             }
         }
-        if resolvedBy.withLock({ $0 }) == "deadline" {
-            print("APPSERVER-ATTR site=\(site) exit=deadline-abandoned \(taskDump())")
-        }
-    } catch is CancellationError {
-        // Deadline: the caller inspects what arrived.
-        print("APPSERVER-ATTR site=\(site) exit=deadline-cancellation \(taskDump())")
-    } catch let error as URLError where error.code == .cancelled {
-        // Same, surfaced through URLSession instead.
-        print("APPSERVER-ATTR site=\(site) exit=deadline-urlcancelled \(taskDump())")
-    } catch {
-        print(
-            "APPSERVER-ATTR site=\(site) exit=threw \(taskDump())"
-                + " thrown: \(errorChainDump(error))"
-        )
-        throw error
     }
+    #expect(
+        head.contains("Content-Type: application/octet-stream"),
+        "avcc stream should be octet-stream"
+    )
+    return state.withLock { $0.seen }
 }

--- a/previewsmcp/Tests/TestSupport/RawHTTPSample.swift
+++ b/previewsmcp/Tests/TestSupport/RawHTTPSample.swift
@@ -1,16 +1,15 @@
 import Foundation
 
-/// Bounded raw sampling of a streaming HTTP response over a plain blocking
-/// socket: status line, headers, and up to `bodyLimit` body bytes.
+/// Bounded raw reading of a streaming HTTP response over a plain blocking
+/// socket.
 ///
-/// Exists because URLSession is unusable for sampling
-/// multipart/x-mixed-replace: its multipart handling is timing-dependent, and
-/// once a full part sits buffered before the consumer starts iterating
-/// (loopback burst + a loaded machine), `AsyncBytes` either throws a bare
-/// NSURLError -1 or delivers no bytes while the task reports no error —
-/// reproduced deterministically and root-caused as #350. A raw read is
-/// timing-independent and asserts the actual wire framing browser clients
-/// consume.
+/// Exists because URLSession is unusable for consuming the app server's
+/// streaming endpoints from tests: its multipart/x-mixed-replace handling is
+/// timing-dependent (a fully-buffered part throws a bare NSURLError -1 or
+/// delivers nothing — root-caused as #350), and `AsyncBytes` parked inside
+/// `next()` cannot be cancelled, so a dead transfer throws NSURLError -999 or
+/// wedges the test. A raw socket with `SO_RCVTIMEO` plus a whole-read deadline
+/// is timing-independent and asserts the actual wire framing.
 public enum RawHTTP {
     public struct SampleError: Error, LocalizedError {
         public let message: String
@@ -19,60 +18,124 @@ public enum RawHTTP {
         }
     }
 
+    private struct Head {
+        let fd: Int32
+        let text: String
+        let bodyPrefix: Data
+    }
+
+    /// Open a blocking socket to 127.0.0.1:port, GET path, and read until the
+    /// response head is complete. Returns the still-open fd (the caller closes
+    /// it), the head text, and any body bytes read alongside the head.
+    /// Validates a 200 status. Bounded by `deadline` measured from `clock`.
+    private static func openAndReadHead(
+        port: Int, path: String, clock: ContinuousClock.Instant, deadline: Duration
+    ) throws -> Head {
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw SampleError(message: "socket() failed errno=\(errno)") }
+        var keepOpen = false
+        defer { if !keepOpen { close(fd) } }
+        var timeout = timeval(tv_sec: 2, tv_usec: 0)
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = UInt16(port).bigEndian
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+        let connected = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                connect(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard connected == 0 else {
+            throw SampleError(message: "connect(127.0.0.1:\(port)) failed errno=\(errno)")
+        }
+        let request = "GET \(path) HTTP/1.1\r\nHost: 127.0.0.1:\(port)\r\nConnection: close\r\n\r\n"
+        _ = request.withCString { write(fd, $0, strlen($0)) }
+
+        var received = Data()
+        let terminator = Data("\r\n\r\n".utf8)
+        var chunk = [UInt8](repeating: 0, count: 16384)
+        while ContinuousClock.now - clock < deadline {
+            let n = read(fd, &chunk, chunk.count)
+            if n < 0, errno == EAGAIN || errno == EWOULDBLOCK { continue }
+            guard n > 0 else {
+                throw SampleError(message: "stream closed before response head (read=\(n) errno=\(errno))")
+            }
+            received.append(contentsOf: chunk[0 ..< n])
+            if let range = received.range(of: terminator) {
+                let text = String(decoding: received[..<range.lowerBound], as: UTF8.self)
+                guard text.hasPrefix("HTTP/1.1 200") else {
+                    throw SampleError(message: "unexpected status: \(text.prefix(40))")
+                }
+                keepOpen = true
+                return Head(fd: fd, text: text, bodyPrefix: received[range.upperBound...])
+            }
+        }
+        throw SampleError(message: "no response head within deadline (\(received.count) bytes)")
+    }
+
     /// Issue a GET and collect the response head plus up to `bodyLimit` body
-    /// bytes. `SO_RCVTIMEO` bounds each read and `deadline` bounds the whole
-    /// sample, so a stalled stream fails loudly instead of hanging. The socket
-    /// is closed on return; a streaming server sees a mid-stream disconnect,
+    /// bytes, then close. A streaming server sees a mid-stream disconnect,
     /// which is an ordinary client departure.
     public static func sample(
         port: Int, path: String, bodyLimit: Int, deadline: Duration
     ) async throws -> (head: String, body: Data) {
         try await Task.detached {
-            let fd = socket(AF_INET, SOCK_STREAM, 0)
-            guard fd >= 0 else { throw SampleError(message: "socket() failed errno=\(errno)") }
-            defer { close(fd) }
-            var timeout = timeval(tv_sec: 2, tv_usec: 0)
-            setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
-            var addr = sockaddr_in()
-            addr.sin_family = sa_family_t(AF_INET)
-            addr.sin_port = UInt16(port).bigEndian
-            addr.sin_addr.s_addr = inet_addr("127.0.0.1")
-            let connected = withUnsafePointer(to: &addr) {
-                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                    connect(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
-                }
-            }
-            guard connected == 0 else {
-                throw SampleError(message: "connect(127.0.0.1:\(port)) failed errno=\(errno)")
-            }
-            let request = "GET \(path) HTTP/1.1\r\nHost: 127.0.0.1:\(port)\r\nConnection: close\r\n\r\n"
-            _ = request.withCString { write(fd, $0, strlen($0)) }
-
-            var received = Data()
-            let headTerminator = Data("\r\n\r\n".utf8)
-            var headEnd: Range<Data.Index>?
             let clock = ContinuousClock.now
+            let head = try openAndReadHead(port: port, path: path, clock: clock, deadline: deadline)
+            defer { close(head.fd) }
+            var body = head.bodyPrefix
             var chunk = [UInt8](repeating: 0, count: 16384)
-            while ContinuousClock.now - clock < deadline {
-                let n = read(fd, &chunk, chunk.count)
+            while body.count < bodyLimit, ContinuousClock.now - clock < deadline {
+                let n = read(head.fd, &chunk, chunk.count)
                 if n < 0, errno == EAGAIN || errno == EWOULDBLOCK { continue }
                 guard n > 0 else {
-                    throw SampleError(
-                        message: "stream closed early after \(received.count) bytes (read=\(n) errno=\(errno))"
-                    )
+                    throw SampleError(message: "stream closed early after \(body.count) body bytes")
                 }
-                received.append(contentsOf: chunk[0 ..< n])
-                if headEnd == nil { headEnd = received.range(of: headTerminator) }
-                if let headEnd, received.count - headEnd.upperBound >= bodyLimit { break }
+                body.append(contentsOf: chunk[0 ..< n])
             }
-            guard let headEnd else {
-                throw SampleError(message: "no response head within deadline (\(received.count) bytes)")
+            return (head.text, body)
+        }.value
+    }
+
+    /// Issue a GET and stream the body to `consume` chunk by chunk until it
+    /// returns false (done) or `deadline` elapses, then close. `onConnected`
+    /// fires once, just before the first body bytes are delivered — the point
+    /// the response is live so the caller can drive the server to emit more.
+    /// Returns the response head text (for content-type assertions). Throws if
+    /// the stream closes before `consume` signals done.
+    @discardableResult
+    public static func stream(
+        port: Int, path: String, deadline: Duration,
+        onConnected: @escaping @Sendable () async -> Void,
+        consume: @escaping @Sendable (Data) -> Bool
+    ) async throws -> String {
+        try await Task.detached {
+            let clock = ContinuousClock.now
+            let head = try openAndReadHead(port: port, path: path, clock: clock, deadline: deadline)
+            defer { close(head.fd) }
+            var fired = false
+            func fireOnce() async {
+                if !fired {
+                    fired = true
+                    await onConnected()
+                }
             }
-            let head = String(decoding: received[..<headEnd.lowerBound], as: UTF8.self)
-            guard head.hasPrefix("HTTP/1.1 200") else {
-                throw SampleError(message: "unexpected status: \(head.prefix(40))")
+            if !head.bodyPrefix.isEmpty {
+                await fireOnce()
+                if !consume(head.bodyPrefix) { return head.text }
             }
-            return (head, received[headEnd.upperBound...])
+            var chunk = [UInt8](repeating: 0, count: 16384)
+            while ContinuousClock.now - clock < deadline {
+                let n = read(head.fd, &chunk, chunk.count)
+                if n < 0, errno == EAGAIN || errno == EWOULDBLOCK { continue }
+                guard n > 0 else {
+                    throw SampleError(message: "stream closed before consume signalled done")
+                }
+                await fireOnce()
+                if !consume(Data(chunk[0 ..< n])) { return head.text }
+            }
+            return head.text
         }.value
     }
 }


### PR DESCRIPTION
Follow-up to #350/#375 (no issue of its own — closes the last streaming consumer that shared the flake class). Coordinator-approved after #262 landed.

## Why

`readAVCCTags` (the `/stream.avcc` test reader) was the last consumer on `URLSession.bytes` + `boundedRead`. That's the AsyncBytes-cancellation-trap exposure that produces the **-999** face of the #350 class (the **-1** buffering face was fixed for MJPEG in PR #375). Under the now-required `bazel` gate, a latent AsyncBytes trap intermittently reds PRs (it already bit #376's stale branch), so this closes it at the root rather than waiting for a specimen.

## Change

- `RawHTTP` gains a streaming sibling to `sample()`: **`stream(port:path:deadline:onConnected:consume:)`**, built on a shared `openAndReadHead` extracted from `sample`. Raw blocking socket, `SO_RCVTIMEO` per read + a whole-read deadline from one clock. `onConnected` fires just before the first body bytes (matching the old first-body-byte timing, so the driven drag still forces an IDR after the subscriber registers), and body chunks feed a stop-predicate.
- `readAVCCTags` uses `stream`, keeping its exact length-prefixed envelope parse and the octet-stream content-type assertion (now read from the returned head text).
- The elaborate continuation-race deadline machinery in `boundedRead` is **deleted** (it existed only to work around AsyncBytes being uncancellable). Net −38 lines.
- One-shot `/control` POSTs keep `URLSession` — not a streaming body, never implicated. **No URLSession streaming consumers remain.**

## Verification

- MCPIntegrationTests 3/3 and PreviewsIOSTests 3/3 (the latter exercises the refactored `sample()`) across `--nocache_test_results` runs; full local suite 11/11 green; lint clean.
- Gates (MEDIUM): /simplify + /code-review medium, both clean — reviewers verified fd lifecycle (no double-close/leak on any path), that the `onConnected` keyframe timing is preserved (0x01 replay + forced-keyframe arming still land), envelope parse equivalence across chunk boundaries, and Sendable safety.

Proposed review tier: **MEDIUM** (test-only, but real socket/async logic + a new shared helper; bounded blast radius).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9tE6iZwyGJcX5Kx9LUnhm