### PR TITLE
test: automated guards for 13 regress matrix rows (tranche 1)

### DIFF
--- a/examples/regress/VERIFICATION.md
+++ b/examples/regress/VERIFICATION.md
@@ -90,6 +90,11 @@ not a nonzero command exit.
   inferred resources relative to the wrong directory name.
 - Added the custom `Preview Debug` configuration to both workspace projects;
   without it, the native control could not build the referenced framework.
+- Made S01/S02 fail closed (2026-07-15, guard automation): the `#else`
+  branches that rendered "setting missing" text became `#error`, and S01's
+  missing-resource fallback became a `fatalError`, so a regression is a
+  loud compile/render failure instead of a silently-wrong render that an
+  exit-code guard would miss. The healthy render is unchanged.
 
 ## Repeatability Notes
 

--- a/examples/regress/spm-settings/Sources/CompilerSettings/CompilerSettingsPreview.swift
+++ b/examples/regress/spm-settings/Sources/CompilerSettings/CompilerSettingsPreview.swift
@@ -19,8 +19,7 @@ struct CompilerSettingsView: View {
             #if COMPILER_SETTINGS_PRESENT
                 Text("Conditional Swift setting present")
             #else
-                Text("Conditional Swift setting missing")
-                    .foregroundStyle(.red)
+                #error("COMPILER_SETTINGS_PRESENT was not forwarded to the compile")
             #endif
         }
         .padding()

