### PR TITLE
core: Xcode Tier 2 compiles with the captured build-log command (resolver stage 3)

### DIFF
--- a/examples/regress/VERIFICATION.md
+++ b/examples/regress/VERIFICATION.md
@@ -4,7 +4,8 @@ Last full manual pass: 2026-07-14. Detection rows (D01–D09, X02's detection
 half) re-verified 2026-07-15 after the ownership-walk resolver landed
 (`docs/build-system-resolver.md`, stage 1). SwiftPM compile rows (S01–S06,
 D09, W01's edit variant) re-verified 2026-07-15 after compile-command
-capture landed (stage 2).
+capture landed (stage 2). Xcode rows (X01, X02, D08, R03, D01/D07 guards)
+re-verified 2026-07-15 after build-log capture landed (stage 3).
 
 Environment: Xcode 26.2, an iOS 26.3 `previewsmcp-test` iPhone simulator,
 and the Bazel-built CLI from this checkout. Commands used an isolated daemon
@@ -28,14 +29,14 @@ not a nonzero command exit.
 | D07 | Guard passes | 2026-07-15 (ownership walk): the start error reports that no target in `StaleOutput.xcodeproj` compiles `NewPreview.swift` and that the project may be stale relative to its XcodeGen manifest. Previously the outer SwiftPM root claimed the file and forced Xcode silently rendered a file outside the project. |
 | D08 | Guard passes | 2026-07-15 (ownership walk): membership confirmed target `Beta`; the `Combined` scheme's build settings are parsed for that target and the preview rendered `Beta owns this preview`. Previously it compiled as module `Alpha` and failed. |
 | D09 | Guard passes | 2026-07-15 (compile capture): derived module names are sanitized to valid identifiers; rendered `path fixture: café` through the spaced/Unicode fixture path. |
-| X01 | Reproduced | Native `xcodebuild` passed for the workspace's `Preview Debug` configuration. PreviewsMCP selected the workspace, built both projects, linked `SharedKit`, and rendered its text, but the snapshot showed `wrong Xcode configuration` because `PREVIEW_WORKSPACE` from the selected `.xcconfig` was missing in Tier 2. |
+| X01 | Guard passes | 2026-07-15 (Xcode compile capture): the iOS snapshot rendered `cross-project dependency` and `custom workspace configuration` — the scheme's own configuration drives the build (no forced -configuration), so `PREVIEW_WORKSPACE` from the selected `.xcconfig` arrives via the captured command, and products-dir dependency frameworks are dlopen-staged for the JIT. |
 | S01 | Guard passes | 2026-07-15 (compile capture): rendered `Compiler settings preserved`, the processed resource, `build-tool generated`, `C module value: 42`, and `Conditional Swift setting present`. The captured command carries the C module map and defines; the captured inputs honor the exclusion and include the plugin-generated source. |
 | S02 | Guard passes | 2026-07-15 (compile capture): rendered `ExistentialAny enabled` and `Conditional Swift setting present` — the conditional define, upcoming feature, and unsafe flags forward through the normalized captured command. |
 | S03 | Guard passes | 2026-07-15 (compile capture): the plugin-generated `GeneratedFixtureStamp` is a captured compile input; rendered `build-tool generated`. |
 | S04 | Guard passes | 2026-07-15 (compile capture): the exclusion is honored by the captured inputs and the Clang module resolves; rendered `C module value: 42`. |
 | S05 | Guard passes | 2026-07-15 (compile capture): rendered `custom macro expansion active`. The captured `-Xfrontend -load-plugin-executable` points at the host-built plugin SwiftPM already produced (#413). |
 | S06 | Guard passes | The `@Observable` toolchain macro compiled through the default plugin path and the preview rendered `toolchain macro active` on macOS. Re-verified 2026-07-15 under compile capture. |
-| X02 | Reproduced | Native `xcodebuild` passed. 2026-07-15: auto-detection now selects the fixture's Xcode project (the outer-SwiftPM misclaim is fixed by the ownership walk); the compile still fails with `cannot find 'BridgedGreeting' in scope` because `SWIFT_OBJC_BRIDGING_HEADER` is not forwarded to Tier 2 (#414). |
+| X02 | Guard passes | 2026-07-15 (Xcode compile capture): rendered `bridged objc active`. The captured command carries `-import-objc-header` and the target's C/ObjC objects are archived for the JIT link, closing #414. |
 | C01 | Reproduced | Native SwiftPM build passed. Literal thunking changed `0 ..< 12` into a parser-invalid operator boundary (`'..<' is not a postfix unary operator`). |
 | C02 | Reproduced | Native SwiftPM build passed. String thunking produced `String` where `String.LocalizationValue` was required. |
 | C03 | Reproduced | A fresh daemon rendered the parent light config. After a nearer dark config appeared and the first session stopped, the same daemon still returned `colorScheme: light`. |
@@ -48,7 +49,7 @@ not a nonzero command exit.
 | F01 | Reproduced | The generator and XCFramework metadata provide only an iPhoneOS device slice. Native simulator and PreviewsMCP builds both failed `no such module 'BadSlice'`; PreviewsMCP did not classify the incompatible slice, while the daemon remained responsive. |
 | R01 | Reproduced | macOS and iOS reached JIT materialization and failed on the target-wide framework/autolink closure. The CLI error was an unclassified symbol dump; the daemon remained responsive. |
 | R02 | Reproduced | English JSON, text, and localization resources rendered on macOS and iOS. Both selecting preview index 1 and an explicit single-preview Spanish localization control produced a blank or partial framebuffer on iOS. Native SwiftPM build passed and both locale directories were present in the staged bundle. |
-| R03 | Reproduced | macOS and iOS rendered the generated color symbol, while the localized key remained `resource.title` and plist/Core Data lookup reported missing. The cold iOS Xcode build also spent about 49 seconds in one progress step. |
+| R03 | Reproduced | macOS and iOS rendered the generated color symbol, while the localized key remained `resource.title` and plist/Core Data lookup reported missing. The cold iOS Xcode build also spent about 49 seconds in one progress step. Re-verified 2026-07-15 under Xcode compile capture: the generated-sources half renders identically; the remaining gap is runtime-resource staging (out of the resolver's scope). |
 | W01 | Partial guard | Editing a dependency Swift file live changed `source version one` to `source version two` in a stable follow-up snapshot without restarting the session. The add/rename/remove variants are present in the fixture instructions but were not all exercised in this pass. Edit variant re-verified 2026-07-15 with the watcher fed by captured compile inputs; the fixture's Swift 6 language mode also forced two generated-source concurrency fixes (DesignTimeStore, window-state observer). |
 | W02 | Reproduced | Changing only `Resources/reload-value.txt` produced a reload transition, but stable follow-up snapshots still showed `resource version one`; the rebuilt/staged resource was stale. |
 | W03 | Guard passes | Both editor save styles reloaded on macOS: write-temp-then-rename-over and rename-away-then-recreate each updated the render to the new source value in a stable follow-up snapshot. |

--- a/previewsmcp/PreviewsCore/CompileCommandNormalizer.swift
+++ b/previewsmcp/PreviewsCore/CompileCommandNormalizer.swift
@@ -25,15 +25,15 @@ enum CompileCommandNormalizer {
                 continue
             }
             if token == "-Xfrontend", index + 1 < args.count,
-               droppedFrontendFlags.contains(args[index + 1])
+               let valueCount = droppedFrontendFlags[args[index + 1]]
             {
-                index += 2
+                index += 2 + valueCount * 2
                 continue
             }
             if token == "-Xcc", index + 1 < args.count,
-               droppedClangFlags.contains(args[index + 1])
+               let valueCount = droppedClangFlags[args[index + 1]]
             {
-                index += 2
+                index += 2 + valueCount * 2
                 continue
             }
             if token.hasSuffix(".swift"), !token.hasPrefix("-") {
@@ -71,14 +71,28 @@ enum CompileCommandNormalizer {
         "-emit-objc-header-path": 1,
         "-module-name": 1,
         "-o": 1,
+        "-explicit-module-build": 0,
+        "-validate-clang-modules-once": 0,
+        "-clang-build-session-file": 1,
+        "-clang-scanner-module-cache-path": 1,
+        "-sdk-module-cache-path": 1,
+        "-save-temps": 0,
+        "-no-color-diagnostics": 0,
+        "-use-frontend-parseable-output": 0,
+        "-experimental-emit-module-separately": 0,
+        "-emit-const-values": 0,
     ]
 
-    private static let droppedFrontendFlags: Set<String> = [
-        "-serialize-debugging-options",
+    /// Frontend flags to drop with their `-Xfrontend`-wrapped value counts.
+    private static let droppedFrontendFlags: [String: Int] = [
+        "-serialize-debugging-options": 0,
+        "-const-gather-protocols-file": 1,
     ]
 
-    private static let droppedClangFlags: Set<String> = [
-        "-g",
+    /// Clang flags to drop with their `-Xcc`-wrapped value counts.
+    private static let droppedClangFlags: [String: Int] = [
+        "-g": 0,
+        "-ivfsstatcache": 1,
     ]
 
     private static func jobCountPattern(_ token: String) -> Bool {

--- a/previewsmcp/PreviewsCore/XcodeBuildSystem.swift
+++ b/previewsmcp/PreviewsCore/XcodeBuildSystem.swift
@@ -60,7 +60,7 @@ public actor XcodeBuildSystem: BuildSystem {
         let scheme = try pickScheme(from: projectInfo)
 
         // 2. Build the project (must happen before getBuildSettings so DerivedData is populated)
-        try await runBuild(scheme: scheme, platform: platform)
+        let buildLog = try await runBuild(scheme: scheme, platform: platform)
 
         // 3. Get build settings (post-build so all paths are valid)
         let settings = try await getBuildSettings(scheme: scheme, platform: platform)
@@ -82,7 +82,23 @@ public actor XcodeBuildSystem: BuildSystem {
             )
         }
 
-        // 5. Collect source files for Tier 2 (from OutputFileMap.json)
+        // 5. Capture the compile command xcodebuild actually ran; a
+        //    build-with-Bazel project logs no SwiftDriver invocation, so the
+        //    settings-derived path below stays as its fallback.
+        let captured = try await captureCommand(
+            buildLog: buildLog, scheme: scheme, platform: platform,
+            moduleName: moduleName, targetName: targetName,
+            builtProductsDir: builtProductsDir
+        )
+        if let captured {
+            return try await buildContext(
+                from: captured, settings: settings,
+                moduleName: moduleName, targetName: targetName,
+                builtProductsDir: builtProductsDir, platform: platform
+            )
+        }
+
+        // 5-fallback. Collect source files for Tier 2 (from OutputFileMap.json)
         var sourceFiles = collectSourceFiles(settings: settings, targetName: targetName)
 
         // 5b. Union Xcode-generated Swift sources from DERIVED_FILE_DIR.
@@ -124,6 +140,220 @@ public actor XcodeBuildSystem: BuildSystem {
             frameworkPaths: package.frameworkPaths,
             sourceFiles: sourceFiles
         )
+    }
+
+    // MARK: - Private: Compile Capture
+
+    /// The captured compile command for the module: parsed from the build
+    /// log, or the persisted capture from an earlier start when this build
+    /// was null, or parsed after forcing the module to recompile (a source
+    /// touch) when neither exists. Nil when the build system never logs
+    /// SwiftDriver invocations (build-with-Bazel).
+    private func captureCommand(
+        buildLog: String, scheme: String, platform: PreviewPlatform,
+        moduleName: String, targetName: String, builtProductsDir: String
+    ) async throws -> XcodeCommandCapture.CapturedCommand? {
+        if let captured = XcodeCommandCapture.parse(
+            log: buildLog, moduleName: moduleName, targetName: targetName
+        ) {
+            XcodeCommandCapture.persist(
+                captured, at: persistedCaptureURL(builtProductsDir, moduleName),
+                validity: captureValidity()
+            )
+            return captured
+        }
+
+        if let persisted = XcodeCommandCapture.loadPersisted(
+            at: persistedCaptureURL(builtProductsDir, moduleName),
+            validity: captureValidity()
+        ) {
+            return persisted
+        }
+
+        // No compile line and no valid persisted capture. A null build and a
+        // build-with-Bazel project both log nothing here, so force the module
+        // to recompile (identity content, only the preview file's mtime
+        // moves): under XCBuild the forced log must carry the driver line;
+        // a forced log without one is Bazel driving the build.
+        try? FileManager.default.setAttributes(
+            [.modificationDate: Date()], ofItemAtPath: sourceFile.path
+        )
+        let forcedLog = try await runBuild(scheme: scheme, platform: platform)
+        if let captured = XcodeCommandCapture.parse(
+            log: forcedLog, moduleName: moduleName, targetName: targetName
+        ) {
+            XcodeCommandCapture.persist(
+                captured, at: persistedCaptureURL(builtProductsDir, moduleName),
+                validity: captureValidity()
+            )
+            return captured
+        }
+        guard XcodeCommandCapture.logsDriverInvocations(forcedLog) else { return nil }
+        throw BuildSystemError.missingArtifacts(
+            "No compile command for module '\(moduleName)' in the xcodebuild log"
+        )
+    }
+
+    private nonisolated func persistedCaptureURL(
+        _ builtProductsDir: String, _ moduleName: String
+    ) -> URL {
+        URL(fileURLWithPath: builtProductsDir)
+            .appendingPathComponent("previewsmcp-capture-\(moduleName).json")
+    }
+
+    private nonisolated func captureValidity() -> [String: Date] {
+        XcodeCommandCapture.validityKeys(projectFile: projectFile, projectRoot: projectRoot)
+    }
+
+    /// Assemble the BuildContext from a captured command: normalized captured
+    /// flags plus the link-time inputs a compile command cannot carry
+    /// (dependency archives from OTHER_LDFLAGS, Xcode-managed package
+    /// products, and the target's own C/ObjC objects for bridging-header
+    /// symbols).
+    private func buildContext(
+        from captured: XcodeCommandCapture.CapturedCommand,
+        settings: [String: String],
+        moduleName: String, targetName: String, builtProductsDir: String,
+        platform: PreviewPlatform
+    ) async throws -> BuildContext {
+        var flags = CompileCommandNormalizer.normalize(
+            Self.stripForeignTargetTriple(captured.arguments, platform: platform)
+        )
+
+        if let ldFlags = settings["OTHER_LDFLAGS"] {
+            let archives = Self.collectDependencyArchives(fromOtherLDFlags: ldFlags)
+            flags += Self.archiveLinkFlags(archivePaths: archives, targetName: targetName)
+        }
+        let package = await Self.swiftPMPackageProducts(builtProductsDir: builtProductsDir)
+        flags += package.flags
+
+        // Dependency frameworks built into the products directory (referenced
+        // projects, X01): -F/-framework pairs are what the JIT agent resolves
+        // to framework binaries to dlopen. The target's own framework is the
+        // Tier 2 recompile itself, never loaded.
+        let dependencyFrameworks = BuildSystemSupport.collectFrameworks(
+            binPath: URL(fileURLWithPath: builtProductsDir)
+        ).filter { $0 != moduleName && $0 != targetName }
+        if !dependencyFrameworks.isEmpty {
+            flags += ["-F", builtProductsDir]
+            for framework in dependencyFrameworks {
+                flags += ["-framework", framework]
+            }
+        }
+
+        let clangObjects = Self.clangObjects(
+            settings: settings, targetName: targetName,
+            swiftSources: captured.swiftSources
+        )
+        if !clangObjects.isEmpty {
+            flags += await Self.clangObjectLinkFlags(
+                objects: clangObjects,
+                moduleName: moduleName,
+                builtProductsDir: builtProductsDir
+            )
+        }
+
+        let previewPath = sourceFile.standardizedFileURL.path
+        var sourceFiles = captured.swiftSources
+            .map { URL(fileURLWithPath: $0).standardizedFileURL }
+            .filter { $0.path != previewPath }
+
+        // Union Xcode-generated Swift sources from DERIVED_FILE_DIR (asset
+        // symbols and friends are generated during the build; a capture from
+        // an earlier log may predate them).
+        if let derivedFileDir = settings["DERIVED_FILE_DIR"] {
+            let generated = Self.collectGeneratedSources(
+                derivedFileDir: URL(fileURLWithPath: derivedFileDir)
+            )
+            let seen = Set(sourceFiles.map(\.path))
+            sourceFiles += generated.filter { !seen.contains($0.path) }
+        }
+        sourceFiles = Self.applyResourceBundleRewrites(sources: sourceFiles, settings: settings)
+
+        return BuildContext(
+            moduleName: moduleName,
+            compilerFlags: flags,
+            projectRoot: projectRoot,
+            targetName: targetName,
+            frameworkPaths: package.frameworkPaths,
+            sourceFiles: sourceFiles.isEmpty ? nil : sourceFiles
+        )
+    }
+
+    /// Xcode pre-processing for the shared normalizer: a scheme can build a
+    /// platform variant the preview environment cannot host (Mac Catalyst
+    /// under the macOS agent), and the captured `-target`/`-sdk` would
+    /// otherwise win over Compiler's injection. Keep the captured pair only
+    /// when the triple matches the preview platform family.
+    static func stripForeignTargetTriple(
+        _ args: [String], platform: PreviewPlatform
+    ) -> [String] {
+        guard
+            let index = args.firstIndex(of: "-target"), index + 1 < args.count
+        else { return args }
+        let triple = args[index + 1]
+        let compatible =
+            switch platform {
+            case .macOS: triple.contains("apple-macos")
+            case .iOS: triple.contains("simulator")
+            }
+        guard !compatible else { return args }
+        var result = args
+        result.removeSubrange(index ... index + 1)
+        if let sdkIndex = result.firstIndex(of: "-sdk"), sdkIndex + 1 < result.count {
+            result.removeSubrange(sdkIndex ... sdkIndex + 1)
+        }
+        return result
+    }
+
+    /// The target's C/ObjC objects: everything in the objects directory that
+    /// is not a Swift compile output. Swift outputs are named after the
+    /// captured Swift sources; over-inclusion is safe because archive
+    /// members link lazily.
+    private static func clangObjects(
+        settings: [String: String], targetName: String, swiftSources: [String]
+    ) -> [String] {
+        guard let objectFileDir = settings["OBJECT_FILE_DIR_normal"] else { return [] }
+        let objectsDir = URL(fileURLWithPath: objectFileDir).appendingPathComponent("arm64")
+        guard
+            let entries = try? FileManager.default.contentsOfDirectory(
+                at: objectsDir, includingPropertiesForKeys: nil
+            )
+        else { return [] }
+        let swiftStems = Set(
+            swiftSources.map {
+                URL(fileURLWithPath: $0).deletingPathExtension().lastPathComponent
+            }
+        )
+        return entries
+            .filter { $0.pathExtension == "o" }
+            .filter {
+                let stem = $0.deletingPathExtension().lastPathComponent
+                return !swiftStems.contains(stem) && stem != targetName
+            }
+            .map(\.path)
+            .sorted()
+    }
+
+    /// Archive the target's C/ObjC objects and emit -L/-l for the
+    /// JIT link, so bridging-header symbols resolve at runtime (X02's link
+    /// half).
+    private static func clangObjectLinkFlags(
+        objects: [String], moduleName: String, builtProductsDir: String
+    ) async -> [String] {
+        let cacheDir = (builtProductsDir as NSString)
+            .appendingPathComponent("previewsmcp-package-archives")
+        try? FileManager.default.createDirectory(
+            atPath: cacheDir, withIntermediateDirectories: true
+        )
+        let libName = "\(moduleName)PreviewClang"
+        let archivePath = (cacheDir as NSString).appendingPathComponent("lib\(libName).a")
+        try? FileManager.default.removeItem(atPath: archivePath)
+        let result = try? await runAsync(
+            "/usr/bin/env", arguments: ["ar", "rcs", archivePath] + objects
+        )
+        guard result?.exitCode == 0 else { return [] }
+        return ["-L", cacheDir, "-l\(libName)"]
     }
 
     // MARK: - Private: Scheme Discovery
@@ -244,15 +474,19 @@ public actor XcodeBuildSystem: BuildSystem {
 
     // MARK: - Private: Build
 
-    private func runBuild(scheme: String, platform: PreviewPlatform) async throws {
+    /// Runs the build and returns the full log — the compile capture reads
+    /// the swiftc invocation out of it, so -quiet must stay off. No
+    /// -configuration override: the scheme's own build configuration (which
+    /// may be custom, X01) selects the xcconfig contents the capture must
+    /// reflect.
+    @discardableResult
+    private func runBuild(scheme: String, platform: PreviewPlatform) async throws -> String {
         let destination = destinationString(for: platform)
-        try await runXcodebuild(
+        return try await runXcodebuild(
             "build",
             xcodebuildFlag, projectFile.path,
             "-scheme", scheme,
-            "-configuration", "Debug",
-            "-destination", destination,
-            "-quiet"
+            "-destination", destination
         )
     }
 

--- a/previewsmcp/PreviewsCore/XcodeBuildSystem.swift
+++ b/previewsmcp/PreviewsCore/XcodeBuildSystem.swift
@@ -87,8 +87,7 @@ public actor XcodeBuildSystem: BuildSystem {
         //    settings-derived path below stays as its fallback.
         let captured = try await captureCommand(
             buildLog: buildLog, scheme: scheme, platform: platform,
-            moduleName: moduleName, targetName: targetName,
-            builtProductsDir: builtProductsDir
+            moduleName: moduleName, builtProductsDir: builtProductsDir
         )
         if let captured {
             return try await buildContext(
@@ -151,44 +150,44 @@ public actor XcodeBuildSystem: BuildSystem {
     /// SwiftDriver invocations (build-with-Bazel).
     private func captureCommand(
         buildLog: String, scheme: String, platform: PreviewPlatform,
-        moduleName: String, targetName: String, builtProductsDir: String
+        moduleName: String, builtProductsDir: String
     ) async throws -> XcodeCommandCapture.CapturedCommand? {
-        if let captured = XcodeCommandCapture.parse(
-            log: buildLog, moduleName: moduleName, targetName: targetName
-        ) {
-            XcodeCommandCapture.persist(
-                captured, at: persistedCaptureURL(builtProductsDir, moduleName),
-                validity: captureValidity()
-            )
+        let persistURL = persistedCaptureURL(builtProductsDir, moduleName)
+        let validity = captureValidity()
+        func parseAndPersist(_ log: String) -> XcodeCommandCapture.CapturedCommand? {
+            guard
+                let captured = XcodeCommandCapture.parse(log: log, moduleName: moduleName)
+            else { return nil }
+            XcodeCommandCapture.persist(captured, at: persistURL, validity: validity)
             return captured
         }
 
-        if let persisted = XcodeCommandCapture.loadPersisted(
-            at: persistedCaptureURL(builtProductsDir, moduleName),
-            validity: captureValidity()
-        ) {
-            return persisted
+        if let captured = parseAndPersist(buildLog) {
+            return captured
+        }
+        switch XcodeCommandCapture.loadPersisted(at: persistURL, validity: validity) {
+        case let .command(persisted): return persisted
+        case .driverless: return nil
+        case nil: break
         }
 
         // No compile line and no valid persisted capture. A null build and a
         // build-with-Bazel project both log nothing here, so force the module
         // to recompile (identity content, only the preview file's mtime
         // moves): under XCBuild the forced log must carry the driver line;
-        // a forced log without one is Bazel driving the build.
+        // a forced log without one is Bazel driving the build, remembered so
+        // the probe does not repeat every start.
         try? FileManager.default.setAttributes(
             [.modificationDate: Date()], ofItemAtPath: sourceFile.path
         )
         let forcedLog = try await runBuild(scheme: scheme, platform: platform)
-        if let captured = XcodeCommandCapture.parse(
-            log: forcedLog, moduleName: moduleName, targetName: targetName
-        ) {
-            XcodeCommandCapture.persist(
-                captured, at: persistedCaptureURL(builtProductsDir, moduleName),
-                validity: captureValidity()
-            )
+        if let captured = parseAndPersist(forcedLog) {
             return captured
         }
-        guard XcodeCommandCapture.logsDriverInvocations(forcedLog) else { return nil }
+        guard XcodeCommandCapture.logsDriverInvocations(forcedLog) else {
+            XcodeCommandCapture.persist(nil, at: persistURL, validity: validity)
+            return nil
+        }
         throw BuildSystemError.missingArtifacts(
             "No compile command for module '\(moduleName)' in the xcodebuild log"
         )
@@ -231,9 +230,18 @@ public actor XcodeBuildSystem: BuildSystem {
         // projects, X01): -F/-framework pairs are what the JIT agent resolves
         // to framework binaries to dlopen. The target's own framework is the
         // Tier 2 recompile itself, never loaded.
+        var ownNames: Set<String> = [moduleName, targetName]
+        for key in ["PRODUCT_NAME", "EXECUTABLE_NAME"] {
+            if let value = settings[key] { ownNames.insert(value) }
+        }
+        if let wrapper = settings["CODESIGNING_FOLDER_PATH"] {
+            ownNames.insert(
+                URL(fileURLWithPath: wrapper).deletingPathExtension().lastPathComponent
+            )
+        }
         let dependencyFrameworks = BuildSystemSupport.collectFrameworks(
             binPath: URL(fileURLWithPath: builtProductsDir)
-        ).filter { $0 != moduleName && $0 != targetName }
+        ).filter { !ownNames.contains($0) }
         if !dependencyFrameworks.isEmpty {
             flags += ["-F", builtProductsDir]
             for framework in dependencyFrameworks {
@@ -314,7 +322,7 @@ public actor XcodeBuildSystem: BuildSystem {
         settings: [String: String], targetName: String, swiftSources: [String]
     ) -> [String] {
         guard let objectFileDir = settings["OBJECT_FILE_DIR_normal"] else { return [] }
-        let objectsDir = URL(fileURLWithPath: objectFileDir).appendingPathComponent("arm64")
+        let objectsDir = URL(fileURLWithPath: objectFileDir).appendingPathComponent(hostArch)
         guard
             let entries = try? FileManager.default.contentsOfDirectory(
                 at: objectsDir, includingPropertiesForKeys: nil
@@ -342,7 +350,7 @@ public actor XcodeBuildSystem: BuildSystem {
         objects: [String], moduleName: String, builtProductsDir: String
     ) async -> [String] {
         let cacheDir = (builtProductsDir as NSString)
-            .appendingPathComponent("previewsmcp-package-archives")
+            .appendingPathComponent(Self.archiveCacheDirName)
         try? FileManager.default.createDirectory(
             atPath: cacheDir, withIntermediateDirectories: true
         )
@@ -350,7 +358,7 @@ public actor XcodeBuildSystem: BuildSystem {
         let archivePath = (cacheDir as NSString).appendingPathComponent("lib\(libName).a")
         try? FileManager.default.removeItem(atPath: archivePath)
         let result = try? await runAsync(
-            "/usr/bin/env", arguments: ["ar", "rcs", archivePath] + objects
+            "/usr/bin/ar", arguments: ["rcs", archivePath] + objects
         )
         guard result?.exitCode == 0 else { return [] }
         return ["-L", cacheDir, "-l\(libName)"]
@@ -838,7 +846,7 @@ extension XcodeBuildSystem {
         guard !objects.isEmpty else { return ([], []) }
 
         let cacheDir = (builtProductsDir as NSString)
-            .appendingPathComponent("previewsmcp-package-archives")
+            .appendingPathComponent(Self.archiveCacheDirName)
         try? fm.createDirectory(atPath: cacheDir, withIntermediateDirectories: true)
 
         // Each object's archive + autolink work is independent, so process them
@@ -894,6 +902,9 @@ extension XcodeBuildSystem {
         )
         return (base, await frameworks)
     }
+
+    /// Archives PreviewsMCP creates beside the build products for the JIT link.
+    static let archiveCacheDirName = "previewsmcp-package-archives"
 
     /// The arch the JIT agent runs as, used to thin universal package objects.
     static var hostArch: String {

--- a/previewsmcp/PreviewsCore/XcodeBuildSystem.swift
+++ b/previewsmcp/PreviewsCore/XcodeBuildSystem.swift
@@ -173,24 +173,36 @@ public actor XcodeBuildSystem: BuildSystem {
 
         // No compile line and no valid persisted capture. A null build and a
         // build-with-Bazel project both log nothing here, so force the module
-        // to recompile (identity content, only the preview file's mtime
-        // moves): under XCBuild the forced log must carry the driver line;
-        // a forced log without one is Bazel driving the build, remembered so
-        // the probe does not repeat every start.
+        // to recompile (identity content; the mtime moves for the build and
+        // is restored right after so watchers and the working tree stay
+        // clean): under XCBuild the forced log carries the driver line.
+        let originalDate = try? FileManager.default
+            .attributesOfItem(atPath: sourceFile.path)[.modificationDate] as? Date
         try? FileManager.default.setAttributes(
             [.modificationDate: Date()], ofItemAtPath: sourceFile.path
         )
         let forcedLog = try await runBuild(scheme: scheme, platform: platform)
+        if let originalDate {
+            try? FileManager.default.setAttributes(
+                [.modificationDate: originalDate], ofItemAtPath: sourceFile.path
+            )
+        }
         if let captured = parseAndPersist(forcedLog) {
             return captured
         }
-        guard XcodeCommandCapture.logsDriverInvocations(forcedLog) else {
+        // Only a log showing Bazel actually drove the build earns the
+        // persisted driverless marker; anything else (content-signature
+        // no-op rebuilds, variant schemes) falls back for this start and
+        // retries the probe next time.
+        if !XcodeCommandCapture.logsDriverInvocations(forcedLog),
+           forcedLog.contains("bazel")
+        {
             XcodeCommandCapture.persist(nil, at: persistURL, validity: validity)
-            return nil
         }
-        throw BuildSystemError.missingArtifacts(
-            "No compile command for module '\(moduleName)' in the xcodebuild log"
+        Log.info(
+            "xcode capture: no compile command for \(moduleName); using settings derivation"
         )
+        return nil
     }
 
     private nonisolated func persistedCaptureURL(
@@ -249,8 +261,10 @@ public actor XcodeBuildSystem: BuildSystem {
             }
         }
 
+        let wholeModule = captured.arguments.contains { $0 == "-whole-module-optimization" || $0 == "-wmo" }
         let clangObjects = Self.clangObjects(
-            settings: settings, targetName: targetName,
+            settings: settings,
+            excludedStems: wholeModule ? [targetName] : [],
             swiftSources: captured.swiftSources
         )
         if !clangObjects.isEmpty {
@@ -261,10 +275,19 @@ public actor XcodeBuildSystem: BuildSystem {
             )
         }
 
-        let previewPath = sourceFile.standardizedFileURL.path
+        let previewPath = sourceFile.resolvingSymlinksInPath().path
         var sourceFiles = captured.swiftSources
             .map { URL(fileURLWithPath: $0).standardizedFileURL }
-            .filter { $0.path != previewPath }
+            .filter { $0.resolvingSymlinksInPath().path != previewPath }
+
+        // An unreadable SwiftFileList must not silently shrink Tier 2 to the
+        // preview file alone; the OutputFileMap enumeration is the fallback
+        // source list.
+        if sourceFiles.isEmpty,
+           let fallback = collectSourceFiles(settings: settings, targetName: targetName)
+        {
+            sourceFiles = fallback
+        }
 
         // Union Xcode-generated Swift sources from DERIVED_FILE_DIR (asset
         // symbols and friends are generated during the build; a capture from
@@ -316,10 +339,11 @@ public actor XcodeBuildSystem: BuildSystem {
 
     /// The target's C/ObjC objects: everything in the objects directory that
     /// is not a Swift compile output. Swift outputs are named after the
-    /// captured Swift sources; over-inclusion is safe because archive
-    /// members link lazily.
+    /// captured Swift sources — plus the whole-module master object named
+    /// after the target when the capture shows WMO — and over-inclusion is
+    /// otherwise safe because archive members link lazily.
     private static func clangObjects(
-        settings: [String: String], targetName: String, swiftSources: [String]
+        settings: [String: String], excludedStems: [String], swiftSources: [String]
     ) -> [String] {
         guard let objectFileDir = settings["OBJECT_FILE_DIR_normal"] else { return [] }
         let objectsDir = URL(fileURLWithPath: objectFileDir).appendingPathComponent(hostArch)
@@ -328,17 +352,15 @@ public actor XcodeBuildSystem: BuildSystem {
                 at: objectsDir, includingPropertiesForKeys: nil
             )
         else { return [] }
-        let swiftStems = Set(
+        var swiftStems = Set(
             swiftSources.map {
                 URL(fileURLWithPath: $0).deletingPathExtension().lastPathComponent
             }
         )
+        swiftStems.formUnion(excludedStems)
         return entries
             .filter { $0.pathExtension == "o" }
-            .filter {
-                let stem = $0.deletingPathExtension().lastPathComponent
-                return !swiftStems.contains(stem) && stem != targetName
-            }
+            .filter { !swiftStems.contains($0.deletingPathExtension().lastPathComponent) }
             .map(\.path)
             .sorted()
     }

--- a/previewsmcp/PreviewsCore/XcodeCommandCapture.swift
+++ b/previewsmcp/PreviewsCore/XcodeCommandCapture.swift
@@ -91,8 +91,10 @@ enum XcodeCommandCapture {
     }
 
     /// The mtimes that must be unchanged for a persisted capture to stay
-    /// valid: the project definition and every xcconfig under the project
-    /// root (X01: xcconfig contents feed the captured settings).
+    /// valid: the project definition(s) — every referenced project's pbxproj
+    /// when the marker is a workspace — and every xcconfig under the project
+    /// root (X01: xcconfig contents feed the captured settings). The
+    /// xcconfig walk is depth-bounded; configs live near the project.
     static func validityKeys(projectFile: URL, projectRoot: URL) -> [String: Date] {
         var keys: [String: Date] = [:]
         func record(_ url: URL) {
@@ -102,14 +104,27 @@ enum XcodeCommandCapture {
                 keys[url.path] = date
             }
         }
-        record(projectFile.appendingPathComponent("project.pbxproj"))
-        record(projectFile.appendingPathComponent("contents.xcworkspacedata"))
+        if projectFile.pathExtension == "xcworkspace" {
+            record(projectFile.appendingPathComponent("contents.xcworkspacedata"))
+            for project in XcodeProjectMembership.projects(inWorkspace: projectFile) {
+                record(project.appendingPathComponent("project.pbxproj"))
+            }
+        } else {
+            record(projectFile.appendingPathComponent("project.pbxproj"))
+        }
+        let rootDepth = projectRoot.pathComponents.count
         if let enumerator = FileManager.default.enumerator(
             at: projectRoot, includingPropertiesForKeys: [.contentModificationDateKey],
             options: [.skipsHiddenFiles, .skipsPackageDescendants]
         ) {
-            for case let url as URL in enumerator where url.pathExtension == "xcconfig" {
-                record(url)
+            for case let url as URL in enumerator {
+                if url.pathComponents.count - rootDepth > 4 {
+                    enumerator.skipDescendants()
+                    continue
+                }
+                if url.pathExtension == "xcconfig" {
+                    record(url)
+                }
             }
         }
         return keys

--- a/previewsmcp/PreviewsCore/XcodeCommandCapture.swift
+++ b/previewsmcp/PreviewsCore/XcodeCommandCapture.swift
@@ -17,14 +17,16 @@ enum XcodeCommandCapture {
         var swiftSources: [String]
     }
 
+    private static let driverMarkers = [
+        "builtin-SwiftDriver -- ", "builtin-Swift-Compilation -- ",
+    ]
+
     /// Parse a build log for the module's compile command. Nil when the log
     /// has no matching SwiftDriver invocation (null build, or a build system
     /// that does not log one). The target's C/ObjC objects are deliberately
     /// not read from the log — an incremental build only logs CompileC for
     /// changed sources — they come from the objects directory on disk.
-    static func parse(log: String, moduleName: String, targetName _: String) -> CapturedCommand? {
-        let driverMarkers = ["builtin-SwiftDriver -- ", "builtin-Swift-Compilation -- "]
-
+    static func parse(log: String, moduleName: String) -> CapturedCommand? {
         for rawLine in log.split(separator: "\n", omittingEmptySubsequences: true) {
             let line = rawLine.trimmingCharacters(in: .whitespaces)
             guard let marker = driverMarkers.first(where: line.contains) else { continue }
@@ -50,18 +52,28 @@ enum XcodeCommandCapture {
     /// recompile to capture) from build-with-Bazel projects (fall back to
     /// settings derivation immediately).
     static func logsDriverInvocations(_ log: String) -> Bool {
-        log.contains("builtin-SwiftDriver")
+        driverMarkers.contains { marker in
+            log.contains(marker.trimmingCharacters(in: .whitespaces))
+        }
     }
 
     // MARK: - Persistence
 
+    /// A valid persisted answer: the captured command, or the knowledge that
+    /// this project's build system never logs one (build-with-Bazel), which
+    /// spares the per-start forced-rebuild probe.
+    enum PersistedResult {
+        case command(CapturedCommand)
+        case driverless
+    }
+
     private struct PersistedCapture: Codable {
         var validity: [String: Date]
-        var command: CapturedCommand
+        var command: CapturedCommand?
     }
 
     static func persist(
-        _ command: CapturedCommand, at url: URL, validity: [String: Date]
+        _ command: CapturedCommand?, at url: URL, validity: [String: Date]
     ) {
         let persisted = PersistedCapture(validity: validity, command: command)
         if let data = try? JSONEncoder().encode(persisted) {
@@ -69,13 +81,13 @@ enum XcodeCommandCapture {
         }
     }
 
-    static func loadPersisted(at url: URL, validity: [String: Date]) -> CapturedCommand? {
+    static func loadPersisted(at url: URL, validity: [String: Date]) -> PersistedResult? {
         guard
             let data = try? Data(contentsOf: url),
             let persisted = try? JSONDecoder().decode(PersistedCapture.self, from: data),
             persisted.validity == validity
         else { return nil }
-        return persisted.command
+        return persisted.command.map(PersistedResult.command) ?? .driverless
     }
 
     /// The mtimes that must be unchanged for a persisted capture to stay

--- a/previewsmcp/PreviewsCore/XcodeCommandCapture.swift
+++ b/previewsmcp/PreviewsCore/XcodeCommandCapture.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+/// Reads the compile command xcodebuild actually ran for a target out of the
+/// build log. XCBuild logs the full swiftc invocation on a
+/// `builtin-SwiftDriver -- <argv>` line (shell-escaped), the Swift source
+/// list rides in the on-disk `@<...>.SwiftFileList` response file that argv
+/// references, and the target's C/ObjC halves appear as `CompileC` lines. A
+/// null build logs no compile lines, so successful captures are persisted
+/// next to the build products, keyed on the project file and xcconfig
+/// mtimes; rules_xcodeproj build-with-Bazel logs contain no SwiftDriver
+/// lines at all, in which case the caller falls back to settings derivation.
+enum XcodeCommandCapture {
+    struct CapturedCommand: Codable {
+        /// The swiftc argument vector, without the executable path.
+        var arguments: [String]
+        /// The target's Swift sources from the SwiftFileList response file.
+        var swiftSources: [String]
+    }
+
+    /// Parse a build log for the module's compile command. Nil when the log
+    /// has no matching SwiftDriver invocation (null build, or a build system
+    /// that does not log one). The target's C/ObjC objects are deliberately
+    /// not read from the log — an incremental build only logs CompileC for
+    /// changed sources — they come from the objects directory on disk.
+    static func parse(log: String, moduleName: String, targetName _: String) -> CapturedCommand? {
+        let driverMarkers = ["builtin-SwiftDriver -- ", "builtin-Swift-Compilation -- "]
+
+        for rawLine in log.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard let marker = driverMarkers.first(where: line.contains) else { continue }
+            let argvText = String(line[line.range(of: marker)!.upperBound...])
+            let tokens = tokenizeShellEscaped(argvText)
+            guard tokens.count > 1, moduleTokenMatches(tokens, moduleName) else { continue }
+            var args: [String] = []
+            var swiftSources: [String] = []
+            for token in tokens.dropFirst() {
+                if token.hasPrefix("@"), token.hasSuffix(".SwiftFileList") {
+                    swiftSources = responseFileLines(String(token.dropFirst()))
+                } else {
+                    args.append(token)
+                }
+            }
+            return CapturedCommand(arguments: args, swiftSources: swiftSources)
+        }
+        return nil
+    }
+
+    /// True when the log came from a build system that logs SwiftDriver
+    /// invocations at all — distinguishes a null build (worth forcing a
+    /// recompile to capture) from build-with-Bazel projects (fall back to
+    /// settings derivation immediately).
+    static func logsDriverInvocations(_ log: String) -> Bool {
+        log.contains("builtin-SwiftDriver")
+    }
+
+    // MARK: - Persistence
+
+    private struct PersistedCapture: Codable {
+        var validity: [String: Date]
+        var command: CapturedCommand
+    }
+
+    static func persist(
+        _ command: CapturedCommand, at url: URL, validity: [String: Date]
+    ) {
+        let persisted = PersistedCapture(validity: validity, command: command)
+        if let data = try? JSONEncoder().encode(persisted) {
+            try? data.write(to: url)
+        }
+    }
+
+    static func loadPersisted(at url: URL, validity: [String: Date]) -> CapturedCommand? {
+        guard
+            let data = try? Data(contentsOf: url),
+            let persisted = try? JSONDecoder().decode(PersistedCapture.self, from: data),
+            persisted.validity == validity
+        else { return nil }
+        return persisted.command
+    }
+
+    /// The mtimes that must be unchanged for a persisted capture to stay
+    /// valid: the project definition and every xcconfig under the project
+    /// root (X01: xcconfig contents feed the captured settings).
+    static func validityKeys(projectFile: URL, projectRoot: URL) -> [String: Date] {
+        var keys: [String: Date] = [:]
+        func record(_ url: URL) {
+            if let date = try? url.resourceValues(forKeys: [.contentModificationDateKey])
+                .contentModificationDate
+            {
+                keys[url.path] = date
+            }
+        }
+        record(projectFile.appendingPathComponent("project.pbxproj"))
+        record(projectFile.appendingPathComponent("contents.xcworkspacedata"))
+        if let enumerator = FileManager.default.enumerator(
+            at: projectRoot, includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+        ) {
+            for case let url as URL in enumerator where url.pathExtension == "xcconfig" {
+                record(url)
+            }
+        }
+        return keys
+    }
+
+    // MARK: - Tokenizing
+
+    /// Split an XCBuild-logged command line into tokens: spaces separate
+    /// tokens unless backslash-escaped, and `\<char>` unescapes to `<char>`
+    /// (XCBuild escapes spaces and `=` this way).
+    static func tokenizeShellEscaped(_ text: String) -> [String] {
+        var tokens: [String] = []
+        var current = ""
+        var escaped = false
+        for character in text {
+            if escaped {
+                current.append(character)
+                escaped = false
+            } else if character == "\\" {
+                escaped = true
+            } else if character == " " {
+                if !current.isEmpty {
+                    tokens.append(current)
+                    current = ""
+                }
+            } else {
+                current.append(character)
+            }
+        }
+        if !current.isEmpty { tokens.append(current) }
+        return tokens
+    }
+
+    private static func moduleTokenMatches(_ tokens: [String], _ moduleName: String) -> Bool {
+        guard let index = tokens.firstIndex(of: "-module-name"), index + 1 < tokens.count
+        else { return false }
+        return tokens[index + 1] == moduleName
+    }
+
+    private static func responseFileLines(_ path: String) -> [String] {
+        guard let content = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+        return content.split(separator: "\n").map {
+            $0.trimmingCharacters(in: .whitespaces)
+        }.filter { !$0.isEmpty }
+    }
+}

--- a/previewsmcp/Tests/PreviewsCoreTests/CompileCaptureTests.swift
+++ b/previewsmcp/Tests/PreviewsCoreTests/CompileCaptureTests.swift
@@ -275,9 +275,7 @@ struct XcodeCommandCaptureTests {
         CompileC /dd/Objects-normal/arm64/Other.o /proj/Other/Other.m normal arm64 objective-c com.apple.compilers.llvm.clang.1_0.compiler (in target 'OtherTarget' from project 'BridgingApp')
         """
         let captured = try #require(
-            XcodeCommandCapture.parse(
-                log: log, moduleName: "BridgingApp", targetName: "BridgingApp"
-            )
+            XcodeCommandCapture.parse(log: log, moduleName: "BridgingApp")
         )
         #expect(captured.arguments.contains("-import-objc-header"))
         #expect(captured.arguments.contains("-enforce-exclusivity=checked"))
@@ -291,7 +289,7 @@ struct XcodeCommandCaptureTests {
         let log = """
             builtin-SwiftDriver -- /toolchain/usr/bin/swiftc -module-name OtherModule -DDEBUG
         """
-        #expect(XcodeCommandCapture.parse(log: log, moduleName: "App", targetName: "App") == nil)
+        #expect(XcodeCommandCapture.parse(log: log, moduleName: "App") == nil)
         #expect(XcodeCommandCapture.logsDriverInvocations(log))
         #expect(!XcodeCommandCapture.logsDriverInvocations("SwiftCompile bazel-out/x"))
     }
@@ -315,11 +313,24 @@ struct XcodeCommandCaptureTests {
         let validity = ["/proj/project.pbxproj": Date(timeIntervalSince1970: 100)]
         XcodeCommandCapture.persist(command, at: url, validity: validity)
 
-        let loaded = XcodeCommandCapture.loadPersisted(at: url, validity: validity)
-        #expect(loaded?.arguments == ["-DDEBUG"])
+        guard case let .command(loaded)? = XcodeCommandCapture.loadPersisted(
+            at: url, validity: validity
+        ) else {
+            Issue.record("expected persisted command")
+            return
+        }
+        #expect(loaded.arguments == ["-DDEBUG"])
 
         let stale = ["/proj/project.pbxproj": Date(timeIntervalSince1970: 200)]
         #expect(XcodeCommandCapture.loadPersisted(at: url, validity: stale) == nil)
+
+        XcodeCommandCapture.persist(nil, at: url, validity: validity)
+        guard case .driverless? = XcodeCommandCapture.loadPersisted(
+            at: url, validity: validity
+        ) else {
+            Issue.record("expected driverless marker")
+            return
+        }
     }
 
     @Test("normalizer drops Xcode bookkeeping incl. wrapped const-gather and vfs stat cache")

--- a/previewsmcp/Tests/PreviewsCoreTests/CompileCaptureTests.swift
+++ b/previewsmcp/Tests/PreviewsCoreTests/CompileCaptureTests.swift
@@ -252,3 +252,95 @@ struct PreviewModuleNameTests {
         #expect(name.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "_") })
     }
 }
+
+@Suite("XcodeCommandCapture")
+struct XcodeCommandCaptureTests {
+    private func makeFileList(_ sources: [String]) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xc-\(UUID().uuidString).SwiftFileList")
+        try sources.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    @Test("parses the driver line and expands the SwiftFileList")
+    func parsesDriverLine() throws {
+        let fileList = try makeFileList(["/proj/Sources/App.swift", "/proj/Sources/View.swift"])
+        defer { try? FileManager.default.removeItem(at: fileList) }
+        let log = """
+        Build description path: /dd/XCBuildData/x.xcbuilddata
+        SwiftDriver\\ Compilation BridgingApp normal arm64 (in target 'BridgingApp' from project 'BridgingApp')
+            builtin-SwiftDriver -- /toolchain/usr/bin/swiftc -module-name BridgingApp -enforce-exclusivity\\=checked @\(fileList
+            .path) -DDEBUG -import-objc-header /proj/Sources/App-Bridging-Header.h -working-directory /proj
+        CompileC /dd/Objects-normal/arm64/BridgedGreeting.o /proj/Sources/BridgedGreeting.m normal arm64 objective-c com.apple.compilers.llvm.clang.1_0.compiler (in target 'BridgingApp' from project 'BridgingApp')
+        CompileC /dd/Objects-normal/arm64/Other.o /proj/Other/Other.m normal arm64 objective-c com.apple.compilers.llvm.clang.1_0.compiler (in target 'OtherTarget' from project 'BridgingApp')
+        """
+        let captured = try #require(
+            XcodeCommandCapture.parse(
+                log: log, moduleName: "BridgingApp", targetName: "BridgingApp"
+            )
+        )
+        #expect(captured.arguments.contains("-import-objc-header"))
+        #expect(captured.arguments.contains("-enforce-exclusivity=checked"))
+        #expect(!captured.arguments.contains { $0.hasSuffix("swiftc") })
+        #expect(!captured.arguments.contains { $0.hasPrefix("@") })
+        #expect(captured.swiftSources == ["/proj/Sources/App.swift", "/proj/Sources/View.swift"])
+    }
+
+    @Test("a log with driver lines for other modules only returns nil")
+    func otherModulesOnly() {
+        let log = """
+            builtin-SwiftDriver -- /toolchain/usr/bin/swiftc -module-name OtherModule -DDEBUG
+        """
+        #expect(XcodeCommandCapture.parse(log: log, moduleName: "App", targetName: "App") == nil)
+        #expect(XcodeCommandCapture.logsDriverInvocations(log))
+        #expect(!XcodeCommandCapture.logsDriverInvocations("SwiftCompile bazel-out/x"))
+    }
+
+    @Test("escaped spaces in paths survive tokenizing")
+    func escapedSpaces() {
+        let tokens = XcodeCommandCapture.tokenizeShellEscaped(
+            #"/usr/bin/swiftc -I /path/With\ Space/Modules -DDEBUG"#
+        )
+        #expect(tokens == ["/usr/bin/swiftc", "-I", "/path/With Space/Modules", "-DDEBUG"])
+    }
+
+    @Test("persisted captures round-trip and invalidate on key change")
+    func persistenceRoundTrip() {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capture-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let command = XcodeCommandCapture.CapturedCommand(
+            arguments: ["-DDEBUG"], swiftSources: ["/a.swift"]
+        )
+        let validity = ["/proj/project.pbxproj": Date(timeIntervalSince1970: 100)]
+        XcodeCommandCapture.persist(command, at: url, validity: validity)
+
+        let loaded = XcodeCommandCapture.loadPersisted(at: url, validity: validity)
+        #expect(loaded?.arguments == ["-DDEBUG"])
+
+        let stale = ["/proj/project.pbxproj": Date(timeIntervalSince1970: 200)]
+        #expect(XcodeCommandCapture.loadPersisted(at: url, validity: stale) == nil)
+    }
+
+    @Test("normalizer drops Xcode bookkeeping incl. wrapped const-gather and vfs stat cache")
+    func xcodeBookkeeping() {
+        let normalized = CompileCommandNormalizer.normalize([
+            "-explicit-module-build",
+            "-clang-build-session-file", "/dd/Session.modulevalidation",
+            "-clang-scanner-module-cache-path", "/dd/ModuleCache.noindex",
+            "-sdk-module-cache-path", "/dd/ModuleCache.noindex",
+            "-validate-clang-modules-once",
+            "-use-frontend-parseable-output",
+            "-save-temps",
+            "-no-color-diagnostics",
+            "-experimental-emit-module-separately",
+            "-emit-const-values",
+            "-Xfrontend", "-const-gather-protocols-file",
+            "-Xfrontend", "/dd/App_const_extract_protocols.json",
+            "-Xcc", "-ivfsstatcache", "-Xcc", "/dd/sdkstatcache",
+            "-import-objc-header", "/proj/Bridging.h",
+            "-DDEBUG",
+        ])
+        #expect(normalized == ["-import-objc-header", "/proj/Bridging.h", "-DDEBUG"])
+    }
+}


### PR DESCRIPTION
Stage 3 of `docs/build-system-resolver.md`: Xcode Tier 2 previews compile with the `swiftc` invocation captured from the `xcodebuild` build log (`XcodeCommandCapture`), normalized through the shared normalizer with Xcode bookkeeping additions. The SwiftFileList response file provides the Tier 2 source list; the target's C/ObjC objects are archived for the JIT link; products-dir dependency frameworks emit `-F`/`-framework` pairs the agent dlopens. Null builds serve a persisted capture keyed on project/xcconfig mtimes, with a forced-recompile probe (mtime restored after) and a Bazel-evidence-gated driverless marker so rules_xcodeproj build-with-Bazel projects keep the settings-derived fallback without paying a per-start probe. The scheme's own configuration drives the build (no more forced `-configuration Debug`), and a per-system pre-processor strips captured `-target`/`-sdk` for platform variants the preview environment cannot host (Catalyst under the macOS agent).

Matrix outcome (rows re-verified manually today, `examples/regress/VERIFICATION.md`):
- **Flip Reproduced → Guard**: X01 (custom workspace configuration + cross-project dependency, on iOS), X02 (bridging header compile + ObjC link, closes the gap behind #414)
- **Stay green**: D08, D01/D07 guards; R03's generated-sources half renders identically (runtime-resource half remains out of the resolver's scope)

Gates: /simplify (driverless persistence, hoisted validity walk, hostArch, own-framework exclusion keys, shared constants), workflow /code-review at high (7 fixes: settings fallback instead of hard-fail, workspace-aware validity keys, probe mtime restore, WMO-conditional stem exclusion, SwiftFileList fallback, symlink-safe preview filter, depth-bounded xcconfig walk; 3 noted as documented limitations), lint clean, unit tier green, integration tier green three times across the branch.

Refs #414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZ2rNwt9TXrHAtGrN5L2ba