### PR TITLE
core: EvidenceSet capture (state-invalidation stage 3)

### DIFF
--- a/previewsmcp/PreviewsCore/BazelBuildSystem.swift
+++ b/previewsmcp/PreviewsCore/BazelBuildSystem.swift
@@ -183,11 +183,26 @@ public actor BazelBuildSystem: BuildSystem {
         // the defines, language mode, dependency module search paths, and
         // module maps Bazel actually compiled with, and its .swift inputs
         // resolve generated sources to execroot paths (B01).
-        let aqueryOutput = try await runBazel(
-            ["bazel", "aquery", "mnemonic(\"SwiftCompile\", \(expr))", "--output=jsonproto"]
-                + platformArgs,
-            discardStderr: true
-        )
+        // One deps()-widened aquery serves both the compile-command capture
+        // (module-name match) and the evidence surface (every action's
+        // sources), per the design's widen-the-existing-query shape. The
+        // narrow retry keeps the load-bearing capture path as reliable as
+        // before if the widened query ever fails where the narrow one
+        // would not.
+        let aqueryOutput: String
+        do {
+            aqueryOutput = try await runBazel(
+                ["bazel", "aquery", "mnemonic(\"SwiftCompile\", deps(\(expr)))",
+                 "--output=jsonproto"] + platformArgs,
+                discardStderr: true
+            )
+        } catch {
+            aqueryOutput = try await runBazel(
+                ["bazel", "aquery", "mnemonic(\"SwiftCompile\", \(expr))", "--output=jsonproto"]
+                    + platformArgs,
+                discardStderr: true
+            )
+        }
         // A graph with no parseable SwiftCompile action (the #279
         // apple-bundle fallback under some configs) degrades to the
         // module-search flags above, as the pre-capture derivation did.
@@ -221,13 +236,76 @@ public actor BazelBuildSystem: BuildSystem {
             .filter { $0.resolvingSymlinksInPath().path != previewPath }
             .filter { !Self.declaresMainEntry($0) }
 
+        let evidence = deriveEvidence(target: target, aqueryOutput: aqueryOutput)
+        if let evidence {
+            Log.info("bazel \(evidence.logDescription)")
+        }
+
         return BuildContext(
             moduleName: moduleName,
             compilerFlags: compilerFlags,
             projectRoot: projectRoot,
             targetName: moduleName,
-            sourceFiles: sourceFiles.isEmpty ? nil : sourceFiles
+            sourceFiles: sourceFiles.isEmpty ? nil : sourceFiles,
+            evidence: evidence
         )
+    }
+
+    /// Derive the stage-3 EvidenceSet from the already-fetched widened
+    /// aquery output: one source root per `SwiftCompile` action,
+    /// realpath-classified against the output base (derived from the
+    /// `bazel-out` symlink, never name-matched) so `path_override` local
+    /// dependencies resolve into the workspace and fetched dependencies
+    /// drop out, plus the module and owning-package build files.
+    private func deriveEvidence(target: String, aqueryOutput: String) -> EvidenceSet? {
+        let productRoots = outputBaseRoot().map { [$0] } ?? []
+
+        let groups = BazelCommandCapture.allSwiftSourceGroups(jsonProto: aqueryOutput)
+            .map { $0.map(resolveExecrootPath) }
+        let roots = EvidenceClassifier.sourceRoots(
+            forGroups: groups, productRoots: productRoots
+        )
+
+        var definitions: Set<URL> = []
+        for name in ["MODULE.bazel", "WORKSPACE.bazel", "WORKSPACE"] {
+            if let file = EvidenceClassifier.evidencePath(
+                projectRoot.appendingPathComponent(name), productRoots: productRoots
+            ) {
+                definitions.insert(file)
+            }
+        }
+        if target.hasPrefix("//"), let colon = target.firstIndex(of: ":") {
+            let packagePath = String(target[target.index(target.startIndex, offsetBy: 2) ..< colon])
+            for name in ["BUILD.bazel", "BUILD"] {
+                if let file = EvidenceClassifier.evidencePath(
+                    projectRoot.appendingPathComponent(packagePath).appendingPathComponent(name),
+                    productRoots: productRoots
+                ) {
+                    definitions.insert(file)
+                    break
+                }
+            }
+        }
+
+        return EvidenceSet.make(sourceDirectories: roots, definitionFiles: definitions)
+    }
+
+    /// The output base owning this workspace's build products, derived
+    /// from where the `bazel-out` convenience symlink points
+    /// (`<output_base>/execroot/<repo>/bazel-out`). Nil when the symlink
+    /// is absent (no build has run — evidence derivation follows a build,
+    /// so this is defensive).
+    private func outputBaseRoot() -> URL? {
+        guard
+            let bazelOut = try? FileManager.default.destinationOfSymbolicLink(
+                atPath: projectRoot.appendingPathComponent("bazel-out").path
+            )
+        else { return nil }
+        let outputBase = URL(fileURLWithPath: bazelOut)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return EvidenceClassifier.productRoot(outputBase)
     }
 
     /// Resolve execroot-relative paths inside a normalized flag token to

--- a/previewsmcp/PreviewsCore/BazelCommandCapture.swift
+++ b/previewsmcp/PreviewsCore/BazelCommandCapture.swift
@@ -17,15 +17,40 @@ enum BazelCommandCapture {
         let swiftSources: [String]
     }
 
-    static func parse(jsonProto: String, moduleName: String) -> CapturedCommand? {
-        struct ActionGraph: Decodable {
-            struct Action: Decodable {
-                let mnemonic: String?
-                let arguments: [String]?
-            }
-
-            let actions: [Action]?
+    private struct ActionGraph: Decodable {
+        struct Action: Decodable {
+            let mnemonic: String?
+            let arguments: [String]?
         }
+
+        let actions: [Action]?
+    }
+
+    /// Every `SwiftCompile` action's Swift sources (execroot-relative),
+    /// one group per action. Fed by a `deps(target)` aquery, this is the
+    /// dependency-source surface for the stage-3 EvidenceSet
+    /// (docs/state-invalidation.md). Exec-config actions contribute
+    /// groups too, deliberately: a macro or tool's workspace sources are
+    /// evidence (editing them must invalidate), and their realpaths
+    /// dedup against the target-config copies while generated inputs
+    /// classify out against the output base.
+    static func allSwiftSourceGroups(jsonProto: String) -> [[String]] {
+        guard
+            let data = jsonProto.data(using: .utf8),
+            let graph = try? JSONDecoder().decode(ActionGraph.self, from: data)
+        else { return [] }
+
+        return (graph.actions ?? [])
+            .filter { $0.mnemonic == "SwiftCompile" }
+            .compactMap { action in
+                let sources = (action.arguments ?? []).filter {
+                    $0.hasSuffix(".swift") && !$0.hasPrefix("-")
+                }
+                return sources.isEmpty ? nil : sources
+            }
+    }
+
+    static func parse(jsonProto: String, moduleName: String) -> CapturedCommand? {
         guard
             let data = jsonProto.data(using: .utf8),
             let graph = try? JSONDecoder().decode(ActionGraph.self, from: data)

--- a/previewsmcp/PreviewsCore/BuildContext.swift
+++ b/previewsmcp/PreviewsCore/BuildContext.swift
@@ -28,6 +28,11 @@ public struct BuildContext: Sendable {
     /// into a single dylib — all types are visible and literal hot-reload works.
     public let sourceFiles: [URL]?
 
+    /// The filesystem inputs this context was derived from
+    /// (docs/state-invalidation.md stage 3). Carried for the stage-4
+    /// watch set; nil when the build system enumerated none.
+    public let evidence: EvidenceSet?
+
     /// Whether this context supports Tier 2 (source compilation with literal hot-reload).
     public var supportsTier2: Bool {
         sourceFiles != nil
@@ -39,7 +44,8 @@ public struct BuildContext: Sendable {
         projectRoot: URL,
         targetName: String,
         frameworkPaths: [URL] = [],
-        sourceFiles: [URL]? = nil
+        sourceFiles: [URL]? = nil,
+        evidence: EvidenceSet? = nil
     ) {
         self.moduleName = moduleName
         self.compilerFlags = compilerFlags
@@ -47,5 +53,6 @@ public struct BuildContext: Sendable {
         self.targetName = targetName
         self.frameworkPaths = frameworkPaths
         self.sourceFiles = sourceFiles
+        self.evidence = evidence
     }
 }

--- a/previewsmcp/PreviewsCore/EvidenceSet.swift
+++ b/previewsmcp/PreviewsCore/EvidenceSet.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+/// The filesystem inputs a session's compile context was derived from
+/// (docs/state-invalidation.md stage 3). Carried on `BuildContext` and
+/// logged at session start; stage 4 turns it into the watch set whose
+/// changes re-run the producer. Enumeration is best-effort per build
+/// system — a missing category degrades to today's behavior (not
+/// watched), never to a wrong watch.
+public struct EvidenceSet: Sendable {
+    /// Source roots of the target and its local dependencies. Directory
+    /// scope is what makes file addition/removal visible; dependency
+    /// source files need no category of their own — an edit under a
+    /// dependency's root fires the directory match.
+    public let sourceDirectories: [URL]
+
+    /// Resource files staged into the preview's runtime bundle (SwiftPM
+    /// `copy-tool` node inputs; scoped out for Xcode and Bazel).
+    public let runtimeInputs: [URL]
+
+    /// Project-definition files: the package manifest and pin file, the
+    /// referenced pbxprojs and xcconfigs, the XcodeGen manifest, the
+    /// Bazel module and package build files.
+    public let definitionFiles: [URL]
+
+    public init(
+        sourceDirectories: [URL] = [],
+        runtimeInputs: [URL] = [],
+        definitionFiles: [URL] = []
+    ) {
+        self.sourceDirectories = sourceDirectories
+        self.runtimeInputs = runtimeInputs
+        self.definitionFiles = definitionFiles
+    }
+
+    public var isEmpty: Bool {
+        sourceDirectories.isEmpty && runtimeInputs.isEmpty && definitionFiles.isEmpty
+    }
+
+    /// One-line summary for the session-start log.
+    public var logDescription: String {
+        "evidence: \(sourceDirectories.count) source dir(s), "
+            + "\(runtimeInputs.count) runtime input(s), "
+            + "\(definitionFiles.count) definition file(s)"
+    }
+
+    /// Assemble a sorted set, nil when nothing was enumerated. The shared
+    /// tail of every build system's derivation.
+    public static func make(
+        sourceDirectories: some Sequence<URL>,
+        runtimeInputs: some Sequence<URL> = [],
+        definitionFiles: some Sequence<URL> = []
+    ) -> EvidenceSet? {
+        let set = EvidenceSet(
+            sourceDirectories: sourceDirectories.sorted { $0.path < $1.path },
+            runtimeInputs: runtimeInputs.sorted { $0.path < $1.path },
+            definitionFiles: definitionFiles.sorted { $0.path < $1.path }
+        )
+        return set.isEmpty ? nil : set
+    }
+}
+
+/// Product-vs-evidence classification (docs/state-invalidation.md,
+/// exclusion rule). Every captured path is realpath-canonicalized — via
+/// the same `FileWatcher.canonicalPath` the stage-4 watcher uses for
+/// fired FSEvents paths, so producer and consumer of the watch set can
+/// never disagree on identity. Realpath is load-bearing for Bazel, where
+/// aquery spells a `path_override` local dependency's sources as
+/// `external/…` paths that resolve back into the workspace, while
+/// fetched dependencies resolve into the output base.
+///
+/// Product exclusion is prefix-based against the product roots each
+/// build system actually uses (its scratch dir, output base, or
+/// DerivedData paths) — never name-convention fragments, which both
+/// miss relocated build dirs (`--scratch-path`, `--output_base`) and
+/// falsely exclude user paths that merely contain a marker-like name.
+public enum EvidenceClassifier {
+    /// Canonicalize `url` and answer whether it is watchable evidence.
+    /// Returns nil for missing paths and for paths under any product
+    /// root.
+    public static func evidencePath(_ url: URL, productRoots: [URL]) -> URL? {
+        guard let canonical = FileWatcher.canonicalPath(url.path) else { return nil }
+        for root in productRoots {
+            if canonical == root.path || canonical.hasPrefix(root.path + "/") {
+                return nil
+            }
+        }
+        return URL(fileURLWithPath: canonical)
+    }
+
+    /// Canonicalize a product root itself (so prefix comparison happens
+    /// realpath-to-realpath). A root that does not exist yet resolves
+    /// as-is.
+    public static func productRoot(_ url: URL) -> URL {
+        if let canonical = FileWatcher.canonicalPath(url.path) {
+            return URL(fileURLWithPath: canonical, isDirectory: true)
+        }
+        return url.standardizedFileURL
+    }
+
+    /// Source roots for groups of compile inputs: per group, classify
+    /// each path, take the survivors' common ancestor, and accept it
+    /// only when no product root lives beneath it — a root containing a
+    /// build-product directory is the watch firehose the design's
+    /// stream-root hygiene forbids. A rejected or unresolvable common
+    /// ancestor degrades to the survivors' parent directories, filtered
+    /// by the same rule; a source sitting directly in a
+    /// product-containing directory (a `path: "."` target root) yields
+    /// no root and keeps today's unwatched behavior, per the design's
+    /// named limitation.
+    public static func sourceRoots(
+        forGroups groups: [[URL]], productRoots: [URL]
+    ) -> Set<URL> {
+        func containsProduct(_ dir: URL) -> Bool {
+            productRoots.contains {
+                $0.path == dir.path || $0.path.hasPrefix(dir.path + "/")
+            }
+        }
+
+        var roots: Set<URL> = []
+        for group in groups {
+            let survivors = group.compactMap { evidencePath($0, productRoots: productRoots) }
+            guard !survivors.isEmpty else { continue }
+            if let common = commonDirectory(of: survivors), !containsProduct(common) {
+                roots.insert(common)
+            } else {
+                for survivor in survivors {
+                    let parent = survivor.deletingLastPathComponent()
+                    if !containsProduct(parent) {
+                        roots.insert(parent)
+                    }
+                }
+            }
+        }
+        return roots
+    }
+
+    /// The deepest directory containing every given file (their common
+    /// ancestor). For a SwiftPM target's sources this is the target's
+    /// source directory. Nil when the files share no ancestor below the
+    /// filesystem root.
+    public static func commonDirectory(of files: [URL]) -> URL? {
+        guard var common = files.first?.deletingLastPathComponent().pathComponents else {
+            return nil
+        }
+        for file in files.dropFirst() {
+            let components = file.deletingLastPathComponent().pathComponents
+            var shared = 0
+            while shared < min(common.count, components.count),
+                  common[shared] == components[shared]
+            {
+                shared += 1
+            }
+            common = Array(common.prefix(shared))
+        }
+        guard common.count > 1 else { return nil }
+        return URL(fileURLWithPath: common.joined(separator: "/").replacingOccurrences(
+            of: "//", with: "/"
+        ), isDirectory: true)
+    }
+}

--- a/previewsmcp/PreviewsCore/SPMBuildSystem.swift
+++ b/previewsmcp/PreviewsCore/SPMBuildSystem.swift
@@ -290,8 +290,9 @@ public actor SPMBuildSystem: BuildSystem {
                 "Could not locate the build manifest for \(binPath.path)"
             )
         }
+        let manifestContents = try SPMCommandCapture.readManifest(at: manifestPath)
         let captured = try SPMCommandCapture.capture(
-            manifestAt: manifestPath, forTarget: targetName
+            contents: manifestContents, forTarget: targetName, manifestPath: manifestPath
         )
         var flags = CompileCommandNormalizer.normalize(captured.arguments)
 
@@ -347,13 +348,88 @@ public actor SPMBuildSystem: BuildSystem {
         let previewPath = sourceFile.standardizedFileURL.path
         let otherSourceFiles = captured.swiftInputs.filter { $0.path != previewPath }
 
+        let evidence = Self.deriveEvidence(
+            manifestContents: manifestContents,
+            scratchDirectory: Self.scratchDirectory(forManifestPath: manifestPath),
+            projectRoot: projectRoot
+        )
+        if let evidence {
+            Log.info("spm \(evidence.logDescription)")
+        }
+
         return BuildContext(
             moduleName: targetName,
             compilerFlags: flags,
             projectRoot: projectRoot,
             targetName: targetName,
-            sourceFiles: otherSourceFiles.isEmpty ? nil : otherSourceFiles
+            sourceFiles: otherSourceFiles.isEmpty ? nil : otherSourceFiles,
+            evidence: evidence
         )
+    }
+
+    /// Derive the stage-3 EvidenceSet from the llbuild manifest: one
+    /// source root per compile node (the target's and its local
+    /// dependencies'; fetched dependencies live under the scratch dir and
+    /// classify as products), `copy-tool` inputs as runtime resources,
+    /// and the package manifests governing each root. The product root is
+    /// the actual scratch directory — derived, not name-matched, so
+    /// `--scratch-path` relocations stay covered.
+    static func deriveEvidence(
+        manifestContents: String, scratchDirectory: URL, projectRoot: URL
+    ) -> EvidenceSet? {
+        let raw = SPMCommandCapture.evidence(contents: manifestContents)
+        let productRoots = [EvidenceClassifier.productRoot(scratchDirectory)]
+
+        let roots = EvidenceClassifier.sourceRoots(
+            forGroups: raw.compileNodeSwiftInputs, productRoots: productRoots
+        )
+        var definitions: Set<URL> = []
+        for root in roots {
+            if let manifest = nearestPackageManifest(above: root, productRoots: productRoots) {
+                definitions.insert(manifest)
+            }
+        }
+
+        let resources = raw.copyToolInputs.compactMap {
+            EvidenceClassifier.evidencePath($0, productRoots: productRoots)
+        }
+
+        for name in ["Package.swift", "Package.resolved"] {
+            if let file = EvidenceClassifier.evidencePath(
+                projectRoot.appendingPathComponent(name), productRoots: productRoots
+            ) {
+                definitions.insert(file)
+            }
+        }
+
+        return EvidenceSet.make(
+            sourceDirectories: roots, runtimeInputs: resources, definitionFiles: definitions
+        )
+    }
+
+    /// The scratch directory owning a build manifest (`<scratch>/<config>.yaml`).
+    static func scratchDirectory(forManifestPath manifestPath: URL) -> URL {
+        manifestPath.deletingLastPathComponent()
+    }
+
+    /// The `Package.swift` governing a source root, found by walking up
+    /// a bounded number of levels (a target source dir sits at most a
+    /// few levels below its package root).
+    private static func nearestPackageManifest(
+        above directory: URL, productRoots: [URL]
+    ) -> URL? {
+        var dir = directory
+        for _ in 0 ..< 6 {
+            if let manifest = EvidenceClassifier.evidencePath(
+                dir.appendingPathComponent("Package.swift"), productRoots: productRoots
+            ) {
+                return manifest
+            }
+            let parent = dir.deletingLastPathComponent()
+            if parent.path == dir.path { break }
+            dir = parent
+        }
+        return nil
     }
 
     // MARK: - Private: Package Description

--- a/previewsmcp/PreviewsCore/SPMCommandCapture.swift
+++ b/previewsmcp/PreviewsCore/SPMCommandCapture.swift
@@ -18,6 +18,10 @@ enum SPMCommandCapture {
     }
 
     static func capture(manifestAt url: URL, forTarget target: String) throws -> CapturedCommand {
+        try capture(contents: readManifest(at: url), forTarget: target, manifestPath: url)
+    }
+
+    static func readManifest(at url: URL) throws -> String {
         guard
             let data = try? Data(contentsOf: url),
             let contents = String(data: data, encoding: .utf8)
@@ -26,7 +30,12 @@ enum SPMCommandCapture {
                 "Could not read the build manifest at \(url.path)"
             )
         }
+        return contents
+    }
 
+    static func capture(
+        contents: String, forTarget target: String, manifestPath: URL
+    ) throws -> CapturedCommand {
         let moduleNeedle = "\"-module-name\",\"\(target)\""
         var inCompileNode = false
         var inputsLine: String?
@@ -75,10 +84,67 @@ enum SPMCommandCapture {
             ?? candidates.first
         else {
             throw BuildSystemError.missingArtifacts(
-                "No compile command for target '\(target)' in the build manifest at \(url.path)"
+                "No compile command for target '\(target)' in the build manifest at \(manifestPath.path)"
             )
         }
         return command
+    }
+
+    struct CapturedEvidence {
+        /// Every compile node's Swift inputs — the target's AND its
+        /// dependencies' (one manifest carries the whole graph). The
+        /// caller derives per-node source roots and classifies paths.
+        let compileNodeSwiftInputs: [[URL]]
+        /// Inputs of `copy-tool` nodes: the editable source resources
+        /// staged into runtime bundles.
+        let copyToolInputs: [URL]
+    }
+
+    /// Enumerate the manifest's evidence surface for the stage-3
+    /// EvidenceSet (docs/state-invalidation.md).
+    static func evidence(contents: String) -> CapturedEvidence {
+        var compileNodes: [[URL]] = []
+        var copyInputs: [URL] = []
+        var inCompileNode = false
+        var inputsLine: String?
+        var toolIsCopy = false
+
+        func closeNode() {
+            defer {
+                inputsLine = nil
+                toolIsCopy = false
+            }
+            guard let inputsLine else { return }
+            let inputs = decodeStringArray(from: inputsLine, prefix: "inputs: ")
+            if inCompileNode {
+                let swift = inputs.filter { $0.hasSuffix(".swift") }
+                    .map { URL(fileURLWithPath: $0).standardizedFileURL }
+                if !swift.isEmpty { compileNodes.append(swift) }
+            } else if toolIsCopy {
+                copyInputs.append(contentsOf: inputs.map {
+                    URL(fileURLWithPath: $0).standardizedFileURL
+                })
+            }
+        }
+
+        for rawLine in contents.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if rawLine.hasPrefix("  \"") {
+                closeNode()
+                inCompileNode = rawLine.hasPrefix("  \"C.")
+                continue
+            }
+            if line.hasPrefix("inputs: ") {
+                inputsLine = line
+            } else if line == "tool: copy-tool" {
+                toolIsCopy = true
+            }
+        }
+        closeNode()
+
+        return CapturedEvidence(
+            compileNodeSwiftInputs: compileNodes, copyToolInputs: copyInputs
+        )
     }
 
     private static func decodeStringArray(from line: String, prefix: String) -> [String] {

--- a/previewsmcp/PreviewsCore/XcodeBuildSystem.swift
+++ b/previewsmcp/PreviewsCore/XcodeBuildSystem.swift
@@ -85,15 +85,18 @@ public actor XcodeBuildSystem: BuildSystem {
         // 5. Capture the compile command xcodebuild actually ran; a
         //    build-with-Bazel project logs no SwiftDriver invocation, so the
         //    settings-derived path below stays as its fallback.
+        let validity = captureValidity()
         let captured = try await captureCommand(
             buildLog: buildLog, scheme: scheme, platform: platform,
-            moduleName: moduleName, builtProductsDir: builtProductsDir
+            moduleName: moduleName, builtProductsDir: builtProductsDir,
+            validity: validity
         )
         if let captured {
             return try await buildContext(
                 from: captured, settings: settings,
                 moduleName: moduleName, targetName: targetName,
-                builtProductsDir: builtProductsDir, platform: platform
+                builtProductsDir: builtProductsDir, platform: platform,
+                validity: validity
             )
         }
 
@@ -131,13 +134,21 @@ public actor XcodeBuildSystem: BuildSystem {
         let package = await Self.swiftPMPackageProducts(builtProductsDir: builtProductsDir)
         compilerFlags += package.flags
 
+        let evidence = deriveEvidence(
+            settings: settings, targetSources: sourceFiles ?? [], validity: validity
+        )
+        if let evidence {
+            Log.info("xcode \(evidence.logDescription)")
+        }
+
         return BuildContext(
             moduleName: moduleName,
             compilerFlags: compilerFlags,
             projectRoot: projectRoot,
             targetName: targetName,
             frameworkPaths: package.frameworkPaths,
-            sourceFiles: sourceFiles
+            sourceFiles: sourceFiles,
+            evidence: evidence
         )
     }
 
@@ -150,10 +161,10 @@ public actor XcodeBuildSystem: BuildSystem {
     /// SwiftDriver invocations (build-with-Bazel).
     private func captureCommand(
         buildLog: String, scheme: String, platform: PreviewPlatform,
-        moduleName: String, builtProductsDir: String
+        moduleName: String, builtProductsDir: String,
+        validity: [String: Date]
     ) async throws -> XcodeCommandCapture.CapturedCommand? {
         let persistURL = persistedCaptureURL(builtProductsDir, moduleName)
-        let validity = captureValidity()
         func parseAndPersist(_ log: String) -> XcodeCommandCapture.CapturedCommand? {
             guard
                 let captured = XcodeCommandCapture.parse(log: log, moduleName: moduleName)
@@ -225,7 +236,8 @@ public actor XcodeBuildSystem: BuildSystem {
         from captured: XcodeCommandCapture.CapturedCommand,
         settings: [String: String],
         moduleName: String, targetName: String, builtProductsDir: String,
-        platform: PreviewPlatform
+        platform: PreviewPlatform,
+        validity: [String: Date]
     ) async throws -> BuildContext {
         var flags = CompileCommandNormalizer.normalize(
             Self.stripForeignTargetTriple(captured.arguments, platform: platform)
@@ -301,14 +313,60 @@ public actor XcodeBuildSystem: BuildSystem {
         }
         sourceFiles = Self.applyResourceBundleRewrites(sources: sourceFiles, settings: settings)
 
+        let evidence = deriveEvidence(
+            settings: settings, targetSources: sourceFiles, validity: validity
+        )
+        if let evidence {
+            Log.info("xcode \(evidence.logDescription)")
+        }
+
         return BuildContext(
             moduleName: moduleName,
             compilerFlags: flags,
             projectRoot: projectRoot,
             targetName: targetName,
             frameworkPaths: package.frameworkPaths,
-            sourceFiles: sourceFiles.isEmpty ? nil : sourceFiles
+            sourceFiles: sourceFiles.isEmpty ? nil : sourceFiles,
+            evidence: evidence
         )
+    }
+
+    /// Derive the stage-3 EvidenceSet: the target's own source root (the
+    /// common directory of its captured sources — dependency-target roots
+    /// are net-new log parsing, scoped out with the referenced-project
+    /// caveat in docs/state-invalidation.md), plus the definition files
+    /// the capture's validity walk already enumerated and the XcodeGen
+    /// manifest when one governs the project. Product roots come from the
+    /// build's own settings (generated sources under OBJROOT/DerivedData
+    /// classify out). Runtime resources are scoped out: incremental build
+    /// logs omit unchanged CpResource lines, so there is no reliable
+    /// start-time enumeration.
+    private func deriveEvidence(
+        settings: [String: String], targetSources: [URL], validity: [String: Date]
+    ) -> EvidenceSet? {
+        let productRoots = ["OBJROOT", "SYMROOT", "BUILT_PRODUCTS_DIR", "DERIVED_FILE_DIR"]
+            .compactMap { settings[$0] }
+            .map { EvidenceClassifier.productRoot(URL(fileURLWithPath: $0)) }
+
+        let roots = EvidenceClassifier.sourceRoots(
+            forGroups: [targetSources], productRoots: productRoots
+        )
+
+        var definitions: Set<URL> = []
+        for path in validity.keys {
+            if let file = EvidenceClassifier.evidencePath(
+                URL(fileURLWithPath: path), productRoots: productRoots
+            ) {
+                definitions.insert(file)
+            }
+        }
+        if let manifest = Self.generatedProjectManifest(
+            in: projectFile.deletingLastPathComponent()
+        ), let file = EvidenceClassifier.evidencePath(manifest, productRoots: productRoots) {
+            definitions.insert(file)
+        }
+
+        return EvidenceSet.make(sourceDirectories: roots, definitionFiles: definitions)
     }
 
     /// Xcode pre-processing for the shared normalizer: a scheme can build a

--- a/previewsmcp/Tests/PreviewsCoreTests/EvidenceSetTests.swift
+++ b/previewsmcp/Tests/PreviewsCoreTests/EvidenceSetTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+@testable import PreviewsCore
+import Testing
+
+/// Stage-3 EvidenceSet derivation (docs/state-invalidation.md): the
+/// classifier's product-root exclusion (prefix-based against derived
+/// roots, never name fragments), the guarded source-root derivation with
+/// its parent-directory fallback, the per-node roots from a SwiftPM
+/// llbuild manifest (dependency nodes included, fetched dependencies and
+/// generated sources excluded), copy-tool resource inputs, and the Bazel
+/// per-action source grouping.
+@Suite("Evidence set derivation")
+struct EvidenceSetTests {
+    private func makeWorkspace() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("evidence-\(UUID().uuidString)")
+        let files = [
+            "App/Package.swift",
+            "App/Package.resolved",
+            "App/Sources/App/Main.swift",
+            "App/Sources/App/Helper.swift",
+            "App/Sources/App/Resources/value.txt",
+            "Dep/Package.swift",
+            "Dep/Sources/Dep/Shared.swift",
+            "App/.build/checkouts/Fetched/Sources/Fetched/F.swift",
+            "App/.build/plugins/outputs/generated/Gen.swift",
+        ]
+        for file in files {
+            let url = root.appendingPathComponent(file)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            try "// \(file)".write(to: url, atomically: true, encoding: .utf8)
+        }
+        return root
+    }
+
+    private func scratch(_ root: URL) -> [URL] {
+        [EvidenceClassifier.productRoot(root.appendingPathComponent("App/.build"))]
+    }
+
+    private func canonical(_ root: URL, _ path: String) -> URL {
+        URL(fileURLWithPath: FileWatcher.canonicalPath(
+            root.appendingPathComponent(path).path
+        )!)
+    }
+
+    @Test("classifier excludes product-root paths and missing files")
+    func classifierExcludesProducts() throws {
+        let root = try makeWorkspace()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let products = scratch(root)
+
+        #expect(EvidenceClassifier.evidencePath(
+            root.appendingPathComponent("App/Sources/App/Main.swift"), productRoots: products
+        ) != nil)
+        #expect(EvidenceClassifier.evidencePath(
+            root.appendingPathComponent("App/.build/checkouts/Fetched/Sources/Fetched/F.swift"),
+            productRoots: products
+        ) == nil)
+        #expect(EvidenceClassifier.evidencePath(
+            root.appendingPathComponent("App/Sources/App/Missing.swift"), productRoots: products
+        ) == nil)
+    }
+
+    @Test("a marker-like name outside the product roots stays evidence")
+    func markerLikeNamesAreNotExcluded() throws {
+        let root = try makeWorkspace()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let odd = root.appendingPathComponent("App/Sources/DerivedData/Odd.swift")
+        try FileManager.default.createDirectory(
+            at: odd.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try "// odd".write(to: odd, atomically: true, encoding: .utf8)
+
+        #expect(EvidenceClassifier.evidencePath(odd, productRoots: scratch(root)) != nil)
+    }
+
+    @Test("common directory is the deepest shared ancestor")
+    func commonDirectory() {
+        let common = EvidenceClassifier.commonDirectory(of: [
+            URL(fileURLWithPath: "/w/App/Sources/App/Main.swift"),
+            URL(fileURLWithPath: "/w/App/Sources/App/Nested/Deep.swift"),
+        ])
+        #expect(common?.path == "/w/App/Sources/App")
+    }
+
+    @Test("a root that would contain a product root degrades to safe parents")
+    func firehoseRootDegradesToParents() throws {
+        let root = try makeWorkspace()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // The two survivors' common ancestor is the App package root,
+        // which contains .build — the forbidden firehose root. The
+        // fallback keeps Main.swift's parent and drops Package.swift's
+        // parent (the package root itself).
+        let roots = EvidenceClassifier.sourceRoots(
+            forGroups: [[
+                root.appendingPathComponent("App/Package.swift"),
+                root.appendingPathComponent("App/Sources/App/Main.swift"),
+            ]],
+            productRoots: scratch(root)
+        )
+
+        #expect(roots == [canonical(root, "App/Sources/App")])
+    }
+
+    @Test("SwiftPM evidence: dependency roots in, fetched and generated out")
+    func spmEvidenceDerivation() throws {
+        let root = try makeWorkspace()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let evidence = try #require(SPMBuildSystem.deriveEvidence(
+            manifestContents: manifestYAML(root: root),
+            scratchDirectory: root.appendingPathComponent("App/.build"),
+            projectRoot: root.appendingPathComponent("App")
+        ))
+
+        #expect(evidence.sourceDirectories == [
+            canonical(root, "App/Sources/App"),
+            canonical(root, "Dep/Sources/Dep"),
+        ])
+        #expect(evidence.runtimeInputs == [
+            canonical(root, "App/Sources/App/Resources/value.txt"),
+        ])
+        #expect(evidence.definitionFiles.map(\.lastPathComponent).sorted() == [
+            "Package.resolved", "Package.swift", "Package.swift",
+        ])
+    }
+
+    @Test("Bazel source groups: one per SwiftCompile action")
+    func bazelSourceGroups() {
+        let jsonProto = """
+        {"actions": [
+          {"mnemonic": "SwiftCompile", "arguments": ["swiftc", "-module-name", "App", \
+        "Sources/App/Main.swift", "Sources/App/Helper.swift"]},
+          {"mnemonic": "SwiftCompile", "arguments": ["swiftc", "-module-name", "Badge", \
+        "external/local_badge+/Sources/LocalBadge.swift"]},
+          {"mnemonic": "CppCompile", "arguments": ["clang", "foo.cc"]}
+        ]}
+        """
+        let groups = BazelCommandCapture.allSwiftSourceGroups(jsonProto: jsonProto)
+        #expect(groups == [
+            ["Sources/App/Main.swift", "Sources/App/Helper.swift"],
+            ["external/local_badge+/Sources/LocalBadge.swift"],
+        ])
+    }
+
+    private func manifestYAML(root: URL) -> String {
+        let app = root.appendingPathComponent("App").path
+        let dep = root.appendingPathComponent("Dep").path
+        let appSources =
+            "\"\(app)/Sources/App/Main.swift\",\"\(app)/Sources/App/Helper.swift\","
+                + "\"\(app)/.build/plugins/outputs/generated/Gen.swift\","
+                + "\"\(app)/.build/debug/Dep.swiftmodule\""
+        return """
+        commands:
+          "C.App-debug.module":
+            tool: swift-compiler
+            inputs: [\(appSources)]
+            args: ["swiftc","-module-name","App","-c"]
+          "C.Dep-debug.module":
+            tool: swift-compiler
+            inputs: ["\(dep)/Sources/Dep/Shared.swift"]
+            args: ["swiftc","-module-name","Dep","-c"]
+          "C.Fetched-debug.module":
+            tool: swift-compiler
+            inputs: ["\(app)/.build/checkouts/Fetched/Sources/Fetched/F.swift"]
+            args: ["swiftc","-module-name","Fetched","-c"]
+          "\(app)/.build/debug/App_App.bundle/value.txt":
+            tool: copy-tool
+            inputs: ["\(app)/Sources/App/Resources/value.txt"]
+            outputs: ["\(app)/.build/debug/App_App.bundle/value.txt"]
+        """
+    }
+}


