### PR TITLE
core: PhaseFailure + typed notices carrier (phase/error stage 1)

### DIFF
--- a/previewsmcp/PreviewsCLI/ConfigureCommand.swift
+++ b/previewsmcp/PreviewsCLI/ConfigureCommand.swift
@@ -104,9 +104,10 @@ struct ConfigureCommand: AsyncParsableCommand {
         }
 
         // Surface the daemon's response (typically a summary of what
-        // changed) to the user.
-        let text = response.content.joinedText()
+        // changed) to the user, then any notices.
+        let text = response.payloadText()
         if !text.isEmpty { fputs("\(text)\n", stderr) }
+        response.surfaceNotices()
     }
 
     // MARK: - Helpers

--- a/previewsmcp/PreviewsCLI/ConfigureCommand.swift
+++ b/previewsmcp/PreviewsCLI/ConfigureCommand.swift
@@ -105,9 +105,7 @@ struct ConfigureCommand: AsyncParsableCommand {
 
         // Surface the daemon's response (typically a summary of what
         // changed) to the user, then any notices.
-        let text = response.payloadText()
-        if !text.isEmpty { fputs("\(text)\n", stderr) }
-        response.surfaceNotices()
+        response.surfacePayloadAndNoticesToStderr()
     }
 
     // MARK: - Helpers

--- a/previewsmcp/PreviewsCLI/ElementsCommand.swift
+++ b/previewsmcp/PreviewsCLI/ElementsCommand.swift
@@ -93,8 +93,10 @@ struct ElementsCommand: AsyncParsableCommand {
         }
 
         // Default: write the bare accessibility tree JSON to stdout
-        // so existing scripts piping into `jq` keep working.
-        let text = response.content.joinedText()
+        // so existing scripts piping into `jq` keep working. Notices go
+        // to stderr so they never corrupt the piped payload.
+        response.surfaceNotices()
+        let text = response.payloadText()
         if !text.isEmpty { print(text) }
     }
 }

--- a/previewsmcp/PreviewsCLI/Handlers/PreviewStartHandler.swift
+++ b/previewsmcp/PreviewsCLI/Handlers/PreviewStartHandler.swift
@@ -181,19 +181,25 @@ enum PreviewStartHandler: ToolHandler {
                 for: fileURL, params: params, platform: .macOS, progress: progress
             )
         } catch {
-            return CallTool.Result(
-                content: [.text("Project build failed: \(error.localizedDescription)")], isError: true
-            )
+            return phaseFailureResult(classifiedFailure(error, at: .buildingProject))
         }
 
         // Build setup plugin if configured
-        let setupResult = try await buildSetupIfConfigured(
-            config: config, configDirectory: configResult?.directory, platform: .macOS
-        )
-        let standaloneSetupWarning =
+        let setupResult: SetupBuilder.Result?
+        do {
+            setupResult = try await buildSetupIfConfigured(
+                config: config, configDirectory: configResult?.directory, platform: .macOS
+            )
+        } catch {
+            return phaseFailureResult(classifiedFailure(error, at: .buildingProject))
+        }
+        let standaloneNotice: Notice? =
             (config?.setup != nil && buildContext == nil)
-                ? " Warning: setup plugin requires a project build system and is ignored in standalone mode."
-                : ""
+                ? Notice(
+                    code: .setupIgnored,
+                    message: "Setup plugin requires a project build system and is ignored in standalone mode."
+                )
+                : nil
 
         await progress.report(.compilingBridge, message: "Compiling \(fileURL.lastPathComponent)...")
         let sessionID = try await startMacOSPreview(
@@ -223,16 +229,19 @@ enum PreviewStartHandler: ToolHandler {
                 DaemonProtocol.PreviewInfoDTO(from: $0, activeIndex: previewIndex)
             },
             activeIndex: previewIndex,
-            setupWarning: standaloneSetupWarning.isEmpty ? nil : standaloneSetupWarning,
+            setupWarning: standaloneNotice?.message,
             appServerPort: nil
         )
-        return try CallTool.Result(
-            content: [
-                .text(
-                    "macOS preview started. Session ID: \(sessionID).\(traitInfo)\(standaloneSetupWarning) File is being watched for changes.\n\(previewList)\(switchHint)"
-                ),
-            ],
-            structuredContent: structured
+        return try appendingNotices(
+            CallTool.Result(
+                content: [
+                    .text(
+                        "macOS preview started. Session ID: \(sessionID).\(traitInfo) File is being watched for changes.\n\(previewList)\(switchHint)"
+                    ),
+                ],
+                structuredContent: structured
+            ),
+            standaloneNotice.map { [$0] } ?? []
         )
     }
 }
@@ -308,16 +317,20 @@ private func handleIOSPreviewStart(
         } catch {
             stage("detectBuildContext failed: \(error)")
             await ctx.iosState.releaseDeviceClaim(deviceUDID, owner: claimOwner)
-            return CallTool.Result(
-                content: [.text("Project build failed: \(error.localizedDescription)")],
-                isError: true
-            )
+            return phaseFailureResult(classifiedFailure(error, at: .buildingProject))
         }
 
         stage("buildSetupIfConfigured begin")
