### PR TITLE
core: Bazel Tier 2 compiles with the captured SwiftCompile action (resolver stage 4)

### DIFF
--- a/docs/build-system-integration.md
+++ b/docs/build-system-integration.md
@@ -162,7 +162,13 @@ bazel-bin/<package>/
 
 PreviewsMCP relies on `bazel cquery --output=files` to locate the `.swiftmodule`, falling back to `bazel-bin/<package>/<moduleName>.swiftmodule` if cquery returns no files. The directory containing the `.swiftmodule` becomes the single `-I` flag passed to swiftc — there is no per-file enumeration of dependency search paths.
 
-Source files for Tier 2 are enumerated via `bazel query 'labels(srcs, <target>)'`. There is **no** `DerivedSources/` walk: rules_swift's `swift_library` does not synthesize a `Bundle.module` accessor (resources are exposed as a separate `apple_resource_bundle` reached via `Bundle(identifier:)` or a hand-written accessor). Auto-generated outputs from `swift_proto_library` / `swift_grpc_library` are also not currently picked up; if needed, extend `collectSourceFiles` to union those `.swift` outputs from `bazel cquery --output=files`.
+Source files for Tier 2 are the captured SwiftCompile action's `.swift`
+inputs (`BazelCommandCapture`), which resolve generated sources —
+genrule/proto outputs included — to their execroot paths. There is **no**
+`DerivedSources/` walk: rules_swift's `swift_library` does not synthesize a
+`Bundle.module` accessor (resources are exposed as a separate
+`apple_resource_bundle` reached via `Bundle(identifier:)` or a hand-written
+accessor).
 
 ### File Watching
 

