### PR TITLE
ci: deterministic head-branch deletion for merged PRs

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,37 @@
+# Deterministic head-branch deletion for merged PRs.
+#
+# The repo's native "automatically delete head branches" setting fires
+# unreliably when the squash-merge is performed by the Actions token via
+# the `merge` label gate's auto-merge (2026-07-15: two of four same-day
+# auto-merged PRs kept their branches, with no head_ref_deleted event).
+# This workflow owns the deletion instead of hoping the native path runs.
+#
+# Deletion is skipped for cross-fork PRs (not our ref to delete) and is
+# best-effort when the native path already removed the ref (422 from the
+# API is logged, not failed).
+name: cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  delete-head-branch:
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete merged head branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${HEAD_REF}"; then
+            echo "deleted ${HEAD_REF}"
+          else
+            echo "branch ${HEAD_REF} already gone (native deletion won the race)"
+          fi

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -65,6 +65,11 @@ deliberately no `concurrency` / `cancel-in-progress` block — do not add one.
   as a standing flake probe while the repo is quiet.
 - `workflow_dispatch` — ad-hoc manual run.
 
+A separate `cleanup.yml` (`pull_request` `types: [closed]`, hosted runner)
+deletes the head branch of every merged same-repo PR. The repo's native
+delete-on-merge setting fires unreliably when auto-merge lands the squash
+via the Actions token, so the workflow owns the deletion.
+
 ## Ruleset (`main`, id 14088159)
 
 - **Require a pull request before merging.**


### PR DESCRIPTION
GitHub's native `delete_branch_on_merge` fires unreliably when the `merge` label gate's auto-merge performs the squash via the Actions token — today two of four auto-merged PRs (#422, #423) kept their branches with no `head_ref_deleted` event, while #421/#424 were deleted minutes late. A tiny `pull_request: closed` workflow on a hosted runner now owns the deletion: merged same-repo PRs get their head ref deleted; cross-fork PRs are skipped; a 422 from the native path winning the race logs instead of failing. Documented in docs/ci.md.

Also cleaned up manually today: `regress-guard-tests`, `state-invalidation-stage1-configcache`, `ci-test-tier-split` (all merged PRs). Left alone: `merge-queue-gate`, `combined-remeasure`, `368-sample`, `340-dead-imports`, `391-*` — no merged PR, unique commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)