### PR TITLE
#41 Phase 1: visual-diff engine + `diff` CLI + preview_diff MCP tool

### DIFF
--- a/previewsmcp/PreviewsCLI/BUILD.bazel
+++ b/previewsmcp/PreviewsCLI/BUILD.bazel
@@ -13,6 +13,7 @@ swift_library(
         "//previewsmcp/PreviewsCore",
         "//previewsmcp/PreviewsEngine",
         "//previewsmcp/PreviewsIOS",
+        "//previewsmcp/PreviewsImageDiff",
         "//previewsmcp/PreviewsJITLink",
         "//previewsmcp/PreviewsMacOS",
         "@swiftpkg_swift_argument_parser//:ArgumentParser",

--- a/previewsmcp/PreviewsCLI/DiffCommand.swift
+++ b/previewsmcp/PreviewsCLI/DiffCommand.swift
@@ -3,6 +3,28 @@ import Foundation
 import PreviewsCore
 import PreviewsImageDiff
 
+/// The machine-readable diff result, shared by the `diff` CLI (`--json`)
+/// and the `preview_diff` MCP tool (`structuredContent`). `diffImage` is
+/// the written PNG path for the CLI; nil for the MCP tool, which returns
+/// the diff image as an inline content block instead.
+struct DiffReport: Codable {
+    let similarity: Double
+    let changedPixelCount: Int
+    let totalPixelCount: Int
+    let changedRegions: [DiffRegion]
+    let sizeMismatch: SizeMismatch?
+    let diffImage: String?
+
+    init(_ result: ImageDiffResult, diffImage: String? = nil) {
+        similarity = result.similarity
+        changedPixelCount = result.changedPixelCount
+        totalPixelCount = result.totalPixelCount
+        changedRegions = result.changedRegions
+        sizeMismatch = result.sizeMismatch
+        self.diffImage = diffImage
+    }
+}
+
 /// Compare two preview snapshots and report how much they changed.
 ///
 /// A pure, local command — it reads two image files, pixel-compares them,
@@ -60,26 +82,10 @@ struct DiffCommand: ParsableCommand {
         }
 
         if json {
-            try emitJSON(DiffJSON(
-                similarity: result.similarity,
-                changedPixelCount: result.changedPixelCount,
-                totalPixelCount: result.totalPixelCount,
-                changedRegions: result.changedRegions,
-                sizeMismatch: result.sizeMismatch,
-                diffImage: diffImagePath
-            ))
+            try emitJSON(DiffReport(result, diffImage: diffImagePath))
         } else {
             emitText(result, diffImagePath: diffImagePath)
         }
-    }
-
-    private struct DiffJSON: Encodable {
-        let similarity: Double
-        let changedPixelCount: Int
-        let totalPixelCount: Int
-        let changedRegions: [DiffRegion]
-        let sizeMismatch: SizeMismatch?
-        let diffImage: String?
     }
 
     private func emitText(_ result: ImageDiffResult, diffImagePath: String?) {

--- a/previewsmcp/PreviewsCLI/DiffCommand.swift
+++ b/previewsmcp/PreviewsCLI/DiffCommand.swift
@@ -1,0 +1,102 @@
+import ArgumentParser
+import Foundation
+import PreviewsCore
+import PreviewsImageDiff
+
+/// Compare two preview snapshots and report how much they changed.
+///
+/// A pure, local command — it reads two image files, pixel-compares them,
+/// and optionally writes a diff image. There is no daemon roundtrip, so it
+/// works on any PNG/JPEG, not only images this tool produced.
+struct DiffCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "diff",
+        abstract: "Compare two preview snapshots; report a similarity score and write a diff image",
+        discussion: """
+        Pixel-compares two images and prints a similarity score (0.0–1.0),
+        the number of changed pixels, and the bounding box of the change.
+        Pass --output to also write a diff image: changed pixels in red over
+        a dimmed copy of the second image.
+
+        Tolerance is per-channel (0–255) and defaults to 8, because two
+        renders of the same view are not bit-identical (anti-aliasing, font
+        hinting). Raise it to absorb more noise, or set 0 for an exact
+        comparison.
+        """
+    )
+
+    @Argument(help: "Baseline image path (PNG or JPEG)", transform: Path.normalize)
+    var baseline: String
+
+    @Argument(help: "Current image path (PNG or JPEG)", transform: Path.normalize)
+    var current: String
+
+    @Option(name: [.short, .long], help: "Write the diff image (PNG) to this path")
+    var output: String?
+
+    @Option(name: .long, help: "Per-channel tolerance 0–255 (default: 8)")
+    var tolerance: Int = ImageDiff.defaultTolerance
+
+    @Flag(help: "Emit machine-readable JSON")
+    var json = false
+
+    func run() throws {
+        guard (0 ... 255).contains(tolerance) else {
+            throw ValidationError("Tolerance must be between 0 and 255.")
+        }
+
+        let result = try ImageDiff.compare(
+            baselineAt: URL(fileURLWithPath: baseline),
+            currentAt: URL(fileURLWithPath: current),
+            tolerance: tolerance,
+            renderDiff: output != nil
+        )
+
+        var diffImagePath: String?
+        if let output, let diffImage = result.diffImage {
+            let url = URL(fileURLWithPath: output)
+            try diffImage.pngData().write(to: url)
+            diffImagePath = url.path
+        }
+
+        if json {
+            try emitJSON(DiffJSON(
+                similarity: result.similarity,
+                changedPixelCount: result.changedPixelCount,
+                totalPixelCount: result.totalPixelCount,
+                changedRegions: result.changedRegions,
+                sizeMismatch: result.sizeMismatch,
+                diffImage: diffImagePath
+            ))
+        } else {
+            emitText(result, diffImagePath: diffImagePath)
+        }
+    }
+
+    private struct DiffJSON: Encodable {
+        let similarity: Double
+        let changedPixelCount: Int
+        let totalPixelCount: Int
+        let changedRegions: [DiffRegion]
+        let sizeMismatch: SizeMismatch?
+        let diffImage: String?
+    }
+
+    private func emitText(_ result: ImageDiffResult, diffImagePath: String?) {
+        if let mismatch = result.sizeMismatch {
+            print(
+                "size mismatch: baseline \(mismatch.baseline), current \(mismatch.current) "
+                    + "— cannot pixel-compare"
+            )
+            return
+        }
+        let percent = String(format: "%.2f", result.similarity * 100)
+        print("similarity: \(percent)% (\(result.changedPixelCount)/\(result.totalPixelCount) pixels changed)")
+        if let region = result.changedRegions.first {
+            print("changed region: x=\(region.x) y=\(region.y) \(region.width)x\(region.height)")
+        }
+        if let diffImagePath {
+            print("diff image: \(diffImagePath)")
+        }
+    }
+}

