### PR TITLE
#368: un-mask awaitSnapshotChange + HID delivery attribution (diagnosis, no root-fix)

### DIFF
--- a/previewsmcp/SimulatorBridge/SimulatorBridge.m
+++ b/previewsmcp/SimulatorBridge/SimulatorBridge.m
@@ -583,9 +583,15 @@ static SBIndigoMouseFunc _loadMouseFunc(void) {
   dispatch_queue_t completionQueue = NULL;
   if (deliveredLabel) {
     NSString *label = [NSString stringWithUTF8String:deliveredLabel];
+    // Send-time marker (#368 (b1) splitter): logged inline before dispatch, so
+    // the down->up gap here reflects the real inter-event hold. The "delivered"
+    // completion below runs on inputQueue *after* the 60ms usleep between the
+    // down and up sends, so its timestamps batch together and can't measure the
+    // hold — this one can.
+    NSLog(@"SimulatorBridge: hid %@ sent at (%.4f, %.4f)", label, x, y);
     completionQueue = self.inputQueue;
     completion = ^{
-      NSLog(@"SimulatorBridge: hid %@ delivered", label);
+      NSLog(@"SimulatorBridge: hid %@ delivered at (%.4f, %.4f)", label, x, y);
     };
   }
   [(id<_SimDeviceLegacyHIDClient>)self.hidClient sendWithMessage:msg
@@ -598,7 +604,7 @@ static SBIndigoMouseFunc _loadMouseFunc(void) {
   if (!_loadMouseFunc())
     return NO;
   dispatch_async(self.inputQueue, ^{
-    [self _sendEventType:1 x:x y:y deliveredLabel:NULL];
+    [self _sendEventType:1 x:x y:y deliveredLabel:"tap down"];
     usleep(60000);
     [self _sendEventType:2 x:x y:y deliveredLabel:"tap up"];
   });
@@ -614,7 +620,7 @@ static SBIndigoMouseFunc _loadMouseFunc(void) {
     return NO;
   NSInteger n = steps < 1 ? 10 : steps;
   dispatch_async(self.inputQueue, ^{
-    [self _sendEventType:1 x:fromX y:fromY deliveredLabel:NULL];
+    [self _sendEventType:1 x:fromX y:fromY deliveredLabel:"drag down"];
     usleep(8000);
     for (NSInteger i = 1; i <= n; i++) {
       double t = (double)i / (double)n;
@@ -1138,8 +1144,12 @@ static const void *const kFBStreamerQueueKey = &kFBStreamerQueueKey;
     // move distinguishes "display content genuinely static" (dropped input)
     // from "reading a detached surface" (seed frozen while the sim renders
     // elsewhere, the #269 display-port class).
-    NSLog(@"SimulatorBridge: fb capture surface=%u seed=%u",
-          IOSurfaceGetID(surface), IOSurfaceGetSeed(surface));
+    // size= is the sim's pixel resolution (#368 (b2) splitter): a sane WxH
+    // confirms the normalized tap coords map to the expected pixel; a
+    // degenerate/rotated size under churn would point at coord/scaling-off.
+    NSLog(@"SimulatorBridge: fb capture surface=%u seed=%u size=%zux%zu",
+          IOSurfaceGetID(surface), IOSurfaceGetSeed(surface),
+          IOSurfaceGetWidth(surface), IOSurfaceGetHeight(surface));
     return _encodeSurface(surface, jpegQuality);
   };
 

--- a/previewsmcp/Tests/MCPIntegrationTests/MCPTestServer.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/MCPTestServer.swift
@@ -572,25 +572,23 @@ final class MCPTestServer: @unchecked Sendable {
         baseline: Data,
         timeout: Duration
     ) async throws -> Data {
+        // Each poll gets snapshotBytes' full default budget — like the sibling
+        // pollers awaitElementsText/awaitStderrContains — NOT a shrinking
+        // slice of the remaining window. A near-zero final slice used to trip
+        // snapshotBytes' withTimeout, which terminates the server and throws a
+        // misleading `callTool(preview_snapshot) timed out after 0.06s`,
+        // masking the honest "bytes did not change" record below (#368). The
+        // `while` deadline stops issuing polls once the window elapses; a poll
+        // that genuinely hangs still surfaces its own snapshot timeout (also
+        // honest, not masked).
         let deadline = ContinuousClock.now + timeout
         while ContinuousClock.now < deadline {
-            let current = try await snapshotBytes(
-                sessionID: sessionID,
-                timeout: Self.remainingBudget(until: deadline)
-            )
+            let current = try await snapshotBytes(sessionID: sessionID)
             if current != baseline { return current }
             try await Task.sleep(for: .milliseconds(200))
         }
         Issue.record("Snapshot bytes did not change within \(timeout). Server stderr:\n\(stderrLog())")
         throw MCPTestError.timedOut(operation: "awaitSnapshotChange(sessionID: \(sessionID))", duration: timeout)
-    }
-
-    private static func remainingBudget(
-        until deadline: ContinuousClock.Instant
-    ) -> Duration {
-        let now = ContinuousClock.now
-        guard now < deadline else { return .milliseconds(1) }
-        return now.duration(to: deadline)
     }
 
     // MARK: - Timeout primitive


### PR DESCRIPTION
Diagnosis-enabling landing for the #368 IOSHIDInputTests flake. **No product/root fix** — un-masks the honest failure and lands permanent HID attribution so every future gate that fires #368 (~1/8) captures the sub-mode.

## 1. Un-mask `awaitSnapshotChange` (worker-a approved)
The poll no longer hands the final iteration a shrinking near-zero budget that tripped `snapshotBytes`' `withTimeout` (which terminates the server and threw a misleading `callTool(preview_snapshot) timed out after 0.06s`, masking the honest cause). Now each poll uses the default budget (like `awaitElementsText`/`awaitStderrContains`) and the deadline loop stops. A dropped/ineffective tap now REDs with the true **"Snapshot bytes did not change within Ns"**; a genuinely hung snapshot still surfaces its own timeout. Validated on a real mini flake (run 29220743305).

## 2. SimulatorBridge HID attribution (NSLog-only, #370 lineage)
Extends #370 (which logged only tap/drag UP) with: tap/drag **DOWN** delivery, a **"sent"** marker (inline before the async send, so the down→up gap is measurable — the completion runs after the 60ms `usleep` and batches), the delivered **(x, y)**, and the fb-capture **size=WxH**. A failing run now distinguishes dropped-down vs delivered-but-ineffective, and within the latter splits hold-too-short (send gap) / coord-off (x,y + resolution) / event-pump-stall.

Characterized so far (run 29220743305): **delivered-but-ineffective** — both down+up delivered at correct (0.86, 0.39) to a live rendering app, bytes frozen. Sub-mode (b1/b2/b3) awaits a marker-carrying fire. No root fix until the markers pick it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)