-        let setupResult = try await buildSetupIfConfigured(
-            config: config, configDirectory: configResult?.directory, platform: .iOS
-        )
+        let setupResult: SetupBuilder.Result?
+        do {
+            setupResult = try await buildSetupIfConfigured(
+                config: config, configDirectory: configResult?.directory, platform: .iOS
+            )
+        } catch {
+            stage("buildSetupIfConfigured failed: \(error)")
+            await ctx.iosState.releaseDeviceClaim(deviceUDID, owner: claimOwner)
+            return phaseFailureResult(classifiedFailure(error, at: .buildingProject))
+        }
         stage("buildSetupIfConfigured done (\(setupResult == nil ? "nil" : "ok"))")
 
         let session = IOSPreviewSession(

--- a/previewsmcp/PreviewsCLI/Handlers/PreviewStartHandler.swift
+++ b/previewsmcp/PreviewsCLI/Handlers/PreviewStartHandler.swift
@@ -181,7 +181,7 @@ enum PreviewStartHandler: ToolHandler {
                 for: fileURL, params: params, platform: .macOS, progress: progress
             )
         } catch {
-            return phaseFailureResult(classifiedFailure(error, at: .buildingProject))
+            return phaseFailureResult(classifiedFailure(error, at: detectionOrBuildPhase(for: error)))
         }
 
         // Build setup plugin if configured
@@ -317,7 +317,7 @@ private func handleIOSPreviewStart(
         } catch {
             stage("detectBuildContext failed: \(error)")
             await ctx.iosState.releaseDeviceClaim(deviceUDID, owner: claimOwner)
-            return phaseFailureResult(classifiedFailure(error, at: .buildingProject))
+            return phaseFailureResult(classifiedFailure(error, at: detectionOrBuildPhase(for: error)))
         }
 
         stage("buildSetupIfConfigured begin")

--- a/previewsmcp/PreviewsCLI/Handlers/PreviewStartHandler.swift
+++ b/previewsmcp/PreviewsCLI/Handlers/PreviewStartHandler.swift
@@ -181,7 +181,7 @@ enum PreviewStartHandler: ToolHandler {
                 for: fileURL, params: params, platform: .macOS, progress: progress
             )
         } catch {
-            return phaseFailureResult(classifiedFailure(error, at: detectionOrBuildPhase(for: error)))
+            return phaseFailureResult(detectBuildContextFailure(error))
         }
 
         // Build setup plugin if configured
@@ -317,7 +317,7 @@ private func handleIOSPreviewStart(
         } catch {
             stage("detectBuildContext failed: \(error)")
             await ctx.iosState.releaseDeviceClaim(deviceUDID, owner: claimOwner)
-            return phaseFailureResult(classifiedFailure(error, at: detectionOrBuildPhase(for: error)))
+            return phaseFailureResult(detectBuildContextFailure(error))
         }
 
         stage("buildSetupIfConfigured begin")
@@ -432,6 +432,20 @@ private func handleIOSPreviewStart(
         }
         throw error
     }
+}
+
+/// `detectBuildContext` spans detection AND the native build; attribute
+/// its failure to the phase that actually produced it: compiler/build
+/// output is a build failure, everything else (ownership walk declines,
+/// ambiguous targets, unavailable build systems) failed while detecting.
+func detectBuildContextFailure(_ error: Error) -> PhaseFailure {
+    let phase: BuildPhase = switch error {
+    case BuildSystemError.buildFailed, BuildSystemError.missingArtifacts:
+        .buildingProject
+    default:
+        .detectingProject
+    }
+    return classifiedFailure(error, at: phase)
 }
 
 /// Build the setup package if configured. Returns nil if no setup or standalone mode.

--- a/previewsmcp/PreviewsCLI/MCPContentHelpers.swift
+++ b/previewsmcp/PreviewsCLI/MCPContentHelpers.swift
@@ -31,10 +31,17 @@ extension CallTool.Result {
     /// The response text minus notice items: what a command may print to
     /// stdout. Notices are diagnostics and go to stderr for every command
     /// (the uniform CLI rule) — call `surfaceNotices()` alongside this.
+    /// Notices are appended as the TRAILING items, so only a matching
+    /// suffix is stripped — a payload line that happens to equal a notice
+    /// message is untouched.
     func payloadText() -> String {
-        let notices = Set(noticeMessages)
-        return content.compactMap { item in
-            if case let .text(t) = item, !notices.contains(t) { return t }
+        var items = content
+        for message in noticeMessages.reversed() {
+            guard case let .text(t) = items.last, t == message else { break }
+            items.removeLast()
+        }
+        return items.compactMap { item in
+            if case let .text(t) = item { return t }
             return nil
         }.joined(separator: "\n")
     }

--- a/previewsmcp/PreviewsCLI/MCPContentHelpers.swift
+++ b/previewsmcp/PreviewsCLI/MCPContentHelpers.swift
@@ -40,10 +40,7 @@ extension CallTool.Result {
             guard case let .text(t) = items.last, t == message else { break }
             items.removeLast()
         }
-        return items.compactMap { item in
-            if case let .text(t) = item { return t }
-            return nil
-        }.joined(separator: "\n")
+        return items.joinedText()
     }
 
     /// Print the response's notices to stderr, message text verbatim.
@@ -51,6 +48,14 @@ extension CallTool.Result {
         for message in noticeMessages {
             fputs("\(message)\n", stderr)
         }
+    }
+
+    /// The shared stderr shape for commands whose payload is user feedback,
+    /// not machine output: payload first, then notices.
+    func surfacePayloadAndNoticesToStderr() {
+        let text = payloadText()
+        if !text.isEmpty { fputs("\(text)\n", stderr) }
+        surfaceNotices()
     }
 }
 

