### PR TITLE
#391: remove the CI host-degradation trigger (reset + --headless + device-pin)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,23 @@ jobs:
 
       # Start from a clean host. A cancelled run (cancel-in-progress) can
       # SIGKILL an xcodebuild/simctl mid-boot and leave a booted simulator, a
-      # thrashing CoreSimulatorService, and orphaned previewsmcp daemons behind
-      # — that leftover state degrades the next run and is the confirmed #391
-      # trigger. Reap it before Lint/Test so every run starts from the same
-      # state. `previewsmcp serve` is matched (not a bare `previewsmcp`) so the
-      # runner's own checkout path is never a match; each line is best-effort.
+      # wedged CoreSimulatorService, and orphaned previewsmcp daemons behind —
+      # that leftover state degrades the next run and is the confirmed #391
+      # trigger. Reap it before Lint/Test so every run starts clean.
+      #
+      # `killall Simulator` is first and load-bearing: a Simulator.app left
+      # holding a device keeps it booted, and `simctl shutdown all` alone can
+      # NOT clear a service that has wedged below simctl's reach (observed —
+      # a "success" shutdown that left the device booted). Killing the app,
+      # then shutting the devices, then kicking the service restores it.
+      # `killall`/`pkill 'previewsmcp serve'` match process names, never the
+      # runner's own checkout path; every line is best-effort.
       - name: Reset simulator and daemon state
         run: |
+          killall -9 Simulator || true
           xcrun simctl shutdown all || true
+          launchctl kickstart -k "gui/$(id -u)/com.apple.CoreSimulator.CoreSimulatorService" 2>/dev/null \
+            || launchctl kickstart -k "system/com.apple.CoreSimulator.CoreSimulatorService" 2>/dev/null || true
           xcrun simctl delete unavailable || true
           pkill -f 'previewsmcp serve' || true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,19 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Start from a clean host. A cancelled run (cancel-in-progress) can
+      # SIGKILL an xcodebuild/simctl mid-boot and leave a booted simulator, a
+      # thrashing CoreSimulatorService, and orphaned previewsmcp daemons behind
+      # — that leftover state degrades the next run and is the confirmed #391
+      # trigger. Reap it before Lint/Test so every run starts from the same
+      # state. `previewsmcp serve` is matched (not a bare `previewsmcp`) so the
+      # runner's own checkout path is never a match; each line is best-effort.
+      - name: Reset simulator and daemon state
+        run: |
+          xcrun simctl shutdown all || true
+          xcrun simctl delete unavailable || true
+          pkill -f 'previewsmcp serve' || true
+
       # Lint first: it costs seconds and fails fast before the minutes of tests.
       - name: Lint
         run: bazel run //tools/lint:check