--- a/examples/regress/VERIFICATION.md
+++ b/examples/regress/VERIFICATION.md
@@ -5,7 +5,9 @@ half) re-verified 2026-07-15 after the ownership-walk resolver landed
 (`docs/build-system-resolver.md`, stage 1). SwiftPM compile rows (S01–S06,
 D09, W01's edit variant) re-verified 2026-07-15 after compile-command
 capture landed (stage 2). Xcode rows (X01, X02, D08, R03, D01/D07 guards)
-re-verified 2026-07-15 after build-log capture landed (stage 3).
+re-verified 2026-07-15 after build-log capture landed (stage 3). Bazel and
+binary-framework rows (B01–B04, D04/D05 guards) re-verified 2026-07-15
+after aquery capture landed (stage 4).
 
 Environment: Xcode 26.2, an iOS 26.3 `previewsmcp-test` iPhone simulator,
 and the Bazel-built CLI from this checkout. Commands used an isolated daemon
@@ -42,9 +44,9 @@ not a nonzero command exit.
 | C03 | Reproduced | A fresh daemon rendered the parent light config. After a nearer dark config appeared and the first session stopped, the same daemon still returned `colorScheme: light`. |
 | C04 | Reproduced | A nearer config was cached with `light`, edited in place to `dark`, and the session was restarted in the same daemon. The response still reported `colorScheme: light`. |
 | C05 | Reproduced | A fresh daemon cached a nearer dark config. After that file was removed, a same-daemon restart still reported `dark` instead of falling back to the parent light config. |
-| B01 | Reproduced | Native Bazel build passed. PreviewsMCP passed a generated target name as a workspace-relative input and `swiftc` rejected `generated_build_stamp` as an unexpected input file. Re-verified identically after bumping the fixture pin from Bazel 8.2.1 to 9.2.0; with `examples/bazel` on 8.6.0 the two Bazel fixtures now cover one workspace per major. |
-| B02 | Reproduced | The physically isolated combined package passed its native iOS simulator build. PreviewsMCP included the dynamic framework flags but its manual compile failed with `no such module 'StaticBadge'`. |
-| B03 | Reproduced | The static-only package passed its native iOS simulator build. PreviewsMCP reached its manual compile with no StaticBadge module search path and failed `no such module 'StaticBadge'`. |
+| B01 | Guard passes | 2026-07-15 (Bazel aquery capture): rendered `Canonical Bzlmod repository` and `Bazel generated source`. The SwiftCompile action's arguments carry the generated source at its execroot path and the canonical external repo's module search path; external dependency archives are force-built for the JIT link. |
+| B02 | Guard passes | 2026-07-15 (compile capture): rendered both `Static simulator XCFramework` and `Dynamic simulator XCFramework` on iOS — the captured flags resolve the StaticBadge module and the copied static archive in binPath links alongside the dynamic framework. |
+| B03 | Guard passes | 2026-07-15 (compile capture): rendered `Static simulator XCFramework` on iOS; the static XCFramework's module resolves from the captured flags and its copied `libStaticBadge.a` links from binPath. |
 | B04 | Reproduced | The dynamic-only package passed natively and PreviewsMCP loaded it on iOS: the snapshot rendered `Dynamic simulator XCFramework`. The same snapshot reported `framework resource missing`, so the framework's internal JSON was not staged with the loaded binary. |
 | F01 | Reproduced | The generator and XCFramework metadata provide only an iPhoneOS device slice. Native simulator and PreviewsMCP builds both failed `no such module 'BadSlice'`; PreviewsMCP did not classify the incompatible slice, while the daemon remained responsive. |
 | R01 | Reproduced | macOS and iOS reached JIT materialization and failed on the target-wide framework/autolink closure. The CLI error was an unclassified symbol dump; the daemon remained responsive. |

--- a/previewsmcp/PreviewsCore/BazelBuildSystem.swift
+++ b/previewsmcp/PreviewsCore/BazelBuildSystem.swift
@@ -579,30 +579,6 @@ public actor BazelBuildSystem: BuildSystem {
             != nil
     }
 
-    /// Convert a Bazel label like "//Sources/ToDo:Item.swift" to a relative path "Sources/ToDo/Item.swift".
-    nonisolated func labelToPath(_ label: String) -> String? {
-        var label = label
-        // Strip leading "//" or "@//"
-        if let atSlashRange = label.range(of: "@//") {
-            label = String(label[atSlashRange.upperBound...])
-        } else if label.hasPrefix("//") {
-            label = String(label.dropFirst(2))
-        } else {
-            return nil
-        }
-
-        // Split on ":" — package:file
-        guard let colonIndex = label.firstIndex(of: ":") else { return nil }
-
-        let packagePath = String(label[label.startIndex ..< colonIndex])
-        let fileName = String(label[label.index(after: colonIndex)...])
-
-        if packagePath.isEmpty {
-            return fileName
-        }
-        return "\(packagePath)/\(fileName)"
-    }
-
     // MARK: - Private: Platform Flags
 
     /// Deployment-target pin shared by both iOS build paths, matching the

--- a/previewsmcp/PreviewsCore/BazelBuildSystem.swift
+++ b/previewsmcp/PreviewsCore/BazelBuildSystem.swift
@@ -179,31 +179,81 @@ public actor BazelBuildSystem: BuildSystem {
             target: target, expr: expr, moduleName: moduleName, platformArgs: platformArgs
         )
 
-        // Add dependency module search paths (swift_library deps and
-        // objc_library module maps) from the target's SwiftCompile action,
-        // so the bridge's `import <Dep>` resolves.
-        compilerFlags += try await findDependencyModuleFlags(
-            expr: expr, platformArgs: platformArgs
+        // Capture the target's own SwiftCompile action: its arguments carry
+        // the defines, language mode, dependency module search paths, and
+        // module maps Bazel actually compiled with, and its .swift inputs
+        // resolve generated sources to execroot paths (B01).
+        let aqueryOutput = try await runBazel(
+            ["bazel", "aquery", "mnemonic(\"SwiftCompile\", \(expr))", "--output=jsonproto"]
+                + platformArgs,
+            discardStderr: true
         )
+        guard
+            let captured = BazelCommandCapture.parse(
+                jsonProto: aqueryOutput, moduleName: moduleName
+            )
+        else {
+            throw BuildSystemError.missingArtifacts(
+                "No SwiftCompile action for module '\(moduleName)' in bazel aquery output"
+            )
+        }
+        compilerFlags += CompileCommandNormalizer.normalize(captured.arguments)
+            .map(resolveExecrootToken)
 
         // Add dependency archive link flags (`-L`/`-l`) for the target's
         // static-library deps, so the preview JIT link resolves their
-        // cross-target symbols (`findDependencyModuleFlags` only covers the
+        // cross-target symbols (the captured compile command only covers the
         // compile-time module search).
         compilerFlags += try await findDependencyArchiveFlags(
             target: target, expr: expr, platformArgs: platformArgs
         )
 
-        // Collect source files for Tier 2
-        let sourceFiles = try await collectSourceFiles(target: target)
+        // Tier 2 sources are the captured compile inputs, minus the preview
+        // file and `@main` entry points (their app-lifecycle entry symbol
+        // poisons the preview JIT link).
+        let previewPath = sourceFile.resolvingSymlinksInPath().path
+        let sourceFiles = captured.swiftSources
+            .map(resolveExecrootPath)
+            .filter { $0.resolvingSymlinksInPath().path != previewPath }
+            .filter { !Self.declaresMainEntry($0) }
 
         return BuildContext(
             moduleName: moduleName,
             compilerFlags: compilerFlags,
             projectRoot: projectRoot,
             targetName: moduleName,
-            sourceFiles: sourceFiles
+            sourceFiles: sourceFiles.isEmpty ? nil : sourceFiles
         )
+    }
+
+    /// Resolve execroot-relative paths inside a normalized flag token to
+    /// absolute paths: bare value tokens, `flag=path` tails, and the
+    /// execroot-root `.` include.
+    private func resolveExecrootToken(_ token: String) -> String {
+        func resolved(_ path: String) -> String? {
+            if path == "." { return projectRoot.path }
+            guard !path.hasPrefix("/"), !path.hasPrefix("-") else { return nil }
+            if path.hasPrefix("bazel-out/")
+                || FileManager.default.fileExists(
+                    atPath: projectRoot.appendingPathComponent(path).path
+                )
+            {
+                return resolveExecrootPath(path).path
+            }
+            return nil
+        }
+        if token.hasPrefix("-") {
+            for joined in ["-I", "-F"] where token.hasPrefix(joined) && token.count > 2 {
+                let tail = String(token.dropFirst(joined.count))
+                guard let absolute = resolved(tail) else { return token }
+                return joined + absolute
+            }
+            guard let equals = token.firstIndex(of: "=") else { return token }
+            let tail = String(token[token.index(after: equals)...])
+            guard let absolute = resolved(tail) else { return token }
+            return String(token[...equals]) + absolute
+        }
+        return resolved(token) ?? token
     }
 
     /// True if `error` is a build failure whose diagnostics contain swiftc's
@@ -452,65 +502,6 @@ public actor BazelBuildSystem: BuildSystem {
             : projectRoot.appendingPathComponent(path).standardizedFileURL
     }
 
-    /// Extract dependency module-search flags from the target's `SwiftCompile`
-    /// action, so the bridge compile can import the target's dependency modules
-    /// (`swift_library` deps via `-I`, `objc_library` modules via
-    /// `-Xcc -fmodule-map-file=`). The target's own `-I` is added by
-    /// `findCompilerFlags`; this fills in everything its `import`s need.
-    ///
-    /// Reuses Bazel's own flags rather than reconstructing them per dependency,
-    /// because objc module maps live at non-obvious paths
-    /// (`<pkg>/<name>_modulemap/_/module.modulemap`) that are not in
-    /// `cquery --output=files`.
-    private func findDependencyModuleFlags(
-        expr: String, platformArgs: [String]
-    ) async throws -> [String] {
-        var args = ["bazel", "aquery", "mnemonic(\"SwiftCompile\", \(expr))"]
-        args += platformArgs
-        let output = (try? await runBazel(args, discardStderr: true)) ?? ""
-
-        func resolve(_ path: String) -> String {
-            resolveExecrootPath(path).path
-        }
-
-        let tokens =
-            output
-                .split(whereSeparator: { $0 == "\n" || $0 == " " || $0 == "\t" })
-                .map { $0.trimmingCharacters(in: CharacterSet(charactersIn: " \t\\'\"")) }
-                .filter { !$0.isEmpty }
-
-        var flags: [String] = []
-        var seen = Set<String>()
-        func add(_ items: [String], key: String) {
-            if seen.insert(key).inserted { flags += items }
-        }
-
-        var i = 0
-        while i < tokens.count {
-            let t = tokens[i]
-            if t.hasPrefix("-I"), t.count > 2 {
-                let p = resolve(String(t.dropFirst(2)))
-                add(["-I", p], key: "I:" + p)
-            } else if t.hasPrefix("-F"), t.count > 2 {
-                let p = resolve(String(t.dropFirst(2)))
-                add(["-F", p], key: "F:" + p)
-            } else if t == "-Xcc", i + 1 < tokens.count {
-                let next = tokens[i + 1]
-                if next.hasPrefix("-fmodule-map-file=") {
-                    let p = resolve(String(next.dropFirst("-fmodule-map-file=".count)))
-                    add(["-Xcc", "-fmodule-map-file=\(p)"], key: "mmap:" + p)
-                    i += 1
-                } else if next.hasPrefix("-I"), next.count > 2 {
-                    let p = resolve(String(next.dropFirst(2)))
-                    add(["-Xcc", "-I\(p)"], key: "XccI:" + p)
-                    i += 1
-                }
-            }
-            i += 1
-        }
-        return flags
-    }
-
     /// Build the target's dependency libraries so their static archives are on
     /// disk before `findDependencyArchiveFlags` scans for them: building
     /// `target` alone materializes its dependency swiftmodules but not their
@@ -523,7 +514,7 @@ public actor BazelBuildSystem: BuildSystem {
                 "kind(\"(swift|objc)_library\", deps(\(target)))"
             )) ?? ""
         let labels = depLibs.split(separator: "\n").map(String.init)