--- a/examples/regress/spm-settings/Sources/SettingsFixture/SettingsPreview.swift
+++ b/examples/regress/spm-settings/Sources/SettingsFixture/SettingsPreview.swift
@@ -16,16 +16,15 @@ struct SettingsFixtureView: View {
     private let provider: any FixtureMessageProviding
 
     init() {
-        let resourceName: String = if let url = Bundle.module.url(forResource: "settings", withExtension: "json"),
-                                      let data = try? Data(contentsOf: url),
-                                      let object = try? JSONSerialization.jsonObject(with: data) as? [String: String]
-        {
-            object["name"] ?? "missing resource value"
-        } else {
-            "missing settings.json"
+        guard let url = Bundle.module.url(forResource: "settings", withExtension: "json"),
+              let data = try? Data(contentsOf: url),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: String],
+              let name = object["name"]
+        else {
+            fatalError("settings.json was not staged with the preview")
         }
 
-        provider = FixtureMessage(message: resourceName)
+        provider = FixtureMessage(message: name)
     }
 
     var body: some View {
@@ -38,8 +37,7 @@ struct SettingsFixtureView: View {
             #if SETTINGS_FIXTURE
                 Text("Conditional Swift setting present")
             #else
-                Text("Conditional Swift setting missing")
-                    .foregroundStyle(.red)
+                #error("SETTINGS_FIXTURE was not forwarded to the compile")
             #endif
         }
         .padding()

--- a/previewsmcp/PreviewsCore/OwnershipResolver.swift
+++ b/previewsmcp/PreviewsCore/OwnershipResolver.swift
@@ -129,6 +129,10 @@ struct OwnershipWalk {
                     of: sourceFile, at: dir, marker: marker, scheme: scheme
                 ) {
                 case let .confirmed(ownership):
+                    Log.info(
+                        "ownership: \(resolver.kind.rawValue) confirmed by "
+                            + "\(marker.lastPathComponent) for \(sourceFile.lastPathComponent)"
+                    )
                     return ownership
                 case let .notMember(reason):
                     declines.append(

--- a/previewsmcp/Tests/CLIIntegrationTests/CLIRunner.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/CLIRunner.swift
@@ -40,6 +40,7 @@ enum CLIRunner {
     static let xcodeprojExampleRoot: URL = repoRoot.appendingPathComponent("examples/xcodeproj")
     static let xcworkspaceExampleRoot: URL = repoRoot.appendingPathComponent("examples/xcworkspace")
     static let bazelExampleRoot: URL = repoRoot.appendingPathComponent("examples/bazel")
+    static let regressRoot: URL = repoRoot.appendingPathComponent("examples/regress")
 
     /// Mirrors `Sources/PreviewsCLI/DaemonPaths.swift`. The daemon writes its
     /// stderr to this file when launched detached. We can't import PreviewsCLI

--- a/previewsmcp/Tests/CLIIntegrationTests/CLIRunner.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/CLIRunner.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import os
 import Testing
@@ -140,6 +141,26 @@ enum CLIRunner {
             #expect(w == expectedWidth, "PNG width should be \(expectedWidth), got \(w)")
             #expect(h == expectedHeight, "PNG height should be \(expectedHeight), got \(h)")
         }
+    }
+
+    /// Assert the PNG decodes and is not a uniform frame. A blank (single
+    /// color) render encodes a perfectly valid PNG over the 1024-byte floor,
+    /// so guards for "renders real content" need a pixel check, not a size
+    /// heuristic. Scans every pixel's raw bytes — sampling grids step over
+    /// thin glyphs (a centered "42" in a 400x600 frame).
+    static func assertNonBlankPNG(at path: String) throws {
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let rep = try #require(NSBitmapImageRep(data: data), "PNG should decode")
+        let bytes = try #require(rep.bitmapData, "PNG should expose bitmap data")
+        let bytesPerPixel = rep.bitsPerPixel / 8
+        let width = rep.pixelsWide
+        for y in 0 ..< rep.pixelsHigh {
+            let row = bytes + y * rep.bytesPerRow
+            for x in 0 ..< width where memcmp(row + x * bytesPerPixel, bytes, bytesPerPixel) != 0 {
+                return
+            }
+        }
+        Issue.record("PNG appears blank: every pixel matches the first")
     }
 
     static func assertValidJPEG(at path: String, minSize: Int = 1024) throws {

--- a/previewsmcp/Tests/CLIIntegrationTests/RegressGuardTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/RegressGuardTests.swift
@@ -4,15 +4,21 @@ import Testing
 /// Automated guards for `examples/regress` matrix rows that flipped to
 /// "Guard passes" (see `examples/regress/VERIFICATION.md`). One test per
 /// row, asserting the row's healthy-result contract: render rows assert a
-/// successful one-shot `snapshot` producing a valid PNG; error rows assert
-/// the exact classified diagnostic. Detection rows run without `--project`
-/// or `--build-system` overrides — auto-detection is what they guard.
+/// successful one-shot `snapshot` producing a valid, non-blank PNG; error
+/// rows assert the diagnostic tokens the contract guarantees (identifiers
+/// and command names, not connective prose). Detection rows run without
+/// `--project` or `--build-system` overrides — auto-detection is what
+/// they guard. Rows whose regression would still render (D05's tie-break)
+/// assert the daemon's ownership log line instead of pixels.
 ///
 /// This first tranche covers the rows that need no Xcode build, no
 /// simulator, no artifact generation, and no network: the deterministic
 /// macOS SwiftPM and error-contract rows. Rows staying manual-only for a
 /// named flake reason: W03 (FSEvents timing, #298), L05 (concurrency),
 /// S05/S06 (swift-syntax fetch), M01/M02 (launch assertions elsewhere).
+/// Future tranches that need simulators, artifact generation, or network
+/// must land in a separate test target, not this file — this target's
+/// glob feeds the required `ci` gate.
 @Suite("Regress guard rows", .serialized)
 struct RegressGuardTests {
     private static func cleanSlate() async throws {
@@ -24,9 +30,13 @@ struct RegressGuardTests {
     }
 
     /// Run a one-shot snapshot of `relativePath` with no detection overrides
-    /// and assert it renders a valid PNG.
+    /// and assert it renders a valid, non-blank PNG. `thenWhileAlive` runs
+    /// inside the same lock block, before the writer-fence kills the daemon,
+    /// for assertions that need the daemon's state (logs, status).
     private static func assertRenders(
-        _ relativePath: String, extraArguments: [String] = []
+        _ relativePath: String,
+        extraArguments: [String] = [],
+        thenWhileAlive: @Sendable () async throws -> Void = {}
     ) async throws {
         try await DaemonTestLock.run {
             try await cleanSlate()
@@ -40,13 +50,19 @@ struct RegressGuardTests {
             )
             #expect(result.exitCode == 0, "stderr: \(result.stderr)")
             try CLIRunner.assertValidPNG(at: outputPath)
+            try CLIRunner.assertNonBlankPNG(at: outputPath)
+            try await thenWhileAlive()
         }
     }
 
     /// Run a one-shot snapshot of `relativePath` and assert it fails with
-    /// every expected diagnostic substring in the combined output.
+    /// every expected diagnostic token in the combined output. `thenWhileAlive`
+    /// runs inside the same lock block, before the writer-fence kills the
+    /// daemon.
     private static func assertFails(
-        _ relativePath: String, containing expected: [String]
+        _ relativePath: String,
+        containing expected: [String],
+        thenWhileAlive: @Sendable () async throws -> Void = {}
     ) async throws {
         try await DaemonTestLock.run {
             try await cleanSlate()
@@ -59,13 +75,26 @@ struct RegressGuardTests {
             )
             #expect(result.exitCode != 0, "expected a classified failure, got success")
             let combined = result.stdout + result.stderr
-            for substring in expected {
+            for token in expected {
                 #expect(
-                    combined.contains(substring),
-                    "diagnostic should contain '\(substring)'; got: \(combined)"
+                    combined.contains(token),
+                    "diagnostic should contain '\(token)'; got: \(combined)"
                 )
             }
+            try await thenWhileAlive()
         }
+    }
+
+    /// Assert the daemon log records the ownership walk confirming `kind`
+    /// for `fileName`. This is the observable for rows whose regression
+    /// still renders (a wrong build system compiling the same source).
+    private static func assertOwnershipLogged(kind: String, fileName: String) async throws {
+        let logs = try await CLIRunner.run("logs", arguments: ["-n", "300"])
+        #expect(logs.exitCode == 0, "logs stderr: \(logs.stderr)")
+        #expect(
+            logs.stdout.contains("ownership: \(kind) confirmed") && logs.stdout.contains(fileName),
+            "daemon log should record '\(kind)' confirming \(fileName)"
+        )
     }
 
     // MARK: - Detection rows
@@ -75,45 +104,52 @@ struct RegressGuardTests {
     func d02NestedPackageBelowBazelRoot() async throws {
         try await Self.assertRenders(
             "detection/mixed-marker-workspace/NestedPackage/Sources/NestedPackage/NestedPackagePreview.swift"
-        )
+        ) {
+            try await Self.assertOwnershipLogged(kind: "spm", fileName: "NestedPackagePreview.swift")
+        }
     }
 
     /// D05: `Package.swift`, `MODULE.bazel`, and `BUILD.bazel` at one root
-    /// resolve through the documented tie-break (SwiftPM first) and render.
+    /// resolve through the documented tie-break (SwiftPM first). All three
+    /// systems compile this fixture to identical pixels, so the guard is the
+    /// daemon's ownership log line, not the render.
     @Test("D05: same-directory marker tie-break", .timeLimit(.minutes(5)))
     func d05SameDirectoryMarkers() async throws {
         try await Self.assertRenders(
             "detection/same-directory-markers/Sources/HybridMarker/HybridMarkerPreview.swift"
-        )
+        ) {
+            try await Self.assertOwnershipLogged(kind: "spm", fileName: "HybridMarkerPreview.swift")
+        }
     }
 
     /// D06: an XcodeGen manifest with no generated project is diagnosed with
-    /// the regeneration hint instead of a generic ownership failure.
+    /// the missing-output-specific message and the regeneration hint.
     @Test("D06: missing generated project diagnosis", .timeLimit(.minutes(5)))
     func d06MissingGeneratedOutput() async throws {
         try await Self.assertFails(
             "generated-project-state/missing-output/Sources/MissingOutputPreview.swift",
-            containing: ["xcodegen generate"]
+            containing: ["no generated .xcodeproj", "xcodegen generate"]
         )
     }
 
     /// D07: a source file missing from a stale generated project is diagnosed
-    /// with the owning project and the staleness hint.
+    /// with the owning project, the file, and the staleness hint. Tokens, not
+    /// prose: the connective sentence may be reworded.
     @Test("D07: stale generated project diagnosis", .timeLimit(.minutes(5)))
     func d07StaleGeneratedOutput() async throws {
         try await Self.assertFails(
             "generated-project-state/stale-output/Sources/NewPreview.swift",
-            containing: [
-                "no target in StaleOutput.xcodeproj compiles NewPreview.swift",
-                "the project may be stale",
-            ]
+            containing: ["StaleOutput.xcodeproj", "NewPreview.swift", "stale"]
         )
     }
 
     // MARK: - SwiftPM compile-capture rows
 
     /// S01: language mode, conditional flags, C module, generated source,
-    /// resources, and explicit membership compile through the captured command.
+    /// resources, and explicit membership compile through the captured
+    /// command. The fixture fails closed: a dropped define is a compile
+    /// error and an unstaged resource is a render crash, so exit 0 + a
+    /// non-blank PNG covers the whole contract.
     @Test("S01: captured settings fixture renders", .timeLimit(.minutes(5)))
     func s01SettingsFixture() async throws {
         try await Self.assertRenders(
@@ -122,7 +158,8 @@ struct RegressGuardTests {
     }
 
     /// S02: upcoming features, unsafe flags, and conditional defines forward
-    /// through the normalized captured command.
+    /// through the normalized captured command. The fixture fails closed on
+    /// a dropped define (#error).
     @Test("S02: compiler settings preserved", .timeLimit(.minutes(5)))
     func s02CompilerSettings() async throws {
         try await Self.assertRenders(
@@ -131,7 +168,7 @@ struct RegressGuardTests {
     }
 
     /// S03: a build-tool plugin's generated Swift source is a captured
-    /// compile input.
+    /// compile input (a miss is a compile error).
     @Test("S03: plugin-generated source compiles", .timeLimit(.minutes(5)))
     func s03GeneratedPlugin() async throws {
         try await Self.assertRenders(
@@ -139,7 +176,8 @@ struct RegressGuardTests {
         )
     }
 
-    /// S04: explicit source exclusion is honored and the Clang module resolves.
+    /// S04: explicit source exclusion is honored and the Clang module
+    /// resolves (a miss is a compile error).
     @Test("S04: membership exclusion and C module", .timeLimit(.minutes(5)))
     func s04MembershipAndC() async throws {
         try await Self.assertRenders(
@@ -158,12 +196,36 @@ struct RegressGuardTests {
     }
 
     /// V03: duplicate display names keep stable index-based selection.
+    /// Renders index 0 and index 1 and asserts the images differ — the two
+    /// declarations render distinguishable content, so identical bytes mean
+    /// index selection collapsed.
     @Test("V03: duplicate names select by index", .timeLimit(.minutes(5)))
     func v03DuplicateNames() async throws {
-        try await Self.assertRenders(
-            "preview-forms/Sources/PreviewForms/DuplicateNames.swift",
-            extraArguments: ["--preview", "1"]
-        )
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            let file = Self.fixture("preview-forms/Sources/PreviewForms/DuplicateNames.swift")
+            let output0 = tempDir.appendingPathComponent("index0.png").path
+            let output1 = tempDir.appendingPathComponent("index1.png").path
+
+            let result0 = try await CLIRunner.run("snapshot", arguments: [file, "-o", output0])
+            #expect(result0.exitCode == 0, "index 0 stderr: \(result0.stderr)")
+            let result1 = try await CLIRunner.run(
+                "snapshot", arguments: [file, "-o", output1, "--preview", "1"]
+            )
+            #expect(result1.exitCode == 0, "index 1 stderr: \(result1.stderr)")
+
+            try CLIRunner.assertValidPNG(at: output0)
+            try CLIRunner.assertValidPNG(at: output1)
+            let data0 = try Data(contentsOf: URL(fileURLWithPath: output0))
+            let data1 = try Data(contentsOf: URL(fileURLWithPath: output1))
+            #expect(
+                data0 != data1,
+                "index 0 and index 1 should render distinct declarations"
+            )
+        }
     }
 
     /// V04: a preview in a constrained generic context compiles and renders.
@@ -175,7 +237,7 @@ struct RegressGuardTests {
     }
 
     /// V05: a source with no preview declaration returns the specific
-    /// zero-preview diagnostic.
+    /// zero-preview diagnostic (a deliberate UX string, pinned verbatim).
     @Test("V05: zero-preview diagnostic", .timeLimit(.minutes(5)))
     func v05NoPreview() async throws {
         try await Self.assertFails(
@@ -189,31 +251,13 @@ struct RegressGuardTests {
     /// T02: a setup package that fails to compile returns a setup-specific
     /// build error while the daemon stays alive. The liveness check runs
     /// inside the same lock block: the writer-fence kills the daemon when
-    /// the block ends, so a second block would always find it dead.
+    /// the block ends.
     @Test("T02: setup build failure is classified", .timeLimit(.minutes(5)))
     func t02SetupBuildFailure() async throws {
-        try await DaemonTestLock.run {
-            try await Self.cleanSlate()
-            let tempDir = try CLIRunner.makeTempDir()
-            defer { try? FileManager.default.removeItem(at: tempDir) }
-
-            let outputPath = tempDir.appendingPathComponent("snapshot.png").path
-            let result = try await CLIRunner.run(
-                "snapshot",
-                arguments: [
-                    Self.fixture(
-                        "setup-faults/build-failure/Sources/SetupFaultApp/SetupFaultPreview.swift"
-                    ),
-                    "-o", outputPath,
-                ]
-            )
-            #expect(result.exitCode != 0, "expected a classified setup failure, got success")
-            let combined = result.stdout + result.stderr
-            #expect(
-                combined.contains("Setup package 'BrokenPreviewSetup' build failed"),
-                "diagnostic should name the setup package; got: \(combined)"
-            )
-
+        try await Self.assertFails(
+            "setup-faults/build-failure/Sources/SetupFaultApp/SetupFaultPreview.swift",
+            containing: ["Setup package 'BrokenPreviewSetup' build failed"]
+        ) {
             let status = try await CLIRunner.run("status")
             #expect(status.exitCode == 0, "daemon should stay healthy after a setup failure")
             #expect(status.stdout.contains("daemon running"), "status: \(status.stdout)")

--- a/previewsmcp/Tests/CLIIntegrationTests/RegressGuardTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/RegressGuardTests.swift
@@ -1,0 +1,222 @@
+import Foundation
+import Testing
+
+/// Automated guards for `examples/regress` matrix rows that flipped to
+/// "Guard passes" (see `examples/regress/VERIFICATION.md`). One test per
+/// row, asserting the row's healthy-result contract: render rows assert a
+/// successful one-shot `snapshot` producing a valid PNG; error rows assert
+/// the exact classified diagnostic. Detection rows run without `--project`
+/// or `--build-system` overrides — auto-detection is what they guard.
+///
+/// This first tranche covers the rows that need no Xcode build, no
+/// simulator, no artifact generation, and no network: the deterministic
+/// macOS SwiftPM and error-contract rows. Rows staying manual-only for a
+/// named flake reason: W03 (FSEvents timing, #298), L05 (concurrency),
+/// S05/S06 (swift-syntax fetch), M01/M02 (launch assertions elsewhere).
+@Suite("Regress guard rows", .serialized)
+struct RegressGuardTests {
+    private static func cleanSlate() async throws {
+        _ = try? await CLIRunner.run("kill-daemon", arguments: ["--timeout", "2"])
+    }
+
+    private static func fixture(_ relativePath: String) -> String {
+        CLIRunner.regressRoot.appendingPathComponent(relativePath).path
+    }
+
+    /// Run a one-shot snapshot of `relativePath` with no detection overrides
+    /// and assert it renders a valid PNG.
+    private static func assertRenders(
+        _ relativePath: String, extraArguments: [String] = []
+    ) async throws {
+        try await DaemonTestLock.run {
+            try await cleanSlate()
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            let outputPath = tempDir.appendingPathComponent("snapshot.png").path
+            let result = try await CLIRunner.run(
+                "snapshot",
+                arguments: [fixture(relativePath), "-o", outputPath] + extraArguments
+            )
+            #expect(result.exitCode == 0, "stderr: \(result.stderr)")
+            try CLIRunner.assertValidPNG(at: outputPath)
+        }
+    }
+
+    /// Run a one-shot snapshot of `relativePath` and assert it fails with
+    /// every expected diagnostic substring in the combined output.
+    private static func assertFails(
+        _ relativePath: String, containing expected: [String]
+    ) async throws {
+        try await DaemonTestLock.run {
+            try await cleanSlate()
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            let outputPath = tempDir.appendingPathComponent("snapshot.png").path
+            let result = try await CLIRunner.run(
+                "snapshot", arguments: [fixture(relativePath), "-o", outputPath]
+            )
+            #expect(result.exitCode != 0, "expected a classified failure, got success")
+            let combined = result.stdout + result.stderr
+            for substring in expected {
+                #expect(
+                    combined.contains(substring),
+                    "diagnostic should contain '\(substring)'; got: \(combined)"
+                )
+            }
+        }
+    }
+
+    // MARK: - Detection rows
+
+    /// D02: a Swift package nested below a Bazel root is selected and renders.
+    @Test("D02: nested package below a Bazel root", .timeLimit(.minutes(5)))
+    func d02NestedPackageBelowBazelRoot() async throws {
+        try await Self.assertRenders(
+            "detection/mixed-marker-workspace/NestedPackage/Sources/NestedPackage/NestedPackagePreview.swift"
+        )
+    }
+
+    /// D05: `Package.swift`, `MODULE.bazel`, and `BUILD.bazel` at one root
+    /// resolve through the documented tie-break (SwiftPM first) and render.
+    @Test("D05: same-directory marker tie-break", .timeLimit(.minutes(5)))
+    func d05SameDirectoryMarkers() async throws {
+        try await Self.assertRenders(
+            "detection/same-directory-markers/Sources/HybridMarker/HybridMarkerPreview.swift"
+        )
+    }
+
+    /// D06: an XcodeGen manifest with no generated project is diagnosed with
+    /// the regeneration hint instead of a generic ownership failure.
+    @Test("D06: missing generated project diagnosis", .timeLimit(.minutes(5)))
+    func d06MissingGeneratedOutput() async throws {
+        try await Self.assertFails(
+            "generated-project-state/missing-output/Sources/MissingOutputPreview.swift",
+            containing: ["xcodegen generate"]
+        )
+    }
+
+    /// D07: a source file missing from a stale generated project is diagnosed
+    /// with the owning project and the staleness hint.
+    @Test("D07: stale generated project diagnosis", .timeLimit(.minutes(5)))
+    func d07StaleGeneratedOutput() async throws {
+        try await Self.assertFails(
+            "generated-project-state/stale-output/Sources/NewPreview.swift",
+            containing: [
+                "no target in StaleOutput.xcodeproj compiles NewPreview.swift",
+                "the project may be stale",
+            ]
+        )
+    }
+
+    // MARK: - SwiftPM compile-capture rows
+
+    /// S01: language mode, conditional flags, C module, generated source,
+    /// resources, and explicit membership compile through the captured command.
+    @Test("S01: captured settings fixture renders", .timeLimit(.minutes(5)))
+    func s01SettingsFixture() async throws {
+        try await Self.assertRenders(
+            "spm-settings/Sources/SettingsFixture/SettingsPreview.swift"
+        )
+    }
+
+    /// S02: upcoming features, unsafe flags, and conditional defines forward
+    /// through the normalized captured command.
+    @Test("S02: compiler settings preserved", .timeLimit(.minutes(5)))
+    func s02CompilerSettings() async throws {
+        try await Self.assertRenders(
+            "spm-settings/Sources/CompilerSettings/CompilerSettingsPreview.swift"
+        )
+    }
+
+    /// S03: a build-tool plugin's generated Swift source is a captured
+    /// compile input.
+    @Test("S03: plugin-generated source compiles", .timeLimit(.minutes(5)))
+    func s03GeneratedPlugin() async throws {
+        try await Self.assertRenders(
+            "spm-settings/Sources/GeneratedPlugin/GeneratedPluginPreview.swift"
+        )
+    }
+
+    /// S04: explicit source exclusion is honored and the Clang module resolves.
+    @Test("S04: membership exclusion and C module", .timeLimit(.minutes(5)))
+    func s04MembershipAndC() async throws {
+        try await Self.assertRenders(
+            "spm-settings/Sources/MembershipAndC/MembershipAndCPreview.swift"
+        )
+    }
+
+    // MARK: - Preview-form rows
+
+    /// V01: a legacy `PreviewProvider` declaration renders.
+    @Test("V01: legacy PreviewProvider renders", .timeLimit(.minutes(5)))
+    func v01LegacyProvider() async throws {
+        try await Self.assertRenders(
+            "preview-forms/Sources/PreviewForms/LegacyProvider.swift"
+        )
+    }
+
+    /// V03: duplicate display names keep stable index-based selection.
+    @Test("V03: duplicate names select by index", .timeLimit(.minutes(5)))
+    func v03DuplicateNames() async throws {
+        try await Self.assertRenders(
+            "preview-forms/Sources/PreviewForms/DuplicateNames.swift",
+            extraArguments: ["--preview", "1"]
+        )
+    }
+
+    /// V04: a preview in a constrained generic context compiles and renders.
+    @Test("V04: constrained generic context renders", .timeLimit(.minutes(5)))
+    func v04GenericContext() async throws {
+        try await Self.assertRenders(
+            "preview-forms/Sources/PreviewForms/GenericContext.swift"
+        )
+    }
+
+    /// V05: a source with no preview declaration returns the specific
+    /// zero-preview diagnostic.
+    @Test("V05: zero-preview diagnostic", .timeLimit(.minutes(5)))
+    func v05NoPreview() async throws {
+        try await Self.assertFails(
+            "preview-forms/Sources/PreviewForms/NoPreview.swift",
+            containing: ["Preview index 0 not found. File has 0 preview(s)."]
+        )
+    }
+
+    // MARK: - Setup-fault rows
+
+    /// T02: a setup package that fails to compile returns a setup-specific
+    /// build error while the daemon stays alive. The liveness check runs
+    /// inside the same lock block: the writer-fence kills the daemon when
+    /// the block ends, so a second block would always find it dead.
+    @Test("T02: setup build failure is classified", .timeLimit(.minutes(5)))
+    func t02SetupBuildFailure() async throws {
+        try await DaemonTestLock.run {
+            try await Self.cleanSlate()
+            let tempDir = try CLIRunner.makeTempDir()
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+
+            let outputPath = tempDir.appendingPathComponent("snapshot.png").path
+            let result = try await CLIRunner.run(
+                "snapshot",
+                arguments: [
+                    Self.fixture(
+                        "setup-faults/build-failure/Sources/SetupFaultApp/SetupFaultPreview.swift"
+                    ),
+                    "-o", outputPath,
+                ]
+            )
+            #expect(result.exitCode != 0, "expected a classified setup failure, got success")
+            let combined = result.stdout + result.stderr
+            #expect(
+                combined.contains("Setup package 'BrokenPreviewSetup' build failed"),
+                "diagnostic should name the setup package; got: \(combined)"
+            )
+
+            let status = try await CLIRunner.run("status")
+            #expect(status.exitCode == 0, "daemon should stay healthy after a setup failure")
+            #expect(status.stdout.contains("daemon running"), "status: \(status.stdout)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

First tranche of automated guards for `examples/regress` rows that flipped to Guard during the resolver campaign — the deterministic macOS rows needing no simulator, no Xcode build, no artifact generation, and no network. One test per row inside `CLIIntegrationTests`, reusing `DaemonTestLock`'s writer-fence and per-target socket isolation; no new lock or socket topology.

- **Render rows** (D02, D05, S01–S04, V01, V03, V04): one-shot `snapshot`, valid + non-blank PNG (exact raw-byte scan — sampling grids step over thin glyphs), no detection overrides.
- **Error rows** (D06, D07, V05, T02): diagnostic tokens the contract guarantees (identifiers and command names, not connective prose); T02 also asserts daemon liveness inside the same lock block.
- **Tie-break rows** (D02, D05): all three build systems compile D05 to identical pixels, so the guard is a new one-line ownership log (`ownership: <kind> confirmed by <marker> for <file>`) asserted via `logs` — the only product change.
- **Fail-closed fixtures**: S01/S02's `#else` render-text branches became `#error`, and S01's missing-resource fallback became `fatalError`, so define/resource regressions fail loud instead of rendering alternate text past an exit-code guard (recorded in VERIFICATION.md).

Rows staying manual-only, each for a named flake reason: W03 (FSEvents timing, #298), L05 (concurrency), S05/S06 (swift-syntax fetch), M01/M02 (launch assertions elsewhere). Future tranches needing simulators or network land in a separate target, not this one.

## Verification

- New guards: 3 consecutive green runs twice (pre- and post-strengthening), ~17s wall, 0.2s spread.
- Full local unit tier and integration tier green.
- Gates: workflow /code-review (4 findings, all folded — D05/V03 discrimination, non-blank check, D06 token) + /simplify 4-angle (T02 hook folded; reuse/efficiency clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)