### PR TITLE
#391: enter [NSApp run] on a gui-capable signal despite a false-null CGSession

### DIFF
--- a/previewsmcp/PreviewAgent/main.cpp
+++ b/previewsmcp/PreviewAgent/main.cpp
@@ -296,12 +296,25 @@ int main(int argc, char *argv[]) {
   // in this process only receive window-server events (clicks, scrolls) when
   // -[NSApplication run] dequeues and dispatches them. The main dispatch
   // queue (run_on_main's dispatch_sync target) drains under it as well.
-  // Guarded on an Aqua session being reachable: registering with the window
-  // server from an SSH login or launchd context can kill the process, and
-  // off-screen rendering works under the bare spin there.
+  // Guarded on gui-capability: registering with the window server from an SSH
+  // login or launchd context can kill the process, and off-screen rendering
+  // works under the bare spin there.
+  //
+  // CGSessionCopyCurrentDictionary is the default guard, but under heavy
+  // concurrent load it returns null even in a gui-capable context where
+  // [NSApp run] is safe (#391 — a false negative that persists for the whole
+  // load window, so no retry recovers it). A launcher that KNOWS it spawned us
+  // in a gui context (the daemon, from its own startup session; JITSession, in
+  // CI) sets PREVIEWSMCP_GUI_CAPABLE, and we enter the AppKit loop despite the
+  // null read. A genuine headless context sets no signal and still takes the
+  // safe fallback below, so the fatal window-server registration never runs.
   auto *SessionDict = reinterpret_cast<void *(*)()>(
       dlsym(RTLD_DEFAULT, "CGSessionCopyCurrentDictionary"));
-  if (SessionDict && SessionDict()) {
+  bool HasSession = SessionDict && SessionDict();
+  if (HasSession || getenv("PREVIEWSMCP_GUI_CAPABLE")) {
+    if (!HasSession)
+      errs() << "PreviewAgent: CGSession null but gui-capable signal set, "
+                "entering [NSApp run]\n";
     auto *GetClass = reinterpret_cast<void *(*)(const char *)>(
         dlsym(RTLD_DEFAULT, "objc_getClass"));
     auto *RegisterSel = reinterpret_cast<void *(*)(const char *)>(

--- a/previewsmcp/PreviewsCLI/PreviewsMCPApp.swift
+++ b/previewsmcp/PreviewsCLI/PreviewsMCPApp.swift
@@ -106,11 +106,20 @@ public enum PreviewsMCPApp {
         // ssh/launchd daemon reads null and sets nothing, so its agents keep the safe CFRunLoop
         // fallback (no `[NSApp run]` WindowServer-registration kill, #196). dlsym-resolved to
         // match the agent's own probe and avoid a deprecated direct CGSession call.
+        // Authoritative: this daemon's own startup read fully determines the signal. Set it
+        // when gui-capable, otherwise CLEAR it — so a stray inherited PREVIEWSMCP_GUI_CAPABLE=1
+        // (exported in the environment, or from a gui parent that spawned this headless daemon)
+        // can never survive into a headless daemon's agents and drive them into a sessionless
+        // [NSApp run] (#196 kill).
+        var guiCapable = false
         if let sym = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "CGSessionCopyCurrentDictionary") {
             typealias CGSessionCopy = @convention(c) () -> UnsafeRawPointer?
-            if unsafeBitCast(sym, to: CGSessionCopy.self)() != nil {
-                setenv("PREVIEWSMCP_GUI_CAPABLE", "1", 1)
-            }
+            guiCapable = unsafeBitCast(sym, to: CGSessionCopy.self)() != nil
+        }
+        if guiCapable {
+            setenv("PREVIEWSMCP_GUI_CAPABLE", "1", 1)
+        } else {
+            unsetenv("PREVIEWSMCP_GUI_CAPABLE")
         }
 
         host.onLaunch = {

--- a/previewsmcp/PreviewsCLI/PreviewsMCPApp.swift
+++ b/previewsmcp/PreviewsCLI/PreviewsMCPApp.swift
@@ -97,6 +97,22 @@ public enum PreviewsMCPApp {
         // Always headless: no Dock icon, windows positioned off-screen.
         app.setActivationPolicy(.accessory)
 
+        // #391: cache gui-capability at daemon startup — a reliable CGSession read now, BEFORE
+        // any simulator workload can spuriously null it under load — and hand it to spawned
+        // agents via their inherited env (the JIT agent is posix_spawn'd with this process's
+        // environ). The macOS PreviewAgent uses it to enter `[NSApplication run]` even when its
+        // OWN CGSession read comes back null under load, which is safe here because this daemon
+        // runs AppKit in a real gui session. Set ONLY when genuinely gui-capable: a headless
+        // ssh/launchd daemon reads null and sets nothing, so its agents keep the safe CFRunLoop
+        // fallback (no `[NSApp run]` WindowServer-registration kill, #196). dlsym-resolved to
+        // match the agent's own probe and avoid a deprecated direct CGSession call.
+        if let sym = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "CGSessionCopyCurrentDictionary") {
+            typealias CGSessionCopy = @convention(c) () -> UnsafeRawPointer?
+            if unsafeBitCast(sym, to: CGSessionCopy.self)() != nil {
+                setenv("PREVIEWSMCP_GUI_CAPABLE", "1", 1)
+            }
+        }
+
         host.onLaunch = {
             Task { @MainActor in
                 do {

--- a/previewsmcp/Tests/PreviewsJITLinkTests/BUILD.bazel
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/BUILD.bazel
@@ -21,6 +21,11 @@ swift_test(
         "//previewsmcp/PreviewAgent",
     ],
     env = {
+        # #391: the CI runner is a gui/501 LaunchAgent (genuinely gui-capable), so tell the
+        # spawned macOS PreviewAgent to enter [NSApp run] even when its CGSession read comes
+        # back null under load — a TRUE assertion here, not masking. The test process's env is
+        # inherited by its posix_spawn'd agent. A non-gui host would fail these tests either way.
+        "PREVIEWSMCP_GUI_CAPABLE": "1",
         "PREVIEWSMCP_AGENT": "$(rlocationpath //previewsmcp/PreviewAgent)",
         "PREVIEWSMCP_ORC_RT": "$(rlocationpath //:orc_rt_archive)",
     },


### PR DESCRIPTION
## The fix for #391

`agentDispatchesAppKitEvents` reds because the macOS preview agent gates its event loop on `CGSessionCopyCurrentDictionary()`, and under heavy concurrent simulator load (the iOS E2E suite booting the pinned pool for ~250s alongside the pump test) that call returns **null for the whole load window** — a false negative, since the agent is genuinely in a gui-capable `gui/501` context where `[NSApp run]` is safe. On the null read the agent drops to a `CFRunLoopRunInMode` fallback that drains the dispatch queue (so `runOnMain` answers and the agent *looks* alive) but never dequeues AppKit events, so a posted event is silently dropped.

**Fix (Option C — gui-capable signal):** the launcher, which *knows* it is in a gui context, tells the agent so, and the agent enters `[NSApp run]` on `CGSession non-null OR the signal`:

- **Daemon** (`PreviewsMCPApp.swift`): reads `CGSession` once at startup — reliable, before any sim workload — and `setenv("PREVIEWSMCP_GUI_CAPABLE","1")` only if non-null. The agent is `posix_spawn`'d with the process environ, so it inherits the signal. A genuine headless daemon reads null at startup, sets nothing, and its agents keep the safe fallback.
- **Tests** (`PreviewsJITLinkTests/BUILD.bazel`): sets the env — CI is `gui/501`, a true assertion — inherited by the pump test's JIT-spawned agent.
- **Agent** (`main.cpp`): enters `[NSApp run]` on `HasSession || getenv("PREVIEWSMCP_GUI_CAPABLE")`; a null session with no signal still takes the safe fallback. Emits a permanent diagnostic line when it enters via the signal despite a null, so a loaded run self-reports that the false-null path was exercised.

**Load-bearing safety invariant:** the CGSession guard is never removed and the bypass fires **only on a positive gui-capable assertion**. A real ssh/launchd headless agent gets no signal → fallback → the window-server registration that #196 warns can kill the process never runs.

## Why this and not the alternatives (all ruled out empirically)

- **Prevention** (device-pin + `--headless`, #394): a pinned+headless run still red `sessionNull=1` — any concurrent sim boot degrades the macOS agent, not just the generic device. Ships as hygiene (#394), not the pump fix.
- **Bounded CGSession retry**: the null is *persistent* (`recoveryMs=-1`, measured) — nothing to retry into.
- **Fallback event-pump**: `_DPSNextEvent` plausibly opens the same window-server connection `[NSApp run]` does → carries the #196 kill in a genuine headless context, and that is untestable in CI (CI is gui-capable).

## Validation

- **Under real CI degradation** (C-derisk run, force-`[NSApp run]`-under-null): `sessionNull=1 enteredNSAppRun=1 observed=1`, PASSED, agent alive, with the E2E suite running 232s concurrently — proves the null is a false negative and `[NSApp run]` delivers without crashing.
- **The production signal wiring, locally**: forcing the null with this PR's real env plumbing logs `CGSession null but gui-capable signal set, entering [NSApp run]` and the test passes — the env propagates and the signal path delivers.

Pairs with #394 (hygiene) and #393 (permanent diagnostic probes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
