### PR TITLE
Fail loudly when required simulators are unavailable

### DIFF
--- a/previewsmcp/Tests/CLIIntegrationTests/IOSCLIWorkflowTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/IOSCLIWorkflowTests.swift
@@ -24,15 +24,6 @@ struct IOSCLIWorkflowTests {
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
         try await DaemonTestLock.run {
-            let simResult = try await CLIRunner.runExternal(
-                "/usr/bin/xcrun",
-                arguments: ["simctl", "list", "devices", "available"]
-            )
-            guard simResult.exitCode == 0, simResult.stdout.contains("iPhone") else {
-                print("No available iOS simulator — skipping iOS CLI workflow")
-                return
-            }
-
             try await Self.cleanSlate()
 
             // Reset host-global CoreSimulator state once before the first iOS
@@ -45,7 +36,7 @@ struct IOSCLIWorkflowTests {
             // device, which lands on the generic default (8958D70E) — and booting a generic
             // sim nulls the agent's CGSession, dropping it into the CFRunLoop fallback that
             // never dequeues AppKit events (#391 H1). A pinned previewsmcp-test-N boots clean.
-            guard let deviceUDID = await SimulatorTestDevices.udid(index: 8) else {
+            guard let deviceUDID = try await SimulatorTestDevices.udid(index: 8) else {
                 print("Host cannot create \(SimulatorTestDevices.name(index: 8)) — skipping iOS CLI workflow")
                 return
             }

--- a/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSAppServerTests.swift
@@ -36,12 +36,7 @@ struct IOSAppServerTests {
         // CoreSimulatorHygiene).
         await CoreSimulatorHygiene.resetOnce()
 
-        guard let deviceUDID = await SimulatorTestDevices.udid(index: 3) else {
-            if let failure = SimulatorTestDevices.missingDeviceFailure(
-                index: 3, requiresDedicatedSim: SimulatorTestDevices.requiresDedicatedSim
-            ) {
-                Issue.record("\(failure)")
-            }
+        guard let deviceUDID = try await SimulatorTestDevices.udid(index: 3) else {
             print("No dedicated test simulator for index 3 — skipping")
             return
         }

--- a/previewsmcp/Tests/MCPIntegrationTests/IOSHIDInputTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSHIDInputTests.swift
@@ -29,12 +29,7 @@ struct IOSHIDInputTests {
         // CoreSimulatorHygiene).
         await CoreSimulatorHygiene.resetOnce()
 
-        guard let deviceUDID = await SimulatorTestDevices.udid(index: 2) else {
-            if let failure = SimulatorTestDevices.missingDeviceFailure(
-                index: 2, requiresDedicatedSim: SimulatorTestDevices.requiresDedicatedSim
-            ) {
-                Issue.record("\(failure)")
-            }
+        guard let deviceUDID = try await SimulatorTestDevices.udid(index: 2) else {
             print("No dedicated test simulator for index 2 — skipping")
             return
         }

--- a/previewsmcp/Tests/MCPIntegrationTests/IOSMCPTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSMCPTests.swift
@@ -60,12 +60,7 @@ struct IOSMCPTests {
         // Index 1 is shared with SimulatorManagerTests.makeFramebufferStreamer
         // (PreviewsIOSTests target) — different targets never run
         // concurrently. See SimulatorTestDevices for the assignments.
-        guard let deviceUDID = await SimulatorTestDevices.udid(index: 1) else {
-            if let failure = SimulatorTestDevices.missingDeviceFailure(
-                index: 1, requiresDedicatedSim: SimulatorTestDevices.requiresDedicatedSim
-            ) {
-                Issue.record("\(failure)")
-            }
+        guard let deviceUDID = try await SimulatorTestDevices.udid(index: 1) else {
             print("No dedicated test simulator for index 1 — skipping iOS MCP tests")
             return
         }

--- a/previewsmcp/Tests/PreviewsIOSTests/SimulatorManagerTests.swift
+++ b/previewsmcp/Tests/PreviewsIOSTests/SimulatorManagerTests.swift
@@ -80,12 +80,7 @@ struct SimulatorManagerTests {
         // but not a scenario this test is trying to validate.
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
-        guard let udid = await SimulatorTestDevices.udid(index: 0) else {
-            if let failure = SimulatorTestDevices.missingDeviceFailure(
-                index: 0, requiresDedicatedSim: SimulatorTestDevices.requiresDedicatedSim
-            ) {
-                Issue.record("\(failure)")
-            }
+        guard let udid = try await SimulatorTestDevices.udid(index: 0) else {
             print("No dedicated test simulator for index 0 — skipping")
             return
         }
@@ -126,12 +121,7 @@ struct SimulatorManagerTests {
     func makeHIDClient() async throws {
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
-        guard let udid = await SimulatorTestDevices.udid(index: 4) else {
-            if let failure = SimulatorTestDevices.missingDeviceFailure(
-                index: 4, requiresDedicatedSim: SimulatorTestDevices.requiresDedicatedSim
-            ) {
-                Issue.record("\(failure)")
-            }
+        guard let udid = try await SimulatorTestDevices.udid(index: 4) else {
             print("No dedicated test simulator for index 4 — skipping")
             return
         }
@@ -167,12 +157,7 @@ struct SimulatorManagerTests {
     func makeFramebufferStreamer() async throws {
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
-        guard let udid = await SimulatorTestDevices.udid(index: 1) else {
-            if let failure = SimulatorTestDevices.missingDeviceFailure(
-                index: 1, requiresDedicatedSim: SimulatorTestDevices.requiresDedicatedSim
-            ) {
-                Issue.record("\(failure)")
-            }
+        guard let udid = try await SimulatorTestDevices.udid(index: 1) else {
             print("No dedicated test simulator for index 1 — skipping")
             return
         }

--- a/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
+++ b/previewsmcp/Tests/PreviewsJITLinkTests/IOSPreviewE2ETests.swift
@@ -776,7 +776,7 @@ struct IOSPreviewE2ETests {
     func stopShutsDownADeviceTheSessionBooted() async throws {
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
-        guard let udid = await SimulatorTestDevices.udid(index: 7) else {
+        guard let udid = try await SimulatorTestDevices.udid(index: 7) else {
             print("Host cannot create \(SimulatorTestDevices.name(index: 7)) — skipping")
             return
         }
@@ -815,7 +815,7 @@ struct IOSPreviewE2ETests {
     func failedStartShutsDownADeviceTheSessionBooted() async throws {
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
-        guard let udid = await SimulatorTestDevices.udid(index: 7) else {
+        guard let udid = try await SimulatorTestDevices.udid(index: 7) else {
             print("Host cannot create \(SimulatorTestDevices.name(index: 7)) — skipping")
             return
         }
@@ -1148,7 +1148,7 @@ enum IOSPreviewE2ESupport {
     /// reused without a shutdown/boot cycle. Callers hold
     /// `SimulatorTestLock`, which `SimulatorTestDevices` requires.
     static func bootSimulator() async throws -> String {
-        guard let udid = await SimulatorTestDevices.udid(index: 6) else {
+        guard let udid = try await SimulatorTestDevices.udid(index: 6) else {
             throw SpikeError.message(
                 "no \(SimulatorTestDevices.name(index: 6)) simulator (missing iPhone 17 device type or iOS 26+ runtime)"
             )

--- a/previewsmcp/Tests/TestSupport/SimulatorTestDevices.swift
+++ b/previewsmcp/Tests/TestSupport/SimulatorTestDevices.swift
@@ -66,16 +66,14 @@ public enum SimulatorTestDevices {
         ProcessInfo.processInfo.environment["PREVIEWSMCP_REQUIRE_DEDICATED_SIM"] != nil
     }
 
-    /// The message a caller should `Issue.record` (failing the test) when a
-    /// dedicated simulator can't be provisioned, or nil to skip. Fails only
-    /// when a dedicated sim is required (the gate); locally it skips.
-    /// `requiresDedicatedSim` is a parameter so this policy is unit-testable
-    /// without mutating the process env; callers pass
-    /// `SimulatorTestDevices.requiresDedicatedSim`.
-    public static func missingDeviceFailure(index: Int, requiresDedicatedSim: Bool) -> String? {
+    /// Apply the fail-vs-skip policy to a resolved device. This seam keeps the
+    /// policy unit-testable without mutating the process environment.
+    public static func enforceAvailability(
+        _ udid: String?, index: Int, requiresDedicatedSim: Bool
+    ) throws -> String? {
+        guard udid == nil else { return udid }
         guard requiresDedicatedSim else { return nil }
-        return "Required gate could not provision dedicated simulator index \(index) — "
-            + "failing, not skipping (must not silently drop iOS coverage)."
+        throw RequiredDeviceUnavailable(index: index)
     }
 
     /// Resolve the dedicated device for `index`, creating it if missing.
@@ -84,11 +82,17 @@ public enum SimulatorTestDevices {
     /// CoreSimulator device set, and the lock is what makes the
     /// check-then-create idempotent across concurrent workspaces.
     ///
-    /// Returns nil whenever the device cannot be provided — no iPhone 17
-    /// device type, no compatible runtime, or simctl itself failing/hanging —
-    /// so callers skip the test exactly as they did when the old picker ran
-    /// out of pool; a failed `simctl list` is nil, never a blind create.
-    public static func udid(index: Int) async -> String? {
+    /// Returns nil locally when the device cannot be provided. On the required
+    /// gate, throws instead so callers cannot silently skip iOS coverage.
+    public static func udid(index: Int) async throws -> String? {
+        try enforceAvailability(
+            await resolveUDID(index: index),
+            index: index,
+            requiresDedicatedSim: requiresDedicatedSim
+        )
+    }
+
+    private static func resolveUDID(index: Int) async -> String? {
         let name = name(index: index)
         do {
             guard let devices = try await list(name: name) else { return nil }
@@ -114,6 +118,15 @@ public enum SimulatorTestDevices {
         } catch {
             print("SimulatorTestDevices: resolving \(name) failed: \(error)")
             return nil
+        }
+    }
+
+    private struct RequiredDeviceUnavailable: LocalizedError {
+        let index: Int
+
+        var errorDescription: String? {
+            "Required gate could not provision dedicated simulator index \(index) — "
+                + "failing, not skipping (must not silently drop iOS coverage)."
         }
     }
 

--- a/previewsmcp/Tests/TestSupportTests/MissingDeviceFailurePolicyTests.swift
+++ b/previewsmcp/Tests/TestSupportTests/MissingDeviceFailurePolicyTests.swift
@@ -1,21 +1,35 @@
 import PreviewsTestSupport
 import Testing
 
-/// The guard that stands between a real CI provisioning failure and a
-/// silent skip-as-green. Deterministic (requiresDedicatedSim injected) so it can't regress:
-/// under CI a missing dedicated simulator must FAIL (yield a message the
-/// caller records), and locally it must SKIP (yield nil).
+/// The guard that stands between a real CI provisioning failure and a silent
+/// skip-as-green. The injected policy keeps this deterministic.
 struct MissingDeviceFailurePolicyTests {
     @Test("under CI, a missing dedicated simulator fails rather than skips")
     func failsUnderCI() {
-        let failure = SimulatorTestDevices.missingDeviceFailure(index: 2, requiresDedicatedSim: true)
-        let message = try? #require(failure)
-        #expect(message?.contains("index 2") == true)
-        #expect(message?.contains("failing") == true)
+        do {
+            _ = try SimulatorTestDevices.enforceAvailability(
+                nil, index: 2, requiresDedicatedSim: true
+            )
+            Issue.record("missing required simulator should throw")
+        } catch {
+            #expect(error.localizedDescription.contains("index 2"))
+            #expect(error.localizedDescription.contains("failing"))
+        }
     }
 
     @Test("locally, a missing dedicated simulator skips (no failure recorded)")
-    func skipsLocally() {
-        #expect(SimulatorTestDevices.missingDeviceFailure(index: 2, requiresDedicatedSim: false) == nil)
+    func skipsLocally() throws {
+        let udid = try SimulatorTestDevices.enforceAvailability(
+            nil, index: 2, requiresDedicatedSim: false
+        )
+        #expect(udid == nil)
+    }
+
+    @Test("an available simulator is preserved in either mode")
+    func preservesAvailableDevice() throws {
+        let udid = try SimulatorTestDevices.enforceAvailability(
+            "TEST-UDID", index: 2, requiresDedicatedSim: true
+        )
+        #expect(udid == "TEST-UDID")
     }
 }

--- a/previewsmcp/Tests/TestSupportTests/SimulatorTestDevicesTests.swift
+++ b/previewsmcp/Tests/TestSupportTests/SimulatorTestDevicesTests.swift
@@ -13,16 +13,11 @@ struct SimulatorTestDevicesTests {
         let simLock = try await SimulatorTestLock.acquire()
         defer { simLock.release() }
 
-        guard let first = await SimulatorTestDevices.udid(index: 5) else {
-            if let failure = SimulatorTestDevices.missingDeviceFailure(
-                index: 5, requiresDedicatedSim: SimulatorTestDevices.requiresDedicatedSim
-            ) {
-                Issue.record("\(failure)")
-            }
+        guard let first = try await SimulatorTestDevices.udid(index: 5) else {
             print("Host cannot create \(SimulatorTestDevices.deviceType) — skipping")
             return
         }
-        let second = await SimulatorTestDevices.udid(index: 5)
+        let second = try await SimulatorTestDevices.udid(index: 5)
         #expect(second == first)
 
         let output = try await runAsync(


### PR DESCRIPTION
## Summary

- centralize the CI fail-vs-local-skip policy in the throwing SimulatorTestDevices.udid resolver
- migrate every dedicated-simulator caller and remove the redundant generic CLI simulator preflight
- add deterministic coverage for required failure, local skip, and successful resolution

## Validation

- USE_BAZEL_VERSION=9.2.0 bazel run //tools/lint:check
- USE_BAZEL_VERSION=9.2.0 bazel test //previewsmcp/Tests/TestSupportTests:TestSupportTests --test_output=errors --nocache_test_results
- USE_BAZEL_VERSION=9.2.0 bazel test //previewsmcp/Tests/... --test_tag_filters=-integration --test_output=errors --nocache_test_results
- PREVIEWSMCP_REQUIRE_DEDICATED_SIM=1 DEVELOPER_DIR=/Applications/Xcode-26.2.0.app/Contents/Developer USE_BAZEL_VERSION=9.2.0 bazel test //previewsmcp/Tests/... --test_tag_filters=integration --test_output=errors --nocache_test_results (6/6 pass)