### PR TITLE
#391: iOS session reclaims its simulator state (stop + failed-start + guards)

### DIFF
--- a/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
+++ b/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
@@ -154,7 +154,11 @@ public actor IOSPreviewSession {
         do {
             return try await performStart()
         } catch {
+            // Mirror stop()'s teardown order so a failed start leaks nothing: SIGKILL the
+            // apps, close host sockets/JIT (incl. jitListenFD if it was bound), then reclaim
+            // the device/GUI. All idempotent — a no-op for whatever the partial start never set.
             await terminateAgentAndShell()
+            await releaseHostResources()
             await reclaimBootedDeviceAndGUI()
             throw error
         }
@@ -239,6 +243,9 @@ public actor IOSPreviewSession {
                 let device = try await simulatorManager.findDevice(udid: deviceUDID)
                 if device.state != .booted {
                     stage("attempt \(attempt): bootDevice")
+                    // Set only after bootDevice returns: a throw mid-boot leaves it false, so
+                    // the failure path won't try to reclaim a device that never fully booted
+                    // (simctl boot is ~atomic — a partial boot is a rare, low-risk exception).
                     try await simulatorManager.bootDevice(udid: deviceUDID)
                     didBootDevice = true
                     stage("attempt \(attempt): boot complete")
@@ -432,13 +439,7 @@ public actor IOSPreviewSession {
         // (EXC_BAD_ACCESS). simctl terminate is a SIGKILL, clean with no crash
         // report, and a dead agent cannot render.
         await terminateAgentAndShell()
-
-        await channel.close()
-        jitReloader = nil
-        if jitListenFD >= 0 {
-            Darwin.close(jitListenFD)
-            jitListenFD = -1
-        }
+        await releaseHostResources()
 
         // Reclaim the simulator state THIS session created, last — after the host
         // sockets + JIT session are down (the device-side agent was already SIGKILLed
@@ -452,6 +453,20 @@ public actor IOSPreviewSession {
     private func terminateAgentAndShell() async {
         await simulatorManager.terminateAppIfRunning(udid: deviceUDID, bundleID: Self.shellBundleID)
         await simulatorManager.terminateAppIfRunning(udid: deviceUDID, bundleID: Self.agentBundleID)
+    }
+
+    /// Close the host-side transport + JIT listener. Idempotent and guarded, so it is a
+    /// safe no-op when an early failure never opened them. Shared by `stop()` and the
+    /// `start()` failure path — a late-start throw (after the JIT listener is bound) must
+    /// not leak `jitListenFD` in the long-lived daemon, since a failed session is never
+    /// registered and has no `stop()`/`deinit` to reclaim it.
+    private func releaseHostResources() async {
+        await channel.close()
+        jitReloader = nil
+        if jitListenFD >= 0 {
+            Darwin.close(jitListenFD)
+            jitListenFD = -1
+        }
     }
 
     /// Reclaim simulator state this session created, gated + best-effort + time-bounded so

--- a/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
+++ b/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
@@ -17,8 +17,12 @@ public actor IOSPreviewSession {
 
     private let compiler: Compiler
     private let agentBuilder: IOSAgentBuilder
-    private let simulatorManager: SimulatorManager
+    private let simulatorManager: any SimulatorControlling
     private let progress: (any ProgressReporter)?
+
+    /// Boot/install/launch retry ceiling (default 3). Injectable so a unit test can force a
+    /// single attempt (no 3s inter-attempt sleeps) to drive the start()-failure reclaim path.
+    private let maxBootAttempts: Int
 
     private var session: PreviewSession?
     public nonisolated let headless: Bool
@@ -46,6 +50,12 @@ public actor IOSPreviewSession {
     private let makeJITReloader: MakeJITReloader
     private var jitReloader: (any IOSStructuralReloader)?
     private var jitListenFD: Int32 = -1
+
+    /// Test-only read of the JIT listener fd (-1 when closed/unbound). Lets a unit test assert
+    /// the start()-failure path released host resources without exposing the fd more broadly.
+    var jitListenFDForTesting: Int32 {
+        jitListenFD
+    }
 
     /// `stop()` was called — suppress the death watcher so an intentional
     /// teardown never respawns. `isRelaunching` is true for the duration of a
@@ -76,7 +86,7 @@ public actor IOSPreviewSession {
         deviceUDID: String,
         compiler: Compiler,
         agentBuilder: IOSAgentBuilder,
-        simulatorManager: SimulatorManager,
+        simulatorManager: any SimulatorControlling,
         headless: Bool = true,
         buildContext: BuildContext? = nil,
         traits: PreviewTraits = PreviewTraits(),
@@ -86,6 +96,7 @@ public actor IOSPreviewSession {
         setupSDKPath: String? = nil,
         setupDylibPath: URL? = nil,
         progress: (any ProgressReporter)? = nil,
+        maxBootAttempts: Int = 3,
         makeJITReloader: @escaping MakeJITReloader
     ) {
         id = UUID().uuidString
@@ -95,6 +106,7 @@ public actor IOSPreviewSession {
         self.compiler = compiler
         self.agentBuilder = agentBuilder
         self.simulatorManager = simulatorManager
+        self.maxBootAttempts = maxBootAttempts
         self.headless = headless
         self.buildContext = buildContext
         self.traits = traits
@@ -237,7 +249,7 @@ public actor IOSPreviewSession {
 
         var launchedPid: Int?
         var lastError: Error?
-        for attempt in 1 ... 3 {
+        for attempt in 1 ... maxBootAttempts {
             do {
                 stage("boot/install/launch attempt \(attempt)/3")
                 let device = try await simulatorManager.findDevice(udid: deviceUDID)
@@ -302,7 +314,7 @@ public actor IOSPreviewSession {
             } catch {
                 stage("attempt \(attempt) failed: \(error)")
                 lastError = error
-                if attempt < 3 {
+                if attempt < maxBootAttempts {
                     // Shut down the device to clear any stuck kernel/backend
                     // state before the next boot attempt. Best-effort — if
                     // shutdown itself fails or hangs, the next findDevice +

--- a/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
+++ b/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
@@ -56,6 +56,13 @@ public actor IOSPreviewSession {
     private var isRelaunching = false
     private var recovering = false
 
+    /// Whether THIS session booted its device (vs finding it already booted). Only a
+    /// device we booted is ours to shut down on `stop()`; a pre-existing device — the
+    /// persistent pinned test pool reused across sessions (#337), or a user's already-
+    /// running simulator — is left for its owner. Prevents a teardown from leaking a
+    /// booted device that degrades the shared CoreSimulator/WindowServer (#391).
+    private var didBootDevice = false
+
     public static let agentBundleID = "com.previewsmcp.agent"
     public static let shellBundleID = "com.previewsmcp.shell"
 
@@ -138,8 +145,22 @@ public actor IOSPreviewSession {
     // MARK: - Lifecycle
 
     /// Start the iOS preview: compile, boot sim, install host, launch, connect socket.
-    /// Returns the PID of the launched agent app.
+    /// Returns the PID of the launched agent app. On failure, reclaims any simulator state
+    /// this partial start created — the device we booted, the launched apps, an opened
+    /// Simulator.app — before rethrowing. The caller registers the session only AFTER a
+    /// successful start, so no later `stop()` runs on a failed one; without this, a start that
+    /// throws post-boot would leak the device it booted, asymmetric with a clean stop (#391).
     public func start() async throws -> Int {
+        do {
+            return try await performStart()
+        } catch {
+            await terminateAgentAndShell()
+            await reclaimBootedDeviceAndGUI()
+            throw error
+        }
+    }
+
+    private func performStart() async throws -> Int {
         guard let orcPath = IOSAgentBuilder.jitOrcRuntimePath else {
             throw IOSPreviewSessionError.jitRuntimeMissing
         }
@@ -219,6 +240,7 @@ public actor IOSPreviewSession {
                 if device.state != .booted {
                     stage("attempt \(attempt): bootDevice")
                     try await simulatorManager.bootDevice(udid: deviceUDID)
+                    didBootDevice = true
                     stage("attempt \(attempt): boot complete")
                 } else {
                     stage("attempt \(attempt): already booted")
@@ -278,6 +300,9 @@ public actor IOSPreviewSession {
                     // state before the next boot attempt. Best-effort — if
                     // shutdown itself fails or hangs, the next findDevice +
                     // bootDevice will handle whatever state we end up in.
+                    // NOTE: this recovery shutdown fires even for a pre-existing
+                    // (pooled) device we did not boot, churning the pinned pool.
+                    // Pre-existing + orthogonal to the leak fix; tracked separately.
                     stage("attempt \(attempt): shutting down for clean reboot")
                     try? await simulatorManager.shutdownDevice(udid: deviceUDID)
                     try await Task.sleep(for: .seconds(3))
@@ -406,14 +431,40 @@ public actor IOSPreviewSession {
         // agent is alive makes its next main-loop render fault on freed pages
         // (EXC_BAD_ACCESS). simctl terminate is a SIGKILL, clean with no crash
         // report, and a dead agent cannot render.
-        await simulatorManager.terminateAppIfRunning(udid: deviceUDID, bundleID: Self.shellBundleID)
-        await simulatorManager.terminateAppIfRunning(udid: deviceUDID, bundleID: Self.agentBundleID)
+        await terminateAgentAndShell()
 
         await channel.close()
         jitReloader = nil
         if jitListenFD >= 0 {
             Darwin.close(jitListenFD)
             jitListenFD = -1
+        }
+
+        // Reclaim the simulator state THIS session created, last — after the host
+        // sockets + JIT session are down (the device-side agent was already SIGKILLed
+        // above) — so a teardown doesn't leak a booted device / open Simulator.app that
+        // degrades the shared CoreSimulator + WindowServer for later runs (#391).
+        await reclaimBootedDeviceAndGUI()
+    }
+
+    /// SIGKILL the agent + shell on the device (best-effort, each simctl-terminate
+    /// time-bounded). Shared by `stop()` and the `start()` failure path.
+    private func terminateAgentAndShell() async {
+        await simulatorManager.terminateAppIfRunning(udid: deviceUDID, bundleID: Self.shellBundleID)
+        await simulatorManager.terminateAppIfRunning(udid: deviceUDID, bundleID: Self.agentBundleID)
+    }
+
+    /// Reclaim simulator state this session created, gated + best-effort + time-bounded so
+    /// cleanup can't inherit a wedged CoreSimulatorService hang (#391):
+    ///  - Shut down ONLY a device we booted; a pre-existing device (the pinned pool reused
+    ///    across sessions, or a user's already-running sim) is left for its owner.
+    ///  - Quit Simulator.app only if this session opened it (non-headless).
+    private func reclaimBootedDeviceAndGUI() async {
+        if didBootDevice {
+            await simulatorManager.shutdownDeviceBestEffort(udid: deviceUDID)
+        }
+        if !headless {
+            await simulatorManager.quitSimulatorApp()
         }
     }
 

--- a/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
+++ b/previewsmcp/PreviewsIOS/IOSPreviewSession.swift
@@ -251,7 +251,7 @@ public actor IOSPreviewSession {
         var lastError: Error?
         for attempt in 1 ... maxBootAttempts {
             do {
-                stage("boot/install/launch attempt \(attempt)/3")
+                stage("boot/install/launch attempt \(attempt)/\(maxBootAttempts)")
                 let device = try await simulatorManager.findDevice(udid: deviceUDID)
                 if device.state != .booted {
                     stage("attempt \(attempt): bootDevice")

--- a/previewsmcp/PreviewsIOS/SimulatorManager.swift
+++ b/previewsmcp/PreviewsIOS/SimulatorManager.swift
@@ -344,6 +344,34 @@ public actor SimulatorManager: SimulatorLister {
         )
     }
 
+    /// Shut down a device via `simctl shutdown`, best-effort and time-bounded. Used by
+    /// session teardown to reclaim a device this process booted (#391). Prefers simctl over
+    /// the SB private-API `shutdownDevice(_:)` because the latter is unbounded and can block
+    /// on a wedged CoreSimulatorService — the very degraded state we are cleaning up after —
+    /// whereas simctl runs as a subprocess bounded by runAsync's SIGTERM→SIGKILL timeout.
+    /// A no-op (harmless nonzero exit) when the device is already shut down.
+    public func shutdownDeviceBestEffort(udid: String) async {
+        _ = try? await runAsync(
+            "/usr/bin/xcrun",
+            arguments: ["simctl", "shutdown", udid],
+            discardStderr: true,
+            timeout: .seconds(30)
+        )
+    }
+
+    /// Quit the Simulator.app GUI (opened for non-headless sessions), best-effort and
+    /// time-bounded. A no-op when it isn't running. Quitting the GUI does not shut down the
+    /// CoreSimulator devices it displays — those are reclaimed separately via
+    /// `shutdownDeviceBestEffort`.
+    public func quitSimulatorApp() async {
+        _ = try? await runAsync(
+            "/usr/bin/osascript",
+            arguments: ["-e", "tell application \"Simulator\" to quit"],
+            discardStderr: true,
+            timeout: .seconds(10)
+        )
+    }
+
     /// Launch an app on a booted device. Returns the PID.
     ///
     /// Uses `xcrun simctl launch` instead of the SBDevice private API.

--- a/previewsmcp/PreviewsIOS/SimulatorManager.swift
+++ b/previewsmcp/PreviewsIOS/SimulatorManager.swift
@@ -10,8 +10,46 @@ public protocol SimulatorLister: Sendable {
     func listDevices() async throws -> [SimulatorManager.Device]
 }
 
+/// The simulator operations `IOSPreviewSession` drives, extracted as a seam so tests can
+/// inject a stub — `SimulatorManager` is a private-API-backed actor that boots real devices,
+/// so a session's boot/install/launch/teardown path is otherwise only reachable via the
+/// real-simulator E2E gate. All requirements are `async` so `SimulatorManager`'s actor-
+/// isolated (and synchronous) methods witness them.
+public protocol SimulatorControlling: Sendable {
+    func findDevice(udid: String) async throws -> SimulatorManager.Device
+    func bootDevice(udid: String, timeout: Duration) async throws
+    func installApp(udid: String, appPath: String) async throws
+    func launchApp(
+        udid: String, bundleID: String, arguments: [String], environment: [String: String]
+    ) async throws -> Int
+    func launchAppInBackground(udid: String, bundleID: String, arguments: [String]) async throws -> Int
+    func terminateAppIfRunning(udid: String, bundleID: String) async
+    func shutdownDevice(udid: String) async throws
+    func shutdownDeviceBestEffort(udid: String) async
+    func quitSimulatorApp() async
+    func makeHIDClient(udid: String) async throws -> SBHIDClient
+    func makeFramebufferStreamer(udid: String, jpegQuality: Double) async throws -> SBFramebufferStreamer
+    func screenshotData(udid: String, jpegQuality: Double) async throws -> Data
+}
+
+public extension SimulatorControlling {
+    /// Default-argument conveniences matching `SimulatorManager`'s own defaults, so call
+    /// sites keep working through `any SimulatorControlling` (a protocol can't carry defaults).
+    func bootDevice(udid: String) async throws {
+        try await bootDevice(udid: udid, timeout: .seconds(600))
+    }
+
+    func launchApp(udid: String, bundleID: String, arguments: [String]) async throws -> Int {
+        try await launchApp(udid: udid, bundleID: bundleID, arguments: arguments, environment: [:])
+    }
+
+    func makeFramebufferStreamer(udid: String) async throws -> SBFramebufferStreamer {
+        try await makeFramebufferStreamer(udid: udid, jpegQuality: 0.7)
+    }
+}
+
 /// Manages iOS simulator devices via CoreSimulator.framework (loaded at runtime).
-public actor SimulatorManager: SimulatorLister {
+public actor SimulatorManager: SimulatorLister, SimulatorControlling {
     /// Sendable snapshot of a simulator device.
     public struct Device: Sendable, CustomStringConvertible {
         public let name: String

--- a/previewsmcp/Tests/PreviewsIOSTests/BUILD.bazel
+++ b/previewsmcp/Tests/PreviewsIOSTests/BUILD.bazel
@@ -13,6 +13,7 @@ swift_test(
     tags = ["local"],
     visibility = ["//visibility:public"],
     deps = [
+        "//previewsmcp/PreviewsCore",
         "//previewsmcp/PreviewsIOS",
         "//previewsmcp/Tests/TestSupport",
     ],

--- a/previewsmcp/Tests/PreviewsIOSTests/IOSPreviewSessionStartFailureTests.swift
+++ b/previewsmcp/Tests/PreviewsIOSTests/IOSPreviewSessionStartFailureTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import PreviewsCore
+@testable import PreviewsIOS
+import PreviewsTestSupport
+@preconcurrency import SimulatorBridge
+import Testing
+
+/// Guards the #391 leak-on-FAILURE symmetry: a `start()` that throws AFTER booting the device
+/// must reclaim what it created — shut down the device WE booted and release the host
+/// sockets/JIT listener — exactly like a clean `stop()`. The host-fd half of that was missing
+/// until review, and a review-caught leak with no regression guard silently regresses.
+///
+/// Drives the real production `start()` with a stub `SimulatorControlling` whose `installApp`
+/// throws right after the boot branch. Off-runner: no sim boots (stub), one attempt
+/// (`maxBootAttempts: 1`, so no 3s inter-attempt sleeps). The agent build + loopback sockets
+/// are real but cheap; the JIT reloader is never reached (install fails first).
+@Suite("IOSPreviewSession start() failure reclaim")
+struct IOSPreviewSessionStartFailureTests {
+    @Test(.enabled(if: IOSAgentBuilder.jitOrcRuntimePath != nil))
+    func failedStartShutsDownDeviceItBootedAndReleasesHostFDs() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ios-start-fail-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let source = dir.appendingPathComponent("V.swift")
+        try "import SwiftUI\n#Preview { Text(\"hi\") }\n"
+            .write(to: source, atomically: true, encoding: .utf8)
+
+        let stub = StubSimulatorControl(deviceState: .shutdown)
+        let session = try await IOSPreviewSession(
+            sourceFile: source,
+            deviceUDID: "STUB-UDID-0001",
+            compiler: Compiler(platform: .iOS),
+            agentBuilder: IOSAgentBuilder(),
+            simulatorManager: stub,
+            maxBootAttempts: 1,
+            makeJITReloader: { _, _ in
+                fatalError("JIT reloader must not be reached: install fails before the JIT step")
+            }
+        )
+
+        await #expect(throws: (any Error).self) {
+            _ = try await session.start()
+        }
+
+        // The device state was .shutdown, so the session booted it (didBootDevice = true) — the
+        // failure path must therefore shut it back down, and only that device.
+        #expect(await stub.bootDeviceCalls == 1)
+        #expect(await stub.shutdownBestEffortUDIDs == ["STUB-UDID-0001"])
+        // Host resources released: the JIT listener fd, bound before the install throw, is closed.
+        #expect(await session.jitListenFDForTesting == -1)
+    }
+}
+
+/// Boots succeed; `installApp` throws just after the boot branch. The methods reached only
+/// after a successful install (`launchApp`, HID/framebuffer, screenshot) `fatalError` — they
+/// require a real booted sim / private-API objects and never fire on this failure path.
+private actor StubSimulatorControl: SimulatorControlling {
+    private let deviceState: SimulatorManager.DeviceState
+    private(set) var bootDeviceCalls = 0
+    private(set) var shutdownBestEffortUDIDs: [String] = []
+
+    init(deviceState: SimulatorManager.DeviceState) {
+        self.deviceState = deviceState
+    }
+
+    func findDevice(udid: String) async throws -> SimulatorManager.Device {
+        SimulatorManager.Device(
+            name: "stub", udid: udid, state: deviceState, stateString: "Shutdown",
+            runtimeName: "iOS 26.2", runtimeIdentifier: nil, deviceTypeName: "iPhone 17",
+            isAvailable: true
+        )
+    }
+
+    func bootDevice(udid _: String, timeout _: Duration) async throws {
+        bootDeviceCalls += 1
+    }
+
+    func installApp(udid _: String, appPath _: String) async throws {
+        throw StubError.installFailedPostBoot
+    }
+
+    func terminateAppIfRunning(udid _: String, bundleID _: String) async {}
+    func shutdownDevice(udid _: String) async throws {}
+    func shutdownDeviceBestEffort(udid: String) async {
+        shutdownBestEffortUDIDs.append(udid)
+    }
+
+    func quitSimulatorApp() async {}
+
+    func launchApp(
+        udid _: String, bundleID _: String, arguments _: [String], environment _: [String: String]
+    ) async throws -> Int {
+        fatalError("unreached on the install-failure path")
+    }
+
+    func launchAppInBackground(
+        udid _: String, bundleID _: String, arguments _: [String]
+    ) async throws -> Int {
+        fatalError("unreached on the install-failure path")
+    }
+
+    func makeHIDClient(udid _: String) async throws -> SBHIDClient {
+        fatalError("unreached on the install-failure path")
+    }
+
+    func makeFramebufferStreamer(
+        udid _: String, jpegQuality _: Double
+    ) async throws -> SBFramebufferStreamer {
+        fatalError("unreached on the install-failure path")
+    }
+
+    func screenshotData(udid _: String, jpegQuality _: Double) async throws -> Data {
+        fatalError("unreached on the install-failure path")
+    }
+}
+
+private enum StubError: Error { case installFailedPostBoot }

--- a/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
@@ -766,6 +766,92 @@ struct IOSPreviewE2ETests {
     }
     """
 
+    /// #391 reclaim contract (device-side, real sim): a session that BOOTS its device must
+    /// shut it back down — both on a clean `stop()` and on a `start()` that throws after the
+    /// boot — so a teardown never leaks a booted device that degrades the shared CoreSimulator/
+    /// WindowServer. Uses the dedicated index-7 device and pre-shuts it so the session boots it
+    /// fresh (`didBootDevice == true`); a device that was ALREADY booted is intentionally left
+    /// alone, so the fresh boot is what makes the shutdown assertion meaningful.
+    @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
+    func stopShutsDownADeviceTheSessionBooted() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
+        guard let udid = await SimulatorTestDevices.udid(index: 7) else {
+            print("Host cannot create \(SimulatorTestDevices.name(index: 7)) — skipping")
+            return
+        }
+        let sim = SimulatorManager()
+        await sim.shutdownDeviceBestEffort(udid: udid)
+
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ios-reclaim-stop-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let sourceFile = tempDir.appendingPathComponent("HelloView.swift")
+        try Self.helloViewSource.write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        let session = try await IOSPreviewSession(
+            sourceFile: sourceFile,
+            deviceUDID: udid,
+            compiler: Compiler(platform: .iOS),
+            agentBuilder: IOSAgentBuilder(),
+            simulatorManager: SimulatorManager(),
+            makeJITReloader: { fd, orcPath in
+                try IOSJITStructuralReloader(remoteFD: fd, orcRuntimePath: orcPath)
+            }
+        )
+        defer {
+            IOSPreviewE2ESupport.terminateApp(udid: udid, bundleID: IOSPreviewSession.agentBundleID)
+        }
+
+        _ = try await session.start()
+        await session.stop()
+
+        let dev = try await sim.findDevice(udid: udid)
+        #expect(dev.state == .shutdown, "stop() must shut down a device the session booted (#391)")
+    }
+
+    @Test(.enabled(if: jitOrcRuntimePresent), .timeLimit(.minutes(10)))
+    func failedStartShutsDownADeviceTheSessionBooted() async throws {
+        let simLock = try await SimulatorTestLock.acquire()
+        defer { simLock.release() }
+        guard let udid = await SimulatorTestDevices.udid(index: 7) else {
+            print("Host cannot create \(SimulatorTestDevices.name(index: 7)) — skipping")
+            return
+        }
+        let sim = SimulatorManager()
+        await sim.shutdownDeviceBestEffort(udid: udid)
+
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ios-reclaim-fail-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let sourceFile = tempDir.appendingPathComponent("HelloView.swift")
+        try Self.helloViewSource.write(to: sourceFile, atomically: true, encoding: .utf8)
+
+        struct InducedJITFailure: Error {}
+        let session = try await IOSPreviewSession(
+            sourceFile: sourceFile,
+            deviceUDID: udid,
+            compiler: Compiler(platform: .iOS),
+            agentBuilder: IOSAgentBuilder(),
+            simulatorManager: SimulatorManager(),
+            // Throw at the JIT step — a real post-boot failure (device booted, agent up); any
+            // earlier post-boot failure would reclaim the same way, so the assertion is robust.
+            makeJITReloader: { _, _ in throw InducedJITFailure() }
+        )
+        defer {
+            IOSPreviewE2ESupport.terminateApp(udid: udid, bundleID: IOSPreviewSession.agentBundleID)
+        }
+
+        await #expect(throws: (any Error).self) {
+            _ = try await session.start()
+        }
+
+        let dev = try await sim.findDevice(udid: udid)
+        #expect(dev.state == .shutdown, "a start() that throws post-boot must shut down the device it booted (#391)")
+    }
+
     static let helloViewSource = """
     import SwiftUI
 

--- a/previewsmcp/Tests/TestSupport/SimulatorTestDevices.swift
+++ b/previewsmcp/Tests/TestSupport/SimulatorTestDevices.swift
@@ -30,7 +30,10 @@ import PreviewsCore
 ///   only, never boots)
 /// - index 6: `IOSPreviewE2ESupport.bootSimulator()` (IOSPreviewE2ETests
 ///   target; one warm-reused device for the whole `.serialized` suite)
-/// - index 7: `IOSPreviewE2ETests` device-reclaim tests (Stream C, #391)
+/// - index 7: `IOSPreviewE2ETests` reclaim tests
+///   (`stopShutsDownADeviceTheSessionBooted`,
+///   `failedStartShutsDownADeviceTheSessionBooted`) — dedicated so pre-shutting
+///   + fresh-booting it doesn't churn the index-6 warm-reused device (#391)
 /// - index 8: `IOSCLIWorkflowTests.iosCLIWorkflow` (CLIIntegrationTests target;
 ///   pins the CLI run + variants sessions so the auto-select can't boot a
 ///   generic default device that nulls the agent CGSession, #391)


### PR DESCRIPTION
## Stream C Part 1 — iOS session lifecycle-leak fix (#391)

`IOSPreviewSession` leaked simulator state on teardown, contributing to the shared CoreSimulator/WindowServer degradation behind #391. This makes a session reclaim only what it created.

- **`stop()`** now shuts down **only a device the session booted** (new `didBootDevice` gate — the persistent pinned pool and a user's already-booted sim are left for their owner) and quits `Simulator.app` only if non-headless. Both **best-effort + time-bounded** (`simctl shutdown` 30s / `osascript` 10s) so cleanup can't inherit a wedged-CoreSimulatorService hang.
- **`start()` failure symmetry**: a `start()` that throws post-boot reclaims the same (device + host sockets/JIT listener via a shared `releaseHostResources()`), so a failed start leaks nothing — the caller registers the session only after success.

### Verification
- **Off-runner unit guard** (`IOSPreviewSessionStartFailureTests`): stub `SimulatorManager` throws at `installApp` post-boot → asserts the booted device is shut down **and** `jitListenFD` released. Deterministic, no sim.
- **Real-sim E2E** (`IOSPreviewE2ETests`, dedicated index 7): device is shut down after a clean stop **and** after a forced post-boot start failure (via the `makeJITReloader` seam).

### Review
- worker-a **HIGH APPROVE** (all 4 commits); worker-jp lifecycle-approved. `/code-review high` + `/simplify` clean.
- Rebased onto post-#391 main (`205b61b`); the one SimulatorTestDevices index-7 doc conflict with #394 resolved (specific reclaim-test wording + #394's index-8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)