### PR TITLE
cli+tests: phase/error guard rows, notice choke point, sleep-proof deadlines

### DIFF
--- a/previewsmcp/PreviewsCLI/DaemonClient.swift
+++ b/previewsmcp/PreviewsCLI/DaemonClient.swift
@@ -283,13 +283,17 @@ enum DaemonClient {
     static func waitForSocket(
         timeout: TimeInterval, child: Process? = nil
     ) async throws -> FileDescriptor {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
+        // Suspending clock: the daemon makes no progress while the machine
+        // sleeps, so a lid-closed nap must not consume the startup window
+        // (a wall-clock deadline expired "instantly" across one).
+        let clock = SuspendingClock()
+        let deadline = clock.now.advanced(by: .seconds(timeout))
+        while clock.now < deadline {
             if let socket = DaemonProbe.connect() { return socket }
             if let child, !child.isRunning {
                 throw DaemonClientError.daemonStartupFailed(exitCode: child.terminationStatus)
             }
-            try await Task.sleep(nanoseconds: 100_000_000)
+            try await Task.sleep(for: .milliseconds(100), clock: .suspending)
         }
         throw DaemonClientError.startupTimedOut
     }

--- a/previewsmcp/PreviewsCLI/DaemonRestart.swift
+++ b/previewsmcp/PreviewsCLI/DaemonRestart.swift
@@ -97,8 +97,11 @@ extension DaemonClient {
         if kill(pid, SIGTERM) != 0, errno != ESRCH {
             throw DaemonClientError.couldNotSignalDaemon(pid: pid, errno: errno)
         }
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
+        // Suspending clock, like DaemonClient.waitForSocket: machine sleep
+        // must not consume the exit window.
+        let clock = SuspendingClock()
+        let deadline = clock.now.advanced(by: .seconds(timeout))
+        while clock.now < deadline {
             if !DaemonLifecycle.isProcessAlive(pid) { return }
             Thread.sleep(forTimeInterval: 0.1)
         }

--- a/previewsmcp/PreviewsCLI/KillDaemonCommand.swift
+++ b/previewsmcp/PreviewsCLI/KillDaemonCommand.swift
@@ -29,9 +29,12 @@ struct KillDaemonCommand: ParsableCommand {
             throw ExitCode(1)
         }
 
-        // Poll until the process is gone or timeout elapses.
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
+        // Poll until the process is gone or timeout elapses. Suspending
+        // clock, like DaemonClient.waitForSocket: machine sleep must not
+        // consume the exit window.
+        let clock = SuspendingClock()
+        let deadline = clock.now.advanced(by: .seconds(timeout))
+        while clock.now < deadline {
             if !DaemonLifecycle.isProcessAlive(pid) {
                 print("daemon stopped (pid \(pid))")
                 return

--- a/previewsmcp/PreviewsCLI/MCPContentHelpers.swift
+++ b/previewsmcp/PreviewsCLI/MCPContentHelpers.swift
@@ -88,6 +88,45 @@ protocol DaemonToolCalling: Sendable {
     ) async throws -> CallTool.Result
 }
 
+extension DaemonToolCalling {
+    /// Start a preview session for a one-shot command and return the new
+    /// session ID. The one place the start response's notices are surfaced:
+    /// setup warnings ride `preview_start`, and the daemon clears notices on
+    /// delivery, so a command that decodes the session ID without this drops
+    /// them permanently (the snapshot/variants T01 gap).
+    func startPreviewSession(arguments: [String: Value]) async throws -> String {
+        let response = try await callToolStructured(
+            name: "preview_start", arguments: arguments
+        )
+        if response.isError == true {
+            throw DaemonToolError.daemonError(
+                "Failed to start preview: \(response.content.joinedText())"
+            )
+        }
+        guard let structured = response.structuredContent else {
+            throw DaemonToolError.daemonError(
+                "preview_start response missing structuredContent"
+            )
+        }
+        response.surfaceNotices()
+        return try structured.decode(DaemonProtocol.PreviewStartResult.self).sessionID
+    }
+
+    /// Tear down a one-shot session, surfacing the stop response's notices.
+    /// Best-effort — warns if the stop RPC fails so a session leak is
+    /// visible instead of silent.
+    func stopPreviewSession(sessionID: String) async {
+        do {
+            let response = try await callToolStructured(
+                name: "preview_stop", arguments: ["sessionID": .string(sessionID)]
+            )
+            response.surfaceNotices()
+        } catch {
+            fputs("warning: failed to stop session \(sessionID): \(error)\n", stderr)
+        }
+    }
+}
+
 /// Write a single JSON document to stdout, followed by a newline. Used by
 /// CLI commands in `--json` mode. Pretty-printed with sorted keys for
 /// stable `diff`-friendly output when piping through `jq` or fixtures.

--- a/previewsmcp/PreviewsCLI/RunCommand.swift
+++ b/previewsmcp/PreviewsCLI/RunCommand.swift
@@ -165,10 +165,11 @@ struct RunCommand: AsyncParsableCommand {
             await blockUntilSignal()
 
             do {
-                _ = try await client.callToolStructured(
+                let response = try await client.callToolStructured(
                     name: "preview_stop",
                     arguments: ["sessionID": .string(sessionID)]
                 )
+                response.surfaceNotices()
             } catch {
                 // Best-effort — the session may still be alive in the daemon.
                 // Surface the session ID so the user can target it with `stop`

--- a/previewsmcp/PreviewsCLI/SnapshotAllCommand.swift
+++ b/previewsmcp/PreviewsCLI/SnapshotAllCommand.swift
@@ -285,7 +285,7 @@ struct SnapshotAllCommand: AsyncParsableCommand {
         // stop would let the batch exit with the session still live, orphaning
         // it in the daemon. The render loop above never throws out (every
         // failure is recorded as an entry), so no defer is needed.
-        await stopSession(sessionID: sessionID, client: client)
+        await client.stopPreviewSession(sessionID: sessionID)
         return result
     }
 
@@ -376,15 +376,7 @@ struct SnapshotAllCommand: AsyncParsableCommand {
         if let buildSystem { startArgs["buildSystem"] = .string(buildSystem.rawValue) }
         if let config { startArgs["config"] = .string(config) }
 
-        let response = try await client.callToolStructured(name: "preview_start", arguments: startArgs)
-        if response.isError == true {
-            throw DaemonToolError.daemonError(response.content.joinedText())
-        }
-        guard let structured = response.structuredContent else {
-            throw DaemonToolError.daemonError("preview_start response missing structuredContent")
-        }
-        response.surfaceNotices()
-        return try structured.decode(DaemonProtocol.PreviewStartResult.self).sessionID
+        return try await client.startPreviewSession(arguments: startArgs)
     }
 
     private func switchTo(index: Int, sessionID: String, client: any DaemonToolCalling) async throws {
@@ -486,17 +478,6 @@ struct SnapshotAllCommand: AsyncParsableCommand {
                 )
             }
         return returned + missing
-    }
-
-    private func stopSession(sessionID: String, client: any DaemonToolCalling) async {
-        do {
-            let response = try await client.callToolStructured(
-                name: "preview_stop", arguments: ["sessionID": .string(sessionID)]
-            )
-            response.surfaceNotices()
-        } catch {
-            fputs("warning: failed to stop session \(sessionID): \(error)\n", stderr)
-        }
     }
 
     // MARK: - Output

--- a/previewsmcp/PreviewsCLI/SnapshotAllCommand.swift
+++ b/previewsmcp/PreviewsCLI/SnapshotAllCommand.swift
@@ -383,6 +383,7 @@ struct SnapshotAllCommand: AsyncParsableCommand {
         guard let structured = response.structuredContent else {
             throw DaemonToolError.daemonError("preview_start response missing structuredContent")
         }
+        response.surfaceNotices()
         return try structured.decode(DaemonProtocol.PreviewStartResult.self).sessionID
     }
 
@@ -394,6 +395,7 @@ struct SnapshotAllCommand: AsyncParsableCommand {
         if response.isError == true {
             throw DaemonToolError.daemonError(response.content.joinedText())
         }
+        response.surfaceNotices()
     }
 
     private func snapshot(sessionID: String, client: any DaemonToolCalling) async throws -> Data {
@@ -404,6 +406,7 @@ struct SnapshotAllCommand: AsyncParsableCommand {
         if response.isError == true {
             throw DaemonToolError.daemonError(response.content.joinedText())
         }
+        response.surfaceNotices()
         for item in response.content {
             if case let .image(base64, _, _) = item {
                 guard let data = Data(base64Encoded: base64) else {
@@ -446,6 +449,7 @@ struct SnapshotAllCommand: AsyncParsableCommand {
         if response.isError == true {
             throw DaemonToolError.daemonError(response.content.joinedText())
         }
+        response.surfaceNotices()
         guard let structured = response.structuredContent else {
             throw DaemonToolError.daemonError("preview_variants response missing structuredContent")
         }
@@ -486,9 +490,10 @@ struct SnapshotAllCommand: AsyncParsableCommand {
 
     private func stopSession(sessionID: String, client: any DaemonToolCalling) async {
         do {
-            _ = try await client.callToolStructured(
+            let response = try await client.callToolStructured(
                 name: "preview_stop", arguments: ["sessionID": .string(sessionID)]
             )
+            response.surfaceNotices()
         } catch {
             fputs("warning: failed to stop session \(sessionID): \(error)\n", stderr)
         }

--- a/previewsmcp/PreviewsCLI/SnapshotCommand.swift
+++ b/previewsmcp/PreviewsCLI/SnapshotCommand.swift
@@ -250,6 +250,7 @@ struct SnapshotCommand: AsyncParsableCommand {
                 "preview_start response missing structuredContent"
             )
         }
+        startResponse.surfaceNotices()
         let sessionID =
             try structured
                 .decode(DaemonProtocol.PreviewStartResult.self).sessionID

--- a/previewsmcp/PreviewsCLI/SnapshotCommand.swift
+++ b/previewsmcp/PreviewsCLI/SnapshotCommand.swift
@@ -237,23 +237,7 @@ struct SnapshotCommand: AsyncParsableCommand {
         if let legibilityWeight { startArgs["legibilityWeight"] = .string(legibilityWeight) }
         if let config { startArgs["config"] = .string(config) }
 
-        let startResponse = try await client.callToolStructured(
-            name: "preview_start", arguments: startArgs
-        )
-        if startResponse.isError == true {
-            let text = startResponse.content.joinedText()
-            throw DaemonToolError.daemonError("Failed to start preview: \(text)")
-        }
-
-        guard let structured = startResponse.structuredContent else {
-            throw DaemonToolError.daemonError(
-                "preview_start response missing structuredContent"
-            )
-        }
-        startResponse.surfaceNotices()
-        let sessionID =
-            try structured
-                .decode(DaemonProtocol.PreviewStartResult.self).sessionID
+        let sessionID = try await client.startPreviewSession(arguments: startArgs)
 
         var snapshotArgs: [String: Value] = ["sessionID": .string(sessionID)]
         snapshotArgs["quality"] = .double(resolvedQuality())
@@ -266,31 +250,12 @@ struct SnapshotCommand: AsyncParsableCommand {
             let snapResponse = try await client.callToolStructured(
                 name: "preview_snapshot", arguments: snapshotArgs
             )
-            await stopEphemeralSession(sessionID: sessionID, client: client)
+            await client.stopPreviewSession(sessionID: sessionID)
             try handleSnapshotResponse(snapResponse, sessionID: sessionID)
         } catch {
             // Best-effort cleanup if the snapshot call itself threw.
-            await stopEphemeralSession(sessionID: sessionID, client: client)
+            await client.stopPreviewSession(sessionID: sessionID)
             throw error
-        }
-    }
-
-    /// Tear down an ephemeral session. Best-effort — logs a warning if the
-    /// stop RPC fails so the session leak is visible instead of silent.
-    /// The session would still be cleaned up when the daemon exits, but a
-    /// long-lived daemon with many leaked sessions could confuse future
-    /// snapshot reuse.
-    private func stopEphemeralSession(sessionID: String, client: any DaemonToolCalling) async {
-        do {
-            _ = try await client.callToolStructured(
-                name: "preview_stop",
-                arguments: ["sessionID": .string(sessionID)]
-            )
-        } catch {
-            fputs(
-                "warning: failed to stop ephemeral session \(sessionID): \(error)\n",
-                stderr
-            )
         }
     }
 

--- a/previewsmcp/PreviewsCLI/VariantsCommand.swift
+++ b/previewsmcp/PreviewsCLI/VariantsCommand.swift
@@ -236,22 +236,7 @@ struct VariantsCommand: AsyncParsableCommand {
         if let device { startArgs["deviceUDID"] = .string(device) }
         if let config { startArgs["config"] = .string(config) }
 
-        let startResponse = try await client.callToolStructured(
-            name: "preview_start", arguments: startArgs
-        )
-        if startResponse.isError == true {
-            throw DaemonToolError.daemonError(
-                "Failed to start preview: \(startResponse.content.joinedText())"
-            )
-        }
-        guard let startStructured = startResponse.structuredContent else {
-            throw DaemonToolError.daemonError(
-                "preview_start response missing structuredContent"
-            )
-        }
-        let sessionID =
-            try startStructured
-                .decode(DaemonProtocol.PreviewStartResult.self).sessionID
+        let sessionID = try await client.startPreviewSession(arguments: startArgs)
 
         do {
             let code = try await captureVariants(
@@ -260,10 +245,10 @@ struct VariantsCommand: AsyncParsableCommand {
                 outputDir: outputDir,
                 client: client
             )
-            await stopEphemeralSession(sessionID: sessionID, client: client)
+            await client.stopPreviewSession(sessionID: sessionID)
             return code
         } catch {
-            await stopEphemeralSession(sessionID: sessionID, client: client)
+            await client.stopPreviewSession(sessionID: sessionID)
             throw error
         }
     }
@@ -427,20 +412,6 @@ struct VariantsCommand: AsyncParsableCommand {
             )
         }
         return Self.exitCode(successCount: successCount, failCount: failCount)
-    }
-
-    private func stopEphemeralSession(sessionID: String, client: any DaemonToolCalling) async {
-        do {
-            _ = try await client.callToolStructured(
-                name: "preview_stop",
-                arguments: ["sessionID": .string(sessionID)]
-            )
-        } catch {
-            fputs(
-                "warning: failed to stop ephemeral session \(sessionID): \(error)\n",
-                stderr
-            )
-        }
     }
 }
 

--- a/previewsmcp/Tests/CLIIntegrationTests/CLIRunner.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/CLIRunner.swift
@@ -273,7 +273,11 @@ enum CLIRunner {
                 // Schedule the timeout. Cancelled when the process exits
                 // normally or when run() throws so it can't fire late.
                 let timeoutTask = Task<Void, Never> {
-                    try? await Task.sleep(for: runTimeout)
+                    // Suspending clock: machine sleep must not count against
+                    // the subprocess — it makes no progress while the host is
+                    // asleep, and the default continuous clock fired a 600s
+                    // watchdog "early" across a lid-closed nap mid-run.
+                    try? await Task.sleep(for: runTimeout, clock: .suspending)
                     if Task.isCancelled { return }
 
                     let pid = state.withLock { s -> pid_t? in

--- a/previewsmcp/Tests/CLIIntegrationTests/DaemonTestLock.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/DaemonTestLock.swift
@@ -147,8 +147,9 @@ enum DaemonTestLock {
     /// poll suspends instead of blocking a cooperative thread — a blocking
     /// teardown poll starves the pool and times out concurrent suites.
     private static func awaitProcessDeath(_ pid: Int32, timeout: TimeInterval) async -> Bool {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
+        let clock = SuspendingClock()
+        let deadline = clock.now.advanced(by: .seconds(timeout))
+        while clock.now < deadline {
             if !isProcessAlive(pid) { return true }
             try? await Task.sleep(nanoseconds: 50_000_000)
         }

--- a/previewsmcp/Tests/CLIIntegrationTests/DaemonTestLockFenceTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/DaemonTestLockFenceTests.swift
@@ -81,8 +81,9 @@ struct DaemonTestLockFenceTests {
         proc.standardError = FileHandle.nullDevice
         try proc.run()
 
-        let deadline = Date().addingTimeInterval(10)
-        while Date() < deadline {
+        let clock = SuspendingClock()
+        let deadline = clock.now.advanced(by: .seconds(10))
+        while clock.now < deadline {
             if FileManager.default.fileExists(atPath: ready.path) {
                 try? FileManager.default.removeItem(at: ready)
                 return proc.processIdentifier
@@ -109,8 +110,9 @@ struct DaemonTestLockFenceTests {
         proc.environment = env
         try proc.run()
 
-        let deadline = Date().addingTimeInterval(10)
-        while Date() < deadline {
+        let clock = SuspendingClock()
+        let deadline = clock.now.advanced(by: .seconds(10))
+        while clock.now < deadline {
             if let pid = readPIDFile(), isAlive(pid) { return pid }
             try await Task.sleep(nanoseconds: 100_000_000)
         }

--- a/previewsmcp/Tests/CLIIntegrationTests/LogsCommandTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/LogsCommandTests.swift
@@ -117,8 +117,9 @@ struct LogsCommandTests {
             #expect(proc.isRunning, "follow mode should not exit on its own")
 
             kill(proc.processIdentifier, SIGINT)
-            let deadline = Date().addingTimeInterval(5)
-            while proc.isRunning, Date() < deadline {
+            let clock = SuspendingClock()
+            let deadline = clock.now.advanced(by: .seconds(5))
+            while proc.isRunning, clock.now < deadline {
                 try await Task.sleep(nanoseconds: 50_000_000)
             }
             if proc.isRunning { proc.terminate() }
@@ -148,8 +149,9 @@ struct LogsCommandTests {
         }
         defer { handle.readabilityHandler = nil }
 
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
+        let clock = SuspendingClock()
+        let deadline = clock.now.advanced(by: .seconds(timeout))
+        while clock.now < deadline {
             if buffer.contents().contains(substring) { return true }
             try await poke()
             try await Task.sleep(nanoseconds: 200_000_000)

--- a/previewsmcp/Tests/CLIIntegrationTests/RegressGuardTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/RegressGuardTests.swift
@@ -19,8 +19,10 @@ import Testing
 /// macOS SwiftPM and error-contract rows. The second tranche adds the
 /// macOS Xcode rows (D01, D03, D08, X02), which build through
 /// `xcodebuild` but still need no simulator, artifact generation, or
-/// network — every fixture's generated project is committed. Rows
-/// staying manual-only for a named flake reason: W03 (FSEvents timing,
+/// network — every fixture's generated project is committed. The
+/// phase/error macOS rows (T01, T03, L02, L03) guard notice,
+/// classification, and phase-clock contracts on plain SwiftPM fixtures.
+/// Rows staying manual-only for a named flake reason: W03 (FSEvents timing,
 /// #298), L05 (concurrency), S05/S06 (swift-syntax fetch), M01/M02
 /// (launch assertions elsewhere). Future tranches that need simulators,
 /// artifact generation, or network must land in a separate test target,
@@ -36,14 +38,16 @@ struct RegressGuardTests {
     }
 
     /// Run a one-shot snapshot of `relativePath` with no detection overrides
-    /// and assert it renders a valid, non-blank PNG. `thenWhileAlive` runs
-    /// inside the same lock block, before the writer-fence kills the daemon,
-    /// for assertions that need the daemon's state (logs, status).
+    /// and assert it renders a valid, non-blank PNG. Returns the CLI result
+    /// so callers can pin stderr notice/progress tokens. `thenWhileAlive`
+    /// runs inside the same lock block, before the writer-fence kills the
+    /// daemon, for assertions that need the daemon's state (logs, status).
+    @discardableResult
     private static func assertRenders(
         _ relativePath: String,
         extraArguments: [String] = [],
         thenWhileAlive: @Sendable () async throws -> Void = {}
-    ) async throws {
+    ) async throws -> CLIResult {
         try await DaemonTestLock.run {
             try await cleanSlate()
             let tempDir = try CLIRunner.makeTempDir()
@@ -58,6 +62,7 @@ struct RegressGuardTests {
             try CLIRunner.assertValidPNG(at: outputPath)
             try CLIRunner.assertNonBlankPNG(at: outputPath)
             try await thenWhileAlive()
+            return result
         }
     }
 
@@ -371,5 +376,82 @@ struct RegressGuardTests {
             #expect(status.exitCode == 0, "daemon should stay healthy after a setup failure")
             #expect(status.stdout.contains("daemon running"), "status: \(status.stdout)")
         }
+    }
+
+    /// T01: setup that throws after a successful build still renders, and
+    /// the documented warning notice reaches the one-shot CLI's stderr
+    /// (the notice rides the internal start response — the drop of that
+    /// response's notices was found writing this guard).
+    @Test("T01: throwing setup renders with a warning notice", .timeLimit(.minutes(10)))
+    func t01ThrowingSetupNotice() async throws {
+        let result = try await Self.assertRenders(
+            "setup-faults/throwing/Sources/SetupFaultApp/SetupFaultPreview.swift"
+        )
+        #expect(
+            result.stderr.contains("Preview setup 'ThrowingSetup' failed"),
+            "stderr should carry the setup-failure notice: \(result.stderr)"
+        )
+        #expect(
+            result.stderr.contains("rendered without setup"),
+            "notice should disclose the skipped setup: \(result.stderr)"
+        )
+    }
+
+    /// T03: an eight-second setup runs as its own phase, ticks an
+    /// elapsed-time heartbeat, and completes before the first render.
+    /// Tick assertions are presence-only (one tick line, any elapsed
+    /// value) — never scheduler-dependent counts.
+    @Test("T03: slow setup heartbeats and precedes render", .timeLimit(.minutes(10)))
+    func t03SlowSetupHeartbeat() async throws {
+        let result = try await Self.assertRenders(
+            "setup-faults/slow/Sources/SetupFaultApp/SetupFaultPreview.swift"
+        )
+        #expect(
+            result.stderr.range(
+                of: #"Running preview setup\.\.\. \(\d+s\)"#, options: .regularExpression
+            ) != nil,
+            "setup phase should tick an elapsed heartbeat: \(result.stderr)"
+        )
+        let setupStart = try #require(result.stderr.range(of: "Running preview setup"))
+        let renderStart = try #require(result.stderr.range(of: "Rendering preview"))
+        #expect(
+            setupStart.lowerBound < renderStart.lowerBound,
+            "setup must complete before the first render: \(result.stderr)"
+        )
+    }
+
+    // MARK: - Lifecycle-fault rows
+
+    /// L02: an unresolved JIT symbol fails only the session with the
+    /// classified error naming the symbol (the ORC reporter carries
+    /// "Symbols not found" WITH the failure); the daemon stays alive.
+    @Test("L02: unresolved symbol is classified, daemon survives", .timeLimit(.minutes(10)))
+    func l02UnresolvedSymbol() async throws {
+        try await Self.assertFails(
+            "lifecycle-faults/Sources/MissingSymbol/MissingSymbolPreview.swift",
+            containing: [
+                "JIT link could not resolve",
+                "_previewsmcp_fixture_symbol_that_does_not_exist",
+            ]
+        ) {
+            let status = try await CLIRunner.run("status")
+            #expect(status.exitCode == 0, "daemon should survive a session-only JIT failure")
+            #expect(status.stdout.contains("daemon running"), "status: \(status.stdout)")
+        }
+    }
+
+    /// L03: an eight-second render ticks an elapsed-time heartbeat on the
+    /// previously silent interval. Presence-only, like T03.
+    @Test("L03: slow render heartbeats", .timeLimit(.minutes(10)))
+    func l03SlowRenderHeartbeat() async throws {
+        let result = try await Self.assertRenders(
+            "lifecycle-faults/Sources/SlowRender/SlowRenderPreview.swift"
+        )
+        #expect(
+            result.stderr.range(
+                of: #"Rendering preview\.\.\. \(\d+s\)"#, options: .regularExpression
+            ) != nil,
+            "render phase should tick an elapsed heartbeat: \(result.stderr)"
+        )
     }
 }

--- a/previewsmcp/Tests/CLIIntegrationTests/RunCommandTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/RunCommandTests.swift
@@ -113,8 +113,9 @@ struct RunCommandTests {
             #expect(proc.isRunning, "run should block after session is established")
 
             kill(proc.processIdentifier, SIGINT)
-            let exitDeadline = Date().addingTimeInterval(10)
-            while proc.isRunning, Date() < exitDeadline {
+            let clock = SuspendingClock()
+            let exitDeadline = clock.now.advanced(by: .seconds(10))
+            while proc.isRunning, clock.now < exitDeadline {
                 try await Task.sleep(nanoseconds: 50_000_000)
             }
             if proc.isRunning { proc.terminate() }
@@ -165,8 +166,9 @@ struct RunCommandTests {
             #expect(proc.isRunning)
 
             kill(proc.processIdentifier, SIGHUP)
-            let exitDeadline = Date().addingTimeInterval(10)
-            while proc.isRunning, Date() < exitDeadline {
+            let clock = SuspendingClock()
+            let exitDeadline = clock.now.advanced(by: .seconds(10))
+            while proc.isRunning, clock.now < exitDeadline {
                 try await Task.sleep(nanoseconds: 50_000_000)
             }
             if proc.isRunning { proc.terminate() }
@@ -197,8 +199,9 @@ struct RunCommandTests {
             try daemonStarter.run()
             defer { if daemonStarter.isRunning { daemonStarter.terminate() } }
 
-            let readyDeadline = Date().addingTimeInterval(5)
-            while Date() < readyDeadline,
+            let clock = SuspendingClock()
+            let readyDeadline = clock.now.advanced(by: .seconds(5))
+            while clock.now < readyDeadline,
                   !FileManager.default.fileExists(atPath: Self.socketPath)
             {
                 try await Task.sleep(nanoseconds: 50_000_000)
@@ -254,8 +257,9 @@ struct RunCommandTests {
         }
         defer { handle.readabilityHandler = nil }
 
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
+        let clock = SuspendingClock()
+        let deadline = clock.now.advanced(by: .seconds(timeout))
+        while clock.now < deadline {
             if buffer.contents().contains(pattern) { return true }
             try await Task.sleep(nanoseconds: 100_000_000)
         }

--- a/previewsmcp/Tests/CLIIntegrationTests/VersionHandshakeTests.swift
+++ b/previewsmcp/Tests/CLIIntegrationTests/VersionHandshakeTests.swift
@@ -45,8 +45,9 @@ struct VersionHandshakeTests {
         // on its own — don't waitUntilExit. The test will kill it via
         // `kill-daemon` during cleanup. Poll until the daemon's pid
         // file is written and the socket is accepting connections.
-        let deadline = Date().addingTimeInterval(10)
-        while Date() < deadline {
+        let clock = SuspendingClock()
+        let deadline = clock.now.advanced(by: .seconds(10))
+        while clock.now < deadline {
             if let pid = try? readPidFile(), isAlive(pid) {
                 // Also wait for the socket — the pid file is written
                 // after `DaemonListener.start` returns, but the daemon
@@ -75,8 +76,9 @@ struct VersionHandshakeTests {
         // Use `previewsmcp status` as a no-op liveness probe that
         // doesn't engage the handshake-restart path. Its exit code is
         // 0 iff the daemon is accepting connections.
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
+        let clock = SuspendingClock()
+        let deadline = clock.now.advanced(by: .seconds(timeout))
+        while clock.now < deadline {
             let result = try await CLIRunner.run("status", timeout: .seconds(5))
             if result.exitCode == 0 { return true }
             try await Task.sleep(nanoseconds: 100_000_000)


### PR DESCRIPTION
Automates the phase/error macOS guard rows and fixes two defect classes the work surfaced.

**Guards (RegressGuardTests):** T01 (setup-failure notice tokens on the one-shot CLI's stderr), T03 (setup heartbeat tick + setup-completes-before-render ordering), L02 (unresolved-symbol classification naming the symbol, daemon liveness), L03 (render heartbeat). Tick assertions are presence-only regexes, never scheduler-dependent counts. `assertRenders` now returns the CLI result for stderr pins.

**Notice drop (product):** writing the T01 guard exposed that `snapshot`'s ephemeral `preview_start` response — and `variants`' (confirmed live) and all of `snapshot-all`'s tool responses — never surfaced notices, which the daemon clears on delivery: the setup warning was silently lost. Root cause was the thrice-hand-rolled ephemeral start/stop lifecycle; it is now two shared helpers on `DaemonToolCalling` (`startPreviewSession`/`stopPreviewSession`) — one choke point where start/stop notices surface. `run` keeps its bespoke teardown message and now surfaces stop notices too.

**Sleep-proof deadlines (product + tests):** two local tier runs "failed" because the laptop slept mid-run — wall/continuous-clock deadlines expired across naps while subprocesses stood still (a 600s watchdog "fired" 39s into a test; a fresh daemon "did not become ready" with no awake time). Every daemon startup/exit wait in the CLI and every subprocess watchdog/spawn wait in CLIIntegrationTests now measures on the suspending clock. Also fixes real user behavior: closing a laptop mid-command no longer falsely times out daemon startup.

Verification: new guards 3x consecutive green; full guard suite green; both tiers fully re-run green post-fix (uncached); lint clean. Gates: /simplify 4-angle + adversarial correctness review; all findings folded (the notice choke point and the variants drop were gate findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)