--- a/previewsmcp/PreviewsCLI/MCPContentHelpers.swift
+++ b/previewsmcp/PreviewsCLI/MCPContentHelpers.swift
@@ -13,6 +13,40 @@ extension [Tool.Content] {
     }
 }
 
+extension CallTool.Result {
+    /// Notice messages the daemon mirrored into `structuredContent.notices`
+    /// (docs/phase-error-protocol.md). Empty when the response carries none.
+    var noticeMessages: [String] {
+        guard case let .object(fields) = structuredContent,
+              case let .array(items)? = fields["notices"]
+        else { return [] }
+        return items.compactMap { item in
+            guard case let .object(notice) = item,
+                  case let .string(message)? = notice["message"]
+            else { return nil }
+            return message
+        }
+    }
+
+    /// The response text minus notice items: what a command may print to
+    /// stdout. Notices are diagnostics and go to stderr for every command
+    /// (the uniform CLI rule) — call `surfaceNotices()` alongside this.
+    func payloadText() -> String {
+        let notices = Set(noticeMessages)
+        return content.compactMap { item in
+            if case let .text(t) = item, !notices.contains(t) { return t }
+            return nil
+        }.joined(separator: "\n")
+    }
+
+    /// Print the response's notices to stderr, message text verbatim.
+    func surfaceNotices() {
+        for message in noticeMessages {
+            fputs("\(message)\n", stderr)
+        }
+    }
+}
+
 enum DecodeStructuredError: Error, CustomStringConvertible {
     case missingStructuredContent
     case decodeFailed(underlying: Error)

--- a/previewsmcp/PreviewsCLI/MCPServerSupport.swift
+++ b/previewsmcp/PreviewsCLI/MCPServerSupport.swift
@@ -186,18 +186,6 @@ func classifiedFailure(_ error: Error, at phase: BuildPhase) -> PhaseFailure {
     )
 }
 
-/// `detectBuildContext` spans detection AND the native build; attribute
-/// its failure to the phase that actually produced it: compiler/build
-/// output is a build failure, everything else (ownership walk declines,
-/// ambiguous targets, unavailable build systems) failed while detecting.
-func detectionOrBuildPhase(for error: Error) -> BuildPhase {
-    switch error {
-    case BuildSystemError.buildFailed, BuildSystemError.missingArtifacts:
-        .buildingProject
-    default:
-        .detectingProject
-    }
-}
 
 /// Classified error for a session whose agent is terminally gone, or nil
 /// while healthy. Session-scoped handlers return this instead of

--- a/previewsmcp/PreviewsCLI/MCPServerSupport.swift
+++ b/previewsmcp/PreviewsCLI/MCPServerSupport.swift
@@ -147,25 +147,86 @@ func configQualityForSession(_ sessionID: String, ctx: HandlerContext) async -> 
     return loadProjectConfig(explicit: nil, fileURL: handle.sourceFile)?.config.quality
 }
 
+// MARK: - Phase failures and notices (docs/phase-error-protocol.md)
+
+/// The ONE place a `PhaseFailure` becomes a tool result: `content[0]` is
+/// "<phase> failed: <message>" plus the bounded detail and remediation,
+/// and `structuredContent.error` carries the machine-readable
+/// classification.
+func phaseFailureResult(_ failure: PhaseFailure) -> CallTool.Result {
+    var text = "\(failure.phase.userLabel) failed: \(failure.message)"
+    if let detail = failure.detail, !detail.isEmpty {
+        text += "\n\(detail)"
+    }
+    if let remediation = failure.remediation {
+        text += "\nRemediation: \(remediation)"
+    }
+    var error: [String: Value] = [
+        "phase": .string(failure.phase.rawValue),
+        "code": .string(failure.code.rawValue),
+        "message": .string(failure.message),
+    ]
+    if let detail = failure.detail { error["detail"] = .string(detail) }
+    if let remediation = failure.remediation { error["remediation"] = .string(remediation) }
+    return CallTool.Result(
+        content: [.text(text)],
+        structuredContent: .object(["error": .object(error)]),
+        isError: true
+    )
+}
+
+/// Boundary adapter: map a thrown domain error to a `PhaseFailure` at the
+/// phase the catch site was running. `message` derives from the error's
+/// own description so pinned guard tokens survive by construction; an
+/// error that is already a `PhaseFailure` passes through untouched.
+func classifiedFailure(_ error: Error, at phase: BuildPhase) -> PhaseFailure {
+    if let failure = error as? PhaseFailure { return failure }
+    return PhaseFailure(
+        phase: phase, code: .buildFailed, message: error.localizedDescription
+    )
+}
+
 /// Classified error for a session whose agent is terminally gone, or nil
 /// while healthy. Session-scoped handlers return this instead of
 /// operating on a dead session (docs/state-invalidation.md, L04).
 func terminalFailureResult(for handle: any PreviewSessionHandle) async -> CallTool.Result? {
     guard let failure = await handle.terminalFailure else { return nil }
-    return CallTool.Result(content: [.text(failure)], isError: true)
+    return phaseFailureResult(failure)
 }
 