--- a/previewsmcp/PreviewsCLI/Handlers/PreviewDiffHandler.swift
+++ b/previewsmcp/PreviewsCLI/Handlers/PreviewDiffHandler.swift
@@ -1,0 +1,92 @@
+import Foundation
+import MCP
+import PreviewsImageDiff
+
+/// `preview_diff` — pixel-compare two snapshot images and return a
+/// similarity score plus a diff image. This is the agent feedback loop:
+/// snapshot before, edit, snapshot after, ask "did it land?".
+///
+/// Pure and path-based: it reads two image files directly rather than
+/// resolving a session, so there is no daemon roundtrip.
+enum PreviewDiffHandler: ToolHandler {
+    static let name: ToolName = .previewDiff
+
+    static let schema = Tool(
+        name: ToolName.previewDiff.rawValue,
+        description:
+        "Compare two snapshot images. Returns a similarity score (0.0–1.0), the changed-pixel count and region, and a diff image highlighting changed pixels in red.",
+        inputSchema: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "snapshotA": .object([
+                    "type": .string("string"),
+                    "description": .string("Absolute path to the baseline image (PNG or JPEG)"),
+                ]),
+                "snapshotB": .object([
+                    "type": .string("string"),
+                    "description": .string("Absolute path to the current image (PNG or JPEG)"),
+                ]),
+                "tolerance": .object([
+                    "type": .string("integer"),
+                    "description": .string(
+                        "Per-channel tolerance 0–255 (default: 8). A pixel differs when any channel exceeds this; nonzero absorbs anti-aliasing and font-hinting noise."
+                    ),
+                ]),
+            ]),
+            "required": .array([.string("snapshotA"), .string("snapshotB")]),
+        ])
+    )
+
+    static func handle(
+        _ params: CallTool.Parameters,
+        ctx _: HandlerContext
+    ) async throws -> CallTool.Result {
+        let pathA: String
+        let pathB: String
+        do {
+            pathA = try extractString("snapshotA", from: params)
+            pathB = try extractString("snapshotB", from: params)
+        } catch {
+            return CallTool.Result(content: [.text(error.localizedDescription)], isError: true)
+        }
+        let tolerance = extractOptionalInt("tolerance", from: params) ?? ImageDiff.defaultTolerance
+
+        let result: ImageDiffResult
+        do {
+            result = try ImageDiff.compare(
+                baselineAt: URL(fileURLWithPath: pathA),
+                currentAt: URL(fileURLWithPath: pathB),
+                tolerance: tolerance
+            )
+        } catch {
+            return CallTool.Result(
+                content: [.text("Diff failed: \(error.localizedDescription)")],
+                isError: true
+            )
+        }
+
+        if let mismatch = result.sizeMismatch {
+            return CallTool.Result(content: [.text(
+                "Size mismatch: baseline is \(mismatch.baseline), current is \(mismatch.current). "
+                    + "Images must share dimensions to pixel-compare."
+            )])
+        }
+
+        var content: [Tool.Content] = [
+            .text(summary(for: result)),
+        ]
+        if let diffImage = result.diffImage, let data = try? diffImage.pngData() {
+            content.append(.image(data: data.base64EncodedString(), mimeType: "image/png", metadata: nil))
+        }
+        return CallTool.Result(content: content)
+    }
+
+    private static func summary(for result: ImageDiffResult) -> String {
+        let percent = String(format: "%.2f", result.similarity * 100)
+        var line = "similarity \(percent)% (\(result.changedPixelCount)/\(result.totalPixelCount) pixels changed)"
+        if let region = result.changedRegions.first {
+            line += "; changed region x=\(region.x) y=\(region.y) \(region.width)x\(region.height)"
+        }
+        return line
+    }
+}