--- a/previewsmcp/Tests/CLIIntegrationTests/IOSCLIWorkflowTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/IOSCLIWorkflowTests.swift
@@ -45,11 +45,15 @@ struct IOSCLIWorkflowTests {
             let configPath = CLIRunner.repoRoot
                 .appendingPathComponent("examples/.previewsmcp.json").path
 
-            // Start a single iOS session for the entire workflow.
+            // Start a single iOS session for the entire workflow. --headless skips
+            // `open -a Simulator` (IOSPreviewSession only opens the GUI when NOT headless),
+            // so this test doesn't leak a persistent Simulator.app that degrades the shared
+            // CoreSimulator/WindowServer for later runs (#391). Touch/elements/variants all go
+            // through the in-app HID + framebuffer path, not the GUI, so headless is transparent.
             let runResult = try await CLIRunner.run(
                 "run",
                 arguments: [
-                    file, "--platform", "ios", "--config", configPath, "--detach",
+                    file, "--platform", "ios", "--config", configPath, "--detach", "--headless",
                 ]
             )
             #expect(runResult.exitCode == 0, "detach stderr: \(runResult.stderr)")

--- a/previewsmcp/Tests/CLIIntegrationTests/IOSCLIWorkflowTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/IOSCLIWorkflowTests.swift
@@ -40,6 +40,16 @@ struct IOSCLIWorkflowTests {
             // CoreSimulatorHygiene).
             await CoreSimulatorHygiene.resetOnce()
 
+            // Pin the session to a dedicated test device. Without --device the CLI
+            // auto-selects (resolveDeviceUDID, BuildHelpers) a booted-or-first-available
+            // device, which lands on the generic default (8958D70E) — and booting a generic
+            // sim nulls the agent's CGSession, dropping it into the CFRunLoop fallback that
+            // never dequeues AppKit events (#391 H1). A pinned previewsmcp-test-N boots clean.
+            guard let deviceUDID = await SimulatorTestDevices.udid(index: 8) else {
+                print("Host cannot create \(SimulatorTestDevices.name(index: 8)) — skipping iOS CLI workflow")
+                return
+            }
+
             let file = CLIRunner.spmExampleRoot
                 .appendingPathComponent("Sources/ToDo/ToDoView.swift").path
             let configPath = CLIRunner.repoRoot
@@ -53,7 +63,8 @@ struct IOSCLIWorkflowTests {
             let runResult = try await CLIRunner.run(
                 "run",
                 arguments: [
-                    file, "--platform", "ios", "--config", configPath, "--detach", "--headless",
+                    file, "--platform", "ios", "--device", deviceUDID,
+                    "--config", configPath, "--detach", "--headless",
                 ]
             )
             #expect(runResult.exitCode == 0, "detach stderr: \(runResult.stderr)")
@@ -115,6 +126,10 @@ struct IOSCLIWorkflowTests {
                     "--variant", "dark",
                     "-o", tempDir.path,
                     "--platform", "ios",
+                    // Pin variants' own ephemeral session to the same dedicated device — it
+                    // auto-selects too, so without this it could still land on the generic
+                    // default (#391).
+                    "--device", deviceUDID,
                     "--project", CLIRunner.spmExampleRoot.path,
                     "--config", configPath,
                 ]

--- a/previewsmcp/Tests/TestSupport/SimulatorTestDevices.swift
+++ b/previewsmcp/Tests/TestSupport/SimulatorTestDevices.swift
@@ -30,6 +30,10 @@ import PreviewsCore
 ///   only, never boots)
 /// - index 6: `IOSPreviewE2ESupport.bootSimulator()` (IOSPreviewE2ETests
 ///   target; one warm-reused device for the whole `.serialized` suite)
+/// - index 7: `IOSPreviewE2ETests` device-reclaim tests (Stream C, #391)
+/// - index 8: `IOSCLIWorkflowTests.iosCLIWorkflow` (CLIIntegrationTests target;
+///   pins the CLI run + variants sessions so the auto-select can't boot a
+///   generic default device that nulls the agent CGSession, #391)
 public enum SimulatorTestDevices {
     public static let deviceType = "com.apple.CoreSimulator.SimDeviceType.iPhone-17"
 


### PR DESCRIPTION
## What (#391 trigger removal)

Three layers, all in CI/test-only code, that stop the host degradation which reds `agentDispatchesAppKitEvents`:

1. **Pre-job reset** (`ci.yml`): `killall Simulator` → `simctl shutdown all` → `launchctl kickstart -k CoreSimulatorService` → reap unavailable devices + stray daemons. Clears whatever a cancelled run left.
2. **`--headless`** on the iOS CLI workflow (`IOSCLIWorkflowTests`): stops `previewsmcp run --platform ios` from opening the persistent `Simulator.app` GUI.
3. **Device-pin** (`IOSCLIWorkflowTests`): pins both `run` and `variants --platform ios` to a dedicated `previewsmcp-test-8`, so the CLI never boots the generic default device (`8958D70E`). `resolveDeviceUDID` defaulted to the first available device — a test-only fix, no product change.

## Why — the mechanism, proven from a failing-agent readout

The pump red is **wrong-loop**, not control-starvation. Under host load (a generic `8958D70E` boot + CoreSimulatorService thrash), the preview agent's `CGSessionCopyCurrentDictionary()` returns **NULL**, so it takes the `CFRunLoopRunInMode` **fallback** instead of `[NSApp run]`. The fallback drains the dispatch queue (so `runOnMain` answers — the agent *looks* alive) but never dequeues AppKit events, so the posted event is dropped.

The first-ever *failing*-agent diagnostic readout confirmed it: `sessionNull=1, enteredNSAppRun=0`. (The "69/69 non-null CGSession" that had declared this theory dead were all *green* agents.) The drain-timer approach was a dead end because the timer lives in the `[NSApp run]` branch the failing agent never enters.

So the fix is **prevention** — stop the generic boot so the host doesn't degrade so the agent's session stays non-null so it enters `[NSApp run]`. The agent-side CGSession-retry is deferred as a risky last resort (the session guard exists because registering with the window server from a headless/launchd context can kill the process, #196).

## Validation

Proven at the mechanism level on branch `391-validate` (this PR's changes + behavior-neutral, count-only diagnostic probes): a green pump with `sessionNull=0, enteredNSAppRun=1` demonstrates the pin kept the session non-null and the agent entered the real loop — not luck. The probes never dequeue or dispatch, so an instrumented green transfers to this clean PR.

Pairs with #393 (diagnostic-only: the permanent count-only branch probes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
