### PR TITLE
Fix #397: fence the daemon at DaemonTestLock teardown so serve.log has one writer

### DIFF
--- a/previewsmcp/Tests/CLIIntegrationTests/DaemonTestLock.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/DaemonTestLock.swift
@@ -36,6 +36,8 @@ enum DaemonTestLock {
         body: @Sendable () async throws -> T
     ) async throws -> T {
         let lock = try await TestFileLock.acquire(DaemonTestPaths.daemonLockPath)
+        // Release ALWAYS — a skipped release from a fence bug would wedge the
+        // lock for every later test, far worse than the flake being fixed.
         defer { lock.release() }
 
         // Inside the lock: prep serve.log so the diagnostic dump on
@@ -43,7 +45,105 @@ enum DaemonTestLock {
         // — they must never fail the test.
         prepareServeLog(testContext: context)
 
-        return try await body()
+        // Writer-fence before releasing: a daemon still draining stderr into
+        // the shared serve.log when the lock frees byte-races the next
+        // locked window's reader (LogsCommandTests etc.). Confirm the daemon
+        // is dead — not merely SIGTERM'd — so the next window is clean by
+        // construction. Awaited before the return/throw (the non-throwing,
+        // bounded fence can't stall the cooperative pool or skip the defer),
+        // on both the success and throw paths.
+        do {
+            let result = try await body()
+            await confirmDaemonDead()
+            return result
+        } catch {
+            await confirmDaemonDead()
+            throw error
+        }
+    }
+
+    /// Grace period for a daemon to exit on SIGTERM before the fence
+    /// escalates to SIGKILL. Generous so a daemon shutting down under CI
+    /// load isn't force-killed spuriously; `kill-daemon`'s 2s give-up was
+    /// the original flake source.
+    private static let fenceGraceSeconds: TimeInterval = 10
+
+    private static var pidFilePath: URL {
+        daemonDirectory.appendingPathComponent("serve.pid")
+    }
+
+    /// Guarantee no daemon in this socket dir is still writing serve.log.
+    ///
+    /// Tests kill their daemon in-block, but some intentionally leave a
+    /// detached daemon alive past the block (RunCommand `--detach`), and a
+    /// slow shutdown can straggle past a client's give-up. Either way a live
+    /// writer must not survive the lock release. Confirm death: SIGTERM,
+    /// await actual exit, escalate to SIGKILL if graceful shutdown won't
+    /// confirm within the grace window. A test that spawned no daemon finds
+    /// no live pid and pays nothing.
+    private static func confirmDaemonDead() async {
+        guard let pid = readDaemonPID(), isProcessAlive(pid) else { return }
+        if await confirmProcessDead(pid, graceSeconds: fenceGraceSeconds) {
+            // SIGKILL skipped the daemon's own unregister; drop the stale
+            // pidfile so a later fence can't signal a recycled pid.
+            try? FileManager.default.removeItem(at: pidFilePath)
+        }
+    }
+
+    /// SIGTERM `pid`, await its actual exit up to `graceSeconds`, and escalate
+    /// to SIGKILL if graceful shutdown won't confirm within the bound. Returns
+    /// whether the SIGKILL escalation fired.
+    ///
+    /// Split from `confirmDaemonDead` (which owns the serve.pid read + stale
+    /// pidfile cleanup) so the escalation path has a hermetic test: the test
+    /// drives it directly with a short grace against its own throwaway pid —
+    /// no daemon lock held, no serve.pid touched — so it can't perturb the
+    /// concurrent suite the way a 10s teardown wait or a serve.pid write would.
+    static func confirmProcessDead(_ pid: Int32, graceSeconds: TimeInterval) async -> Bool {
+        kill(pid, SIGTERM)
+        if await awaitProcessDeath(pid, timeout: graceSeconds) { return false }
+
+        // Graceful shutdown didn't confirm within the bound. Surface it —
+        // a daemon that won't die on SIGTERM in the grace window is a real
+        // shutdown bug worth fixing later, not masking — then force it dead.
+        FileHandle.standardError.write(Data(
+            """
+            DaemonTestLock: pid \(pid) did not exit within \
+            \(graceSeconds)s of SIGTERM; escalating to SIGKILL. \
+            This is a daemon-shutdown bug worth surfacing — see #397.
+
+            """.utf8
+        ))
+        kill(pid, SIGKILL)
+        _ = await awaitProcessDeath(pid, timeout: 2)
+        return true
+    }
+
+    /// The daemon pid recorded in this socket dir, or nil if absent/unparseable.
+    private static func readDaemonPID() -> Int32? {
+        guard
+            let contents = try? String(contentsOf: pidFilePath, encoding: .utf8),
+            let pid = Int32(contents.trimmingCharacters(in: .whitespacesAndNewlines))
+        else { return nil }
+        return pid
+    }
+
+    /// `kill(pid, 0)` succeeds iff the process exists and is signalable.
+    private static func isProcessAlive(_ pid: Int32) -> Bool {
+        kill(pid, 0) == 0
+    }
+
+    /// Poll until `pid` is gone or the timeout elapses. Returns whether the
+    /// process is dead at return. `Task.sleep` (not `Thread.sleep`) so the
+    /// poll suspends instead of blocking a cooperative thread — a blocking
+    /// teardown poll starves the pool and times out concurrent suites.
+    private static func awaitProcessDeath(_ pid: Int32, timeout: TimeInterval) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if !isProcessAlive(pid) { return true }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return !isProcessAlive(pid)
     }
 
     /// Truncate `serve.log` on the first call in this process; always append