-/// Append the session's undisclosed crash notice (if any) as a TRAILING
-/// content item. Called as the last step of assembling a success
-/// response; never touches `content[0]`, which clients parse as the
-/// primary payload.
+/// Append notices as TRAILING content items and mirror them into
+/// `structuredContent.notices`. The single attach point: called as the
+/// last step of assembling a success response; never touches
+/// `content[0]`, which clients parse as the primary payload. The mirror
+/// is created even when the result had no structure, so CLI consumers
+/// can always identify notice items to route to stderr.
+func appendingNotices(
+    _ result: CallTool.Result, _ notices: [Notice]
+) -> CallTool.Result {
+    guard !notices.isEmpty else { return result }
+    let mirror = Value.array(notices.map {
+        .object(["code": .string($0.code.rawValue), "message": .string($0.message)])
+    })
+    let structured: Value? = switch result.structuredContent {
+    case let .object(fields):
+        .object(fields.merging(["notices": mirror]) { _, new in new })
+    case nil:
+        .object(["notices": mirror])
+    case let .some(other):
+        other
+    }
+    return CallTool.Result(
+        content: result.content + notices.map { .text($0.message) },
+        structuredContent: structured,
+        isError: result.isError
+    )
+}
+
+/// Append the session's undisclosed crash notice (if any) through the
+/// notices carrier.
 func appendingIncidentNotice(
     _ result: CallTool.Result, from handle: any PreviewSessionHandle
 ) async -> CallTool.Result {
     guard let notice = await handle.takeIncidentNotice() else { return result }
-    return CallTool.Result(
-        content: result.content + [.text(notice)],
-        structuredContent: result.structuredContent,
-        isError: result.isError
-    )
+    return appendingNotices(result, [notice])
 }

--- a/previewsmcp/PreviewsCLI/MCPServerSupport.swift
+++ b/previewsmcp/PreviewsCLI/MCPServerSupport.swift
@@ -186,6 +186,19 @@ func classifiedFailure(_ error: Error, at phase: BuildPhase) -> PhaseFailure {
     )
 }
 
+/// `detectBuildContext` spans detection AND the native build; attribute
+/// its failure to the phase that actually produced it: compiler/build
+/// output is a build failure, everything else (ownership walk declines,
+/// ambiguous targets, unavailable build systems) failed while detecting.
+func detectionOrBuildPhase(for error: Error) -> BuildPhase {
+    switch error {
+    case BuildSystemError.buildFailed, BuildSystemError.missingArtifacts:
+        .buildingProject
+    default:
+        .detectingProject
+    }
+}
+
 /// Classified error for a session whose agent is terminally gone, or nil
 /// while healthy. Session-scoped handlers return this instead of
 /// operating on a dead session (docs/state-invalidation.md, L04).
@@ -199,7 +212,9 @@ func terminalFailureResult(for handle: any PreviewSessionHandle) async -> CallTo
 /// last step of assembling a success response; never touches
 /// `content[0]`, which clients parse as the primary payload. The mirror
 /// is created even when the result had no structure, so CLI consumers
-/// can always identify notice items to route to stderr.
+/// can always identify notice items to route to stderr. A non-object
+/// structure keeps its shape and skips the mirror — a handler that
+/// carries notices must use an object structure (all current ones do).
 func appendingNotices(
     _ result: CallTool.Result, _ notices: [Notice]
 ) -> CallTool.Result {

--- a/previewsmcp/PreviewsCLI/MCPServerSupport.swift
+++ b/previewsmcp/PreviewsCLI/MCPServerSupport.swift
@@ -186,7 +186,6 @@ func classifiedFailure(_ error: Error, at phase: BuildPhase) -> PhaseFailure {
     )
 }
 
-
 /// Classified error for a session whose agent is terminally gone, or nil
 /// while healthy. Session-scoped handlers return this instead of
 /// operating on a dead session (docs/state-invalidation.md, L04).

--- a/previewsmcp/PreviewsCLI/RunCommand.swift
+++ b/previewsmcp/PreviewsCLI/RunCommand.swift
@@ -141,7 +141,7 @@ struct RunCommand: AsyncParsableCommand {
                 throw ExitCode(1)
             }
             let sessionID = start.sessionID
