### PR TITLE
Fetch @llvm_src via sha256-pinned download_and_extract (idiomatic, hermetic, kills the 602s per-worktree LLVM fetch)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -64,18 +64,10 @@ llvm_repository = use_repo_rule("//bazel:llvm.bzl", "llvm_repository")
 
 llvm_repository(
     name = "llvm_src",
-    commit = "9784760565e8cae0bc0b97bad69aaf498408dc3d",
     patches = [
         "//patches:llvm-machoplatform-bootstrap-race.patch",
         "//patches:llvm-mapperjitlink-abandon-slab.patch",
     ],
-    remote = "https://github.com/swiftlang/llvm-project.git",
-    sparse_paths = [
-        "llvm",
-        "compiler-rt",
-        "cmake",
-        "third-party",
-        "runtimes",
-    ],
-    tag = "swift-6.2.3-RELEASE",
+    sha256 = "a906c066310e19d876faae4119b5269d7bcee1abab8eebc3e30839b7f81bbbc7",
+    url = "https://github.com/obj-p/PreviewsMCP/releases/download/llvm-src-swift-6.2.3-RELEASE/llvm-src-swift-6.2.3-RELEASE.tar.gz",
 )

--- a/bazel/llvm.bzl
+++ b/bazel/llvm.bzl
@@ -1,9 +1,10 @@
 """Hermetic fetch of the swiftlang/llvm-project fork PreviewsJITLink links against.
 
 Downloads a pinned, sha256-verified sparse source archive (the same tree the
-former git sparse-checkout produced), applies the local patches, strips a
-cyclic test symlink that otherwise breaks Bazel's source glob, and writes the
-BUILD that consumes @llvm_src//:all.
+former git sparse-checkout produced), applies the local patches with the
+native `ctx.patch` (no git on PATH), strips a cyclic test symlink that
+otherwise breaks Bazel's source glob, and writes the BUILD that consumes
+@llvm_src//:all.
 
 The archive is a self-hosted, immutable release asset. A `download_and_extract`
 fetch is content-addressable, so it populates Bazel's repository cache and is
@@ -26,13 +27,8 @@ def _llvm_repository_impl(ctx):
         sha256 = ctx.attr.sha256,
     )
 
-    git = ctx.which("git")
-    if git == None:
-        fail("git not found on PATH")
     for patch in ctx.attr.patches:
-        res = ctx.execute([git, "apply", str(ctx.path(patch))])
-        if res.return_code != 0:
-            fail("git apply %s failed:\n%s%s" % (patch, res.stdout, res.stderr))
+        ctx.patch(ctx.path(patch), strip = 1)
 
     ctx.delete("llvm/test/tools/llvm-cas/Inputs/self")
     ctx.file("BUILD.bazel", _BUILD_FILE, executable = False)

--- a/bazel/llvm.bzl
+++ b/bazel/llvm.bzl
@@ -1,9 +1,15 @@
 """Hermetic fetch of the swiftlang/llvm-project fork PreviewsJITLink links against.
 
-Clones the fork (shallow + sparse + partial, pinned to the exact commit),
-applies the local patches, and strips a cyclic test
-symlink that otherwise breaks Bazel's source glob. The cmake build of the result
-lives in the BUILD file that consumes @llvm_src//:all.
+Downloads a pinned, sha256-verified sparse source archive (the same tree the
+former git sparse-checkout produced), applies the local patches, strips a
+cyclic test symlink that otherwise breaks Bazel's source glob, and writes the
+BUILD that consumes @llvm_src//:all.
+
+The archive is a self-hosted, immutable release asset. A `download_and_extract`
+fetch is content-addressable, so it populates Bazel's repository cache and is
+fetched once per machine — unlike the former `ctx.execute(git)` clone, which
+bypassed the repository cache and re-ran per output base (a ~600s fetch each
+time). The sha256 pin subsumes the old commit check.
 """
 
 _BUILD_FILE = """\