-            .filter { $0.hasPrefix("//") }
+            .filter { $0.hasPrefix("//") || $0.hasPrefix("@") }
         if !labels.isEmpty {
             try await runBazel(["bazel", "build"] + labels + platformArgs)
         }
@@ -578,46 +569,6 @@ public actor BazelBuildSystem: BuildSystem {
     }
 
     // MARK: - Private: Source Files (Tier 2)
-
-    /// Collect all source files for the target, excluding the preview file.
-    ///
-    /// Unlike SPM and Xcode, we do not walk a "DerivedSources" directory for
-    /// auto-generated Swift files. rules_swift's `swift_library` does not
-    /// synthesize a `Bundle.module` accessor for resources — `apple_resource_bundle`
-    /// yields a separate bundle reached via `Bundle(identifier:)` or a
-    /// hand-written accessor. Known gaps this method does not cover:
-    ///   * `swift_proto_library` / `swift_grpc_library` emit `.swift` under
-    ///     `bazel-bin/<pkg>/<name>.proto_library/`.
-    ///   * Consumer macros that produce adjacent `.swift` outputs.
-    /// If those cases need to be previewed, extend by querying
-    /// `labels(outs, <target>)` or `bazel cquery --output=files <target>` and
-    /// unioning any `.swift` outputs with the `srcs` result below.
-    private func collectSourceFiles(target: String) async throws -> [URL]? {
-        let output: String
-        do {
-            output = try await runBazelQuery("labels(srcs, \(target))")
-        } catch {
-            // If query fails, fall back to Tier 1 (no source files)
-            return nil
-        }
-
-        let labels = output.split(separator: "\n").map(String.init)
-        var sourceFiles: [URL] = []
-
-        for label in labels {
-            guard let path = labelToPath(label) else { continue }
-            let url = projectRoot.appendingPathComponent(path).standardizedFileURL
-            // Exclude the preview file
-            if url.path == sourceFile.path { continue }
-            // Exclude `@main` entry-point files: their app-lifecycle entry
-            // symbol poisons the preview JIT link, and the preview never needs
-            // the app entry point.
-            if Self.declaresMainEntry(url) { continue }
-            sourceFiles.append(url)
-        }
-
-        return sourceFiles.isEmpty ? nil : sourceFiles
-    }
 
     /// True if `file` declares an `@main` entry point at the start of a line.
     private static func declaresMainEntry(_ file: URL) -> Bool {

--- a/previewsmcp/PreviewsCore/BazelBuildSystem.swift
+++ b/previewsmcp/PreviewsCore/BazelBuildSystem.swift
@@ -188,17 +188,21 @@ public actor BazelBuildSystem: BuildSystem {
                 + platformArgs,
             discardStderr: true
         )
-        guard
-            let captured = BazelCommandCapture.parse(
-                jsonProto: aqueryOutput, moduleName: moduleName
-            )
-        else {
-            throw BuildSystemError.missingArtifacts(
-                "No SwiftCompile action for module '\(moduleName)' in bazel aquery output"
+        // A graph with no parseable SwiftCompile action (the #279
+        // apple-bundle fallback under some configs) degrades to the
+        // module-search flags above, as the pre-capture derivation did.
+        let captured = BazelCommandCapture.parse(
+            jsonProto: aqueryOutput, moduleName: moduleName
+        )
+        if captured == nil {
+            Log.info(
+                "bazel capture: no SwiftCompile action for \(moduleName); degrading to module search paths"
             )
         }
-        compilerFlags += CompileCommandNormalizer.normalize(captured.arguments)
-            .map(resolveExecrootToken)
+        if let captured {
+            compilerFlags += CompileCommandNormalizer.normalize(captured.arguments)
+                .map(resolveExecrootToken)
+        }
 
         // Add dependency archive link flags (`-L`/`-l`) for the target's
         // static-library deps, so the preview JIT link resolves their
@@ -212,7 +216,7 @@ public actor BazelBuildSystem: BuildSystem {
         // file and `@main` entry points (their app-lifecycle entry symbol
         // poisons the preview JIT link).
         let previewPath = sourceFile.resolvingSymlinksInPath().path
-        let sourceFiles = captured.swiftSources
+        let sourceFiles = (captured?.swiftSources ?? [])
             .map(resolveExecrootPath)
             .filter { $0.resolvingSymlinksInPath().path != previewPath }
             .filter { !Self.declaresMainEntry($0) }
@@ -248,10 +252,17 @@ public actor BazelBuildSystem: BuildSystem {
                 guard let absolute = resolved(tail) else { return token }
                 return joined + absolute
             }
-            guard let equals = token.firstIndex(of: "=") else { return token }
-            let tail = String(token[token.index(after: equals)...])
-            guard let absolute = resolved(tail) else { return token }
-            return String(token[...equals]) + absolute
+            // Only known path-bearing `flag=path` forms are rewritten; a
+            // define like -DASSET_ROOT=Resources must keep its literal value
+            // even when it happens to match an on-disk path.
+            for prefix in ["-fmodule-map-file=", "-explicit-swift-module-map-file="]
+                where token.hasPrefix(prefix)
+            {
+                let tail = String(token.dropFirst(prefix.count))
+                guard let absolute = resolved(tail) else { return token }
+                return prefix + absolute
+            }
+            return token
         }
         return resolved(token) ?? token
     }
@@ -495,11 +506,25 @@ public actor BazelBuildSystem: BuildSystem {
     }
 
     /// Resolve a Bazel `cquery`/`aquery` output path (relative to the execroot,
-    /// or already absolute) to an absolute URL.
+    /// or already absolute) to an absolute URL. `bazel-out/` and workspace
+    /// paths resolve through the workspace's convenience symlinks; the
+    /// `external/` tree has no symlink and resolves through the execroot the
+    /// `bazel-out` symlink points into.
     private func resolveExecrootPath(_ path: String) -> URL {
-        path.hasPrefix("/")
-            ? URL(fileURLWithPath: path)
-            : projectRoot.appendingPathComponent(path).standardizedFileURL
+        if path.hasPrefix("/") {
+            return URL(fileURLWithPath: path)
+        }
+        if path.hasPrefix("external/"),
+           let bazelOut = try? FileManager.default.destinationOfSymbolicLink(
+               atPath: projectRoot.appendingPathComponent("bazel-out").path
+           )
+        {
+            return URL(fileURLWithPath: bazelOut)
+                .deletingLastPathComponent()
+                .appendingPathComponent(path)
+                .standardizedFileURL
+        }
+        return projectRoot.appendingPathComponent(path).standardizedFileURL
     }
 
     /// Build the target's dependency libraries so their static archives are on
@@ -514,9 +539,17 @@ public actor BazelBuildSystem: BuildSystem {
                 "kind(\"(swift|objc)_library\", deps(\(target)))"
             )) ?? ""
         let labels = depLibs.split(separator: "\n").map(String.init)
-            .filter { $0.hasPrefix("//") || $0.hasPrefix("@") }
-        if !labels.isEmpty {
-            try await runBazel(["bazel", "build"] + labels + platformArgs)
+        let workspaceLabels = labels.filter { $0.hasPrefix("//") }
+        if !workspaceLabels.isEmpty {
+            try await runBazel(["bazel", "build"] + workspaceLabels + platformArgs)
+        }
+        // External-repository archives (B01's canonical repo) are built
+        // best-effort: some external libraries only configure through a rule
+        // transition and fail as bare top-level targets, and a miss surfaces
+        // later as a link diagnostic rather than failing the preview here.
+        let externalLabels = labels.filter { $0.hasPrefix("@") }
+        if !externalLabels.isEmpty {
+            _ = try? await runBazel(["bazel", "build"] + externalLabels + platformArgs)
         }
     }
 

--- a/previewsmcp/PreviewsCore/BazelCommandCapture.swift
+++ b/previewsmcp/PreviewsCore/BazelCommandCapture.swift
@@ -31,6 +31,7 @@ enum BazelCommandCapture {
             let graph = try? JSONDecoder().decode(ActionGraph.self, from: data)
         else { return nil }
 
+        var fallback: CapturedCommand?
         for action in graph.actions ?? [] where action.mnemonic == "SwiftCompile" {
             guard
                 let arguments = action.arguments,
@@ -39,14 +40,22 @@ enum BazelCommandCapture {
                 arguments[moduleIndex + 1] == moduleName
             else { continue }
             let stripped = preprocess(arguments)
-            return CapturedCommand(
+            let command = CapturedCommand(
                 arguments: stripped,
                 swiftSources: stripped.filter {
                     $0.hasSuffix(".swift") && !$0.hasPrefix("-")
                 }
             )
+            // A module analyzed in more than one configuration (an exec-config
+            // copy for a tool or macro) must not shadow the target-config
+            // action; exec-config output paths carry an "-exec" segment.
+            if stripped.contains(where: { $0.contains("-exec-") || $0.contains("-exec/") }) {
+                fallback = fallback ?? command
+                continue
+            }
+            return command
         }
-        return nil
+        return fallback
     }
 
     /// Drop the persistent-worker/driver prefix (everything through the

--- a/previewsmcp/PreviewsCore/BazelCommandCapture.swift
+++ b/previewsmcp/PreviewsCore/BazelCommandCapture.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Reads the compile command Bazel actually runs for a target out of
+/// `bazel aquery 'mnemonic("SwiftCompile", <target>)' --output=jsonproto`.
+/// The action's `arguments` carry the full swiftc invocation — dependency
+/// module search paths, module maps, defines, and the source inputs, with
+/// generated files as execroot-relative paths (B01). Bazel pre-processing
+/// strips the persistent-worker prefix and the placeholder-bearing pairs
+/// (`-sdk __BAZEL_XCODE_SDKROOT__` and friends are never expanded by
+/// aquery); `Compiler`'s own `-target`/`-sdk` injection stays authoritative.
+enum BazelCommandCapture {
+    struct CapturedCommand {
+        /// The swiftc argument vector after worker-prefix and placeholder
+        /// stripping, still execroot-relative.
+        let arguments: [String]
+        /// The action's Swift source inputs, execroot-relative.
+        let swiftSources: [String]
+    }
+
+    static func parse(jsonProto: String, moduleName: String) -> CapturedCommand? {
+        struct ActionGraph: Decodable {
+            struct Action: Decodable {
+                let mnemonic: String?
+                let arguments: [String]?
+            }
+
+            let actions: [Action]?
+        }
+        guard
+            let data = jsonProto.data(using: .utf8),
+            let graph = try? JSONDecoder().decode(ActionGraph.self, from: data)
+        else { return nil }
+
+        for action in graph.actions ?? [] where action.mnemonic == "SwiftCompile" {
+            guard
+                let arguments = action.arguments,
+                let moduleIndex = arguments.firstIndex(of: "-module-name"),
+                moduleIndex + 1 < arguments.count,
+                arguments[moduleIndex + 1] == moduleName
+            else { continue }
+            let stripped = preprocess(arguments)
+            return CapturedCommand(
+                arguments: stripped,
+                swiftSources: stripped.filter {
+                    $0.hasSuffix(".swift") && !$0.hasPrefix("-")
+                }
+            )
+        }
+        return nil
+    }
+
+    /// Drop the persistent-worker/driver prefix (everything through the
+    /// `swiftc` token) and the placeholder-bearing flag pairs aquery never
+    /// expands.
+    private static func preprocess(_ arguments: [String]) -> [String] {
+        var args = arguments
+        if let driverIndex = args.firstIndex(where: {
+            $0 == "swiftc" || $0.hasSuffix("/swiftc")
+        }) {
+            args.removeSubrange(...driverIndex)
+        }
+        let droppedPairs: Set = ["-sdk", "-target", "-file-prefix-map"]
+        var result: [String] = []
+        var index = 0
+        while index < args.count {
+            let token = args[index]
+            if droppedPairs.contains(token), index + 1 < args.count {
+                index += 2
+                continue
+            }
+            // Worker-protocol directives are consumed by rules_swift's
+            // persistent worker, never by swiftc.
+            if token.hasPrefix("-Xwrapped-swift") {
+                index += 1
+                continue
+            }
+            result.append(token)
+            index += 1
+        }
+        return result
+    }
+}

--- a/previewsmcp/PreviewsCore/SPMBuildSystem.swift
+++ b/previewsmcp/PreviewsCore/SPMBuildSystem.swift
@@ -301,9 +301,27 @@ public actor SPMBuildSystem: BuildSystem {
         //                   object files actually referenced get pulled in)
         //    -F <binPath>   framework search path for binary XCFramework deps
         //    -framework X   link against a binary framework
-        if !dependencyLibs.isEmpty {
+        //    SPM also copies static binaryTarget archives (libX.a out of a
+        //    static XCFramework slice) straight into binPath; scanning for
+        //    lib*.a picks up both those and the archives created above.
+        var linkLibs = dependencyLibs
+        let binPathEntries =
+            (try? FileManager.default.contentsOfDirectory(
+                at: binPath, includingPropertiesForKeys: nil
+            )) ?? []
+        for entry in binPathEntries
+            where entry.pathExtension == "a" && entry.lastPathComponent.hasPrefix("lib")
+        {
+            let name = String(
+                entry.deletingPathExtension().lastPathComponent.dropFirst(3)
+            )
+            if !linkLibs.contains(name) {
+                linkLibs.append(name)
+            }
+        }
+        if !linkLibs.isEmpty {
             flags += ["-L", binPath.path]
-            for dep in dependencyLibs {
+            for dep in linkLibs {
                 flags += ["-l\(dep)"]
             }
         }

--- a/previewsmcp/PreviewsCore/SPMBuildSystem.swift
+++ b/previewsmcp/PreviewsCore/SPMBuildSystem.swift
@@ -315,7 +315,11 @@ public actor SPMBuildSystem: BuildSystem {
             let name = String(
                 entry.deletingPathExtension().lastPathComponent.dropFirst(3)
             )
-            if !linkLibs.contains(name) {
+            if !linkLibs.contains(name),
+               !Self.shouldSkipDependencyTarget(
+                   targetName: name, consumerTargetName: targetName, binPath: binPath
+               )
+            {
                 linkLibs.append(name)
             }
         }

--- a/previewsmcp/Tests/PreviewsCoreTests/BuildSystemTests.swift
+++ b/previewsmcp/Tests/PreviewsCoreTests/BuildSystemTests.swift
@@ -223,22 +223,6 @@ struct BuildSystemTests {
         #expect(label == "//Sources/Feature:Sub/View.swift")
     }
 
-    // MARK: - BazelBuildSystem label-to-path conversion
-
-    @Test("BazelBuildSystem converts label to relative path")
-    func labelToPath() {
-        let bazel = BazelBuildSystem(
-            projectRoot: URL(fileURLWithPath: "/tmp"),
-            sourceFile: URL(fileURLWithPath: "/tmp/a.swift")
-        )
-
-        #expect(bazel.labelToPath("//Sources/ToDo:Item.swift") == "Sources/ToDo/Item.swift")
-        #expect(bazel.labelToPath("//lib:Lib.swift") == "lib/Lib.swift")
-        #expect(bazel.labelToPath("//:root.swift") == "root.swift")
-        #expect(bazel.labelToPath("@//Sources/ToDo:Item.swift") == "Sources/ToDo/Item.swift")
-        #expect(bazel.labelToPath("invalid") == nil)
-    }
-
     // MARK: - BazelBuildSystem module-redefinition classification (#279)
 
     @Test("isModuleRedefinition matches the cross-config duplicate-modulemap failure")

--- a/previewsmcp/Tests/PreviewsCoreTests/CompileCaptureTests.swift
+++ b/previewsmcp/Tests/PreviewsCoreTests/CompileCaptureTests.swift
@@ -355,3 +355,51 @@ struct XcodeCommandCaptureTests {
         #expect(normalized == ["-import-objc-header", "/proj/Bridging.h", "-DDEBUG"])
     }
 }
+
+@Suite("BazelCommandCapture")
+struct BazelCommandCaptureTests {
+    private let jsonProto = """
+    {"actions": [
+      {"mnemonic": "SwiftCompile", "arguments": [
+        "bazel-out/darwin_arm64-opt-exec/bin/external/rules_swift/tools/worker/worker",
+        "swiftc", "-target", "arm64-apple-macos14.0",
+        "-sdk", "__BAZEL_XCODE_SDKROOT__",
+        "-file-prefix-map", "__BAZEL_XCODE_DEVELOPER_DIR__=/PLACEHOLDER_DEVELOPER_DIR",
+        "-module-name", "BzlmodFixture", "-DSTAMPED",
+        "-I", "bazel-out/darwin_arm64-fastbuild/bin/deps",
+        "-Xcc", "-iquote", "-Xcc", ".",
+        "Sources/BzlmodPreview.swift",
+        "bazel-out/darwin_arm64-fastbuild/bin/generated_build_stamp.swift",
+        "-c"
+      ]},
+      {"mnemonic": "SwiftCompile", "arguments": [
+        "swiftc", "-module-name", "OtherModule", "-c", "Other.swift"
+      ]}
+    ]}
+    """
+
+    @Test("parses the module's action, strips worker prefix and placeholder pairs")
+    func parsesAction() throws {
+        let captured = try #require(
+            BazelCommandCapture.parse(jsonProto: jsonProto, moduleName: "BzlmodFixture")
+        )
+        #expect(captured.arguments.first == "-module-name")
+        #expect(!captured.arguments.contains { $0.hasSuffix("worker") || $0 == "swiftc" })
+        #expect(!captured.arguments.contains("-sdk"))
+        #expect(!captured.arguments.contains("-target"))
+        #expect(!captured.arguments.contains { $0.contains("__BAZEL_XCODE_") })
+        #expect(captured.arguments.contains("-DSTAMPED"))
+        #expect(
+            captured.swiftSources == [
+                "Sources/BzlmodPreview.swift",
+                "bazel-out/darwin_arm64-fastbuild/bin/generated_build_stamp.swift",
+            ]
+        )
+    }
+
+    @Test("an unmatched module or unparseable output returns nil")
+    func unmatchedModule() {
+        #expect(BazelCommandCapture.parse(jsonProto: jsonProto, moduleName: "Nope") == nil)
+        #expect(BazelCommandCapture.parse(jsonProto: "not json", moduleName: "X") == nil)
+    }
+}


### PR DESCRIPTION
Stage 4 of `docs/build-system-resolver.md`, the final capture stage: Bazel Tier 2 previews compile with the target's SwiftCompile action captured via `bazel aquery --output=jsonproto` (`BazelCommandCapture`). The action's arguments carry the defines, dependency module search paths, and module maps Bazel actually compiled with; its `.swift` inputs resolve generated sources to execroot paths, retiring B01's workspace-relative guess. Per-system pre-processing strips the persistent-worker prefix, `-Xwrapped-swift` worker directives, and the placeholder pairs aquery never expands; a post-normalize pass absolutizes execroot-relative paths including joined `-I`/`-F` forms, known path-bearing `flag=path` forms, and the `external/` tree via the bazel-out symlink. External-repository dependency archives are force-built (best-effort) for the JIT link, and SwiftPM's link set picks up static `binaryTarget` archives copied into binPath — B02/B03's remaining link half after stage 2 fixed their compile.

Matrix outcome (rows re-verified manually today, `examples/regress/VERIFICATION.md`):
- **Flip Reproduced → Guard**: B01 (canonical repo + generated source, macOS), B02 and B03 (static/dynamic XCFrameworks, iOS simulator)
- **Stay green / expected partial**: B04 (runtime-resource half out of scope), F01 unchanged, D04/D05 Bazel detection guards

This completes the resolver plan: all 17 targeted rows plus R03's generated-sources half are now Guard rows across stages 1–4 (#417, #418, #419, this PR).

Gates: /simplify (skip-guard reuse for the archive scan, dead labelToPath deleted, integration doc updated), workflow /code-review at high (5 fixes: missing-action tolerance restoring the #279 fallback, define-value token safety, exec-config action preference, external/ resolution, best-effort external builds; 1 noted), lint clean, unit tier green, integration tier green twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZ2rNwt9TXrHAtGrN5L2ba