-            let text = response.content.joinedText()
+            let text = response.payloadText()
 
             if detach {
                 if json {
@@ -151,6 +151,7 @@ struct RunCommand: AsyncParsableCommand {
                     print(sessionID)
                 }
                 fputs("session \(sessionID) started in daemon\n", stderr)
+                response.surfaceNotices()
                 return
             }
 
@@ -158,6 +159,7 @@ struct RunCommand: AsyncParsableCommand {
             // then block until Ctrl+C. On signal, stop the session and
             // exit cleanly.
             fputs("\(text)\n", stderr)
+            response.surfaceNotices()
             fputs("Press Ctrl+C to stop the preview.\n", stderr)
 
             await blockUntilSignal()

--- a/previewsmcp/PreviewsCLI/SnapshotCommand.swift
+++ b/previewsmcp/PreviewsCLI/SnapshotCommand.swift
@@ -341,6 +341,7 @@ struct SnapshotCommand: AsyncParsableCommand {
             throw DaemonToolError.daemonError("snapshot failed: \(text)")
         }
 
+        response.surfaceNotices()
         for item in response.content {
             if case let .image(base64, mimeType, _) = item {
                 guard let data = Data(base64Encoded: base64) else {

--- a/previewsmcp/PreviewsCLI/SwitchCommand.swift
+++ b/previewsmcp/PreviewsCLI/SwitchCommand.swift
@@ -74,7 +74,8 @@ struct SwitchCommand: AsyncParsableCommand {
             throw DaemonToolError.daemonError(response.content.joinedText())
         }
 
-        let text = response.content.joinedText()
+        let text = response.payloadText()
         if !text.isEmpty { fputs("\(text)\n", stderr) }
+        response.surfaceNotices()
     }
 }

--- a/previewsmcp/PreviewsCLI/SwitchCommand.swift
+++ b/previewsmcp/PreviewsCLI/SwitchCommand.swift
@@ -74,8 +74,6 @@ struct SwitchCommand: AsyncParsableCommand {
             throw DaemonToolError.daemonError(response.content.joinedText())
         }
 
-        let text = response.payloadText()
-        if !text.isEmpty { fputs("\(text)\n", stderr) }
-        response.surfaceNotices()
+        response.surfacePayloadAndNoticesToStderr()
     }
 }

--- a/previewsmcp/PreviewsCLI/TouchCommand.swift
+++ b/previewsmcp/PreviewsCLI/TouchCommand.swift
@@ -107,7 +107,8 @@ struct TouchCommand: AsyncParsableCommand {
             throw DaemonToolError.daemonError(response.content.joinedText())
         }
 
-        let text = response.content.joinedText()
+        let text = response.payloadText()
         if !text.isEmpty { fputs("\(text)\n", stderr) }
+        response.surfaceNotices()
     }
 }

--- a/previewsmcp/PreviewsCLI/TouchCommand.swift
+++ b/previewsmcp/PreviewsCLI/TouchCommand.swift
@@ -107,8 +107,6 @@ struct TouchCommand: AsyncParsableCommand {
             throw DaemonToolError.daemonError(response.content.joinedText())
         }
 
-        let text = response.payloadText()
-        if !text.isEmpty { fputs("\(text)\n", stderr) }
-        response.surfaceNotices()
+        response.surfacePayloadAndNoticesToStderr()
     }
 }

--- a/previewsmcp/PreviewsCLI/VariantsCommand.swift
+++ b/previewsmcp/PreviewsCLI/VariantsCommand.swift
@@ -294,6 +294,7 @@ struct VariantsCommand: AsyncParsableCommand {
             )
         }
         let result = try structured.decode(DaemonProtocol.VariantsResult.self)
+        response.surfaceNotices()
 
         let ext = format == .png ? "png" : "jpg"
         var successCount = 0

--- a/previewsmcp/PreviewsCore/PhaseFailure.swift
+++ b/previewsmcp/PreviewsCore/PhaseFailure.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// One error carrier for everything a phase can fail with
+/// (docs/phase-error-protocol.md). Domain enums remain the internal
+/// throwing vocabulary; the boundary adapter in PreviewsCLI maps them
+/// into this shape, deriving `message` from their `errorDescription` so
+/// pinned guard tokens survive by construction.
+public struct PhaseFailure: Error, LocalizedError, Sendable {
+    public let phase: BuildPhase
+    public let code: FailureCode
+    /// One-line classification. Stable tokens: guards pin identifiers and
+    /// commands from this line, never connective prose.
+    public let message: String
+    /// Bounded raw evidence: the compiler stderr tail, the symbol list.
+    public let detail: String?
+    /// The actionable next step, when one is known.
+    public let remediation: String?
+
+    public init(
+        phase: BuildPhase, code: FailureCode, message: String,
+        detail: String? = nil, remediation: String? = nil
+    ) {
+        self.phase = phase
+        self.code = code
+        self.message = message
+        self.detail = detail
+        self.remediation = remediation
+    }
+
+    public var errorDescription: String? { message }
+}
+
+/// Only codes a designed flow actually produces; a case is added when a
+/// migration reaches it, never speculatively.
+public enum FailureCode: String, Sendable {
+    case buildFailed
+    case incompatibleSlice
+    case unresolvedSymbols
+    case sessionFailed
+}
+
+/// A disclosure that rides a successful response: a crash incident, a
+/// setup that failed but rendered without setup, an ownership loss on a
+/// live session. Appended as a trailing content item (never content[0])
+/// and mirrored into `structuredContent.notices`; cleared only when a
+/// response actually carried it.
+public struct Notice: Sendable {
+    public let code: NoticeCode
+    public let message: String
+
+    public init(code: NoticeCode, message: String) {
+        self.code = code
+        self.message = message
+    }
+}
+
+public enum NoticeCode: String, Sendable {
+    case agentCrashed
+    case setupFailed
+    case setupIgnored
+    case ownershipLost
+}