--- a/previewsmcp/Tests/CLIIntegrationTests/DaemonTestLockFenceTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/DaemonTestLockFenceTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+
+/// The writer-fence in `DaemonTestLock.run` teardown must guarantee no daemon
+/// is left writing the shared `serve.log` when the lock frees — otherwise its
+/// stderr byte-races the next locked window's reader (the LogsCommandTests
+/// flake). These drive the fence deterministically, without the CI-load race
+/// that surfaced it: a daemon left alive in-block, and a writer that refuses
+/// SIGTERM, must both be dead by the time `run` returns.
+@Suite(.serialized)
+struct DaemonTestLockFenceTests {
+    @Test(
+        "a daemon left alive in-block is confirmed dead after the lock releases",
+        .timeLimit(.minutes(2))
+    )
+    func fenceReapsDaemonLeftAliveInBlock() async throws {
+        // Return the pid out of the @Sendable block rather than capturing a var.
+        let pid: Int32 = try await DaemonTestLock.run {
+            // Start from a known state, then spawn a daemon and deliberately
+            // do NOT stop it — mirroring RunCommand `--detach`, whose daemon
+            // outlives its block today.
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+            let pid = try await Self.spawnDaemon()
+            #expect(Self.isAlive(pid), "precondition: daemon should be live in-block")
+            return pid
+        }
+
+        let dead = !Self.isAlive(pid)
+        if !dead {
+            // Don't orphan the daemon into the rest of the run on the fail path.
+            _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "5"])
+        }
+        #expect(dead, "teardown fence must confirm daemon pid \(pid) dead before releasing the lock")
+    }
+
+    @Test(
+        "the fence escalates to SIGKILL when a writer refuses SIGTERM",
+        .timeLimit(.minutes(1))
+    )
+    func fenceEscalatesToSIGKILL() async throws {
+        // Hermetic: drive the escalation primitive DIRECTLY against a throwaway
+        // stub with a short grace — no daemon lock held, no serve.pid touched —
+        // so this test can't perturb the concurrent suite. The stub signals
+        // READY only after its SIGTERM trap is installed, so the grace wait is
+        // guaranteed to elapse and force the SIGKILL escalation.
+        let pid = try await Self.spawnSIGTERMIgnoringProcess()
+        let escalated = await DaemonTestLock.confirmProcessDead(pid, graceSeconds: 0.2)
+
+        let dead = !Self.isAlive(pid)
+        if !dead { kill(pid, SIGKILL) }
+        // escalated == true rules out a false green: a graceful SIGTERM reap
+        // would return false, so this only passes via the actual SIGKILL path.
+        #expect(escalated, "a SIGTERM-proof writer must force the SIGKILL escalation, not a graceful reap")
+        #expect(dead, "the fence must reap the writer (pid \(pid))")
+    }
+
+    // MARK: - Helpers
+
+    private static var pidFile: URL {
+        URL(fileURLWithPath: DaemonTestLock.effectiveSocketDir, isDirectory: true)
+            .appendingPathComponent("serve.pid")
+    }
+
+    private static func isAlive(_ pid: Int32) -> Bool {
+        kill(pid, 0) == 0
+    }
+
+    /// Spawn a shell that traps SIGTERM to a no-op, then — only once the trap
+    /// is installed — touches a ready file and loops. Waiting on the ready
+    /// file before returning closes the run()-returns-before-trap race, so the
+    /// teardown fence is guaranteed to meet a genuinely SIGTERM-proof writer
+    /// and must escalate to SIGKILL to reap it.
+    private static func spawnSIGTERMIgnoringProcess() async throws -> Int32 {
+        let ready = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fence-stub-ready-\(UUID().uuidString)")
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/sh")
+        proc.arguments = ["-c", "trap '' TERM; : > '\(ready.path)'; while :; do sleep 1; done"]
+        proc.standardInput = FileHandle.nullDevice
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+        try proc.run()
+
+        let deadline = Date().addingTimeInterval(10)
+        while Date() < deadline {
+            if FileManager.default.fileExists(atPath: ready.path) {
+                try? FileManager.default.removeItem(at: ready)
+                return proc.processIdentifier
+            }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        proc.terminate()
+        throw FenceTestError.stubReadyTimeout
+    }
+
+    /// Spawn a real daemon (`serve --daemon`) on this run's socket dir and
+    /// wait until its pid file is written and it is alive. No render, so it's
+    /// cheap. Mirrors VersionHandshakeTests.spawnStaleDaemon minus the
+    /// version override.
+    private static func spawnDaemon() async throws -> Int32 {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: CLIRunner.binaryPath)
+        proc.arguments = ["serve", "--daemon"]
+        proc.standardInput = FileHandle.nullDevice
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+        var env = ProcessInfo.processInfo.environment
+        env["PREVIEWSMCP_SOCKET_DIR"] = DaemonTestLock.effectiveSocketDir
+        proc.environment = env
+        try proc.run()
+
+        let deadline = Date().addingTimeInterval(10)
+        while Date() < deadline {
+            if let pid = readPIDFile(), isAlive(pid) { return pid }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+        throw FenceTestError.daemonStartupTimeout
+    }
+
+    private static func readPIDFile() -> Int32? {
+        guard
+            let contents = try? String(contentsOf: pidFile, encoding: .utf8),
+            let pid = Int32(contents.trimmingCharacters(in: .whitespacesAndNewlines))
+        else { return nil }
+        return pid
+    }
+}
+
+private enum FenceTestError: Error {
+    case daemonStartupTimeout
+    case stubReadyTimeout
+}


