### PR TITLE
#262: isolate the agent event-pump probe into its own exclusive target

### DIFF
--- a/previewsmcp/Tests/PreviewsJITLinkTests/BUILD.bazel
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/BUILD.bazel
@@ -10,8 +10,45 @@ swift_test(
             "Fixtures/**",
             # The iOS end-to-end suite is its own (slow, simulator-driven) target.
             "IOSPreviewE2ETests.swift",
+            # The event-pump probe runs in its own target so its async run-loop
+            # poll isn't starved by these suites' concurrent agent spawns (#262).
+            "EventPumpTests.swift",
         ],
     ),
+    copts = [
+        "-swift-version",
+        "6",
+    ],
+    data = [
+        "//:orc_rt_archive",
+        "//previewsmcp/PreviewAgent",
+    ],
+    env = {
+        "PREVIEWSMCP_AGENT": "$(rlocationpath //previewsmcp/PreviewAgent)",
+        "PREVIEWSMCP_ORC_RT": "$(rlocationpath //:orc_rt_archive)",
+    },
+    tags = [
+        "exclusive",
+        "local",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//previewsmcp/PreviewsCore",
+        "//previewsmcp/PreviewsJITLink",
+    ],
+)
+
+# The agent AppKit event-pump probe, isolated into its own binary so its async
+# event-dequeue poll runs without the in-process contention from the JITLink
+# suites' concurrent agent spawns (the #262/#368 load flake). Shares
+# FixtureSupport.swift with the main target (compiled into both).
+swift_test(
+    name = "EventPumpTests",
+    size = "small",
+    srcs = [
+        "EventPumpTests.swift",
+        "FixtureSupport.swift",
+    ],
     copts = [
         "-swift-version",
         "6",

--- a/previewsmcp/Tests/PreviewsJITLinkTests/EventPumpTests.swift
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/EventPumpTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import PreviewsJITLink
+import Testing
+
+/// The agent's AppKit event-pump probe lives in its own swift_test target so it
+/// runs alone. Its async event-dequeue poll needs the agent's run loop to be
+/// scheduled within a budget; when it shared a binary with the other JITLink
+/// suites, their concurrent JIT-agent spawns and fixture compiles starved that
+/// run loop under CI load and the poll timed out (#262/#368 flake). bazel
+/// `exclusive` keeps other test targets off the machine, and being the sole
+/// test in this binary removes the in-process contention that `exclusive`
+/// alone could not (Swift Testing parallelizes across suites within a binary).
+struct EventPumpTests {
+    @Test func agentDispatchesAppKitEvents() throws {
+        let object = try FixtureSupport.compile("event_loop_probe.swift")
+        let session = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
+        try session.addObject(path: object.path)
+        #expect(try session.runOnMain(symbol: "event_pump_install") == 1)
+        // 10s budget: event dequeue lags behind runOnMain's main-queue blocks
+        // on a loaded host (the mini's first CI run failed the old 2s budget
+        // while the agent was still answering polls).
+        var observed: Int32 = 0
+        for _ in 0 ..< 100 where observed != 1 {
+            Thread.sleep(forTimeInterval: 0.1)
+            observed = try session.runOnMain(symbol: "event_pump_check")
+        }
+        #expect(observed == 1)
+    }
+}

--- a/previewsmcp/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/PreviewsJITLinkTests.swift
@@ -123,22 +123,6 @@ struct PreviewsJITLinkTests {
         #expect(result == 7)
     }
 
-    @Test func agentDispatchesAppKitEvents() throws {
-        let object = try FixtureSupport.compile("event_loop_probe.swift")
-        let session = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())
-        try session.addObject(path: object.path)
-        #expect(try session.runOnMain(symbol: "event_pump_install") == 1)
-        // 10s budget: event dequeue lags behind runOnMain's main-queue blocks
-        // on a loaded host (the mini's first CI run failed the old 2s budget
-        // while the agent was still answering polls).
-        var observed: Int32 = 0
-        for _ in 0 ..< 100 where observed != 1 {
-            Thread.sleep(forTimeInterval: 0.1)
-            observed = try session.runOnMain(symbol: "event_pump_check")
-        }
-        #expect(observed == 1)
-    }
-
     @Test func buildsHostingViewOnMainThreadRemotely() throws {
         let object = try FixtureSupport.compile("hosting_probe.swift")
         let session = try JITSession(remoteAgentPath: JITSession.bundledAgentPath())


### PR DESCRIPTION
Fixes the pipeline-wide `agentDispatchesAppKitEvents` flake that's been redding the required gate (main + every PR) under runner load.

## Root cause (pinned from code + log ground truth, not theory)

The test's async event-dequeue poll needs the agent's AppKit run loop scheduled within a 10s budget (already bumped 2s→10s once — not bumping again, that's masking). It reds because the `PreviewsJITLinkTests` binary has ~9 suites and **8 of them spawn `JITSession` agents + compile fixtures, which Swift Testing runs in parallel within the one xctest process** — starving the pump's run-loop scheduling.

Ruled out from the same failing run:
- **Not a WindowServer wedge**: the sibling heavy-AppKit tests (NSHostingView build, SwiftUI→bitmap render) pass sub-second in the same run; only the async poll fails. WindowServer is healthy (verified on the mini: 9% CPU, no leaked agents).
- **Not a bazel-target race**: the target is already `tags=[exclusive]` and still fails → the contention is *in-binary*, which `exclusive` (cross-target only) and `.serialized`/`--no-parallel` (cross-suite parallelism remains; rules_swift 3.5.0 ignores the flag) cannot reach.

## Fix

Move the one test into its own `swift_test` target, `EventPumpTests` (`exclusive`+`local`, `size="small"`), excluded from the main target's glob. Alone in its binary it has zero in-binary contention. Structural isolation, strictly contention-reducing — **not** a budget change. `FixtureSupport.swift` is shared into both targets.

## Verification

- `EventPumpTests` isolated: 5/5 green.
- Trimmed `PreviewsJITLinkTests`: green, and no longer registers the test (0 occurrences in its log).
- Lint clean. The under-load proof is this PR's own CI run on the mini (green locally regardless).

Proposed review tier: **LOW** (BUILD-target move + test relocation + FixtureSupport share; no product logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9tE6iZwyGJcX5Kx9LUnhm