--- a/previewsmcp/PreviewsCLI/Handlers/PreviewDiffHandler.swift
+++ b/previewsmcp/PreviewsCLI/Handlers/PreviewDiffHandler.swift
@@ -18,11 +18,11 @@ enum PreviewDiffHandler: ToolHandler {
         inputSchema: .object([
             "type": .string("object"),
             "properties": .object([
-                "snapshotA": .object([
+                "baseline": .object([
                     "type": .string("string"),
                     "description": .string("Absolute path to the baseline image (PNG or JPEG)"),
                 ]),
-                "snapshotB": .object([
+                "current": .object([
                     "type": .string("string"),
                     "description": .string("Absolute path to the current image (PNG or JPEG)"),
                 ]),
@@ -33,7 +33,7 @@ enum PreviewDiffHandler: ToolHandler {
                     ),
                 ]),
             ]),
-            "required": .array([.string("snapshotA"), .string("snapshotB")]),
+            "required": .array([.string("baseline"), .string("current")]),
         ])
     )
 
@@ -41,11 +41,11 @@ enum PreviewDiffHandler: ToolHandler {
         _ params: CallTool.Parameters,
         ctx _: HandlerContext
     ) async throws -> CallTool.Result {
-        let pathA: String
-        let pathB: String
+        let baselinePath: String
+        let currentPath: String
         do {
-            pathA = try extractString("snapshotA", from: params)
-            pathB = try extractString("snapshotB", from: params)
+            baselinePath = try extractString("baseline", from: params)
+            currentPath = try extractString("current", from: params)
         } catch {
             return CallTool.Result(content: [.text(error.localizedDescription)], isError: true)
         }
@@ -54,8 +54,8 @@ enum PreviewDiffHandler: ToolHandler {
         let result: ImageDiffResult
         do {
             result = try ImageDiff.compare(
-                baselineAt: URL(fileURLWithPath: pathA),
-                currentAt: URL(fileURLWithPath: pathB),
+                baselineAt: URL(fileURLWithPath: baselinePath),
+                currentAt: URL(fileURLWithPath: currentPath),
                 tolerance: tolerance
             )
         } catch {
@@ -66,10 +66,13 @@ enum PreviewDiffHandler: ToolHandler {
         }
 
         if let mismatch = result.sizeMismatch {
-            return CallTool.Result(content: [.text(
-                "Size mismatch: baseline is \(mismatch.baseline), current is \(mismatch.current). "
-                    + "Images must share dimensions to pixel-compare."
-            )])
+            return try CallTool.Result(
+                content: [.text(
+                    "Size mismatch: baseline is \(mismatch.baseline), current is \(mismatch.current). "
+                        + "Images must share dimensions to pixel-compare."
+                )],
+                structuredContent: DiffReport(result)
+            )
         }
 
         var content: [Tool.Content] = [
@@ -78,7 +81,7 @@ enum PreviewDiffHandler: ToolHandler {
         if let diffImage = result.diffImage, let data = try? diffImage.pngData() {
             content.append(.image(data: data.base64EncodedString(), mimeType: "image/png", metadata: nil))
         }
-        return CallTool.Result(content: content)
+        return try CallTool.Result(content: content, structuredContent: DiffReport(result))
     }
 
     private static func summary(for result: ImageDiffResult) -> String {

--- a/previewsmcp/PreviewsCLI/Handlers/ToolName.swift
+++ b/previewsmcp/PreviewsCLI/Handlers/ToolName.swift
@@ -11,6 +11,7 @@ enum ToolName: String {
     case previewElements = "preview_elements"
     case previewTouch = "preview_touch"
     case previewVariants = "preview_variants"
+    case previewDiff = "preview_diff"
     case simulatorList = "simulator_list"
     case sessionList = "session_list"
     case previewBuildInfo = "preview_build_info"

--- a/previewsmcp/PreviewsCLI/MCPServer.swift
+++ b/previewsmcp/PreviewsCLI/MCPServer.swift
@@ -22,6 +22,7 @@ let handlerRegistry: [any ToolHandler.Type] = [
     PreviewElementsHandler.self,
     PreviewTouchHandler.self,
     PreviewVariantsHandler.self,
+    PreviewDiffHandler.self,
     SimulatorListHandler.self,
     SessionListHandler.self,
     PreviewBuildInfoHandler.self,

--- a/previewsmcp/PreviewsCLI/PreviewsMCPApp.swift
+++ b/previewsmcp/PreviewsCLI/PreviewsMCPApp.swift
@@ -166,6 +166,7 @@ struct PreviewsMCPCommand: ParsableCommand {
             ConfigureCommand.self, SwitchCommand.self, ElementsCommand.self,
             TouchCommand.self, SimulatorsCommand.self, StopCommand.self,
             ServeCommand.self, StatusCommand.self, LogsCommand.self, KillDaemonCommand.self,
+            DiffCommand.self,
         ],
         defaultSubcommand: RunCommand.self
     )

--- a/previewsmcp/PreviewsImageDiff/BUILD.bazel
+++ b/previewsmcp/PreviewsImageDiff/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_swift//swift:swift.bzl", "swift_library")
+
+swift_library(
+    name = "PreviewsImageDiff",
+    srcs = glob(["*.swift"]),
+    copts = [
+        "-swift-version",
+        "6",
+    ],
+    module_name = "PreviewsImageDiff",
+    visibility = ["//visibility:public"],
+)

--- a/previewsmcp/PreviewsImageDiff/ImageDiff.swift
+++ b/previewsmcp/PreviewsImageDiff/ImageDiff.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+/// Pixel dimensions of an image, reported when a diff can't proceed.
+public struct PixelSize: Equatable, Sendable, Codable, CustomStringConvertible {
+    public let width: Int
+    public let height: Int
+
+    public init(width: Int, height: Int) {
+        self.width = width
+        self.height = height
+    }
+
+    public var description: String {
+        "\(width)x\(height)"
+    }
+}
+
+/// An axis-aligned bounding box of changed pixels. Always returned as an
+/// array so later phases can subdivide into connected components without
+/// reshaping the result type.
+public struct DiffRegion: Equatable, Sendable, Codable {
+    public let x: Int
+    public let y: Int
+    public let width: Int
+    public let height: Int
+
+    public init(x: Int, y: Int, width: Int, height: Int) {
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+    }
+}
+
+/// Returned instead of a pixel comparison when the two images differ in
+/// size — a structural change that can't be pixel-aligned.
+public struct SizeMismatch: Equatable, Sendable, Codable {
+    public let baseline: PixelSize
+    public let current: PixelSize
+
+    public init(baseline: PixelSize, current: PixelSize) {
+        self.baseline = baseline
+        self.current = current
+    }
+}
+
+public struct ImageDiffResult: Sendable {
+    /// Fraction of pixels within tolerance, `0.0...1.0`. `0` on a size
+    /// mismatch.
+    public let similarity: Double
+    public let changedPixelCount: Int
+    public let totalPixelCount: Int
+    public let changedRegions: [DiffRegion]
+    /// Non-nil only when the images differ in size; the other fields are
+    /// then not meaningful and `diffImage` is nil.
+    public let sizeMismatch: SizeMismatch?
+    /// Changed pixels in red over a dimmed grayscale of the current image;
+    /// nil on a size mismatch.
+    public let diffImage: RGBAImage?
+}
+
+public enum ImageDiff {
+    /// Default per-channel tolerance. Nonzero on purpose: two renders of
+    /// the same view are not bit-identical — subpixel anti-aliasing and
+    /// font hinting perturb edge pixels even with lossless PNG. A lossy
+    /// JPEG baseline only raises this floor further.
+    public static let defaultTolerance = 8
+
+    /// Compare two already-decoded images.
+    ///
+    /// A pixel counts as changed when any channel (including alpha) differs
+    /// by more than `tolerance` (clamped to `0...255`). `similarity` is the
+    /// fraction of unchanged pixels. Pass `renderDiff: false` to skip
+    /// building the diff image when only the score is needed — that avoids
+    /// the per-pixel dimming work and the full-image allocation.
+    public static func compare(
+        _ baseline: RGBAImage,
+        _ current: RGBAImage,
+        tolerance: Int = defaultTolerance,
+        renderDiff: Bool = true
+    ) -> ImageDiffResult {
+        let tolerance = max(0, min(255, tolerance))
+        guard baseline.width == current.width, baseline.height == current.height else {
+            return ImageDiffResult(
+                similarity: 0,
+                changedPixelCount: 0,
+                totalPixelCount: 0,
+                changedRegions: [],
+                sizeMismatch: SizeMismatch(
+                    baseline: PixelSize(width: baseline.width, height: baseline.height),
+                    current: PixelSize(width: current.width, height: current.height)
+                ),
+                diffImage: nil
+            )
+        }
+
+        let width = baseline.width
+        let height = baseline.height
+        let total = width * height
+        let a = baseline.pixels
+        let b = current.pixels
+
+        var changed = 0
+        var minX = width, minY = height, maxX = -1, maxY = -1
+        var diff = renderDiff ? [UInt8](repeating: 0, count: total * 4) : []
+
+        for y in 0 ..< height {
+            for x in 0 ..< width {
+                let i = (y * width + x) * 4
+                let dr = abs(Int(a[i]) - Int(b[i]))
+                let dg = abs(Int(a[i + 1]) - Int(b[i + 1]))
+                let db = abs(Int(a[i + 2]) - Int(b[i + 2]))
+                let da = abs(Int(a[i + 3]) - Int(b[i + 3]))
+
+                if max(max(dr, dg), max(db, da)) > tolerance {
+                    changed += 1
+                    if x < minX { minX = x }
+                    if x > maxX { maxX = x }
+                    if y < minY { minY = y }
+                    if y > maxY { maxY = y }
+                    if renderDiff {
+                        diff[i] = 255
+                        diff[i + 1] = 0
+                        diff[i + 2] = 0
+                        diff[i + 3] = 255
+                    }
+                } else if renderDiff {
+                    let luma = (Int(b[i]) * 299 + Int(b[i + 1]) * 587 + Int(b[i + 2]) * 114) / 1000
+                    let dimmed = UInt8(luma / 2)
+                    diff[i] = dimmed
+                    diff[i + 1] = dimmed
+                    diff[i + 2] = dimmed
+                    diff[i + 3] = 255
+                }
+            }
+        }
+
+        let regions: [DiffRegion] = maxX >= 0
+            ? [DiffRegion(x: minX, y: minY, width: maxX - minX + 1, height: maxY - minY + 1)]
+            : []
+        let similarity = total == 0 ? 1.0 : Double(total - changed) / Double(total)
+
+        return ImageDiffResult(
+            similarity: similarity,
+            changedPixelCount: changed,
+            totalPixelCount: total,
+            changedRegions: regions,
+            sizeMismatch: nil,
+            diffImage: renderDiff ? RGBAImage(width: width, height: height, pixels: diff) : nil
+        )
+    }
+
+    /// Load both images from disk and compare them.
+    public static func compare(
+        baselineAt baselineURL: URL,
+        currentAt currentURL: URL,
+        tolerance: Int = defaultTolerance,
+        renderDiff: Bool = true
+    ) throws -> ImageDiffResult {
+        let baseline = try RGBAImage(contentsOf: baselineURL)
+        let current = try RGBAImage(contentsOf: currentURL)
+        return compare(baseline, current, tolerance: tolerance, renderDiff: renderDiff)
+    }
+}

--- a/previewsmcp/PreviewsImageDiff/RGBAImage.swift
+++ b/previewsmcp/PreviewsImageDiff/RGBAImage.swift
@@ -1,0 +1,108 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+/// A decoded image as row-major RGBA8 pixels: four bytes per pixel in
+/// `R, G, B, A` order, `width * height * 4` bytes total.
+///
+/// A pure value type on purpose. Keeping the diff surface off `NSImage`
+/// and off the main actor lets the comparison run headless and lets tests
+/// build images pixel-by-pixel with no graphics session.
+public struct RGBAImage: Equatable, Sendable {
+    public let width: Int
+    public let height: Int
+    public let pixels: [UInt8]
+
+    public init(width: Int, height: Int, pixels: [UInt8]) {
+        precondition(
+            pixels.count == width * height * 4,
+            "pixel buffer must be width * height * 4 bytes"
+        )
+        self.width = width
+        self.height = height
+        self.pixels = pixels
+    }
+}
+
+public enum ImageLoadError: Error, LocalizedError {
+    case unreadable(URL)
+    case decodeFailed(URL)
+    case contextFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case let .unreadable(url): "Cannot read image at \(url.path)"
+        case let .decodeFailed(url): "Cannot decode image at \(url.path)"
+        case .contextFailed: "Failed to create a bitmap context"
+        }
+    }
+}
+
+public extension RGBAImage {
+    /// Decode a PNG or JPEG file into a normalized RGBA8 buffer.
+    ///
+    /// The source is redrawn into a device-RGB, premultiplied-last context
+    /// so pixels are comparable regardless of the file's own color space,
+    /// alpha layout, or row padding.
+    init(contentsOf url: URL) throws {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+            throw ImageLoadError.unreadable(url)
+        }
+        guard let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            throw ImageLoadError.decodeFailed(url)
+        }
+        try self.init(cgImage: cgImage)
+    }
+
+    internal init(cgImage: CGImage) throws {
+        let width = cgImage.width
+        let height = cgImage.height
+        let byteCount = width * height * 4
+        guard let context = RGBAImage.makeContext(width: width, height: height) else {
+            throw ImageLoadError.contextFailed
+        }
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+        guard let base = context.data else { throw ImageLoadError.contextFailed }
+        let buffer = base.bindMemory(to: UInt8.self, capacity: byteCount)
+        self.init(
+            width: width,
+            height: height,
+            pixels: Array(UnsafeBufferPointer(start: buffer, count: byteCount))
+        )
+    }
+
+    /// Encode the buffer as PNG (lossless — the format for baselines and
+    /// diff artifacts). For opaque pixels (alpha 255, the case for preview
+    /// snapshots) a re-decode round-trips exactly. Translucent pixels are
+    /// stored premultiplied by the bitmap context, so alpha < 255 loses a
+    /// little precision across a premultiply/unpremultiply round-trip.
+    func pngData() throws -> Data {
+        guard let context = RGBAImage.makeContext(width: width, height: height),
+              let base = context.data
+        else { throw ImageLoadError.contextFailed }
+        pixels.withUnsafeBytes { src in
+            base.copyMemory(from: src.baseAddress!, byteCount: src.count)
+        }
+        guard let cgImage = context.makeImage() else { throw ImageLoadError.contextFailed }
+        let out = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            out, UTType.png.identifier as CFString, 1, nil
+        ) else { throw ImageLoadError.contextFailed }
+        CGImageDestinationAddImage(destination, cgImage, nil)
+        guard CGImageDestinationFinalize(destination) else { throw ImageLoadError.contextFailed }
+        return out as Data
+    }
+
+    private static func makeContext(width: Int, height: Int) -> CGContext? {
+        CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )
+    }
+}

--- a/previewsmcp/Tests/PreviewsCLITests/list_tools_snapshot.json
+++ b/previewsmcp/Tests/PreviewsCLITests/list_tools_snapshot.json
@@ -333,11 +333,11 @@
     "description" : "Compare two snapshot images. Returns a similarity score (0.0–1.0), the changed-pixel count and region, and a diff image highlighting changed pixels in red.",
     "inputSchema" : {
       "properties" : {
-        "snapshotA" : {
+        "baseline" : {
           "description" : "Absolute path to the baseline image (PNG or JPEG)",
           "type" : "string"
         },
-        "snapshotB" : {
+        "current" : {
           "description" : "Absolute path to the current image (PNG or JPEG)",
           "type" : "string"
         },
@@ -347,8 +347,8 @@
         }
       },
       "required" : [
-        "snapshotA",
-        "snapshotB"
+        "baseline",
+        "current"
       ],
       "type" : "object"
     },

--- a/previewsmcp/Tests/PreviewsCLITests/list_tools_snapshot.json
+++ b/previewsmcp/Tests/PreviewsCLITests/list_tools_snapshot.json
@@ -330,6 +330,31 @@
     "name" : "preview_variants"
   },
   {
+    "description" : "Compare two snapshot images. Returns a similarity score (0.0–1.0), the changed-pixel count and region, and a diff image highlighting changed pixels in red.",
+    "inputSchema" : {
+      "properties" : {
+        "snapshotA" : {
+          "description" : "Absolute path to the baseline image (PNG or JPEG)",
+          "type" : "string"
+        },
+        "snapshotB" : {
+          "description" : "Absolute path to the current image (PNG or JPEG)",
+          "type" : "string"
+        },
+        "tolerance" : {
+          "description" : "Per-channel tolerance 0–255 (default: 8). A pixel differs when any channel exceeds this; nonzero absorbs anti-aliasing and font-hinting noise.",
+          "type" : "integer"
+        }
+      },
+      "required" : [
+        "snapshotA",
+        "snapshotB"
+      ],
+      "type" : "object"
+    },
+    "name" : "preview_diff"
+  },
+  {
     "description" : "List available iOS simulator devices with their UDIDs and states.",
     "inputSchema" : {
       "properties" : {

--- a/previewsmcp/Tests/PreviewsImageDiffTests/BUILD.bazel
+++ b/previewsmcp/Tests/PreviewsImageDiffTests/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_swift//swift:swift.bzl", "swift_test")
+
+swift_test(
+    name = "PreviewsImageDiffTests",
+    size = "small",
+    srcs = glob(["**/*.swift"]),
+    copts = [
+        "-swift-version",
+        "6",
+    ],
+    tags = ["local"],
+    visibility = ["//visibility:public"],
+    deps = ["//previewsmcp/PreviewsImageDiff"],
+)

--- a/previewsmcp/Tests/PreviewsImageDiffTests/ImageDiffTests.swift
+++ b/previewsmcp/Tests/PreviewsImageDiffTests/ImageDiffTests.swift
@@ -124,6 +124,18 @@ struct ImageDiffTests {
         #expect(result.diffImage == nil)
     }
 
+    @Test("decoding a non-image file throws an ImageLoadError")
+    func nonImageFileThrows() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-bad-\(UUID().uuidString).png")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data("not an image".utf8).write(to: url)
+
+        #expect(throws: ImageLoadError.self) {
+            _ = try RGBAImage(contentsOf: url)
+        }
+    }
+
     @Test("PNG round-trip preserves pixels — decode and pixel-compare, never byte-compare")
     func pngRoundTripIsLossless() throws {
         let original = solid(5, 5, r: 12, g: 200, b: 77)

--- a/previewsmcp/Tests/PreviewsImageDiffTests/ImageDiffTests.swift
+++ b/previewsmcp/Tests/PreviewsImageDiffTests/ImageDiffTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+@testable import PreviewsImageDiff
+import Testing
+
+@Suite("ImageDiff")
+struct ImageDiffTests {
+    /// A solid-color image, built pixel-by-pixel so the comparison math is
+    /// exercised with no image decoding in the way.
+    private func solid(
+        _ width: Int,
+        _ height: Int,
+        r: UInt8,
+        g: UInt8,
+        b: UInt8,
+        a: UInt8 = 255
+    ) -> RGBAImage {
+        var pixels = [UInt8]()
+        pixels.reserveCapacity(width * height * 4)
+        for _ in 0 ..< (width * height) {
+            pixels.append(contentsOf: [r, g, b, a])
+        }
+        return RGBAImage(width: width, height: height, pixels: pixels)
+    }
+
+    @Test("identical images score 1.0 with no changed regions")
+    func identical() {
+        let image = solid(4, 4, r: 10, g: 20, b: 30)
+        let result = ImageDiff.compare(image, image, tolerance: 0)
+        #expect(result.similarity == 1.0)
+        #expect(result.changedPixelCount == 0)
+        #expect(result.changedRegions.isEmpty)
+        #expect(result.sizeMismatch == nil)
+    }
+
+    @Test("a single changed pixel yields a 1x1 region and a known score")
+    func singleChangedPixel() {
+        let baseline = solid(2, 2, r: 0, g: 0, b: 0)
+        var pixels = baseline.pixels
+        // Pixel (x: 1, y: 0) → byte index (0 * 2 + 1) * 4 = 4.
+        pixels[4] = 255
+        pixels[5] = 255
+        pixels[6] = 255
+        let current = RGBAImage(width: 2, height: 2, pixels: pixels)
+
+        let result = ImageDiff.compare(baseline, current, tolerance: 0)
+        #expect(result.totalPixelCount == 4)
+        #expect(result.changedPixelCount == 1)
+        #expect(result.similarity == 0.75)
+        #expect(result.changedRegions == [DiffRegion(x: 1, y: 0, width: 1, height: 1)])
+    }
+
+    @Test("fully differing images score 0 and the region spans the image")
+    func fullyDifferent() {
+        let black = solid(3, 3, r: 0, g: 0, b: 0)
+        let white = solid(3, 3, r: 255, g: 255, b: 255)
+        let result = ImageDiff.compare(black, white, tolerance: 0)
+        #expect(result.similarity == 0.0)
+        #expect(result.changedPixelCount == 9)
+        #expect(result.changedRegions == [DiffRegion(x: 0, y: 0, width: 3, height: 3)])
+    }
+
+    @Test("sub-tolerance noise is ignored")
+    func toleranceAbsorbsNoise() {
+        let baseline = solid(2, 2, r: 100, g: 100, b: 100)
+        var pixels = baseline.pixels
+        pixels[0] = 105 // one channel off by 5, under the tolerance of 8
+        let noisy = RGBAImage(width: 2, height: 2, pixels: pixels)
+
+        let result = ImageDiff.compare(baseline, noisy, tolerance: 8)
+        #expect(result.similarity == 1.0)
+        #expect(result.changedPixelCount == 0)
+        #expect(result.changedRegions.isEmpty)
+    }
+
+    @Test("a delta above tolerance still counts as changed")
+    func aboveToleranceCounts() {
+        let baseline = solid(1, 1, r: 100, g: 100, b: 100)
+        var pixels = baseline.pixels
+        pixels[0] = 109 // off by 9, over the tolerance of 8
+        let current = RGBAImage(width: 1, height: 1, pixels: pixels)
+
+        let result = ImageDiff.compare(baseline, current, tolerance: 8)
+        #expect(result.changedPixelCount == 1)
+        #expect(result.similarity == 0.0)
+    }
+
+    @Test("renderDiff: false scores without producing a diff image")
+    func scoreOnlySkipsDiffImage() {
+        let baseline = solid(2, 2, r: 0, g: 0, b: 0)
+        var pixels = baseline.pixels
+        pixels[4] = 255
+        let current = RGBAImage(width: 2, height: 2, pixels: pixels)
+
+        let result = ImageDiff.compare(baseline, current, tolerance: 0, renderDiff: false)
+        #expect(result.changedPixelCount == 1)
+        #expect(result.similarity == 0.75)
+        #expect(result.changedRegions == [DiffRegion(x: 1, y: 0, width: 1, height: 1)])
+        #expect(result.diffImage == nil)
+    }
+
+    @Test("out-of-range tolerance is clamped to 0...255")
+    func toleranceIsClamped() {
+        let black = solid(2, 2, r: 0, g: 0, b: 0)
+        let white = solid(2, 2, r: 255, g: 255, b: 255)
+        // Above 255 → clamped to 255, so a full-range change still counts as unchanged.
+        #expect(ImageDiff.compare(black, white, tolerance: 999).similarity == 1.0)
+        // Below 0 → clamped to 0, so any nonzero delta counts as changed.
+        var pixels = black.pixels
+        pixels[0] = 1
+        let nudged = RGBAImage(width: 2, height: 2, pixels: pixels)
+        #expect(ImageDiff.compare(black, nudged, tolerance: -5).changedPixelCount == 1)
+    }
+
+    @Test("dimension mismatch reports a size mismatch instead of comparing")
+    func dimensionMismatch() {
+        let small = solid(2, 2, r: 0, g: 0, b: 0)
+        let big = solid(3, 3, r: 0, g: 0, b: 0)
+        let result = ImageDiff.compare(small, big, tolerance: 0)
+        #expect(result.sizeMismatch == SizeMismatch(
+            baseline: PixelSize(width: 2, height: 2),
+            current: PixelSize(width: 3, height: 3)
+        ))
+        #expect(result.similarity == 0.0)
+        #expect(result.diffImage == nil)
+    }
+
+    @Test("PNG round-trip preserves pixels — decode and pixel-compare, never byte-compare")
+    func pngRoundTripIsLossless() throws {
+        let original = solid(5, 5, r: 12, g: 200, b: 77)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("previewsmcp-diff-\(UUID().uuidString).png")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try original.pngData().write(to: url)
+        let reloaded = try RGBAImage(contentsOf: url)
+
+        let result = ImageDiff.compare(original, reloaded, tolerance: 0)
+        #expect(result.sizeMismatch == nil)
+        #expect(result.similarity == 1.0)
+    }
+}


### PR DESCRIPTION
Phase 1 of #41 — the agent feedback loop: snapshot before, edit, snapshot after, ask "did it land?".

## What this adds
- **`PreviewsImageDiff`** — a new pure, headless module. Loads two images to normalized RGBA8 via CoreGraphics, pixel-compares with a per-channel tolerance, and returns a similarity score, a red-overlay diff PNG (changed pixels over a dimmed copy of the current image), the changed-region bounding box, and an explicit size-mismatch result. No `PreviewsMacOS`/main-actor coupling, so it runs off the main actor and unit tests build images pixel-by-pixel with no graphics session.
- **`previewsmcp diff A B`** — local CLI (no daemon). `--tolerance`, `-o/--output` (writes the diff PNG), `--json`. Works on any PNG/JPEG.
- **`preview_diff(snapshotA, snapshotB[, tolerance])`** MCP tool — the pairwise agent surface, returning a text summary + the diff image.

No `#267` dependency — this is engine + pairwise diff only. **Phase 2** (batch manifest-diff consuming #267's now-merged manifest + `version` field, `--threshold` CI gate, HTML triptych gallery) is a follow-up.

## Design notes
- **Tolerance is mandatory**, defaulting to 8: two renders of the same view aren't bit-identical (subpixel AA, font hinting); lossy JPEG only raises the floor. Clamped to `0...255` in the engine (single source of truth).
- **`changedRegions` is an array from day one** so Phase 2's connected-component regions don't reshape the output.
- Diff-image generation is skipped when only the score is needed (`renderDiff: false`; the CLI passes `output != nil`).
- Premultiplied-alpha limitation for translucent pixels is documented (opaque preview snapshots are exact); CoreGraphics offers no straight-alpha 8bpc RGB context.

## Verification
- 10 engine unit tests: identical→1.0, single-pixel→known score+region, fully-different→0, tolerance/above-tolerance boundary, clamp, score-only-skips-image, size-mismatch, and a PNG round-trip verified by **decode + pixel-compare** (never byte-compare — `NSBitmapImageRep`/PNG output isn't byte-stable).
- Drove the `diff` CLI end-to-end on real PNGs (identical→100%, one-pixel→98.44% with exact region, size-mismatch→clean message).
- `bazel build //...` green, lint clean, `ListTools` schema golden regenerated byte-exact (`ListToolsSnapshotTests` stays bazel-excluded per its `#filePath` note).

## Gates
Self-run at MEDIUM: adversarial correctness review (no critical/high bugs) + the four `/simplify` angles (fixes applied: shared `emitJSON` helper, skip diff-image alloc when scoring, `PixelSize` formatting dedup, engine-side clamp, honest premultiplied-alpha docs, schema `tolerance` type → integer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)