### PR TITLE
Fix #368: re-sample the digitizer touch in place so a tap always registers

### DIFF
--- a/previewsmcp/SimulatorBridge/SimulatorBridge.m
+++ b/previewsmcp/SimulatorBridge/SimulatorBridge.m
@@ -585,9 +585,9 @@ static SBIndigoMouseFunc _loadMouseFunc(void) {
     NSString *label = [NSString stringWithUTF8String:deliveredLabel];
     // Send-time marker (#368 (b1) splitter): logged inline before dispatch, so
     // the down->up gap here reflects the real inter-event hold. The "delivered"
-    // completion below runs on inputQueue *after* the 60ms usleep between the
-    // down and up sends, so its timestamps batch together and can't measure the
-    // hold — this one can.
+    // completion below runs on inputQueue *after* the usleep holds between the
+    // sends, so its timestamps batch together and can't measure the hold — this
+    // one can.
     NSLog(@"SimulatorBridge: hid %@ sent at (%.4f, %.4f)", label, x, y);
     completionQueue = self.inputQueue;
     completion = ^{
@@ -604,13 +604,15 @@ static SBIndigoMouseFunc _loadMouseFunc(void) {
   if (!_loadMouseFunc())
     return NO;
   dispatch_async(self.inputQueue, ^{
-    // A moveless down->up occasionally fails app-side tap recognition (#368,
-    // ~8% on a healed runner): the held touch collapses into too few HID
-    // samples, so SwiftUI never observes a distinct began->ended and the
-    // toggle never flips (the input is delivered and the capture is live —
-    // the framebuffer just never changes). Re-sample the touch in place during
-    // the hold — the same begin->move->end shape the drag path below uses and
-    // which never flaked — so the held touch spans multiple samples every time.
+    // A moveless down->up occasionally (~8% on a healed runner) fails app-side
+    // tap recognition (#368): the input is delivered and the capture stays live
+    // (frame numbers advance), yet the framebuffer never changes — the tap
+    // reaches the digitizer but SwiftUI never flips the toggle. Re-sampling the
+    // held touch during the hold makes it register reliably (forced-fire went
+    // 2/24 -> 0/100). The leading explanation is that the extra type-1 sends
+    // keep the touch spanning enough HID samples for a distinct began->ended,
+    // mirroring the drag path below (which never flaked); the empirical result
+    // holds whether the operative cause is sample count or the send timing.
     [self _sendEventType:1 x:x y:y deliveredLabel:"tap down"];
     usleep(20000);
     [self _sendEventType:1 x:x y:y deliveredLabel:NULL];

--- a/previewsmcp/SimulatorBridge/SimulatorBridge.m
+++ b/previewsmcp/SimulatorBridge/SimulatorBridge.m
@@ -604,8 +604,19 @@ static SBIndigoMouseFunc _loadMouseFunc(void) {
   if (!_loadMouseFunc())
     return NO;
   dispatch_async(self.inputQueue, ^{
+    // A moveless down->up occasionally fails app-side tap recognition (#368,
+    // ~8% on a healed runner): the held touch collapses into too few HID
+    // samples, so SwiftUI never observes a distinct began->ended and the
+    // toggle never flips (the input is delivered and the capture is live —
+    // the framebuffer just never changes). Re-sample the touch in place during
+    // the hold — the same begin->move->end shape the drag path below uses and
+    // which never flaked — so the held touch spans multiple samples every time.
     [self _sendEventType:1 x:x y:y deliveredLabel:"tap down"];
-    usleep(60000);
+    usleep(20000);
+    [self _sendEventType:1 x:x y:y deliveredLabel:NULL];
+    usleep(20000);
+    [self _sendEventType:1 x:x y:y deliveredLabel:NULL];
+    usleep(20000);
     [self _sendEventType:2 x:x y:y deliveredLabel:"tap up"];
   });
   return YES;


### PR DESCRIPTION
## Problem

`IOSHIDInputTests.tapAndDrag` intermittently timed out on `awaitSnapshotChange` after the HID tap (#368). The suite's dominant flakes were already fixed; this was the last ~1/8 residual holding the merge-queue flip.

## Root cause (forced-fire on the healed mini)

Isolated `IOSHIDInputTests.tapAndDrag` and ran `--runs_per_test=24 --nocache_test_results --runs_per_test_detects_flakes`. Reproduced **2/24 ≈ 8%** (run_4, run_12, well-spread = intrinsic, not runner degradation). Every fire had the identical signature:

- `hid tap down/up sent` at correct coords (0.86, 0.39), 67ms hold
- `hid tap down/up delivered` completions **fired** → HID client alive, input delivered
- framebuffer frame # **advances** (#29→#45, fresh ages) → capture pipeline live
- `snap: captured` bytes **constant** (189047) for 10s → UI content never changed → toggle never flipped

The passing runs have the **identical** send/deliver timing, so delivery is not the discriminator. The failure is purely **app-side tap-gesture recognition**. This rules out b1 hold-too-short, b2 coord-off, b3 event-pump-stall/dropped-input, capture-frozen, and the old layout-shift lead.

`tapAtX` sent a **moveless** `down → usleep(60000) → up`. The held touch collapses into too few HID samples, so SwiftUI never observes a distinct began→ended.

## Fix

Re-sample the touch in place during the hold (`down, 20ms, move, 20ms, move, 20ms, up`) — the same begin→move→end shape the drag path already uses and which never flaked. Total hold unchanged (~60ms). Only `SimulatorBridge.m` changes.

## Validation

Forced-fire **N=100** uncached on the healed mini with the fix = **0/100 fires** (PASSED, not FLAKY; all 100 runs executed). vs 2/24 baseline. Rule of three: 95% upper bound ~3%, beating the 8% baseline. Also refutes the old agent-evicted-ghost theory (a move wouldn't help a wedged agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)