--- a/previewsmcp/PreviewsCore/PhaseFailure.swift
+++ b/previewsmcp/PreviewsCore/PhaseFailure.swift
@@ -27,7 +27,9 @@ public struct PhaseFailure: Error, LocalizedError, Sendable {
         self.remediation = remediation
     }
 
-    public var errorDescription: String? { message }
+    public var errorDescription: String? {
+        message
+    }
 }
 
 /// Only codes a designed flow actually produces; a case is added when a

--- a/previewsmcp/PreviewsCore/PreviewSessionHandle.swift
+++ b/previewsmcp/PreviewsCore/PreviewSessionHandle.swift
@@ -59,23 +59,24 @@ public protocol PreviewSessionHandle: Sendable {
     /// A classified reason this session can no longer serve calls (e.g.
     /// its agent died and could not be respawned), or nil while healthy.
     /// Handlers return this as an error instead of operating on a dead
-    /// session (docs/state-invalidation.md, L04).
-    var terminalFailure: String? { get async }
+    /// session (docs/state-invalidation.md, L04;
+    /// docs/phase-error-protocol.md).
+    var terminalFailure: PhaseFailure? { get async }
 
     /// An undisclosed incident notice (agent crash + relaunch) the next
     /// response must carry, cleared by this call. Callers take it as the
     /// LAST step of assembling a response so a taken notice is always
     /// carried; it is appended as a trailing content item, never at
     /// index 0, which clients parse as the primary payload.
-    func takeIncidentNotice() async -> String?
+    func takeIncidentNotice() async -> Notice?
 }
 
 public extension PreviewSessionHandle {
-    var terminalFailure: String? {
+    var terminalFailure: PhaseFailure? {
         nil
     }
 
-    func takeIncidentNotice() async -> String? {
+    func takeIncidentNotice() async -> Notice? {
         nil
     }
 }

--- a/previewsmcp/PreviewsCore/ProgressReporter.swift
+++ b/previewsmcp/PreviewsCore/ProgressReporter.swift
@@ -9,6 +9,22 @@ public enum BuildPhase: String, Sendable {
     case launchingApp
     case connectingToApp
     case capturingSnapshot
+
+    /// The phase name as it reads in a failure line:
+    /// "<userLabel> failed: <message>".
+    public var userLabel: String {
+        switch self {
+        case .detectingProject: "Detecting the project"
+        case .buildingProject: "Building the project"
+        case .compilingBridge: "Compiling the preview"
+        case .compilingAgentApp: "Compiling the agent app"
+        case .bootingSimulator: "Booting the simulator"
+        case .installingApp: "Installing the app"
+        case .launchingApp: "Launching the app"
+        case .connectingToApp: "Connecting to the app"
+        case .capturingSnapshot: "Capturing the snapshot"
+        }
+    }
 }
 
 /// A receiver for build/launch progress updates.

--- a/previewsmcp/PreviewsEngine/IOSPreviewHandle.swift
+++ b/previewsmcp/PreviewsEngine/IOSPreviewHandle.swift
@@ -31,17 +31,22 @@ public actor IOSPreviewHandle: PreviewSessionHandle {
         }
     }
 
-    public var terminalFailure: String? {
+    public var terminalFailure: PhaseFailure? {
         get async {
             await iosSession.failed
-                ? "The preview agent for session \(id) crashed and could not be "
-                + "relaunched. Stop the session and start a new one."
+                ? PhaseFailure(
+                    phase: .connectingToApp, code: .sessionFailed,
+                    message: "The preview agent for session \(id) crashed and could not be "
+                        + "relaunched. Stop the session and start a new one."
+                )
                 : nil
         }
     }
 
-    public func takeIncidentNotice() async -> String? {
-        await iosSession.takeUndisclosedCrashNotice()
+    public func takeIncidentNotice() async -> Notice? {
+        await iosSession.takeUndisclosedCrashNotice().map {
+            Notice(code: .agentCrashed, message: $0)
+        }
     }
 
     public func setTraits(_ traits: PreviewTraits) async throws {

--- a/previewsmcp/Tests/PreviewsCLITests/MCPHandlerContractTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/MCPHandlerContractTests.swift
@@ -530,22 +530,24 @@ private actor FakePreviewSessionHandle: PreviewSessionHandle {
     private(set) var snapshotQualities: [Double] = []
     private(set) var stopCallCount = 0
     private var registered = true
-    var terminalFailureValue: String?
-    private var pendingIncidentNotice: String?
+    var terminalFailureValue: PhaseFailure?
+    private var pendingIncidentNotice: Notice?
 
     func setTerminalFailure(_ value: String?) {
-        terminalFailureValue = value
+        terminalFailureValue = value.map {
+            PhaseFailure(phase: .connectingToApp, code: .sessionFailed, message: $0)
+        }
     }
 
     func setPendingIncidentNotice(_ value: String?) {
-        pendingIncidentNotice = value
+        pendingIncidentNotice = value.map { Notice(code: .agentCrashed, message: $0) }
     }
 
-    var terminalFailure: String? {
+    var terminalFailure: PhaseFailure? {
         terminalFailureValue
     }
 
-    func takeIncidentNotice() async -> String? {
+    func takeIncidentNotice() async -> Notice? {
         defer { pendingIncidentNotice = nil }
         return pendingIncidentNotice
     }

--- a/previewsmcp/Tests/PreviewsCLITests/PhaseFailureCarrierTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/PhaseFailureCarrierTests.swift
@@ -7,7 +7,7 @@ import Testing
 @Suite("Phase failure and notice carriers")
 struct PhaseFailureCarrierTests {
     @Test("phaseFailureResult formats phase, message, detail, and remediation")
-    func failureResultShape() throws {
+    func failureResultShape() {
         let result = phaseFailureResult(
             PhaseFailure(
                 phase: .buildingProject, code: .incompatibleSlice,

--- a/previewsmcp/Tests/PreviewsCLITests/PhaseFailureCarrierTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/PhaseFailureCarrierTests.swift
@@ -112,6 +112,30 @@ struct PhaseFailureCarrierTests {
         #expect(carried.content.count == 2)
     }
 
+    @Test("payloadText strips only the trailing notice suffix, not equal payload lines")
+    func payloadKeepsEqualBodyLines() {
+        let carried = appendingNotices(
+            CallTool.Result(content: [.text("crash notice"), .text("payload")]),
+            [Notice(code: .agentCrashed, message: "crash notice")]
+        )
+
+        #expect(carried.payloadText() == "crash notice\npayload")
+    }
+
+    @Test("detection failures classify at detectingProject, build output at buildingProject")
+    func detectionVersusBuildPhase() {
+        #expect(
+            detectionOrBuildPhase(
+                for: BuildSystemError.buildFailed(stderr: "no such module", exitCode: 1)
+            ) == .buildingProject
+        )
+        #expect(
+            detectionOrBuildPhase(
+                for: BuildSystemError.ambiguousTarget(sourceFile: "A.swift", candidates: ["X", "Y"])
+            ) == .detectingProject
+        )
+    }
+
     @Test("empty notices leave the result untouched")
     func emptyNoticesNoOp() {
         let base = CallTool.Result(content: [.text("payload")])

--- a/previewsmcp/Tests/PreviewsCLITests/PhaseFailureCarrierTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/PhaseFailureCarrierTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import MCP
+@testable import PreviewsCLI
+import PreviewsCore
+import Testing
+
+@Suite("Phase failure and notice carriers")
+struct PhaseFailureCarrierTests {
+    @Test("phaseFailureResult formats phase, message, detail, and remediation")
+    func failureResultShape() throws {
+        let result = phaseFailureResult(
+            PhaseFailure(
+                phase: .buildingProject, code: .incompatibleSlice,
+                message: "XCFramework 'BadSlice' has no iOS simulator slice",
+                detail: "available: ios-arm64",
+                remediation: "Rebuild the XCFramework with a simulator slice."
+            )
+        )
+
+        #expect(result.isError == true)
+        guard case let .text(text) = result.content.first else {
+            Issue.record("content[0] is not text")
+            return
+        }
+        #expect(text.hasPrefix("Building the project failed: XCFramework 'BadSlice'"))
+        #expect(text.contains("available: ios-arm64"))
+        #expect(text.contains("Remediation: Rebuild the XCFramework"))
+
+        guard case let .object(fields) = result.structuredContent,
+              case let .object(error)? = fields["error"]
+        else {
+            Issue.record("structuredContent.error missing")
+            return
+        }
+        #expect(error["phase"] == .string("buildingProject"))
+        #expect(error["code"] == .string("incompatibleSlice"))
+    }
+
+    @Test("classifiedFailure derives the message from the domain error's description")
+    func adapterPreservesDomainTokens() {
+        let failure = classifiedFailure(
+            SetupBuilderError.buildFailed(package: "BrokenPreviewSetup", stderr: "expected '}'"),
+            at: .buildingProject
+        )
+
+        #expect(failure.code == .buildFailed)
+        #expect(failure.message.contains("Setup package 'BrokenPreviewSetup' build failed"))
+        #expect(failure.message.contains("expected '}'"))
+    }
+
+    @Test("classifiedFailure passes an existing PhaseFailure through untouched")
+    func adapterPassthrough() {
+        let original = PhaseFailure(
+            phase: .compilingBridge, code: .unresolvedSymbols, message: "_missingSymbol"
+        )
+        let adapted = classifiedFailure(original, at: .buildingProject)
+
+        #expect(adapted.phase == .compilingBridge)
+        #expect(adapted.code == .unresolvedSymbols)
+        #expect(adapted.message == "_missingSymbol")
+    }
+
+    @Test("appendingNotices trails content, mirrors into structuredContent, keeps content[0]")
+    func noticesCarrier() {
+        let base = CallTool.Result(
+            content: [.text("payload")],
+            structuredContent: .object(["sessionID": .string("abc")])
+        )
+        let notice = Notice(
+            code: .agentCrashed,
+            message: "The preview agent crashed and was relaunched; UI state was reset (crash #1 for this session)."
+        )
+
+        let carried = appendingNotices(base, [notice])
+
+        guard case let .text(first) = carried.content.first else {
+            Issue.record("content[0] is not text")
+            return
+        }
+        #expect(first == "payload")
+        guard case let .text(last) = carried.content.last else {
+            Issue.record("trailing item is not text")
+            return
+        }
+        #expect(last == notice.message)
+        guard case let .object(fields) = carried.structuredContent else {
+            Issue.record("structuredContent missing")
+            return
+        }
+        #expect(fields["sessionID"] == .string("abc"))
+        #expect(carried.noticeMessages == [notice.message])
+    }
+
+    @Test("appendingNotices creates the structured mirror when the result had none")
+    func noticesMirrorCreated() {
+        let carried = appendingNotices(
+            CallTool.Result(content: [.text("Tap sent")]),
+            [Notice(code: .ownershipLost, message: "no build system resolves the file anymore")]
+        )
+
+        #expect(carried.noticeMessages == ["no build system resolves the file anymore"])
+    }
+
+    @Test("payloadText excludes notice items so piped stdout stays clean")
+    func payloadExcludesNotices() {
+        let carried = appendingNotices(
+            CallTool.Result(content: [.text("{\"elements\":[]}")]),
+            [Notice(code: .agentCrashed, message: "crash notice")]
+        )
+
+        #expect(carried.payloadText() == "{\"elements\":[]}")
+        #expect(carried.content.count == 2)
+    }
+
+    @Test("empty notices leave the result untouched")
+    func emptyNoticesNoOp() {
+        let base = CallTool.Result(content: [.text("payload")])
+        let carried = appendingNotices(base, [])
+
+        #expect(carried.content.count == 1)
+        #expect(carried.structuredContent == nil)
+        #expect(carried.noticeMessages.isEmpty)
+        #expect(carried.payloadText() == "payload")
+    }
+}

--- a/previewsmcp/Tests/PreviewsCLITests/PhaseFailureCarrierTests.swift
+++ b/previewsmcp/Tests/PreviewsCLITests/PhaseFailureCarrierTests.swift
@@ -125,14 +125,14 @@ struct PhaseFailureCarrierTests {
     @Test("detection failures classify at detectingProject, build output at buildingProject")
     func detectionVersusBuildPhase() {
         #expect(
-            detectionOrBuildPhase(
-                for: BuildSystemError.buildFailed(stderr: "no such module", exitCode: 1)
-            ) == .buildingProject
+            detectBuildContextFailure(
+                BuildSystemError.buildFailed(stderr: "no such module", exitCode: 1)
+            ).phase == .buildingProject
         )
         #expect(
-            detectionOrBuildPhase(
-                for: BuildSystemError.ambiguousTarget(sourceFile: "A.swift", candidates: ["X", "Y"])
-            ) == .detectingProject
+            detectBuildContextFailure(
+                BuildSystemError.ambiguousTarget(sourceFile: "A.swift", candidates: ["X", "Y"])
+            ).phase == .detectingProject
         )
     }
 


### PR DESCRIPTION
## Summary

Stage 1 of `docs/phase-error-protocol.md` (#430): the protocol carrier.

- **`PhaseFailure`** `{phase, code, message, detail, remediation}` in PreviewsCore with the four reachable `FailureCode`s. Domain enums stay the throwing vocabulary; `classifiedFailure` derives `message` from `errorDescription`, so pinned guard tokens survive by construction. `phaseFailureResult` is the single formatting place; `structuredContent.error` carries the machine-readable classification. `terminalFailure` becomes `PhaseFailure`-typed through the same path.
- **Typed notices**: `Notice {code, message}` rides as trailing content items and mirrors into `structuredContent.notices` (mirror created even on structure-less results). Crash-notice text is verbatim (L04 tokens). The standalone setup warning becomes a `setupIgnored` notice, still mirrored into `setupWarning` for wire compat.
- **Uniform CLI rule**: notices route to stderr for every command. `elements`' piped stdout stays clean JSON; its `--json` path now shows notices at all (previously cleared without ever being shown).
- Start-path build/setup catches migrate to the adapter; detect failures classify `.detectingProject` vs `.buildingProject` by error case; the iOS catches release the device claim.

Flips no matrix rows by design — the enabler stage. Stages 2–4 build on it.

## Verification

- Unit + integration tiers green (integration twice — pre- and post-folds; all RegressGuardTests tokens hold: T02, D06, D07, V05).
- Manual L04 pass: agent crash #1 → notice on stderr with parseable stdout (default `elements` path); crash #2 → notice inside the `--json` structure; follow-up call clean (cleared on delivery); daemon alive throughout.
- Workflow /code-review high: 7 findings — 2 fixed (detect-phase misattribution, suffix-only notice strip), 1 documented precondition, 4 skipped with recorded reasons (designed `--json` mirror visibility, wire-compat `setupWarning`, doc-declared enum).
- /simplify 4-angle: 3 folds (joinedText reuse, shared stderr surface helper, detectBuildContextFailure locality); efficiency clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)