### PR TITLE
CI: fail fast with unit and integration test tiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       # xcode-select.
       DEVELOPER_DIR: /Applications/Xcode-26.2.0.app/Contents/Developer
       # Required-gate iOS-coverage signal. The "Assert iOS-coverage signal"
-      # step reads it here (runner shell); the Test step propagates it into
+      # step reads it here (runner shell); the Bazel test steps propagate it into
       # bazel's scrubbed sandbox via .bazelrc --test_env so
       # SimulatorTestDevices.requiresDedicatedSim is true → a nil provision
       # FAILS the gate instead of silently skipping iOS coverage.
@@ -151,12 +151,19 @@ jobs:
             exit 1
           }
 
-      - name: Test
+      # Run in-process tests first so a fast failure does not spend time on the
+      # simulator/daemon/agent tier. Both steps belong to the required `ci` job,
+      # so both must pass before a PR can merge.
+      - name: Test (unit)
+        if: steps.dedup.outputs.skip != 'true'
+        run: bazel test //... --test_tag_filters=-integration --test_output=errors
+
+      - name: Test (integration)
         if: steps.dedup.outputs.skip != 'true'
         # The job-level PREVIEWSMCP_REQUIRE_DEDICATED_SIM reaches bazel's
         # scrubbed test env via the .bazelrc --test_env line, so a nil
         # provision FAILS on the required gate instead of skip-as-green.
-        run: bazel test //... --test_output=errors
+        run: bazel test //... --test_tag_filters=integration --test_output=errors
 
       # The state a flake leaves behind (booted sims, orphan daemons, the
       # per-run daemon logs #350 collects specimens from) persists on the

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -19,6 +19,20 @@ Adding `merge` after a green `ci` on the same commit does **not** re-run the
 suite: the `ci` job sees the existing green check for that commit and exits fast,
 so auto-merge lands it without a second full run.
 
+## Test tiers
+
+The required `ci` job runs tests in two ordered Bazel steps after lint:
+
+1. **Unit:** `bazel test //... --test_tag_filters=-integration` runs the
+   in-process, parallel-safe targets first.
+2. **Integration:** `bazel test //... --test_tag_filters=integration` runs the
+   simulator, daemon, agent, and AppKit targets only after the unit tier passes.
+
+A unit failure stops the job before the slow integration tier, while either
+tier failing still blocks the merge through the same required `ci` check. The
+`integration` tag is only a selection label; existing `exclusive` tags and
+runtime simulator locks continue to control scheduling and isolation.
+
 ## Normal flow
 
 1. Open the PR. Nothing runs.

--- a/previewsmcp/Tests/CLIIntegrationTests/BUILD.bazel
+++ b/previewsmcp/Tests/CLIIntegrationTests/BUILD.bazel
@@ -28,6 +28,7 @@ swift_test(
     },
     tags = [
         "exclusive",
+        "integration",
         "local",
     ],
     visibility = ["//visibility:public"],

--- a/previewsmcp/Tests/MCPIntegrationTests/BUILD.bazel
+++ b/previewsmcp/Tests/MCPIntegrationTests/BUILD.bazel
@@ -35,6 +35,7 @@ swift_test(
     },
     tags = [
         "exclusive",
+        "integration",
         "local",
     ],
     visibility = ["//visibility:public"],

--- a/previewsmcp/Tests/PreviewsIOSTests/BUILD.bazel
+++ b/previewsmcp/Tests/PreviewsIOSTests/BUILD.bazel
@@ -10,7 +10,10 @@ swift_test(
     ],
     data = ["//:ios_jit_resources"],
     env = {"PREVIEWSMCP_IOS_JIT_DIR": "$(rlocationpath //:ios_jit_resources)"},
-    tags = ["local"],
+    tags = [
+        "integration",
+        "local",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//previewsmcp/PreviewsCore",

--- a/previewsmcp/Tests/PreviewsJITLinkTests/BUILD.bazel
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/BUILD.bazel
@@ -31,6 +31,7 @@ swift_test(
     },
     tags = [
         "exclusive",
+        "integration",
         "local",
     ],
     visibility = ["//visibility:public"],
@@ -60,6 +61,7 @@ swift_test(
     },
     tags = [
         "exclusive",
+        "integration",
         "local",
     ],
     visibility = ["//visibility:public"],

--- a/previewsmcp/Tests/TestSupportTests/BUILD.bazel
+++ b/previewsmcp/Tests/TestSupportTests/BUILD.bazel
@@ -23,7 +23,10 @@ swift_test(
         "-swift-version",
         "6",
     ],
-    tags = ["local"],
+    tags = [
+        "integration",
+        "local",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//previewsmcp/PreviewsCore",


### PR DESCRIPTION
Summary
- tag the six simulator, daemon, agent, and AppKit test targets as integration
- run the six unit targets before the six integration targets in the required ci job
- document that unit failures skip the slow tier while both tiers remain blocking

Measured locally
- uncached unit tier: 6/6 passed in 104s
- uncached integration tier with required simulator coverage: 6/6 passed in 542s

Validation
- bazel run //tools/lint:check
- bazel test //previewsmcp/Tests/... --test_tag_filters=-integration --test_output=errors --nocache_test_results
- PREVIEWSMCP_REQUIRE_DEDICATED_SIM=1 bazel test //previewsmcp/Tests/... --test_tag_filters=integration --test_output=errors --nocache_test_results
- workflow YAML parse and exact six/six Bazel query partition