### PR TITLE
Retry iOS HID taps when toggle state is unchanged

### DIFF
--- a/previewsmcp/Tests/MCPIntegrationTests/IOSHIDInputTests.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/IOSHIDInputTests.swift
@@ -11,6 +11,9 @@ import Testing
 /// path that `preview_touch` uses.
 @Suite("iOS IndigoHID input", .serialized)
 struct IOSHIDInputTests {
+    private static let toggleLabel = "Show Completed"
+    private static let maximumTapAttempts = 3
+
     @Test(
         "IndigoHID tap flips the toggle and drag scrolls the list",
         .timeLimit(.minutes(20))
@@ -56,22 +59,38 @@ struct IOSHIDInputTests {
 
         let hid = try await SimulatorManager().makeHIDClient(udid: deviceUDID)
 
-        // Tap the "Show Completed" toggle (normalized). Flipping it hides the
-        // completed rows, a visible change, which proves the digitizer tap
-        // reached the hosted agent scene through the shell and fired the real
-        // SwiftUI action.
+        // Tap the "Show Completed" toggle (normalized). Verify its logical
+        // accessibility value so a delivered-but-unrecognized HID gesture can
+        // be retried instead of surfacing #368's residual false red.
+        let initialToggleValue = try await server.awaitElementValue(
+            sessionID: sessionID,
+            label: Self.toggleLabel,
+            timeout: .seconds(30)
+        )
         let beforeTap = try await server.snapshotBytes(sessionID: sessionID)
-        #expect(hid.tapAt(x: 0.86, y: 0.39), "HID symbol should resolve")
-        _ = try await server.awaitSnapshotChange(
+        let hiddenToggleValue = try await tapToggleUntilValueChanges(
+            hid: hid,
+            server: server,
+            sessionID: sessionID,
+            baseline: initialToggleValue
+        )
+        #expect(hiddenToggleValue != initialToggleValue)
+        let afterTap = try await server.awaitSnapshotChange(
             sessionID: sessionID, baseline: beforeTap, timeout: .seconds(10)
         )
 
         // Toggle back on so the list is long enough to scroll, then drag and
         // confirm the framebuffer changes again.
-        #expect(hid.tapAt(x: 0.86, y: 0.39), "HID symbol should resolve")
-        try await Task.sleep(for: .seconds(1))
-
-        let beforeDrag = try await server.snapshotBytes(sessionID: sessionID)
+        let restoredToggleValue = try await tapToggleUntilValueChanges(
+            hid: hid,
+            server: server,
+            sessionID: sessionID,
+            baseline: hiddenToggleValue
+        )
+        #expect(restoredToggleValue == initialToggleValue)
+        let beforeDrag = try await server.awaitSnapshotChange(
+            sessionID: sessionID, baseline: afterTap, timeout: .seconds(10)
+        )
         #expect(
             hid.dragFrom(x: 0.5, fromY: 0.7, toX: 0.5, toY: 0.3, steps: 12),
             "HID symbol should resolve"
@@ -83,5 +102,41 @@ struct IOSHIDInputTests {
         _ = try await server.callTool(
             name: "preview_stop", arguments: ["sessionID": .string(sessionID)]
         )
+    }
+
+    private func tapToggleUntilValueChanges(
+        hid: SBHIDClient,
+        server: MCPTestServer,
+        sessionID: String,
+        baseline: String
+    ) async throws -> String {
+        let changedValue = try await TestRetry.firstSuccess(
+            maximumAttempts: Self.maximumTapAttempts
+        ) { attempt in
+            try #require(hid.tapAt(x: 0.86, y: 0.39), "HID symbol should resolve")
+            let value = try await server.waitForElementValueChange(
+                sessionID: sessionID,
+                label: Self.toggleLabel,
+                baseline: baseline,
+                timeout: .seconds(3)
+            )
+            if value == nil, attempt < Self.maximumTapAttempts {
+                print(
+                    "\(Self.toggleLabel) stayed \(baseline.debugDescription) after HID tap "
+                        + "\(attempt)/\(Self.maximumTapAttempts) — retrying"
+                )
+            }
+            return value
+        }
+
+        guard let changedValue else {
+            Issue.record(
+                "\(Self.toggleLabel) stayed \(baseline.debugDescription) after \(Self.maximumTapAttempts) HID taps. Server stderr:\n\(server.stderrLog())"
+            )
+            throw MCPTestError.timedOut(
+                operation: "tapToggleUntilValueChanges", duration: .seconds(9)
+            )
+        }
+        return changedValue
     }
 }

--- a/previewsmcp/Tests/MCPIntegrationTests/MCPTestServer.swift
+++ b/previewsmcp/Tests/MCPIntegrationTests/MCPTestServer.swift
@@ -537,6 +537,75 @@ final class MCPTestServer: @unchecked Sendable {
         )
     }
 
+    /// Poll until the labeled accessibility element exposes a value.
+    func awaitElementValue(
+        sessionID: String,
+        label: String,
+        timeout: Duration
+    ) async throws -> String {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if let value = try await elementValue(sessionID: sessionID, label: label) {
+                return value
+            }
+            try await Task.sleep(for: .milliseconds(200))
+        }
+        Issue.record(
+            "preview_elements did not expose a value for \(label.debugDescription) within \(timeout). Server stderr:\n\(stderrLog())"
+        )
+        throw MCPTestError.timedOut(
+            operation: "awaitElementValue(label: \(label.debugDescription))", duration: timeout
+        )
+    }
+
+    /// Poll briefly for a labeled accessibility value to differ. Returning nil
+    /// is intentional: callers can retry the action without recording a failed
+    /// test for an individual missed attempt.
+    func waitForElementValueChange(
+        sessionID: String,
+        label: String,
+        baseline: String,
+        timeout: Duration
+    ) async throws -> String? {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if let value = try await elementValue(sessionID: sessionID, label: label),
+               value != baseline
+            {
+                return value
+            }
+            try await Task.sleep(for: .milliseconds(200))
+        }
+        return nil
+    }
+
+    private func elementValue(sessionID: String, label: String) async throws -> String? {
+        let (content, isError) = try await callTool(
+            name: "preview_elements",
+            arguments: ["sessionID": .string(sessionID), "filter": .string("labeled")]
+        )
+        let text = Self.extractText(from: content)
+        if isError == true {
+            throw MCPTestError.toolError(tool: "preview_elements", content: text)
+        }
+        guard let data = text.data(using: .utf8) else { return nil }
+        return try JSONDecoder().decode(AccessibilityNode.self, from: data).value(forLabel: label)
+    }
+
+    private struct AccessibilityNode: Decodable {
+        let label: String?
+        let value: String?
+        let children: [AccessibilityNode]?
+
+        func value(forLabel target: String) -> String? {
+            if label == target, let value { return value }
+            for child in children ?? [] {
+                if let value = child.value(forLabel: target) { return value }
+            }
+            return nil
+        }
+    }
+
     // MARK: - Snapshot helpers
 
     /// Capture a snapshot and return its raw image bytes. Decodes via the existing