### PR DESCRIPTION
## Summary

Stage 3 of `docs/state-invalidation.md`: each build system enumerates the filesystem inputs its compile context was derived from, carried on `BuildContext.evidence` and logged at session start — the watch-set enabler stage 4 consumes. Carry-and-log only; no behavior change.

- **SwiftPM**: one source root per llbuild compile node from a single shared manifest read (the whole graph rides in one manifest — the W04 fixture logs both the app's and the `SharedLocal` dependency's roots live), `copy-tool` inputs as runtime resources, per-root package manifests + pin file.
- **Bazel**: the existing aquery widened to `deps()` (one query serving capture and evidence, with a narrow-query retry preserving the load-bearing capture's reliability), realpath classification against the output base derived from the `bazel-out` symlink.
- **Xcode**: the target's own source root, the validity walk's definition files (computed once, threaded through capture and evidence), the XcodeGen manifest; both the captured-command and settings-fallback paths carry evidence; runtime resources scoped out per the design.
- **EvidenceClassifier**: product exclusion is prefix-based against each system's derived product roots — never name fragments — and canonicalizes via `FileWatcher.canonicalPath`, the same mechanism the stage-4 watcher will use on fired paths. Source-root derivation rejects any root a product root lives beneath (the firehose rule) with a filtered parent-directory fallback.

## Verification

- `EvidenceSetTests`: hermetic temp workspaces + canned manifests/jsonproto covering exclusion, marker-like user paths, the firehose fallback, dependency-root derivation, and Bazel grouping.
- Guard suite (14 rows) green; live W04 session logs `spm evidence: 2 source dir(s) ...`; full local unit + integration tiers green; lint clean.
- Gates: workflow /code-review high (10 findings folded — derived product roots replacing unanchored markers, commonDirectory guardrails, Xcode fallback-path coverage, one-query Bazel, single-read SwiftPM, shared validity walk) + /simplify 2-pass (canonicalization unification, `EvidenceSet.make`, `sourceRoots` helper).

Stage 4 (tiered invalidation) closes W02/W04 (#415) + the D07 residue next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)