@@ -15,32 +21,18 @@ filegroup(
 """
 
 def _llvm_repository_impl(ctx):
+    ctx.download_and_extract(
+        url = ctx.attr.url,
+        sha256 = ctx.attr.sha256,
+    )
+
     git = ctx.which("git")
     if git == None:
         fail("git not found on PATH")
-
-    def git_run(args, timeout = 600):
-        res = ctx.execute([git] + args, timeout = timeout)
-        if res.return_code != 0:
-            fail("git %s failed:\n%s%s" % (" ".join(args), res.stdout, res.stderr))
-        return res
-
-    git_run(["init", "-q", "."])
-    git_run(["remote", "add", "origin", ctx.attr.remote])
-    git_run(["config", "extensions.partialClone", "origin"])
-    git_run(["sparse-checkout", "set", "--cone"] + ctx.attr.sparse_paths)
-    git_run(
-        ["fetch", "-q", "--depth", "1", "--filter=blob:none", "origin", "refs/tags/" + ctx.attr.tag],
-        timeout = 1800,
-    )
-    git_run(["checkout", "-q", "FETCH_HEAD"])
-
-    got = git_run(["rev-parse", "HEAD"]).stdout.strip()
-    if got != ctx.attr.commit:
-        fail("pinned SHA mismatch: got %s, expected %s" % (got, ctx.attr.commit))
-
     for patch in ctx.attr.patches:
-        git_run(["apply", str(ctx.path(patch))])
+        res = ctx.execute([git, "apply", str(ctx.path(patch))])
+        if res.return_code != 0:
+            fail("git apply %s failed:\n%s%s" % (patch, res.stdout, res.stderr))
 
     ctx.delete("llvm/test/tools/llvm-cas/Inputs/self")
     ctx.file("BUILD.bazel", _BUILD_FILE, executable = False)
@@ -48,10 +40,8 @@ def _llvm_repository_impl(ctx):
 llvm_repository = repository_rule(
     implementation = _llvm_repository_impl,
     attrs = {
-        "remote": attr.string(mandatory = True),
-        "tag": attr.string(mandatory = True),
-        "commit": attr.string(mandatory = True),
-        "sparse_paths": attr.string_list(mandatory = True),
+        "url": attr.string(mandatory = True),
+        "sha256": attr.string(mandatory = True),
         "patches": attr.label_list(allow_files = [".patch"]),
     },
 )


### PR DESCRIPTION
## What

Rewrites the `@llvm_src` repo rule (`//bazel:llvm.bzl`) from a `ctx.execute(git)` sparse clone to a `ctx.download_and_extract(url, sha256)` of a self-hosted, immutable release asset.

## Why (CI-hardening point 4, near-term piece)

`ctx.execute(git)` repo rules **bypass Bazel's repository cache** (only `ctx.download*`-by-sha256 is content-addressable), so the ~1.2G LLVM source **re-fetched per output_base** — a ~600s `git checkout FETCH_HEAD` on every fresh worktree/machine (observed: 28 × 1.2G ≈ 34GB duplicated locally). That's the non-idiomatic, non-hermetic anti-pattern.

`download_and_extract` of a sha256-pinned asset populates the repository cache → **downloaded once per machine, shared across all output_bases**. The sha256 pin subsumes the old commit check (pins the exact tree bytes — stronger than the git commit). Folding N1, patches now apply via native `ctx.patch` (no git on PATH) → the rule is **fully hermetic**.

## Correctness (validated)

- **Byte-identity proven:** the `//:llvm` `CcCmakeMakeRule` action key is **unchanged** (`fcd7567…`) via the new path — same via `git apply` and `ctx.patch` — so the LLVM build is provably identical.
- Real release-URL fetch (fresh `--repository_cache`) downloads + redirect-follows + sha-verifies; `//:llvm` builds green; PreviewAgent links.
- Archive is the identical sparse tree (`llvm compiler-rt cmake third-party runtimes` + root files) the git sparse-checkout produced; patches / cyclic-symlink-strip / BUILD-gen unchanged.

Design + review: worker-a APPROVED. Does not touch `ci.yml`.