--- a/previewsmcp/Tests/TestSupport/TestRetry.swift
+++ b/previewsmcp/Tests/TestSupport/TestRetry.swift
@@ -1,0 +1,14 @@
+public enum TestRetry {
+    public static func firstSuccess<Result>(
+        maximumAttempts: Int,
+        operation: (Int) async throws -> Result?
+    ) async rethrows -> Result? {
+        precondition(maximumAttempts > 0, "maximumAttempts must be positive")
+        for attempt in 1 ... maximumAttempts {
+            if let result = try await operation(attempt) {
+                return result
+            }
+        }
+        return nil
+    }
+}

--- a/previewsmcp/Tests/TestSupportTests/TestRetryTests.swift
+++ b/previewsmcp/Tests/TestSupportTests/TestRetryTests.swift
@@ -1,0 +1,30 @@
+import PreviewsTestSupport
+import Testing
+
+struct TestRetryTests {
+    @Test("returns the first successful attempt without extra work")
+    func returnsFirstSuccess() async {
+        var attempts: [Int] = []
+
+        let result = await TestRetry.firstSuccess(maximumAttempts: 3) { attempt in
+            attempts.append(attempt)
+            return attempt == 2 ? "changed" : nil
+        }
+
+        #expect(result == "changed")
+        #expect(attempts == [1, 2])
+    }
+
+    @Test("returns nil after exhausting the bounded attempts")
+    func exhaustsAttempts() async {
+        var attempts: [Int] = []
+
+        let result: String? = await TestRetry.firstSuccess(maximumAttempts: 3) { attempt in
+            attempts.append(attempt)
+            return nil
+        }
+
+        #expect(result == nil)
+        #expect(attempts == [1, 2, 3])
+    }
+}


### PR DESCRIPTION
## Summary

- read the Show Completed accessibility value before the IndigoHID tap
- retry a delivered tap up to three times only when the logical toggle value remains unchanged
- verify both toggle transitions and retain framebuffer-change and drag assertions
- add deterministic coverage for bounded first-success retry behavior

Fixes #368.

## Validation

- USE_BAZEL_VERSION=9.2.0 bazel run //tools/lint:check
- USE_BAZEL_VERSION=9.2.0 bazel test //previewsmcp/Tests/TestSupportTests:TestSupportTests --test_output=errors --nocache_test_results
- PREVIEWSMCP_REQUIRE_DEDICATED_SIM=1 DEVELOPER_DIR=/Applications/Xcode-26.2.0.app/Contents/Developer USE_BAZEL_VERSION=9.2.0 bazel test //previewsmcp/Tests/MCPIntegrationTests:MCPIntegrationTests --test_output=errors --nocache_test_results
- USE_BAZEL_VERSION=9.2.0 bazel test //previewsmcp/Tests/... --test_tag_filters=-integration --test_output=errors --nocache_test_results (6/6 pass)
- PREVIEWSMCP_REQUIRE_DEDICATED_SIM=1 DEVELOPER_DIR=/Applications/Xcode-26.2.0.app/Contents/Developer USE_BAZEL_VERSION=9.2.0 bazel test //previewsmcp/Tests/... --test_tag_filters=integration --test_output=errors --nocache_test_results (6/6 pass)