### PR DESCRIPTION
## Fix #397 — serve.log writer-race in CLIIntegrationTests

`CLIIntegrationTests` share one `serve.log` per test process. Reader suites write a sentinel and read it back (`LogsCommandTests` :34/:44/:86, the `VersionHandshakeTests` breadcrumb count :204), assuming nothing else writes during their `DaemonTestLock`-held window. A daemon still draining stderr into `serve.log` when the previous test released the lock breaks that — it byte-races the sentinel. Observed on the Stream C gate (run 29208398627): a tail line with its `logs-` prefix sheared off, interleaved with live `jit_latency` / `daemon connection error` / `Cleaned up stale temp dir` daemon output.

### Root cause
Daemons outlive their block: `RunCommand --detach` intentionally leaves one alive (reaped by the next test's `cleanSlate`), and every teardown's `kill-daemon --timeout 2` gives up under CI load (swallowed by `try?`), so the daemon straggles past the released lock and concurrently writes the next locked window.

### Fix — a writer-fence at `DaemonTestLock.run` teardown
With the lock still held (release stays in a `defer`, so it **always** fires even if the fence misbehaves), await confirmation the daemon is dead before returning — SIGTERM, await actual exit, escalate to SIGKILL if graceful shutdown won't confirm within the grace bound. Key points:

- **Async, not blocking.** The exit poll uses `Task.sleep`, never `Thread.sleep` — a blocking teardown poll starves the cooperative pool and times out concurrent suites (caught locally before push).
- **Confirm death, don't just wait.** SIGKILL escalation makes the next window clean by construction, not by hope. The loud stderr log fires **only** on the SIGKILL path (a real daemon-shutdown bug worth surfacing, ref #397); routine graceful reaps are silent.
- **Pays nothing when idle.** A test that spawned no daemon finds no live pid and returns immediately.

Closes all four CLI `serve.log` consumers by construction.

### Tests (`DaemonTestLockFenceTests`)
- **Reap** (integration, through `run()` teardown): a daemon left alive in-block must be dead after `run()` returns. Fail-first verified — fails with the fence disabled.
- **Escalation** (hermetic unit): `confirmProcessDead(pid, graceSeconds:)` is extracted so the SIGKILL path is driven **directly** — short grace, a READY-handshake SIGTERM-proof stub, no daemon lock held and no `serve.pid` touched, so the test can't perturb the concurrent suite. Asserts `escalated == true`, which structurally rules out a graceful-path false green.

### Scope / follow-up
CLI `DaemonTestLock` only. The `MCPIntegrationTests` copy has a **separate** `serve.log` (unique `TEST_TMPDIR` per Bazel target) and **zero** `serve.log` content consumers, so it cannot exhibit this flake today; a shared fence helper is a defensive follow-up (noted in #397).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
